### PR TITLE
Fix for prediciton sort to only include participatory drops

### DIFF
--- a/src/drops/drops.db.ts
+++ b/src/drops/drops.db.ts
@@ -1084,7 +1084,7 @@ export class DropsDb extends LazyDbAccessCompatibleService {
         )`
       : '';
     const sql = `
-        select d.* from ${WAVE_LEADERBOARD_ENTRIES_TABLE} r join ${DROPS_TABLE} d on d.id = r.drop_id and d.drop_type = '${DropType.PARTICIPATORY}' and d.wave_id = :wave_id ${curationFilter} order by r.vote_on_decision_time ${params.sort_direction} limit :page_size offset :offset
+        select d.* from ${WAVE_LEADERBOARD_ENTRIES_TABLE} r join ${DROPS_TABLE} d on d.id = r.drop_id where d.drop_type = '${DropType.PARTICIPATORY}' and d.wave_id = :wave_id ${curationFilter} order by r.vote_on_decision_time ${params.sort_direction} limit :page_size offset :offset
     `;
     const sqlParams = {
       wave_id: params.wave_id,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved leaderboard accuracy by filtering to include only participatory drops in weighted prediction rankings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->