### PR TITLE
Add initial delay for push notifications in SQS queue configuration

### DIFF
--- a/src/pushNotificationsHandler/identityPushNotifications.ts
+++ b/src/pushNotificationsHandler/identityPushNotifications.ts
@@ -23,6 +23,13 @@ export async function sendIdentityNotification(id: number) {
     throw new Error(`Notification not found: ${id}`);
   }
 
+  if (notification.read_at) {
+    logger.info(
+      `[ID ${notification.id}] Notification already read at ${notification.read_at}`
+    );
+    return;
+  }
+
   const userDevice = await getDataSource()
     .getRepository(PushNotificationDevice)
     .findOneBy({

--- a/src/pushNotificationsHandler/serverless.yaml
+++ b/src/pushNotificationsHandler/serverless.yaml
@@ -38,6 +38,7 @@ resources:
       Properties:
         QueueName: firebase-push-notifications
         VisibilityTimeout: 120
+        DelaySeconds: 2
         RedrivePolicy:
           deadLetterTargetArn:
             Fn::GetAtt: [FirebasePushNotificationsDLQ, Arn]

--- a/src/pushNotificationsHandler/serverless.yaml
+++ b/src/pushNotificationsHandler/serverless.yaml
@@ -38,7 +38,7 @@ resources:
       Properties:
         QueueName: firebase-push-notifications
         VisibilityTimeout: 60
-        DelaySeconds: 5
+        DelaySeconds: 3
         RedrivePolicy:
           deadLetterTargetArn:
             Fn::GetAtt: [FirebasePushNotificationsDLQ, Arn]

--- a/src/pushNotificationsHandler/serverless.yaml
+++ b/src/pushNotificationsHandler/serverless.yaml
@@ -37,12 +37,12 @@ resources:
       Type: AWS::SQS::Queue
       Properties:
         QueueName: firebase-push-notifications
-        VisibilityTimeout: 120
-        DelaySeconds: 2
+        VisibilityTimeout: 60
+        DelaySeconds: 5
         RedrivePolicy:
           deadLetterTargetArn:
             Fn::GetAtt: [FirebasePushNotificationsDLQ, Arn]
-          maxReceiveCount: 5
+          maxReceiveCount: 10
 
     FirebasePushNotificationsDLQ:
       Type: AWS::SQS::Queue


### PR DESCRIPTION
- Set DelaySeconds to 2 in FirebasePushNotificationsQueue properties

- This delay helps manage the flow of notifications and reduces immediate load on the system