### PR TITLE
Support for text/html ipfs and arweave media

### DIFF
--- a/src/api-serverless/src/drops/drop.validator.ts
+++ b/src/api-serverless/src/drops/drop.validator.ts
@@ -55,9 +55,7 @@ const NewDropPartSchema: Joi.ObjectSchema<ApiCreateDropPart> = Joi.object({
     .items(
       Joi.object({
         mime_type: Joi.string().required(),
-        url: Joi.string()
-          .required()
-          .regex(/^https:\/\/d3lqz0a4bldqgf.cloudfront.net\//)
+        url: Joi.string().required()
       })
     )
     .default([])


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * URL validation for media items relaxed to accept a broader range of formats.
  * Media-source validation tightened per media item: images/videos/audios must come from the designated CDN; text/html must come from Arweave or IPFS; other MIME types now raise unsupported-type errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->