### PR TITLE
Use write pool for POST minting actions response

### DIFF
--- a/src/api-serverless/src/minting-claims/minting-claim-actions-post-write-consistency.test.ts
+++ b/src/api-serverless/src/minting-claims/minting-claim-actions-post-write-consistency.test.ts
@@ -2,11 +2,11 @@ import type { ApiMintingClaimActionUpdateRequest } from '@/api/generated/models/
 import type { MintingClaimActionRow } from '@/api/minting-claims/minting-claim-actions.db';
 import { upsertMintingClaimActionAndGetResponse } from '@/api/minting-claims/minting-claim-actions.api.service';
 import { mintingClaimActionsDb } from '@/api/minting-claims/minting-claim-actions.db';
-import { DbPoolName } from '@/db-query.options';
 import { MEMES_MINTING_CLAIM_ACTION_TYPES } from '@/minting-claims/minting-claim-actions';
 
 jest.mock('@/api/minting-claims/minting-claim-actions.db', () => ({
   mintingClaimActionsDb: {
+    executeNativeQueriesInTransaction: jest.fn(),
     findByContractAndClaimId: jest.fn(),
     upsertAction: jest.fn()
   }
@@ -35,20 +35,27 @@ describe('upsertMintingClaimActionAndGetResponse', () => {
     mintingClaimActionsDb.findByContractAndClaimId
   );
   const upsertActionMock = jest.mocked(mintingClaimActionsDb.upsertAction);
+  const executeNativeQueriesInTransactionMock = jest.mocked(
+    mintingClaimActionsDb.executeNativeQueriesInTransaction
+  );
 
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('re-reads from the write pool before building the POST response', async () => {
+  it('uses one transaction connection for the POST write and readback', async () => {
     const contract = '0x33FD426905F149f8376e227d0C9D3340AaD17aF1';
     const claimId = 123;
     const action = MEMES_MINTING_CLAIM_ACTION_TYPES[0];
+    const connection = { connection: {} };
     const body: ApiMintingClaimActionUpdateRequest = {
       action,
       completed: true
     };
 
+    executeNativeQueriesInTransactionMock.mockImplementation(async (callback) =>
+      callback(connection as any)
+    );
     upsertActionMock.mockResolvedValue(undefined);
     findByContractAndClaimIdMock.mockResolvedValue([
       actionRow(action, { completed: true })
@@ -62,14 +69,65 @@ describe('upsertMintingClaimActionAndGetResponse', () => {
       {}
     );
 
+    expect(executeNativeQueriesInTransactionMock).toHaveBeenCalledTimes(1);
+    expect(upsertActionMock).toHaveBeenCalledWith(
+      {
+        contract: contract.toLowerCase(),
+        claim_id: claimId,
+        action,
+        completed: true,
+        wallet: '0x1111111111111111111111111111111111111111'
+      },
+      { connection }
+    );
     expect(findByContractAndClaimIdMock).toHaveBeenCalledWith(
       contract.toLowerCase(),
       claimId,
-      {},
-      { forcePool: DbPoolName.WRITE }
+      { connection }
     );
     expect(
       response.actions.find((item) => item.action === action)?.completed
     ).toBe(true);
+  });
+
+  it('reuses an existing context connection without opening another transaction', async () => {
+    const contract = '0x33FD426905F149f8376e227d0C9D3340AaD17aF1';
+    const claimId = 123;
+    const action = MEMES_MINTING_CLAIM_ACTION_TYPES[0];
+    const txCtx = { connection: { connection: {} } } as any;
+    const body: ApiMintingClaimActionUpdateRequest = {
+      action,
+      completed: true
+    };
+
+    upsertActionMock.mockResolvedValue(undefined);
+    findByContractAndClaimIdMock.mockResolvedValue([
+      actionRow(action, { completed: true })
+    ]);
+
+    await upsertMintingClaimActionAndGetResponse(
+      contract,
+      claimId,
+      body,
+      '0x1111111111111111111111111111111111111111',
+      txCtx
+    );
+
+    expect(executeNativeQueriesInTransactionMock).not.toHaveBeenCalled();
+    expect(upsertActionMock).toHaveBeenCalledWith(
+      {
+        contract: contract.toLowerCase(),
+        claim_id: claimId,
+        action,
+        completed: true,
+        wallet: '0x1111111111111111111111111111111111111111'
+      },
+      txCtx
+    );
+    expect(findByContractAndClaimIdMock).toHaveBeenCalledWith(
+      contract.toLowerCase(),
+      claimId,
+      txCtx
+    );
   });
 });

--- a/src/api-serverless/src/minting-claims/minting-claim-actions.api.service.ts
+++ b/src/api-serverless/src/minting-claims/minting-claim-actions.api.service.ts
@@ -6,7 +6,6 @@ import {
   mintingClaimActionsDb,
   type MintingClaimActionRow
 } from '@/api/minting-claims/minting-claim-actions.db';
-import { DbPoolName, type DbQueryOptions } from '@/db-query.options';
 import {
   getMintingClaimActionsContractLabel,
   getSupportedMintingClaimActionTypes,
@@ -95,16 +94,14 @@ export function getMintingClaimActionTypesResponse(
 export async function getMintingClaimActionsResponse(
   contract: string,
   claimId: number,
-  ctx: RequestContext,
-  options?: DbQueryOptions
+  ctx: RequestContext
 ): Promise<ApiMintingClaimActionsResponse> {
   const normalizedContract = canonicalizeMintingClaimActionsContract(contract);
   getSupportedMintingClaimActionTypesOrThrow(normalizedContract);
   const rows = await mintingClaimActionsDb.findByContractAndClaimId(
     normalizedContract,
     claimId,
-    ctx,
-    options
+    ctx
   );
   return buildMintingClaimActionsResponse(normalizedContract, claimId, rows);
 }
@@ -118,19 +115,31 @@ export async function upsertMintingClaimActionAndGetResponse(
 ): Promise<ApiMintingClaimActionsResponse> {
   const normalizedContract = canonicalizeMintingClaimActionsContract(contract);
   assertSupportedMintingClaimAction(normalizedContract, body.action);
+  const performUpsertAndReadback = async (
+    txCtx: RequestContext
+  ): Promise<ApiMintingClaimActionsResponse> => {
+    await mintingClaimActionsDb.upsertAction(
+      {
+        contract: normalizedContract,
+        claim_id: claimId,
+        action: body.action,
+        completed: body.completed,
+        wallet
+      },
+      txCtx
+    );
 
-  await mintingClaimActionsDb.upsertAction(
-    {
-      contract: normalizedContract,
-      claim_id: claimId,
-      action: body.action,
-      completed: body.completed,
-      wallet
-    },
-    ctx
+    return getMintingClaimActionsResponse(normalizedContract, claimId, txCtx);
+  };
+
+  if (ctx.connection) {
+    return performUpsertAndReadback(ctx);
+  }
+
+  return mintingClaimActionsDb.executeNativeQueriesInTransaction(
+    async (connection) => {
+      const txCtx: RequestContext = { ...ctx, connection };
+      return performUpsertAndReadback(txCtx);
+    }
   );
-
-  return getMintingClaimActionsResponse(normalizedContract, claimId, ctx, {
-    forcePool: DbPoolName.WRITE
-  });
 }

--- a/src/api-serverless/src/minting-claims/minting-claim-actions.db.ts
+++ b/src/api-serverless/src/minting-claims/minting-claim-actions.db.ts
@@ -1,6 +1,5 @@
 import { randomUUID } from 'node:crypto';
 import { MINTING_CLAIM_ACTIONS_TABLE } from '@/constants';
-import { type DbQueryOptions } from '@/db-query.options';
 import { RequestContext } from '@/request.context';
 import { dbSupplier, LazyDbAccessCompatibleService } from '@/sql-executor';
 import { Time } from '@/time';
@@ -21,8 +20,7 @@ export class MintingClaimActionsDb extends LazyDbAccessCompatibleService {
   public async findByContractAndClaimId(
     contract: string,
     claimId: number,
-    ctx: RequestContext,
-    options?: DbQueryOptions
+    ctx: RequestContext
   ): Promise<MintingClaimActionRow[]> {
     try {
       ctx.timer?.start(`${this.constructor.name}->findByContractAndClaimId`);
@@ -47,10 +45,7 @@ export class MintingClaimActionsDb extends LazyDbAccessCompatibleService {
           contract: contract.toLowerCase(),
           claimId
         },
-        {
-          wrappedConnection: ctx.connection,
-          forcePool: options?.forcePool
-        }
+        { wrappedConnection: ctx.connection }
       );
     } finally {
       ctx.timer?.stop(`${this.constructor.name}->findByContractAndClaimId`);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test coverage for minting claim operations covering transaction handling and data consistency scenarios.

* **Refactor**
  * Improved transaction handling for minting claim operations to ensure reliable data retrieval after updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->