### PR TITLE
In some cases get wallet from header x-connected-wallet

### DIFF
--- a/src/api-serverless/src/api-constants.ts
+++ b/src/api-serverless/src/api-constants.ts
@@ -8,6 +8,7 @@ export const ACCESS_CONTROL_ALLOW_ORIGIN_HEADER =
   'Access-Control-Allow-Headers';
 export const CONTENT_TYPE_HEADER = 'Content-Type';
 export const JSON_HEADER_VALUE = 'application/json';
+export const CONNECTED_WALLET_HEADER = 'x-connected-wallet';
 export const DEFAULT_PAGE_SIZE = 50;
 export const NFTS_PAGE_SIZE = 101;
 export const DISTRIBUTION_PAGE_SIZE = 250;
@@ -23,7 +24,8 @@ export const corsOptions = {
     'Origin',
     'Accept',
     'X-Requested-With',
-    'Authorization'
+    'Authorization',
+    CONNECTED_WALLET_HEADER
   ]
 };
 

--- a/src/api-serverless/src/api-constants.ts
+++ b/src/api-serverless/src/api-constants.ts
@@ -8,8 +8,6 @@ export const ACCESS_CONTROL_ALLOW_ORIGIN_HEADER =
   'Access-Control-Allow-Headers';
 export const CONTENT_TYPE_HEADER = 'Content-Type';
 export const JSON_HEADER_VALUE = 'application/json';
-export const CONNECTED_WALLET_HEADER = 'x-connected-wallet';
-export const DEFAULT_PAGE_SIZE = 50;
 export const NFTS_PAGE_SIZE = 101;
 export const DISTRIBUTION_PAGE_SIZE = 250;
 export const SORT_DIRECTIONS = ['ASC', 'DESC'];
@@ -24,8 +22,7 @@ export const corsOptions = {
     'Origin',
     'Accept',
     'X-Requested-With',
-    'Authorization',
-    CONNECTED_WALLET_HEADER
+    'Authorization'
   ]
 };
 

--- a/src/api-serverless/src/api-constants.ts
+++ b/src/api-serverless/src/api-constants.ts
@@ -8,6 +8,7 @@ export const ACCESS_CONTROL_ALLOW_ORIGIN_HEADER =
   'Access-Control-Allow-Headers';
 export const CONTENT_TYPE_HEADER = 'Content-Type';
 export const JSON_HEADER_VALUE = 'application/json';
+export const DEFAULT_PAGE_SIZE = 50;
 export const NFTS_PAGE_SIZE = 101;
 export const DISTRIBUTION_PAGE_SIZE = 250;
 export const SORT_DIRECTIONS = ['ASC', 'DESC'];

--- a/src/api-serverless/src/auth/auth.ts
+++ b/src/api-serverless/src/auth/auth.ts
@@ -1,6 +1,5 @@
 import * as passport from 'passport';
 import { Request } from 'express';
-import { CONNECTED_WALLET_HEADER } from '../api-constants';
 
 export function getJwtSecret() {
   const jwtsecret = process.env.JWT_SECRET;
@@ -44,12 +43,4 @@ export function getWalletOrThrow(req: Request): string {
     throw new Error('Wallet not found');
   }
   return wallet;
-}
-
-export function getConnectedWalletOrNull(req: Request): string | null {
-  const header = req.headers[CONNECTED_WALLET_HEADER];
-  if (Array.isArray(header)) {
-    return header[0] ?? null;
-  }
-  return header ?? null;
 }

--- a/src/api-serverless/src/auth/auth.ts
+++ b/src/api-serverless/src/auth/auth.ts
@@ -1,5 +1,6 @@
 import * as passport from 'passport';
 import { Request } from 'express';
