### PR TITLE
EvoResolver - Harden memes minting auth, SSRF-safe fetch, and deterministic allowlist merkle handling

### DIFF
--- a/src/api-serverless/openapi.yaml
+++ b/src/api-serverless/openapi.yaml
@@ -1884,7 +1884,8 @@ paths:
         Returns allowlist merkle proofs for the given merkle root. If address
         query param is provided, returns proofs for that address only
         (MemesMintingProofsResponse). If address is omitted, returns proofs for
-        all addresses (MemesMintingProofsByAddressResponse).
+        all addresses (MemesMintingProofsByAddressResponse). Listing all
+        addresses requires DISTRIBUTION_ADMIN_WALLETS.
       operationId: getMemesMintingProofs
       parameters:
         - name: merkle_root
@@ -1900,6 +1901,7 @@ paths:
           description: Wallet address. If omitted, returns proofs for all addresses.
           schema:
             type: string
+            pattern: ^0x[a-fA-F0-9]{40}$
       responses:
         "200":
           description: successful operation
@@ -1911,6 +1913,10 @@ paths:
                   - $ref: "#/components/schemas/MemesMintingProofsByAddressResponse"
         "400":
           description: Invalid request (missing or invalid parameters)
+        "403":
+          description: >-
+            Forbidden - only distribution admins can list all proofs for a
+            merkle_root
         "404":
           description: No proofs found for the given merkle_root (and address if provided)
   /memes-minting/roots/{contract}/{card_id}:
@@ -1927,6 +1933,7 @@ paths:
           description: Contract address
           schema:
             type: string
+            pattern: ^0x[a-fA-F0-9]{40}$
         - name: card_id
           in: path
           required: true
@@ -1950,7 +1957,7 @@ paths:
         - Memes minting
       summary: Get meme claims (paginated, admin only)
       description: >
-        Returns a page of meme claims, ordered by meme_id ascending. Default
+        Returns a page of meme claims, ordered by meme_id descending. Default
         page_size 10, max 20. Only DISTRIBUTION_ADMIN_WALLETS can call this.
       operationId: getMemesMintingClaims
       parameters:
@@ -1978,6 +1985,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/MemesMintingClaimsPageResponse"
+        "401":
+          description: Unauthorized - authentication required
         "403":
           description: Forbidden - only distribution admins can access
   /memes-minting/claims/{meme_id}:
@@ -2003,6 +2012,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/MemeClaim"
+        "401":
+          description: Unauthorized - authentication required
         "403":
           description: Forbidden - only distribution admins can access
         "404":
@@ -2034,6 +2045,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/MemeClaim"
+        "401":
+          description: Unauthorized - authentication required
         "403":
           description: Forbidden - only distribution admins can access
         "404":
@@ -2064,6 +2077,8 @@ paths:
                 $ref: "#/components/schemas/MemeClaim"
         "400":
           description: Bad Request - claim has no image URL or edition_size not set
+        "401":
+          description: Unauthorized - authentication required
         "403":
           description: Forbidden - only distribution admins can access
         "404":

--- a/src/api-serverless/package-lock.json
+++ b/src/api-serverless/package-lock.json
@@ -928,6 +928,7 @@
       "integrity": "sha512-FAORK6KoMQbd2VyLq/BMwcViy1txYd7XD9eYd5IGrXFpoOgWrSjp4zaSDlFPIEGgm68+n8fN0RelkbuMHCkSsg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "find-my-way-ts": "^0.1.5",
         "multipasta": "^0.2.5"
@@ -989,6 +990,7 @@
       "deprecated": "this package has been merged into the main effect package",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-check": "^3.21.0"
       },
@@ -2247,6 +2249,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.13.tgz",
       "integrity": "sha512-ieqWtipT+VlyDWLz5Rvz0f3E5rXcVAnaAi+D53DEHLjc1kmFxCgZ62qVfTX2vwkywwqNkTNXvBgGR72hYqV//Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "file-type": "21.3.0",
         "iterare": "1.2.1",
