### PR TITLE
added left_to_vote_in_current_round to quickvote api

### DIFF
--- a/src/api-serverless/openapi.yaml
+++ b/src/api-serverless/openapi.yaml
@@ -10956,12 +10956,16 @@ components:
       type: object
       required:
         - drop
+        - left_to_vote_in_current_round
         - total_count
       properties:
         drop:
           anyOf:
             - type: "null"
             - $ref: "#/components/schemas/ApiDrop"
+        left_to_vote_in_current_round:
+          type: integer
+          format: int64
         total_count:
           type: integer
           format: int64

--- a/src/api-serverless/src/generated/models/ApiUndiscoveredDrop.ts
+++ b/src/api-serverless/src/generated/models/ApiUndiscoveredDrop.ts
@@ -15,6 +15,7 @@ import { HttpFile } from '../http/http';
 
 export class ApiUndiscoveredDrop {
     'drop': ApiDrop | null;
+    'left_to_vote_in_current_round': number;
     'total_count': number;
 
     static readonly discriminator: string | undefined = undefined;
@@ -25,6 +26,12 @@ export class ApiUndiscoveredDrop {
             "baseName": "drop",
             "type": "ApiDrop",
             "format": ""
+        },
+        {
+            "name": "left_to_vote_in_current_round",
+            "baseName": "left_to_vote_in_current_round",
+            "type": "number",
+            "format": "int64"
         },
         {
             "name": "total_count",

--- a/src/api-serverless/src/waves/wave-quick-vote-api-service.test.ts
+++ b/src/api-serverless/src/waves/wave-quick-vote-api-service.test.ts
@@ -140,6 +140,7 @@ describe('WaveQuickVoteApiService', () => {
 
     expect(result).toEqual({
       drop: { id: 'drop-1' },
+      left_to_vote_in_current_round: 2,
       total_count: 2
     });
   });
@@ -208,6 +209,7 @@ describe('WaveQuickVoteApiService', () => {
 
     expect(result).toEqual({
       drop: { id: 'drop-1' },
+      left_to_vote_in_current_round: 0,
       total_count: 2
     });
   });
@@ -268,6 +270,7 @@ describe('WaveQuickVoteApiService', () => {
 
     expect(result).toEqual({
       drop: { id: 'drop-1' },
+      left_to_vote_in_current_round: 2,
       total_count: 2
     });
   });
@@ -328,6 +331,7 @@ describe('WaveQuickVoteApiService', () => {
 
     expect(result).toEqual({
       drop: { id: 'drop-1' },
+      left_to_vote_in_current_round: 0,
       total_count: 2
     });
   });

--- a/src/api-serverless/src/waves/wave-quick-vote.api.service.ts
+++ b/src/api-serverless/src/waves/wave-quick-vote.api.service.ts
@@ -43,6 +43,7 @@ export class WaveQuickVoteApiService {
         this.waveQuickVoteDb.countUnvotedDrops(quickVoteParams, ctx),
         this.waveQuickVoteDb.countUndiscoveredDrops(quickVoteParams, ctx)
       ]);
+      const leftToVoteInCurrentRound = undiscoveredCount;
       let drop: DropEntity | null;
       if (undiscoveredCount > 0) {
         drop =
@@ -62,10 +63,18 @@ export class WaveQuickVoteApiService {
         );
       }
       if (!drop) {
-        return { drop: null, total_count: totalCount };
+        return {
+          drop: null,
+          total_count: totalCount,
+          left_to_vote_in_current_round: leftToVoteInCurrentRound
+        };
       }
       const apiDrop = await this.toApiDrop(drop, param.identityId, ctx);
-      return { drop: apiDrop, total_count: totalCount };
+      return {
+        drop: apiDrop,
+        total_count: totalCount,
+        left_to_vote_in_current_round: leftToVoteInCurrentRound
+      };
     } finally {
       ctx.timer?.stop(`${this.constructor.name}->findUndiscoveredDrop`);
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new metric displaying the number of items remaining to vote in the current voting round. This enhancement provides improved visibility into voting progress and clearly shows how many drops are available to vote on within each round before advancing to the next.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->