### PR TITLE
last_drop_time to ApiWave(Min)

### DIFF
--- a/src/api-serverless/openapi.yaml
+++ b/src/api-serverless/openapi.yaml
@@ -10225,6 +10225,7 @@ components:
         - chat
         - wave
         - created_at
+        - last_drop_time
         - contributors_overview
         - subscribed_actions
         - metrics
@@ -10249,6 +10250,10 @@ components:
           example: https://example.com/picture.jpg
           nullable: true
         created_at:
+          type: number
+          format: int64
+        last_drop_time:
+          description: Unix timestamp in milliseconds of the most recent drop in this wave
           type: number
           format: int64
         description_drop:
@@ -10615,6 +10620,7 @@ components:
         - name
         - picture
         - description_drop_id
+        - last_drop_time
         - authenticated_user_eligible_to_vote
         - authenticated_user_eligible_to_participate
         - authenticated_user_eligible_to_chat
@@ -10640,6 +10646,10 @@ components:
           nullable: true
         description_drop_id:
           type: string
+        last_drop_time:
+          description: Unix timestamp in milliseconds of the most recent drop in this wave
+          type: number
+          format: int64
         authenticated_user_eligible_to_vote:
           type: boolean
         authenticated_user_eligible_to_participate:

--- a/src/api-serverless/src/drops/drops.api.service.ts
+++ b/src/api-serverless/src/drops/drops.api.service.ts
@@ -517,6 +517,7 @@ export class DropsApiService {
         displayByWaveId[wave.id]
       ),
       description_drop_id: wave.description_drop_id,
+      last_drop_time: wave.last_drop_time,
       authenticated_user_eligible_to_vote:
         wave.voting_group_id === null ||
         group_ids_user_is_eligible_for.includes(wave.voting_group_id),
@@ -676,6 +677,7 @@ export class DropsApiService {
         displayByWaveId[waveEntity.id]
       ),
       description_drop_id: waveEntity.description_drop_id,
+      last_drop_time: waveEntity.last_drop_time,
       authenticated_user_eligible_to_vote:
         waveEntity.voting_group_id === null ||
         groupIdsUserIsEligibleFor.includes(waveEntity.voting_group_id),

