### PR TITLE
Escaped id in /nfts query (https://seize-ff.sentry.io/issues/4601832786)

### DIFF
--- a/src/db-api.ts
+++ b/src/db-api.ts
@@ -468,7 +468,13 @@ export async function fetchNFTs(
     );
   }
   if (nfts) {
-    filters = constructFilters(filters, `id in (${nfts})`);
+    filters = constructFilters(
+      filters,
+      `id in (${nfts
+        .split(',')
+        .map((it) => mysql.escape(it))
+        .join(',')})`
+    );
   }
   return fetchPaginated(
     NFTS_TABLE,


### PR DESCRIPTION
This `curl "localhost:3000/api/nfts?contract=0x33FD426905F149f8376e227d0C9D3340AaD17aF1&id=\[id\]"` made the API crash with:

```
Error: ER_PARSE_ERROR: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '[id])' at line 1
```