+import { CONNECTED_WALLET_HEADER } from '../api-constants';
 
 export function getJwtSecret() {
   const jwtsecret = process.env.JWT_SECRET;
@@ -29,7 +30,7 @@ export function maybeAuthenticatedUser() {
   return passport.authenticate(['jwt', 'anonymous'], { session: false });
 }
 
-export function getWalletOrNull(req: Request): string | null {
+export function getAuthenticatedWalletOrNull(req: Request): string | null {
   const user = req.user as any;
   if (!user) {
     return null;
@@ -38,9 +39,17 @@ export function getWalletOrNull(req: Request): string | null {
 }
 
 export function getWalletOrThrow(req: Request): string {
-  const wallet = getWalletOrNull(req);
+  const wallet = getAuthenticatedWalletOrNull(req);
   if (!wallet) {
     throw new Error('Wallet not found');
   }
   return wallet;
+}
+
+export function getConnectedWalletOrNull(req: Request): string | null {
+  const header = req.headers[CONNECTED_WALLET_HEADER];
+  if (Array.isArray(header)) {
+    return header[0] ?? null;
+  }
+  return header ?? null;
 }

--- a/src/api-serverless/src/profiles/profiles.routes.ts
+++ b/src/api-serverless/src/profiles/profiles.routes.ts
@@ -1,7 +1,8 @@
 import { Request, Response } from 'express';
 import { ApiResponse } from '../api-response';
 import {
-  getWalletOrNull,
+  getAuthenticatedWalletOrNull,
+  getConnectedWalletOrNull,
   getWalletOrThrow,
   maybeAuthenticatedUser,
   needsAuthenticatedUser
@@ -52,9 +53,10 @@ async function prepProfileApiResponse(
   >
 ) {
   const targetProfileId = profile.profile?.external_id;
-  const authenticatedWallet = getWalletOrNull(req);
-  const authenticatedProfileId = authenticatedWallet
-    ? await profilesService.getProfileIdByWallet(authenticatedWallet)
+  const connectedWallet =
+    getAuthenticatedWalletOrNull(req) ?? getConnectedWalletOrNull(req);
+  const authenticatedProfileId = connectedWallet
+    ? await profilesService.getProfileIdByWallet(connectedWallet)
     : null;
   let cic_left_for_authenticated_profile = 0;
   let authenticated_profile_contribution = 0;
@@ -121,7 +123,7 @@ router.get(
     >,
     res: Response<ApiResponse<{ available: boolean; message: string }>>
   ) {
-    const maybeAuthenticatedWallet = getWalletOrNull(req);
+    const maybeAuthenticatedWallet = getAuthenticatedWalletOrNull(req);
     const proposedHandle = req.params.handle.toLowerCase();
     if (!proposedHandle.match(PROFILE_HANDLE_REGEX)) {
       return res.status(200).send({

--- a/src/rates/cic-ratings.service.ts
+++ b/src/rates/cic-ratings.service.ts
@@ -27,6 +27,19 @@ export class CicRatingsService {
     return result;
   }
 
+  public async getTdhSpe(profileId: string): Promise<AggregatedCicRating> {
+    const result = await this.cicRatingsDb.getAggregatedCicRatingForProfile(
+      profileId
+    );
+    if (result === null) {
+      return {
+        cic_rating: 0,
+        contributor_count: 0
+      };
+    }
+    return result;
+  }
+
   public async getProfilesAggregatedCicRatingForProfile(
     targetProfileId: string,
     raterProfileId: string

--- a/src/rates/rates.db.ts
+++ b/src/rates/rates.db.ts
@@ -105,7 +105,7 @@ export class RatesDb extends LazyDbAccessCompatibleService {
     );
   }
 
-  public async getTotalRatesSpentOnMatterByProfileId({
+  public async getRatesTallyOnMatterByProfileId({
     profileId,
     matter,
     matterTargetType,
@@ -120,7 +120,7 @@ export class RatesDb extends LazyDbAccessCompatibleService {
       return 0;
     }
     const result: { rates_spent: number }[] = await this.db.execute(
-      `SELECT ABS(SUM(amount)) AS rates_spent FROM ${RATE_EVENTS_TABLE}
+      `SELECT SUM(amount) AS rates_spent FROM ${RATE_EVENTS_TABLE}
      WHERE rater = :profileId 
      AND matter = :matter 
      AND matter_target_type = :matterTargetType`,

--- a/src/rates/rates.service.test.ts
+++ b/src/rates/rates.service.test.ts
@@ -170,7 +170,7 @@ describe('RatesService', () => {
   describe('getRatesLeftOnMatterForWallet', () => {
     it('gives correct rates left count', async () => {
       when(ratesDb.getTdhInfoForProfile).mockResolvedValue(10);
-      when(ratesDb.getTotalRatesSpentOnMatterByProfileId).mockResolvedValue(5);
+      when(ratesDb.getRatesTallyOnMatterByProfileId).mockResolvedValue(5);
       const result = await service.getRatesLeftOnMatterForProfile({
         profileId: 'pid123',
         matterTargetType: RateMatterTargetType.PROFILE_ID,
@@ -188,6 +188,7 @@ describe('RatesService', () => {
       when(
         ratesDb.getRatesTallyForProfileOnMatterByCategories
       ).mockResolvedValue({});
+      when(ratesDb.getRatesTallyOnMatterByProfileId).mockResolvedValue(0);
       when(ratesDb.getCategoriesForMatter).mockResolvedValue([]);
       await expectExceptionWithMessage(async () => {
         await service.registerUserRating({
@@ -203,7 +204,7 @@ describe('RatesService', () => {
     });
 
     it('adding positive rating to an already positive rating over TDH not allowed', async () => {
-      when(ratesDb.getTotalRatesSpentOnMatterByProfileId).mockResolvedValue(5);
+      when(ratesDb.getRatesTallyOnMatterByProfileId).mockResolvedValue(5);
       when(ratesDb.getTdhInfoForProfile).mockResolvedValue(5);
       when(ratesDb.getCategoriesForMatter).mockResolvedValue([
         {
@@ -231,7 +232,7 @@ describe('RatesService', () => {
     });
 
     it('adding positive rating to an already positive rating in limits of TDH allowed', async () => {
-      when(ratesDb.getTotalRatesSpentOnMatterByProfileId).mockResolvedValue(4);
+      when(ratesDb.getRatesTallyOnMatterByProfileId).mockResolvedValue(4);
       when(ratesDb.getTdhInfoForProfile).mockResolvedValue(5);
       when(ratesDb.getCategoriesForMatter).mockResolvedValue([
         {
@@ -271,7 +272,7 @@ describe('RatesService', () => {
     });
 
     it('changing from positive to negative rating more than allowed', async () => {
-      when(ratesDb.getTotalRatesSpentOnMatterByProfileId).mockResolvedValue(5);
+      when(ratesDb.getRatesTallyOnMatterByProfileId).mockResolvedValue(5);
       when(ratesDb.getTdhInfoForProfile).mockResolvedValue(5);
       when(ratesDb.getCategoriesForMatter).mockResolvedValue([
         {
@@ -299,7 +300,7 @@ describe('RatesService', () => {
     });
 
     it('changing from positive to negative rating in allowed limits', async () => {
-      when(ratesDb.getTotalRatesSpentOnMatterByProfileId).mockResolvedValue(5);
+      when(ratesDb.getRatesTallyOnMatterByProfileId).mockResolvedValue(5);
       when(ratesDb.getTdhInfoForProfile).mockResolvedValue(5);
       when(ratesDb.getCategoriesForMatter).mockResolvedValue([
         {
@@ -340,7 +341,7 @@ describe('RatesService', () => {
 
     it('rate on a disabled matter not allowed', async () => {
       when(ratesDb.getTdhInfoForProfile).mockResolvedValue(5);
-      when(ratesDb.getTotalRatesSpentOnMatterByProfileId).mockResolvedValue(2);
+      when(ratesDb.getRatesTallyOnMatterByProfileId).mockResolvedValue(2);
       when(
         ratesDb.getRatesTallyForProfileOnMatterByCategories
       ).mockResolvedValue({
@@ -373,7 +374,7 @@ describe('RatesService', () => {
 
     it('revoke rating on a disabled matter successfully', async () => {
       when(ratesDb.getTdhInfoForProfile).mockResolvedValue(5);
-      when(ratesDb.getTotalRatesSpentOnMatterByProfileId).mockResolvedValue(2);
+      when(ratesDb.getRatesTallyOnMatterByProfileId).mockResolvedValue(2);
       when(
         ratesDb.getRatesTallyForProfileOnMatterByCategories
       ).mockResolvedValue({

--- a/src/rates/rates.service.ts
+++ b/src/rates/rates.service.ts
@@ -55,14 +55,12 @@ export class RatesService {
       matterTargetType,
       connectionHolder
     });
-    const ratesTally = await this.ratesDb.getTotalRatesSpentOnMatterByProfileId(
-      {
-        profileId: raterProfileId,
-        matter,
-        matterTargetType,
-        connectionHolder
-      }
-    );
+    const ratesTally = await this.ratesDb.getRatesTallyOnMatterByProfileId({
+      profileId: raterProfileId,
+      matter,
+      matterTargetType,
+      connectionHolder
+    });
     const maxRatesUserCanSpend = Math.abs(ratesTally) + ratesLeft;
     const ratesSpentAfterThisRating = Math.abs(ratesTally + amount);
     if (ratesSpentAfterThisRating > maxRatesUserCanSpend) {
@@ -116,14 +114,14 @@ export class RatesService {
       profileId,
       connectionHolder
     );
-    const ratesSpent = await this.ratesDb.getTotalRatesSpentOnMatterByProfileId(
-      {
+    const ratesSpent = await this.ratesDb
+      .getRatesTallyOnMatterByProfileId({
         profileId,
         matter,
         matterTargetType,
         connectionHolder
-      }
-    );
+      })
+      .then((t) => Math.abs(t ?? 0));
     return {
       ratesLeft: tdh - ratesSpent,
       ratesSpent: ratesSpent


### PR DESCRIPTION
There are cases where we would want to add extra context to REST responses depending on who is requesting but the user may be just connected with wallet, not fully authenticated. For those cases we start putting the connected wallet in frontend to a header and read it in backend from there.