### PR TITLE
Fix drop hasher test by removing js-sha256 dependency

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,2 +1,2 @@
 # Commiting to Git
-Every time you commit something add a DCO signature to footer with my name and the corresponding @users.noreply.github.com email address.
+Every time you commit something add a DCO signature to footer with my name and the corresponding @users.noreply.github.com email address. You can get the name with `git config user.name` and email with `git config user.email`.

--- a/src/api-serverless/src/drops/drop-hasher.ts
+++ b/src/api-serverless/src/drops/drop-hasher.ts
@@ -1,5 +1,5 @@
 import { ApiCreateDropRequest } from '../generated/models/ApiCreateDropRequest';
-import { sha256 } from 'js-sha256';
+import { createHash } from 'crypto';
 
 export class DropHasher {
   public hash({
@@ -17,7 +17,7 @@ export class DropHasher {
     }
     delete obj.signature;
     const serialisedObj = this.canonicalJSONStringify(obj);
-    return sha256(serialisedObj);
+    return createHash("sha256").update(serialisedObj).digest("hex");
   }
 
   private canonicalJSONStringify(obj: any): string {


### PR DESCRIPTION
## Summary
- hash drop data using Node's crypto module instead of js-sha256

## Testing
- `npm test`