--- a/src/api-serverless/src/drops/drops.mappers.ts
+++ b/src/api-serverless/src/drops/drops.mappers.ts
@@ -1042,6 +1042,7 @@ export class DropsMappers {
       name: string;
       picture: string | null;
       description_drop_id: string;
+      last_drop_time: number;
       chat_enabled: boolean;
       chat_group_id: string | null;
       voting_group_id: string | null;
@@ -1066,6 +1067,7 @@ export class DropsMappers {
         displayByWaveId[waveEntity.id]
       ),
       description_drop_id: waveEntity.description_drop_id,
+      last_drop_time: waveEntity.last_drop_time,
       authenticated_user_eligible_to_chat:
         waveEntity.chat_enabled &&
         (waveEntity.chat_group_id === null ||

--- a/src/api-serverless/src/generated/models/ApiWave.ts
+++ b/src/api-serverless/src/generated/models/ApiWave.ts
@@ -42,6 +42,10 @@ export class ApiWave {
     */
     'picture': string | null;
     'created_at': number;
+    /**
+    * Unix timestamp in milliseconds of the most recent drop in this wave
+    */
+    'last_drop_time': number;
     'description_drop': ApiDrop;
     'voting': ApiWaveVotingConfig;
     'visibility': ApiWaveVisibilityConfig;
@@ -90,6 +94,12 @@ export class ApiWave {
         {
             "name": "created_at",
             "baseName": "created_at",
+            "type": "number",
+            "format": "int64"
+        },
+        {
+            "name": "last_drop_time",
+            "baseName": "last_drop_time",
             "type": "number",
             "format": "int64"
         },

--- a/src/api-serverless/src/generated/models/ApiWaveMin.ts
+++ b/src/api-serverless/src/generated/models/ApiWaveMin.ts
@@ -18,6 +18,10 @@ export class ApiWaveMin {
     'name': string;
     'picture': string | null;
     'description_drop_id': string;
+    /**
+    * Unix timestamp in milliseconds of the most recent drop in this wave
+    */
+    'last_drop_time': number;
     'authenticated_user_eligible_to_vote': boolean;
     'authenticated_user_eligible_to_participate': boolean;
     'authenticated_user_eligible_to_chat': boolean;
@@ -60,6 +64,12 @@ export class ApiWaveMin {
             "baseName": "description_drop_id",
             "type": "string",
             "format": ""
+        },
+        {
+            "name": "last_drop_time",
+            "baseName": "last_drop_time",
+            "type": "number",
+            "format": "int64"
         },
         {
             "name": "authenticated_user_eligible_to_vote",

--- a/src/api-serverless/src/generated/models/ObjectSerializer.ts
+++ b/src/api-serverless/src/generated/models/ObjectSerializer.ts
@@ -477,7 +477,7 @@ import { ApiWaveDropsFeed } from '../models/ApiWaveDropsFeed';
 import { ApiWaveLog } from '../models/ApiWaveLog';
 import { ApiWaveMetadataType } from '../models/ApiWaveMetadataType';
 import { ApiWaveMetrics } from '../models/ApiWaveMetrics';
-import { ApiWaveMin                    } from '../models/ApiWaveMin';
+import { ApiWaveMin                     } from '../models/ApiWaveMin';
 import { ApiWaveOutcome        } from '../models/ApiWaveOutcome';
 import { ApiWaveOutcomeCredit } from '../models/ApiWaveOutcomeCredit';
 import { ApiWaveOutcomeDistributionItem } from '../models/ApiWaveOutcomeDistributionItem';

--- a/src/api-serverless/src/waves/waves.api.db.ts
+++ b/src/api-serverless/src/waves/waves.api.db.ts
@@ -59,6 +59,14 @@ type RawWaveEntity = Omit<
   decisions_strategy: string;
 };
 
+type RawWaveEntityWithLastDropTime = RawWaveEntity & {
+  last_drop_time: number;
+};
+
+type WaveEntityWithLastDropTime = WaveEntity & {
+  last_drop_time: number;
+};
+
 export class WavesApiDb extends LazyDbAccessCompatibleService {
   private parseWaveEntity(entity: RawWaveEntity): WaveEntity {
     return {
@@ -75,17 +83,29 @@ export class WavesApiDb extends LazyDbAccessCompatibleService {
     };
   }
 
+  private parseWaveEntityWithLastDropTime(
+    entity: RawWaveEntityWithLastDropTime
+  ): WaveEntityWithLastDropTime {
+    return {
+      ...this.parseWaveEntity(entity),
+      last_drop_time: entity.last_drop_time
+    };
+  }
+
   public async findWaveById(
     id: string,
     connection?: ConnectionWrapper<any>
-  ): Promise<WaveEntity | null> {
+  ): Promise<WaveEntityWithLastDropTime | null> {
     return this.db
-      .oneOrNull<RawWaveEntity>(
-        `SELECT * FROM ${WAVES_TABLE} WHERE id = :id`,
+      .oneOrNull<RawWaveEntityWithLastDropTime>(
+        `SELECT w.*, COALESCE(wm.latest_drop_timestamp, 0) as last_drop_time
+         FROM ${WAVES_TABLE} w
+         LEFT JOIN ${WAVE_METRICS_TABLE} wm ON wm.wave_id = w.id
+         WHERE w.id = :id`,
         { id },
         connection ? { wrappedConnection: connection } : undefined
       )
-      .then((it) => (it ? this.parseWaveEntity(it) : null));
+      .then((it) => (it ? this.parseWaveEntityWithLastDropTime(it) : null));
   }
 
   public async findWavesByIds(
@@ -113,21 +133,24 @@ export class WavesApiDb extends LazyDbAccessCompatibleService {
     ids: string[],
     groupIdsUserIsEligibleFor: string[],
     connection?: ConnectionWrapper<any>
-  ): Promise<WaveEntity[]> {
+  ): Promise<WaveEntityWithLastDropTime[]> {
     if (!ids.length) {
       return [];
     }
     return this.db
-      .execute<RawWaveEntity>(
-        `SELECT * FROM ${WAVES_TABLE} WHERE id in (:ids) and (visibility_group_id is null ${
-          groupIdsUserIsEligibleFor.length
-            ? `or visibility_group_id in (:groupIdsUserIsEligibleFor) or admin_group_id in (:groupIdsUserIsEligibleFor)`
-            : ``
-        })`,
+      .execute<RawWaveEntityWithLastDropTime>(
+        `SELECT w.*, COALESCE(wm.latest_drop_timestamp, 0) as last_drop_time
+         FROM ${WAVES_TABLE} w
+         LEFT JOIN ${WAVE_METRICS_TABLE} wm ON wm.wave_id = w.id
+         WHERE w.id in (:ids) and (w.visibility_group_id is null ${
+           groupIdsUserIsEligibleFor.length
+             ? `or w.visibility_group_id in (:groupIdsUserIsEligibleFor) or w.admin_group_id in (:groupIdsUserIsEligibleFor)`
+             : ``
+         })`,
         { ids, groupIdsUserIsEligibleFor },
         connection ? { wrappedConnection: connection } : undefined
       )
-      .then((res) => res.map((it) => this.parseWaveEntity(it)));
+      .then((res) => res.map((it) => this.parseWaveEntityWithLastDropTime(it)));
   }
 
   public async insertWave(wave: InsertWaveEntity, ctx: RequestContext) {
@@ -391,29 +414,25 @@ export class WavesApiDb extends LazyDbAccessCompatibleService {
   async getWavesByDropIds(
     dropIds: string[],
     connection?: ConnectionWrapper<any>
-  ): Promise<Record<string, WaveEntity>> {
+  ): Promise<Record<string, WaveEntityWithLastDropTime>> {
     if (dropIds.length === 0) {
       return {};
     }
     return this.db
       .execute<
-        Omit<
-          WaveEntity,
-          | 'participation_required_media'
-          | 'participation_required_metadata'
-          | 'decisions_strategy'
-        > & {
-          participation_required_media: string;
-          participation_required_metadata: string;
-          decisions_strategy: string;
+        RawWaveEntityWithLastDropTime & {
           drop_id: string;
         }
       >(
         `
         select 
           d.id as drop_id, 
-          w.*
-        from ${DROPS_TABLE} d join ${WAVES_TABLE} w on w.id = d.wave_id where d.id in (:dropIds)
+          w.*,
+          COALESCE(wm.latest_drop_timestamp, 0) as last_drop_time
+        from ${DROPS_TABLE} d
+        join ${WAVES_TABLE} w on w.id = d.wave_id
+        left join ${WAVE_METRICS_TABLE} wm on wm.wave_id = w.id
+        where d.id in (:dropIds)
         `,
         {
           dropIds
@@ -421,24 +440,13 @@ export class WavesApiDb extends LazyDbAccessCompatibleService {
         connection ? { wrappedConnection: connection } : undefined
       )
       .then((it) =>
-        it.reduce<Record<string, WaveEntity>>(
+        it.reduce<Record<string, WaveEntityWithLastDropTime>>(
           (acc, wave) => {
-            acc[wave.drop_id] = {
-              ...wave,
-              participation_required_media: JSON.parse(
-                wave.participation_required_media
-              ),
-              participation_required_metadata: JSON.parse(
-                wave.participation_required_metadata
-              ),
-              decisions_strategy: wave.decisions_strategy
-                ? JSON.parse(wave.decisions_strategy)
-                : null
-            };
+            acc[wave.drop_id] = this.parseWaveEntityWithLastDropTime(wave);
             delete (acc[wave.drop_id] as any).drop_id;
             return acc;
           },
-          {} as Record<string, WaveEntity>
+          {} as Record<string, WaveEntityWithLastDropTime>
         )
       );
   }

--- a/src/api-serverless/src/waves/waves.mappers.ts
+++ b/src/api-serverless/src/waves/waves.mappers.ts
@@ -386,6 +386,7 @@ export class WavesMappers {
       contributors_overview: contributorsOverview,
       description_drop: creationDrop,
       created_at: waveEntity.created_at,
+      last_drop_time: waveMetrics.latest_drop_timestamp,
       voting: voting,
       visibility: visibility,
       participation: participation,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Wave data now includes a timestamp field showing the most recent drop time for each wave, providing users with immediate visibility into drop activity timelines.
  * This new metadata is available across all wave-related endpoints and interfaces, allowing users to see when the latest drops occurred.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->