### PR TITLE
add primary address to vote response

### DIFF
--- a/src/profiles/profiles.db.ts
+++ b/src/profiles/profiles.db.ts
@@ -575,7 +575,7 @@ export class ProfilesDb extends LazyDbAccessCompatibleService {
     }
     return this.db
       .execute(
-        `select profile_id as id, handle, pfp, cic, rep, tdh, banner1 as banner1_color, banner2 as banner2_color, level_raw as level from ${IDENTITIES_TABLE} where profile_id in (:ids)`,
+        `select profile_id as id, handle, pfp, cic, rep, tdh, banner1 as banner1_color, banner2 as banner2_color, level_raw as level, primary_address from ${IDENTITIES_TABLE} where profile_id in (:ids)`,
         { ids },
         connection ? { wrappedConnection: connection } : undefined
       )
@@ -752,6 +752,7 @@ export interface ProfileOverview {
   banner1_color: string | null;
   banner2_color: string | null;
   archived: boolean;
+  primary_address: string | null;
 }
 
 export const profilesDb = new ProfilesDb(dbSupplier);

--- a/src/profiles/profiles.service.ts
+++ b/src/profiles/profiles.service.ts
@@ -1394,7 +1394,8 @@ export class ProfilesService {
           tdh: 0,
           level: 0,
           pfp: null,
-          archived: true
+          archived: true,
+          primary_address: null
         }))
       );
     return [...activeProfiles, ...archivedProfiles];


### PR DESCRIPTION
I would like this so that the primary address of a voter is returned in this API call -

`https://api.6529.io/api/waves/b6128077-ea78-4dd9-b381-52c4eadb2077/voters?page_size=100&sort_direction=DESC&sort=ABSOLUTE&drop_id=9db6cce3-c10b-442b-a5e7-4368882e9ec4`

```
{
  "page": 1,
  "count": 130,
  "next": true,
  "data": [
    {
      "voter": {
        "id": "0f82fecc-87b4-11ee-9d82-029a0e4b6159",
        "handle": "lotsofreasons",
        "pfp": "https://d3lqz0a4bldqgf.cloudfront.net/images/scaled_x450/0x33FD426905F149f8376e227d0C9D3340AaD17aF1/87.GIF",
        "cic": 1818860,
        "rep": 3120048,
        "tdh": 4282951,
        "banner1_color": "#7e97c8",
        "banner2_color": "#435e93",
        "level": 79,
        "archived": false,
        "subscribed_actions": []
      },
      "votes_summed": 4282951,
      "positive_votes_summed": 4282951,
      "negative_votes_summed": 0,
      "absolute_votes_summed": 4282951,
      "min_vote": 4282951,
      "max_vote": 4282951,
      "different_drops_voted": 1,
      "average_vote": 4282951
    },
```

Inside the `voter`. It would make it easier to get oracle data about the voter. For example, right now to get full tdh data you need 3 calls - 

1. Call described above
2. Call to the `/profiles` API (`https://api.6529.io/api/profiles/0f82fecc-87b4-11ee-9d82-029a0e4b6159`)
3. Call to the Oracle `https://freenode.6529.io/oracle/address/0xc02e6b0d0c1a5d8cd26beeba0fe8d76c5d2f19b9`

it would be nice to skip step 2 here, especially as you may have to call step 2 here a bunch of times (once per voter)