@@ -3726,7 +3729,8 @@
       "version": "14.18.63",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
       "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/qs": {
       "version": "6.14.0",
@@ -3846,6 +3850,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4188,6 +4193,7 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.4.tgz",
       "integrity": "sha512-1wVkUaAO6WyaYtCkcYCOx12ZgpGf9Zif+qXa4n+oYzK558YryKqiL6UWwd5DqiH3VRW0GYhTZQ/vlgJrCoNQlg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.4",
@@ -5357,6 +5363,7 @@
       "integrity": "sha512-7+XC3vGrbAhCHd8LTFHvnZjRpZKZ8YHRZqJTkpNoxcJ2mCyNs2SwI+6VkV/ij8Y3YW7wfBN4EbU06/F5+m/wkQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "fast-check": "^3.23.1"
@@ -5439,6 +5446,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -5529,6 +5537,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5589,6 +5598,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -7115,6 +7125,7 @@
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -8702,7 +8713,8 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -8876,6 +8888,7 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -8978,6 +8991,7 @@
       "integrity": "sha512-P2N5qTFGLOg+kTlvk8y4p7+e4CPmJoSGuBM47Oxw2nXZ0wI2Z6BG9lUgEYa2iKvpJYplwntbkM8bInjH0NPqdw==",
       "dev": true,
       "hasInstallScript": true,
+      "peer": true,
       "dependencies": {
         "axios": "^1.13.2",
         "axios-proxy-builder": "^0.1.2",
@@ -10015,6 +10029,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10056,6 +10071,13 @@
       "engines": {
         "node": ">=18.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/universalify": {
       "version": "2.0.1",

--- a/src/api-serverless/src/memes-minting/allowlist-merkle.test.ts
+++ b/src/api-serverless/src/memes-minting/allowlist-merkle.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from '@jest/globals';
+import fc from 'fast-check';
+import { computeAllowlistMerkle } from './allowlist-merkle';
+
+function sumAmountsByAddress(
+  entries: Array<{ address: string; amount: number }>
+) {
+  const map = new Map<string, number>();
+  for (const e of entries) {
+    const k = e.address.toLowerCase();
+    map.set(k, (map.get(k) ?? 0) + e.amount);
+  }
+  return map;
+}
+
+describe('computeAllowlistMerkle', () => {
+  it('is deterministic regardless of input ordering', () => {
+    fc.assert(
+      fc.property(
+        fc.array(
+          fc.record({
+            address: fc
+              .hexaString({ minLength: 40, maxLength: 40 })
+              .map((h) => `0x${h}`),
+            amount: fc.integer({ min: 1, max: 5 })
+          }),
+          { minLength: 1, maxLength: 50 }
+        ),
+        (entries) => {
+          const a = computeAllowlistMerkle(entries);
+          const b = computeAllowlistMerkle([...entries].reverse());
+          expect(a.merkleRoot).toBe(b.merkleRoot);
+          expect(a.proofsByAddress).toEqual(b.proofsByAddress);
+        }
+      ),
+      { numRuns: 50 }
+    );
+  });
+
+  it('returns one proof item per allowed spot and assigns unique indices', () => {
+    fc.assert(
+      fc.property(
+        fc.array(
+          fc.record({
+            address: fc
+              .hexaString({ minLength: 40, maxLength: 40 })
+              .map((h) => `0x${h}`),
+            amount: fc.integer({ min: 1, max: 5 })
+          }),
+          { minLength: 1, maxLength: 25 }
+        ),
+        (entries) => {
+          const result = computeAllowlistMerkle(entries);
+          expect(result.merkleRoot).toMatch(/^0x[a-fA-F0-9]{64}$/);
+
+          const totals = sumAmountsByAddress(entries);
+          for (const [address, total] of Array.from(totals.entries())) {
+            expect(result.proofsByAddress[address]).toHaveLength(total);
+          }
+
+          const allValues = Object.values(result.proofsByAddress)
+            .flat()
+            .map((p) => p.value);
+          const totalLeaves = Array.from(totals.values()).reduce(
+            (a, b) => a + b,
+            0
+          );
+          expect(allValues).toHaveLength(totalLeaves);
+          const unique = new Set(allValues);
+          expect(unique.size).toBe(totalLeaves);
+          expect(Math.min(...allValues)).toBe(0);
+          expect(Math.max(...allValues)).toBe(totalLeaves - 1);
+        }
+      ),
+      { numRuns: 50 }
+    );
+  });
+
+  it('throws on invalid addresses', () => {
+    expect(() =>
+      computeAllowlistMerkle([{ address: 'not-an-address', amount: 1 }])
+    ).toThrow(/Invalid allowlist address/);
+  });
+});

--- a/src/api-serverless/src/memes-minting/allowlist-merkle.ts
+++ b/src/api-serverless/src/memes-minting/allowlist-merkle.ts
@@ -1,4 +1,4 @@
-import { getBytes, keccak256 } from 'ethers';
+import { isAddress, keccak256, solidityPackedKeccak256 } from 'ethers';
 import { MerkleTree } from 'merkletreejs';
 
 export interface AllowlistMerkleEntry {
@@ -16,9 +16,8 @@ export interface AllowlistMerkleResult {
   proofsByAddress: Record<string, AllowlistMerkleProofItem[]>;
 }
 
-function toHexIndex(index: number): string {
-  return index.toString(16).padStart(8, '0');
-}
+const MAX_LEAVES = 250_000;
+const MAX_UINT32 = 0xffffffff;
 
 function hashToBuffer(data: Buffer): Buffer {
   const hex = keccak256(new Uint8Array(data));
@@ -28,39 +27,71 @@ function hashToBuffer(data: Buffer): Buffer {
 export function computeAllowlistMerkle(
   entries: AllowlistMerkleEntry[]
 ): AllowlistMerkleResult {
-  const expanded: { address: string; index: number }[] = [];
-  let globalIndex = 0;
+  const byAddress = new Map<string, number>();
   for (const entry of entries) {
-    const address = entry.address.toLowerCase().replace(/^0x/, '');
-    for (let i = 0; i < entry.amount; i++) {
-      expanded.push({ address, index: globalIndex });
+    const rawAddress = entry?.address?.trim();
+    if (!rawAddress || !isAddress(rawAddress)) {
+      throw new Error(`Invalid allowlist address: ${String(entry?.address)}`);
+    }
+    const amount = Number(entry?.amount);
+    if (!Number.isInteger(amount) || amount <= 0) {
+      throw new Error(
+        `Invalid allowlist amount for ${rawAddress}: ${String(entry?.amount)}`
+      );
+    }
+    const address = rawAddress.toLowerCase();
+    byAddress.set(address, (byAddress.get(address) ?? 0) + amount);
+  }
+
+  if (byAddress.size === 0) {
+    return { merkleRoot: '', proofsByAddress: {} };
+  }
+
+  const sortedEntries = Array.from(byAddress.entries()).sort((a, b) =>
+    a[0].localeCompare(b[0])
+  );
+
+  const leaves: Buffer[] = [];
+  const leafOwners: string[] = [];
+  const leafValues: number[] = [];
+
+  let globalIndex = 0;
+  for (const [address, amount] of sortedEntries) {
+    for (let i = 0; i < amount; i++) {
+      if (globalIndex > MAX_UINT32) {
+        throw new Error(
+          `Allowlist index exceeded uint32 max: ${globalIndex} > ${MAX_UINT32}`
+        );
+      }
+      if (leaves.length >= MAX_LEAVES) {
+        throw new Error(
+          `Allowlist too large: ${leaves.length + 1} leaves exceeds max ${MAX_LEAVES}`
+        );
+      }
+      const leafHex = solidityPackedKeccak256(
+        ['address', 'uint32'],
+        [address, globalIndex]
+      );
+      leaves.push(Buffer.from(leafHex.slice(2), 'hex'));
+      leafOwners.push(address);
+      leafValues.push(globalIndex);
       globalIndex++;
     }
   }
-  if (expanded.length === 0) {
-    return { merkleRoot: '', proofsByAddress: {} };
-  }
-  const leaves = expanded.map((entry) => {
-    const hexIndex = toHexIndex(entry.index);
-    const concatenatedData = entry.address + hexIndex;
-    const bufferData = Buffer.from(getBytes('0x' + concatenatedData));
-    return hashToBuffer(bufferData);
-  });
+
   const merkleTree = new MerkleTree(leaves, hashToBuffer, {
     sortPairs: true
   });
   const merkleRoot = merkleTree.getHexRoot();
   const proofsByAddress: Record<string, AllowlistMerkleProofItem[]> = {};
-  expanded.forEach((entry, idx) => {
-    const address = '0x' + entry.address;
+  for (let idx = 0; idx < leaves.length; idx++) {
+    const address = leafOwners[idx];
     const proof = merkleTree.getHexProof(leaves[idx]);
-    if (!proofsByAddress[address]) {
-      proofsByAddress[address] = [];
-    }
+    if (!proofsByAddress[address]) proofsByAddress[address] = [];
     proofsByAddress[address].push({
       merkleProof: proof,
-      value: entry.index
+      value: leafValues[idx]
     });
-  });
+  }
   return { merkleRoot, proofsByAddress };
 }

--- a/src/http/safe-fetch.test.ts
+++ b/src/http/safe-fetch.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  isForbiddenHostname,
+  isPrivateIp,
+  parseAndValidatePublicHttpUrl
+} from './safe-fetch';
+
+describe('safe-fetch', () => {
+  describe('isPrivateIp', () => {
+    it('detects private IPv4 ranges', () => {
+      expect(isPrivateIp('127.0.0.1')).toBe(true);
+      expect(isPrivateIp('10.0.0.1')).toBe(true);
+      expect(isPrivateIp('100.64.0.1')).toBe(true);
+      expect(isPrivateIp('192.168.1.1')).toBe(true);
+      expect(isPrivateIp('172.16.0.1')).toBe(true);
+      expect(isPrivateIp('169.254.169.254')).toBe(true);
+    });
+
+    it('detects private IPv6 ranges', () => {
+      expect(isPrivateIp('::1')).toBe(true);
+      expect(isPrivateIp('fe80::1')).toBe(true);
+      expect(isPrivateIp('fc00::1')).toBe(true);
+      expect(isPrivateIp('fd00::1')).toBe(true);
+      expect(isPrivateIp('::ffff:127.0.0.1')).toBe(true);
+      expect(isPrivateIp('::ffff:7f00:1')).toBe(true);
+    });
+
+    it('treats public IPs as public', () => {
+      expect(isPrivateIp('1.1.1.1')).toBe(false);
+      expect(isPrivateIp('8.8.8.8')).toBe(false);
+    });
+  });
+
+  describe('isForbiddenHostname', () => {
+    it('blocks localhost hostnames', () => {
+      expect(isForbiddenHostname('localhost')).toBe(true);
+      expect(isForbiddenHostname('LOCALHOST')).toBe(true);
+      expect(isForbiddenHostname('a.localhost')).toBe(true);
+    });
+  });
+
+  describe('parseAndValidatePublicHttpUrl', () => {
+    it('rejects non-http protocols', () => {
+      expect(() => parseAndValidatePublicHttpUrl('file:///etc/passwd')).toThrow(
+        /Unsupported URL protocol/
+      );
+      expect(() => parseAndValidatePublicHttpUrl('ftp://example.com')).toThrow(
+        /Unsupported URL protocol/
+      );
+    });
+
+    it('rejects URLs with credentials', () => {
+      expect(() =>
+        parseAndValidatePublicHttpUrl('https://user:pass@example.com/a')
+      ).toThrow(/credentials/);
+    });
+
+    it('rejects localhost and private IP literals', () => {
+      expect(() => parseAndValidatePublicHttpUrl('http://localhost/a')).toThrow(
+        /Forbidden hostname/
+      );
+      expect(() => parseAndValidatePublicHttpUrl('http://127.0.0.1/a')).toThrow(
+        /Forbidden IP/
+      );
+    });
+
+    it('accepts https URLs with public hostnames', () => {
+      const url = parseAndValidatePublicHttpUrl('https://arweave.net/abc');
+      expect(url.protocol).toBe('https:');
+      expect(url.hostname).toBe('arweave.net');
+    });
+  });
+});

--- a/src/http/safe-fetch.ts
+++ b/src/http/safe-fetch.ts
@@ -1,0 +1,242 @@
+import { lookup } from 'node:dns/promises';
+import { isIP } from 'node:net';
+import fetch, {
+  RequestInit as NodeFetchRequestInit,
+  Response
+} from 'node-fetch';
+
+export type SafeFetchOptions = {
+  timeoutMs?: number;
+  maxBytes?: number;
+  headers?: Record<string, string>;
+  maxRedirects?: number;
+};
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_MAX_BYTES = 50 * 1024 * 1024; // 50 MiB
+const DEFAULT_MAX_REDIRECTS = 3;
+
+function parseIpv4ToInt(ip: string): number | null {
+  const parts = ip.split('.');
+  if (parts.length !== 4) return null;
+  const nums = parts.map((p) => Number(p));
+  if (nums.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) return null;
+  return (
+    ((nums[0] << 24) + (nums[1] << 16) + (nums[2] << 8) + (nums[3] << 0)) >>> 0
+  );
+}
+
+function isPrivateIpv4(ip: string): boolean {
+  const n = parseIpv4ToInt(ip);
+  if (n == null) return true;
+  const masked = (mask: number) => (n & mask) >>> 0;
+  // 0.0.0.0/8
+  if (masked(0xff000000) === 0x00000000) return true;
+  // 100.64.0.0/10 (carrier-grade NAT)
+  if (masked(0xffc00000) === 0x64400000) return true;
+  // 10.0.0.0/8
+  if (masked(0xff000000) === 0x0a000000) return true;
+  // 127.0.0.0/8
+  if (masked(0xff000000) === 0x7f000000) return true;
+  // 169.254.0.0/16 (link-local, incl. AWS metadata)
+  if (masked(0xffff0000) === 0xa9fe0000) return true;
+  // 172.16.0.0/12
+  if (masked(0xfff00000) === 0xac100000) return true;
+  // 192.168.0.0/16
+  if (masked(0xffff0000) === 0xc0a80000) return true;
+  // 192.0.0.0/24 (IETF protocol assignments)
+  if (masked(0xffffff00) === 0xc0000000) return true;
+  // 192.0.2.0/24, 198.51.100.0/24, 203.0.113.0/24 (TEST-NET ranges)
+  if (masked(0xffffff00) === 0xc0000200) return true;
+  if (masked(0xffffff00) === 0xc6336400) return true;
+  if (masked(0xffffff00) === 0xcb007100) return true;
+  // 198.18.0.0/15 (benchmarking)
+  if (masked(0xfffe0000) === 0xc6120000) return true;
+  // 224.0.0.0/4 multicast, 240.0.0.0/4 reserved
+  if (masked(0xf0000000) === 0xe0000000) return true;
+  if (masked(0xf0000000) === 0xf0000000) return true;
+  return false;
+}
+
+function isPrivateIpv6(ip: string): boolean {
+  const s = ip.toLowerCase();
+  if (s === '::1' || s === '::') return true;
+  if (s.startsWith('fe80:')) return true; // link-local
+  if (s.startsWith('fc') || s.startsWith('fd')) return true; // unique local
+  // IPv4-mapped IPv6 ::ffff:a.b.c.d or ::ffff:7f00:1
+  const dotted = s.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
+  if (dotted?.[1]) {
+    return isPrivateIp(dotted[1]);
+  }
+  const hexMapped = s.match(/(?:^|:)ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
+  if (hexMapped?.[1] && hexMapped?.[2]) {
+    const hi = Number.parseInt(hexMapped[1], 16);
+    const lo = Number.parseInt(hexMapped[2], 16);
+    if (Number.isFinite(hi) && Number.isFinite(lo)) {
+      const ipv4 = `${(hi >> 8) & 255}.${hi & 255}.${(lo >> 8) & 255}.${lo & 255}`;
+      return isPrivateIp(ipv4);
+    }
+  }
+  return false;
+}
+
+export function isPrivateIp(ip: string): boolean {
+  const family = isIP(ip);
+  if (family === 4) return isPrivateIpv4(ip);
+  if (family === 6) return isPrivateIpv6(ip);
+  return true;
+}
+
+export function isForbiddenHostname(hostname: string): boolean {
+  const h = hostname.trim().toLowerCase();
+  if (h === 'localhost' || h === 'localhost.' || h.endsWith('.localhost'))
+    return true;
+  return false;
+}
+
+export function parseAndValidatePublicHttpUrl(url: string): URL {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`Invalid URL: ${url}`);
+  }
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+    throw new Error(`Unsupported URL protocol: ${parsed.protocol}`);
+  }
+  if (parsed.username || parsed.password) {
+    throw new Error('URLs with credentials are not allowed');
+  }
+  if (!parsed.hostname) {
+    throw new Error('URL hostname is required');
+  }
+  if (isForbiddenHostname(parsed.hostname)) {
+    throw new Error(`Forbidden hostname: ${parsed.hostname}`);
+  }
+  const literalIp = parsed.hostname;
+  if (isIP(literalIp)) {
+    if (isPrivateIp(literalIp)) {
+      throw new Error(`Forbidden IP address: ${literalIp}`);
+    }
+  }
+  return parsed;
+}
+
+async function assertHostnameResolvesToPublicIps(hostname: string) {
+  if (isIP(hostname)) {
+    // already validated in parse step
+    return;
+  }
+  const results = await lookup(hostname, { all: true });
+  if (!results.length) {
+    throw new Error(`DNS lookup returned no results for ${hostname}`);
+  }
+  for (const r of results) {
+    if (isPrivateIp(r.address)) {
+      throw new Error(`DNS resolved to forbidden IP for ${hostname}`);
+    }
+  }
+}
+
+async function readResponseToBufferOrThrow(
+  res: Response,
+  maxBytes: number
+): Promise<Buffer> {
+  const contentLength = res.headers.get('content-length');
+  if (contentLength) {
+    const n = Number(contentLength);
+    if (Number.isFinite(n) && n > maxBytes) {
+      throw new Error(`Response too large: ${n} bytes`);
+    }
+  }
+  const chunks: Buffer[] = [];
+  let total = 0;
+  const body = res.body as any;
+  if (!body) return Buffer.alloc(0);
+  for await (const chunk of body) {
+    const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    total += buf.length;
+    if (total > maxBytes) {
+      try {
+        body.destroy?.();
+      } catch {
+        // ignore
+      }
+      throw new Error(`Response exceeded max size of ${maxBytes} bytes`);
+    }
+    chunks.push(buf);
+  }
+  return Buffer.concat(chunks);
+}
+
+function contentTypeFromResponse(res: Response): string | null {
+  const raw = res.headers.get('content-type');
+  if (!raw) return null;
+  return raw.split(';')[0]?.trim() || null;
+}
+
+export async function fetchPublicUrlToBuffer(
+  url: string,
+  options: SafeFetchOptions = {}
+): Promise<{ buffer: Buffer; contentType: string | null; finalUrl: string }> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const maxBytes = options.maxBytes ?? DEFAULT_MAX_BYTES;
+  const maxRedirects = options.maxRedirects ?? DEFAULT_MAX_REDIRECTS;
+
+  let currentUrl = parseAndValidatePublicHttpUrl(url);
+  let redirectsRemaining = maxRedirects;
+
+  // Validate the initial hostname (and each redirect target) before fetching.
+  await assertHostnameResolvesToPublicIps(currentUrl.hostname);
+
+  while (true) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+    timeout.unref?.();
+
+    let res: Response;
+    try {
+      const init: NodeFetchRequestInit = {
+        method: 'GET',
+        redirect: 'manual',
+        headers: options.headers,
+        signal: controller.signal as any
+      };
+      res = await fetch(currentUrl.toString(), init);
+    } finally {
+      clearTimeout(timeout);
+    }
+
+    if (
+      res.status === 301 ||
+      res.status === 302 ||
+      res.status === 303 ||
+      res.status === 307 ||
+      res.status === 308
+    ) {
+      if (redirectsRemaining <= 0) {
+        throw new Error(`Too many redirects fetching ${url}`);
+      }
+      const location = res.headers.get('location');
+      if (!location) {
+        throw new Error(`Redirect without location fetching ${url}`);
+      }
+      const next = new URL(location, currentUrl);
+      currentUrl = parseAndValidatePublicHttpUrl(next.toString());
+      await assertHostnameResolvesToPublicIps(currentUrl.hostname);
+      redirectsRemaining--;
+      continue;
+    }
+
+    if (!res.ok) {
+      throw new Error(`Fetch failed: ${res.status} ${currentUrl.toString()}`);
+    }
+
+    const buffer = await readResponseToBufferOrThrow(res, maxBytes);
+    return {
+      buffer,
+      contentType: contentTypeFromResponse(res),
+      finalUrl: currentUrl.toString()
+    };
+  }
+}

--- a/src/meme-claims/media-inspector.ts
+++ b/src/meme-claims/media-inspector.ts
@@ -5,7 +5,7 @@ import type {
   MemeClaimAnimationDetailsVideo,
   MemeClaimImageDetails
 } from '@/entities/IMemeClaim';
-import fetch from 'node-fetch';
+import { fetchPublicUrlToBuffer } from '@/http/safe-fetch';
 import { imageSize } from 'image-size';
 import * as MP4Box from 'mp4box';
 
@@ -39,12 +39,15 @@ function sniffKindAndFormat(
 async function fetchUrlToBuffer(
   url: string
 ): Promise<{ buffer: Buffer; contentType: string | null }> {
-  const res = await fetch(url);
-  if (!res.ok) {
-    throw new Error(`Fetch failed: ${res.status} ${url}`);
-  }
-  const buffer = Buffer.from(await res.arrayBuffer());
-  const contentType = res.headers.get('content-type');
+  const { buffer, contentType } = await fetchPublicUrlToBuffer(url, {
+    timeoutMs: 30_000,
+    maxBytes: 50 * 1024 * 1024,
+    headers: {
+      'User-Agent':
+        'Mozilla/5.0 (compatible; 6529MediaInspector/1.0; +https://6529.io)',
+      Accept: '*/*'
+    }
+  });
   return { buffer, contentType };
 }
 

--- a/src/meme-claims/meme-claim-from-drop.builder.ts
+++ b/src/meme-claims/meme-claim-from-drop.builder.ts
@@ -161,6 +161,7 @@ export function buildMemeClaimRowFromDrop(
   metadatas: DropMetadataEntity[],
   maxSeasonId: number
 ): MemeClaimRowInput {
+  const season = Math.max(1, Number.isFinite(maxSeasonId) ? maxSeasonId : 1);
   const title = metadatas.find((m) => m.data_key === 'title')?.data_value ?? '';
   const description =
     metadatas.find((m) => m.data_key === 'description')?.data_value ?? '';
@@ -188,7 +189,7 @@ export function buildMemeClaimRowFromDrop(
       description: description || ' ',
       name: title || ' ',
       image_url: null,
-      season: maxSeasonId,
+      season,
       attributes: buildAttributes(metadatas),
       image_details: null,
       animation_url: null,
@@ -238,7 +239,7 @@ export function buildMemeClaimRowFromDrop(
   return {
     drop_id: dropId,
     meme_id: memeId,
-    season: maxSeasonId,
+    season,
     image_location: null,
     animation_location: null,
     metadata_location: null,


### PR DESCRIPTION
Automated change generated by `evoticketresolver`.

- Execution ID: `8b734b30-6478-456c-9723-e752bc562fb2`
- Provider: `openai`
- Model: `gpt-5.2-pro`
- Target branch: `manifold-migration`

### Prompt
```
1/ the Memes by 6529 use a Manifold NFT contract (go check which one)

2/ the 6529 team wants to move away from minting (e.g. the admin/creator minting) through the Manifold website to doing it internally in their website as part of the decentralization pathway

3/ this branch has the current work done so far on this topic

"New Features

Memes Minting API: manage meme claims, merkle proofs/roots, and Arweave uploads.
Merkle-based allowlists and proof generation for distributions.
Media handling: image, video, GLB and HTML animation inspection and metadata extraction.
Automated meme claim creation workflow and DB-backed meme claims support.
Chores

Added media/crypto/runtime dependencies and docs for API types, schema changes, and workflows.
Style

.gitignore updated to ignore a top-level temp directory."

4/ I would like you to do extensive review of what has been done so far and check for errors, inconsistencies, security holes, edge cases, documentation, unit testing, performance and so on

5/ make the relevant changes
```

### Engine output (last message)
```
**Manifold Contracts (from repo)**
- Memes creator contract: `0x33FD426905F149f8376e227d0C9D3340AaD17aF1` in `src/constants/index.ts:14`
- Manifold Lazy Claim contract used for mint stats: `0x26BBEA7803DcAc346D5F5f135b57Cf2c752A02bE` in `src/mintAnnouncementsLoop/manifold-claim.service.ts:7`

**Key Fixes / Hardening**
- Fixed a serious auth-bypass risk where `cacheRequest()` could serve cached admin responses to non-admins; replaced with safe, non-JWT cache keys + made “list all proofs” admin-only in `src/api-serverless/src/memes-minting/api.memes-minting.routes.ts:44`.
- Added SSRF/DoS-hardened fetching (private/reserved IP blocking, redirect validation, abortable timeouts, max size) and reused it for both Arweave uploads + media inspection in `src/http/safe-fetch.ts:29`, `src/meme-claims/media-inspector.ts:39`, `src/api-serverless/src/memes-minting/api.memes-minting.routes.ts:356`.
- Made allowlist merkle generation deterministic + validated + bounded; fixed DB merkle cleanup (delete *all* roots’ proofs, chunked inserts) and ensured stale merkle data is removed when allowlist becomes empty in `src/api-serverless/src/memes-minting/allowlist-merkle.ts:27`, `src/api-serverless/src/memes-minting/api.memes-minting.db.ts:11`, `src/api-serverless/src/distributions/api.distributions.service.ts:145`.
- Fixed claim patch semantics so `arweave_synced_at` is only reset when content-affecting fields change; improved animation type inference in `src/api-serverless/src/memes-minting/api.memes-minting.service.ts:93`.
- Tightened OpenAPI docs (ordering, address patterns, admin-only full proofs) in `src/api-serverless/openapi.yaml:1878`.

**Tests / Validation**
- Added tests: `src/http/safe-fetch.test.ts:1`, `src/api-serverless/src/memes-minting/allowlist-merkle.test.ts:1`.
- Ran `npm run lint` + `npm run tsc`, and a targeted non-DB Jest run for the new tests.
- Could not run full `npm test` (needs Docker) or `src/api-serverless` OpenAPI `npm run generate` (needs Java) in this environment.
```

_Generated at 2026-02-08 12:52:17Z._

<!-- execution-id: 8b734b30-6478-456c-9723-e752bc562fb2 -->