### PR TITLE
EvoResolver - Fix Lambda time drift by awaiting init and tightening Secrets Manager timeouts

### DIFF
--- a/src/api-serverless/src/app.ts
+++ b/src/api-serverless/src/app.ts
@@ -1199,6 +1199,14 @@ function getInitializationPromise(): Promise<void> {
 
 app.use(initializationGuard());
 
-void getInitializationPromise();
+export async function ensureInitialized(): Promise<void> {
+  await getInitializationPromise();
+}
+
+if (!process.env.AWS_LAMBDA_FUNCTION_NAME) {
+  ensureInitialized().catch((err) => {
+    logger.error('[EAGER INIT FAILED]', err);
+  });
+}
 
 export { app };

--- a/src/api-serverless/src/handler.ts
+++ b/src/api-serverless/src/handler.ts
@@ -1,4 +1,4 @@
-import { app } from './app';
+import { app, ensureInitialized } from './app';
 import * as sentryContext from '../../sentry.context';
 import type {
   APIGatewayEvent,
@@ -22,6 +22,7 @@ export const handler = sentryContext.wrapLambdaHandler(
     event: APIGatewayEvent,
     context: Context
   ): Promise<APIGatewayProxyResult> => {
+    await ensureInitialized();
     if (event.requestContext && event.requestContext.routeKey) {
       return wsHandler(event);
     } else {


### PR DESCRIPTION
Automated change generated by `evoticketresolver-test`.

- Execution ID: `5124dbbe-d024-440b-b709-8030ef9888c5`
- Provider: `openai`
- Model: `gpt-5.2-pro`
- Target branch: `main`

### Prompt
```
Review this theory

"
You said:
Uploaded image
issue is definitely not with secrets manager itself. it's more with lambda side. when we try to fetch secrets theres a multistep handshake verification and in one of those steps secrets manager says that the time drift between client (lambda) and secrets manager is too big.. but i still don't understand what even causes this time drift. but as soon as i retry its fixed

GelatoGenesis4311:53 PMhow i understood it from codex is that it has something to do with lambda warmup an how its later used. so lambda is warmed up and part of the secret fetching happens later then or smth and the time drift has happened by then.

what is going on here and how to fix

ChatGPT said:

Thought for 29s
What you’re seeing usually isn’t “Lambda’s clock drifting by 9 minutes.” Lambda nodes are NTP-synced; a real 9-minute wall-clock skew would be a major AWS incident and you’d see it everywhere.

What’s much more likely: you’re sending a request whose SigV4 signature was generated minutes earlier (stale signing time), so Secrets Manager compares:

X-Amz-Date (client signing timestamp baked into the signature)

server time (Secrets Manager)

…and rejects it as SignatureExpired / RequestTimeTooSkewed. Then on retry, you generate a fresh signature with the current time and it works. That perfectly matches “retry fixes it immediately.”

How that stale signature happens in Lambda
The common patterns:

You start a secret fetch, but it doesn’t actually hit the wire until much later

example: you create/prepare/sign something early (or create a request object early), then await it later after other init work, or it gets stuck behind a hung socket/DNS/TLS.

by the time it finally reaches AWS, the signature timestamp is old.

A hung in-flight request survives across the “freeze” boundary

Lambda can freeze your process between invocations.

If you have an in-flight HTTP request (or a Promise that wraps one) that’s stuck, it can resume later and finally send/complete with an old X-Amz-Date.

You accidentally cache anything that includes signing material

caching pre-signed headers/URLs, a signed request, or a custom signer output.

caching the result (the secret) is fine; caching the signed request is not.

The “warmup then used later” intuition is basically #2/#3: something created during warmup carries a signing timestamp that becomes invalid when it’s used later.

What to do (practical fixes)
1) Put hard timeouts on the Secrets Manager HTTP call
This prevents the “request hangs for minutes then completes with a stale signature” failure mode.

In AWS SDK v3 (Node), set socket/connect timeouts via the request handler:

import { SecretsManagerClient } from "@aws-sdk/client-secrets-manager";
import { NodeHttpHandler } from "@smithy/node-http-handler";

export const secretsClient = new SecretsManagerClient({
  requestHandler: new NodeHttpHandler({
    connectionTimeout: 1_000,  // connect/TLS handshake budget
    socketTimeout: 3_000,       // no-progress budget
  }),
  maxAttempts: 5,
});
If you already have retries, timeouts are the missing piece. Without timeouts, a single bad socket can “delay” the signed request long enough to expire.

2) Never reuse an in-flight init promise that might have started a request
Your “restartable getInitializationPromise()” change is exactly the right direction.

Also make sure you do not keep a pending secret-fetch Promise alive if init fails or the invocation is about to return. If init fails, discard everything related to that attempt.

3) Ensure signing happens immediately before send
If you have any custom signing / presigning / middleware that precomputes headers, remove it.
Let the SDK sign per-request at send time.

4) On SignatureExpired specifically: recreate the client + retry
If the underlying HTTP agent/socket state is poisoned (hung connection, odd reuse), rebuilding the client/request handler is a clean escape hatch.

keep a function like getSecretsClient() that can rebuild on this error

don’t just retry the same stuck client forever

5) Reduce “background init” that can outlive the invocation
If you do eager init on cold start, make it:

fast

time-bounded

fail-fast and restartable

Avoid launching a bunch of async init work and then returning from the handler while it’s still running.

How to confirm in 2 logs
Add a single log line on failure:

now = new Date().toISOString()

parse the server’s time from the error message / response headers if available (AWS often includes it)

log the X-Amz-Date you signed with (SDK error sometimes includes it; otherwise you can capture it in a middleware)

If you see:

now is correct

server time is correct

X-Amz-Date is several minutes earlier

…then you’ve proven it’s stale signing, not system clock drift.

Your current patch
The “infer clock offset from SignatureExpired and set systemClockOffset” is clever, and it will mask some cases, but it’s treating a symptom. If the real issue is “requests hanging long enough to expire,” offsets won’t prevent the next hang.

If you implement only one thing: tight HTTP timeouts + restartable init. That combination usually eliminates this class of bursty startup failures.


You said:
this is why the retry fixes it (because it gets a fresh signature?)

ChatGPT said:
Yes. In almost every case like this, the retry fixes it because it produces a new SigV4 signature with a new X-Amz-Date, so the request is no longer “too old” when Secrets Manager validates it.

What happened on the failed attempt is usually:

the SDK signed the request at time T

the request didn’t actually complete its network path until T + N minutes (stalled DNS/TLS/socket, frozen process boundary, hung connection reuse, etc.)

Secrets Manager sees X-Amz-Date = T and server time ≈ T + N, decides it’s outside the allowed skew window, returns SignatureExpired / RequestTimeTooSkewed

retry signs at the current time (T + N), and because the network path is now healthy (or it uses a different connection), it succeeds

So the key is: it’s not that Lambda’s wall clock is drifting and then “snaps back.” It’s that one request is effectively “delayed” long enough that its signature timestamp is stale, and the next request isn’t.

The durable fix is to prevent “delayed-to-the-wire” requests:

put strict connect + socket timeouts on the AWS SDK HTTP handler

avoid reusing a stuck in-flight init promise

on SignatureExpired, rebuild the client/request handler before retrying (cheap + effective)"

Check the repo to see if this is possibly happening and, if it is, make a fix
```

### Engine output (last message)
```
Yes — this repo had a concrete way to produce “time drift” errors without any real clock drift: `src/api-serverless/src/app.ts:1182` starts initialization in the background at module load (previously `void getInitializationPromise()`), and that init can include `loadSecrets()` (`src/api-serverless/src/app.ts:207`). If a warmup invocation returns while that promise is still in-flight, Lambda can freeze the process and later resume it, so the SigV4-signed Secrets Manager request effectively arrives “too late” and fails with `SignatureExpired/RequestTimeTooSkewed` (retry works because it re-signs).

Fixes applied:
- Await init in the Lambda entrypoint before handling HTTP/WS events (`src/api-serverless/src/handler.ts:25` + `src/api-serverless/src/app.ts:1202`) so init can’t outlive an invocation/freeze boundary.
- Keep eager init only for non-Lambda runtimes (`src/api-serverless/src/app.ts:1207`) so local/always-on servers still boot automatically.
- Add Secrets Manager connect/socket timeouts via `NodeHttpHandler` to prevent multi-minute hangs (`src/env.ts:13`, `src/env.ts:107`).
- Stop treating “request age” as “clock skew”: only apply `systemClockOffset` when server time meaningfully differs from local *now*; otherwise log it as a stale signature/delayed request (`src/env.ts:36`, `src/env.ts:119`).
```

_Generated at 2026-02-07 23:08:56Z._

<!-- execution-id: 5124dbbe-d024-440b-b709-8030ef9888c5 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved system initialization reliability and error diagnostics for signature validation and clock synchronization issues.
  * Enhanced timeout configuration for credential retrieval operations with better error messaging.

* **Chores**
  * Streamlined internal initialization process for improved system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->