### PR TITLE
Endpoint for favourite waves of an identity

### DIFF
--- a/src/api-serverless/openapi.yaml
+++ b/src/api-serverless/openapi.yaml
@@ -4690,6 +4690,50 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/ApiWave"
+  /waves-overview/favourites-of-identity/{identityKey}:
+    get:
+      tags:
+        - Waves
+      summary: Get waves where a profile has written the most messages.
+      description: >-
+        Returns non-DM waves ranked by how many chat messages the resolved
+        profile has written in them. Results only include waves the requester
+        can access.
+      operationId: getFavouriteWavesOfIdentity
+      parameters:
+        - name: identityKey
+          in: path
+          description: Profile id, wallet, ENS, or handle to resolve
+          required: true
+          schema:
+            type: string
+        - name: limit
+          in: query
+          description: How many waves to return (50 by default)
+          required: false
+          schema:
+            type: integer
+            format: int64
+            minimum: 1
+            maximum: 100
+            default: 50
+        - name: offset
+          in: query
+          description: Used to find next waves
+          required: false
+          schema:
+            type: integer
+            format: int64
+            minimum: 0
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ApiWave"
   /waves-overview/hot:
     get:
       tags:

--- a/src/api-serverless/src/waves/wave.api.service.ts
+++ b/src/api-serverless/src/waves/wave.api.service.ts
@@ -1078,6 +1078,64 @@ export class WaveApiService {
     );
   }
 
