### PR TITLE
Added ENS names to all profile response wallets

### DIFF
--- a/src/entities/IWallet.ts
+++ b/src/entities/IWallet.ts
@@ -1,0 +1,4 @@
+export interface Wallet {
+  readonly address: string;
+  readonly ens?: string;
+}


### PR DESCRIPTION
Added ens name field for each consolidated wallet in profiles response.

Profile response before this development:

```
{
  "profile": null,
  "consolidation": {
    "wallets": [
      {
        "wallet": "0xfd22004806a6846ea67ad883356be810f0428793",
        "tdh": 1894026
      }
    ],
    "tdh": 1894026
  }
}
```

Profile response after this development:

```
{
  "profile": null,
  "consolidation": {
    "wallets": [
      {
        "wallet": {
          "address": "0xfd22004806a6846ea67ad883356be810f0428793",
          "ens": "6529.eth"
        },
        "tdh": 1894026
      }
    ],
    "tdh": 1894026
  }
}
```

If wallet doesn't have ENS:

```
{
  "profile": {
    "normalised_handle": "simo",
    "handle": "Simo",
    "primary_wallet": "0x23a867c9b39c940e9467f5b3b43fa0e5a2bd1e6e",
    "created_at": "2023-10-19T04:08:16.000Z",
    "created_by_wallet": "0x23a867c9b39c940e9467f5b3b43fa0e5a2bd1e6e",
    "updated_at": "2023-10-20T06:34:12.000Z",
    "updated_by_wallet": "0x23a867c9b39c940e9467f5b3b43fa0e5a2bd1e6e",
    "pfp_url": "https://d3lqz0a4bldqgf.cloudfront.net/images/scaled_x450/0x33FD426905F149f8376e227d0C9D3340AaD17aF1/4.WEBP",
    "website": "https://www.google.com",
    "banner_1_url": null,
    "banner_2_url": null
  },
  "consolidation": {
    "wallets": [
      {
        "wallet": {
          "address": "0x23a867c9b39c940e9467f5b3b43fa0e5a2bd1e6e",
          "ens": null
        },
        "tdh": 27
      }
    ],
    "tdh": 27
  }
}
```