### PR TITLE
Fix delegations.test timeout by ignoring build directory

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,7 +4,8 @@ module.exports = {
   transform: {
     '^.+\\.ts?$': 'ts-jest'
   },
-  transformIgnorePatterns: ['<rootDir>/node_modules/']
+  transformIgnorePatterns: ['<rootDir>/node_modules/'],
+  testPathIgnorePatterns: ['<rootDir>/build/']
 };
 
 process.env = Object.assign(process.env, {


### PR DESCRIPTION
## Summary
- prevent Jest from running compiled tests

## Testing
- `npm test`