+  public async getFavouriteWavesOfIdentity(
+    { identityKey, limit, offset }: FavouriteWavesOfIdentityParams,
+    ctx: RequestContext
+  ): Promise<ApiWave[]> {
+    const authenticationContext = ctx?.authenticationContext;
+    const authenticatedProfileId =
+      authenticationContext?.getActingAsId() ?? null;
+    const eligibleGroups =
+      !authenticationContext ||
+      !authenticatedProfileId ||
+      (authenticationContext.isAuthenticatedAsProxy() &&
+        !authenticationContext.activeProxyActions[
+          ProfileProxyActionType.READ_WAVE
+        ])
+        ? []
+        : await this.userGroupsService.getGroupsUserIsEligibleFor(
+            authenticatedProfileId,
+            ctx.timer
+          );
+    const targetProfileId =
+      await this.identityFetcher.getProfileIdByIdentityKeyOrThrow(
+        { identityKey },
+        ctx
+      );
+    const waveEntities = await this.wavesApiDb.findFavouriteWavesOfIdentity(
+      {
+        identityId: targetProfileId,
+        eligibleGroups,
+        limit,
+        offset
+      },
+      ctx
+    );
+    const noRightToVote =
+      !authenticationContext ||
+      !authenticatedProfileId ||
+      (authenticationContext.isAuthenticatedAsProxy() &&
+        !authenticationContext.activeProxyActions[
+          ProfileProxyActionType.RATE_WAVE_DROP
+        ]);
+    const noRightToParticipate =
+      !authenticationContext ||
+      !authenticatedProfileId ||
+      (authenticationContext.isAuthenticatedAsProxy() &&
+        !authenticationContext.activeProxyActions[
+          ProfileProxyActionType.CREATE_DROP_TO_WAVE
+        ]);
+    return this.waveMappers.waveEntitiesToApiWaves(
+      {
+        waveEntities,
+        groupIdsUserIsEligibleFor: eligibleGroups,
+        noRightToVote,
+        noRightToParticipate
+      },
+      ctx
+    );
+  }
+
   private async findWaveEntitiesByType({
     eligibleGroups,
     type,
@@ -1613,6 +1671,12 @@ export interface WavesOverviewParams {
 
 export interface RankedWavesOverviewParams {
   exclude_followed: boolean;
+}
+
+export interface FavouriteWavesOfIdentityParams {
+  identityKey: string;
+  limit: number;
+  offset: number;
 }
 
 export const waveApiService = new WaveApiService(

--- a/src/api-serverless/src/waves/waves-overview.routes.ts
+++ b/src/api-serverless/src/waves/waves-overview.routes.ts
@@ -6,6 +6,7 @@ import { ApiWave } from '../generated/models/ApiWave';
 import * as Joi from 'joi';
 import { getValidatedByJoiOrThrow } from '../validation';
 import {
+  FavouriteWavesOfIdentityParams,
   RankedWavesOverviewParams,
   waveApiService,
   WavesOverviewParams
@@ -16,6 +17,33 @@ import { ApiWavesPinFilter } from '../generated/models/ApiWavesPinFilter';
 import { cacheRequest } from '../request-cache';
 
 const router = asyncRouter();
+
+router.get(
+  '/favourites-of-identity/:identityKey',
+  maybeAuthenticatedUser(),
+  async (
+    req: Request<
+      { identityKey: string },
+      any,
+      any,
+      { limit: number; offset: number },
+      any
+    >,
+    res: Response<ApiResponse<ApiWave[]>>
+  ) => {
+    const timer = Timer.getFromRequest(req);
+    const authenticationContext = await getAuthenticationContext(req, timer);
+    const params = getValidatedByJoiOrThrow(
+      { ...req.params, ...req.query },
+      FavouriteWavesOfIdentityParamsSchema
+    );
+    const waves = await waveApiService.getFavouriteWavesOfIdentity(params, {
+      timer,
+      authenticationContext
+    });
+    res.send(waves);
+  }
+);
 
 router.get(
   '/hot',
@@ -83,5 +111,12 @@ const RankedWavesOverviewParamsSchema = Joi.object<RankedWavesOverviewParams>({
     .optional()
     .default(false)
 });
+
+const FavouriteWavesOfIdentityParamsSchema =
+  Joi.object<FavouriteWavesOfIdentityParams>({
+    identityKey: Joi.string().trim().required().min(1).max(200),
+    limit: Joi.number().integer().optional().min(1).max(100).default(50),
+    offset: Joi.number().integer().optional().min(0).default(0)
+  });
 
 export default router;

--- a/src/api-serverless/src/waves/waves.api.db.ts
+++ b/src/api-serverless/src/waves/waves.api.db.ts
@@ -649,6 +649,62 @@ export class WavesApiDb extends LazyDbAccessCompatibleService {
       );
   }
 
+  async findFavouriteWavesOfIdentity(
+    {
+      identityId,
+      eligibleGroups,
+      limit,
+      offset
+    }: {
+      identityId: string;
+      eligibleGroups: string[];
+      limit: number;
+      offset: number;
+    },
+    ctx: RequestContext
+  ): Promise<WaveEntity[]> {
+    try {
+      ctx.timer?.start(
+        `${this.constructor.name}->findFavouriteWavesOfIdentity`
+      );
+      return await this.db
+        .execute<RawWaveEntity>(
+          `
+            select w.*
+            from ${WAVE_DROPPER_METRICS_TABLE} wdm
+              join ${WAVES_TABLE} w on w.id = wdm.wave_id
+            where wdm.dropper_id = :identityId
+              and wdm.drops_count > 0
+              and w.is_direct_message = false
+              and (
+                w.visibility_group_id is null
+                ${
+                  eligibleGroups.length
+                    ? `or w.visibility_group_id in (:eligibleGroups)
+                       or w.admin_group_id in (:eligibleGroups)`
+                    : ``
+                }
+              )
+            order by
+              wdm.drops_count desc,
+              wdm.latest_drop_timestamp desc,
+              w.id desc
+            limit :limit offset :offset
+          `,
+          {
+            identityId,
+            eligibleGroups,
+            limit,
+            offset
+          },
+          ctx.connection ? { wrappedConnection: ctx.connection } : undefined
+        )
+        .then((result) => result.map((it) => this.parseWaveEntity(it)));
+    } finally {
+      ctx.timer?.stop(`${this.constructor.name}->findFavouriteWavesOfIdentity`);
+    }
+  }
+
   async findWavesMetricsByWaveIds(
     waveIds: string[],
     { connection, timer }: RequestContext


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New API endpoint to retrieve favourite waves for a specific identity, showing waves where they have authored the most messages. Supports pagination with configurable limits (1-100) and offsets. Returns non-DM waves accessible to the requester with appropriate access controls and permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->