### PR TITLE
Add tie-breaker unit test for wave leaderboard

### DIFF
--- a/src/waves/wave-leaderboard-calculation.service.test.ts
+++ b/src/waves/wave-leaderboard-calculation.service.test.ts
@@ -1,4 +1,5 @@
 import { mock } from 'ts-jest-mocker';
+import { when } from 'jest-when';
 import { WaveLeaderboardCalculationService } from './wave-leaderboard-calculation.service';
 import { DropVotingDb } from '../api-serverless/src/drops/drop-voting.db';
 import { Time } from '../time';
@@ -155,6 +156,44 @@ describe('WaveLeaderboardCalculationService', () => {
         endTime: Time.millis(100)
       });
       expect(actual).toEqual(62);
+    });
+  });
+
+  describe('calculateWaveLeaderBoardInTimeAndGetTopNDropsWithVotes', () => {
+    it('orders drops with equal final votes by most recent vote increase', async () => {
+      when(dropVotingDb.getWavesParticipatoryDropsVoteStatesInTimespan)
+        .calledWith(
+          {
+            fromTime: 0,
+            toTime: 1000,
+            waveId: 'wave-id'
+          },
+          expect.anything()
+        )
+        .mockResolvedValue([
+          { drop_id: 'A', wave_id: 'wave-id', vote: 100, timestamp: 0 },
+          { drop_id: 'B', wave_id: 'wave-id', vote: 100, timestamp: 0 },
+          { drop_id: 'C', wave_id: 'wave-id', vote: 50, timestamp: 0 }
+        ]);
+
+      when(dropVotingDb.getLastVoteIncreaseTimesForEachDrop)
+        .calledWith(['B', 'A'], expect.anything())
+        .mockResolvedValue({ A: 1000, B: 2000 });
+
+      const result = await service.calculateWaveLeaderBoardInTimeAndGetTopNDropsWithVotes(
+        {
+          waveId: 'wave-id',
+          startTime: Time.millis(0),
+          endTime: Time.millis(1000),
+          n: 2
+        },
+        {}
+      );
+
+      expect(result).toEqual([
+        { drop_id: 'B', vote: 100, rank: 1 },
+        { drop_id: 'A', vote: 100, rank: 2 }
+      ]);
     });
   });
 });


### PR DESCRIPTION
## Summary
- add test verifying tie break logic for leaderboard rank calculation

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*