### PR TITLE
identity waves

### DIFF
--- a/src/api-serverless/openapi.yaml
+++ b/src/api-serverless/openapi.yaml
@@ -5754,6 +5754,32 @@ paths:
               schema:
                 type: object
                 additionalProperties: false
+  /waves/{id}/identity-wave:
+    post:
+      tags:
+        - Waves
+      summary: Set identity wave
+      operationId: setIdentityWave
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
+        "400":
+          description: Invalid identity wave
+        "403":
+          description: Forbidden
+        "404":
+          description: Wave not found
   /waves/{id}/mute:
     post:
       tags:
@@ -9092,6 +9118,7 @@ components:
         - winner_main_stage_drop_ids
         - artist_of_prevote_cards
         - is_wave_creator
+        - identity_wave
       properties:
         id:
           type: string
@@ -9165,6 +9192,10 @@ components:
             format: int64
         is_wave_creator:
           type: boolean
+        identity_wave:
+          anyOf:
+            - $ref: "#/components/schemas/ApiWaveMin"
+            - type: "null"
     ApiIdentityActivity:
       type: object
       required:
@@ -10250,6 +10281,7 @@ components:
         - winner_main_stage_drop_ids
         - artist_of_prevote_cards
         - is_wave_creator
+        - identity_wave
       properties:
         id:
           type: string
@@ -10310,6 +10342,10 @@ components:
             format: int64
         is_wave_creator:
           type: boolean
+        identity_wave:
+          anyOf:
+            - $ref: "#/components/schemas/ApiWaveMin"
+            - type: "null"
     ApiProfileMinsPage:
       type: object
       required:

--- a/src/api-serverless/package-lock.json
+++ b/src/api-serverless/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-managedblockchain": "^3.980.0",
-        "@openapitools/openapi-generator-cli": "^2.28.0",
+        "@openapitools/openapi-generator-cli": "^2.28.3",
         "@types/express": "^4.17.25",
         "@types/swagger-ui-express": "^4.1.8",
         "@wagmi/chains": "^1.8.0",

--- a/src/api-serverless/src/drops/drop-bookmarks.api.service.ts
+++ b/src/api-serverless/src/drops/drop-bookmarks.api.service.ts
@@ -54,7 +54,8 @@ export class DropBookmarksApiService {
         const drops = await this.dropsMappers.convertToDropFulls(
           {
             dropEntities: [dropEntity],
-            contextProfileId: identityId
+            contextProfileId: identityId,
+            authenticationContext: ctx.authenticationContext
           },
           connection
         );
@@ -97,7 +98,8 @@ export class DropBookmarksApiService {
         const drops = await this.dropsMappers.convertToDropFulls(
           {
             dropEntities: [dropEntity],
-            contextProfileId: identityId
+            contextProfileId: identityId,
+            authenticationContext: ctx.authenticationContext
           },
           connection
         );
@@ -163,7 +165,8 @@ export class DropBookmarksApiService {
     const drops = await this.dropsMappers.convertToDropFulls(
       {
         dropEntities: orderedDropEntities,
-        contextProfileId: identityId
+        contextProfileId: identityId,
+        authenticationContext: ctx.authenticationContext
       },
       ctx.connection
     );

--- a/src/api-serverless/src/drops/drops-mappers.test.ts
+++ b/src/api-serverless/src/drops/drops-mappers.test.ts
@@ -1,5 +1,7 @@
 import { AuthenticationContext } from '@/auth-context';
+import { directMessageWaveDisplayService } from '@/api/waves/direct-message-wave-display.service';
 import { DropType, DropEntity } from '@/entities/IDrop';
+import { ProfileProxyActionType } from '@/entities/IProfileProxyAction';
 import { ApiProfileMin } from '../generated/models/ApiProfileMin';
 import { DropsMappers } from './drops.mappers';
 
@@ -23,7 +25,8 @@ function aProfileMin(id: string): ApiProfileMin {
     active_main_stage_submission_ids: [],
     winner_main_stage_drop_ids: [],
     artist_of_prevote_cards: [],
-    is_wave_creator: false
+    is_wave_creator: false,
+    identity_wave: null
   };
 }
 
@@ -45,6 +48,26 @@ function aResolvedIdentityProfile(id: string) {
 }
 
 describe('DropsMappers', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function createReadOnlyProxyContext(roleProfileId: string) {
+    return new AuthenticationContext({
+      authenticatedWallet: null,
+      authenticatedProfileId: 'proxy-profile',
+      roleProfileId,
+      activeProxyActions: [
+        {
+          id: 'read-wave-action',
+          type: ProfileProxyActionType.READ_WAVE,
+          credit_amount: null,
+          credit_spent: null
+        }
+      ]
+    });
+  }
+
   it('uses the transactional connection when resolving identity metadata profiles', async () => {
     const userGroupsService = {
       getGroupsUserIsEligibleFor: jest.fn().mockResolvedValue([])
@@ -86,7 +109,7 @@ describe('DropsMappers', () => {
         .mockResolvedValue(new Set<string>())
     };
     const identitySubscriptionsDb = {
-      findIdentitySubscriptionActionsOfTargets: jest.fn()
+      findIdentitySubscriptionActionsOfTargets: jest.fn().mockResolvedValue({})
     };
     const dropVotingDb = {
       getParticipationDropsRealtimeRanks: jest.fn().mockResolvedValue({}),
@@ -94,6 +117,7 @@ describe('DropsMappers', () => {
       getTallyForDrops: jest.fn().mockResolvedValue({}),
       getWinningDropsTopRaters: jest.fn().mockResolvedValue({}),
       getWinningDropsRatersCount: jest.fn().mockResolvedValue({}),
+      getWinningDropsRatingsByVoter: jest.fn().mockResolvedValue({}),
       getTimeLockedDropsWeightedVotes: jest.fn().mockResolvedValue({}),
       getWeightedDropRates: jest.fn().mockResolvedValue({})
     };
@@ -104,7 +128,7 @@ describe('DropsMappers', () => {
       getByDropIds: jest.fn().mockResolvedValue(new Map())
     };
     const dropBookmarksDb = {
-      findBookmarkedDropIds: jest.fn()
+      findBookmarkedDropIds: jest.fn().mockResolvedValue(new Set())
     };
     const curationsDb = {
       findWaveCurationGroupsByWaveIds: jest.fn().mockResolvedValue([]),
@@ -181,6 +205,231 @@ describe('DropsMappers', () => {
     });
     expect(mappedDrop.metadata[0].resolved_profile).toEqual(
       aResolvedIdentityProfile('nominated-profile')
+    );
+  });
+
+  it('does not overstate top-level wave eligibility for read-only proxies', async () => {
+    const userGroupsService = {
+      getGroupsUserIsEligibleFor: jest.fn().mockResolvedValue([])
+    };
+    const wavesApiDb = {
+      getWavesByDropIds: jest.fn().mockResolvedValue({
+        'drop-1': {
+          id: 'wave-1',
+          name: 'wave-1',
+          picture: null,
+          description_drop_id: 'description-drop-1',
+          last_drop_time: 42,
+          submission_type: null,
+          chat_enabled: true,
+          chat_group_id: null,
+          voting_group_id: null,
+          participation_group_id: null,
+          admin_group_id: null,
+          voting_credit_type: 'TDH',
+          voting_period_start: null,
+          voting_period_end: null,
+          visibility_group_id: null,
+          admin_drop_deletion_enabled: false,
+          forbid_negative_votes: false
+        }
+      }),
+      whichOfWavesArePinnedByGivenProfile: jest
+        .fn()
+        .mockResolvedValue(new Set<string>())
+    };
+    const mapper = new DropsMappers(
+      userGroupsService as any,
+      {} as any,
+      {} as any,
+      wavesApiDb as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any
+    );
+    const dropEntity = {
+      id: 'drop-1',
+      wave_id: 'wave-1'
+    } as DropEntity;
+    jest
+      .spyOn(mapper, 'convertToDropsWithoutWaves')
+      .mockResolvedValue([{ id: 'drop-1' } as any]);
+    jest
+      .spyOn(
+        directMessageWaveDisplayService,
+        'resolveWaveDisplayByWaveIdForContext'
+      )
+      .mockResolvedValue({});
+
+    const drops = await mapper.convertToDropFulls(
+      {
+        dropEntities: [dropEntity],
+        contextProfileId: 'author-profile',
+        authenticationContext: createReadOnlyProxyContext('author-profile')
+      },
+      { connection: { id: 'tx' } } as any
+    );
+
+    expect(drops[0]?.wave).toEqual(
+      expect.objectContaining({
+        authenticated_user_eligible_to_vote: false,
+        authenticated_user_eligible_to_participate: false
+      })
+    );
+  });
+
+  it('does not overstate mentioned wave eligibility for read-only proxies', async () => {
+    const userGroupsService = {
+      getGroupsUserIsEligibleFor: jest.fn().mockResolvedValue([])
+    };
+    const identityFetcher = {
+      getOverviewsByIds: jest.fn().mockResolvedValue({
+        'author-profile': aProfileMin('author-profile')
+      })
+    };
+    const dropsDb = {
+      getQuoteIds: jest.fn().mockResolvedValue([]),
+      getDropsByIds: jest.fn().mockResolvedValue([]),
+      getDropsParts: jest.fn().mockResolvedValue({ 'drop-1': [] }),
+      findMentionsByDropIds: jest.fn().mockResolvedValue([]),
+      findMentionedWavesByDropIds: jest.fn().mockResolvedValue([
+        {
+          drop_id: 'drop-1',
+          wave_id: 'wave-2',
+          wave_name_in_content: 'wave-2'
+        }
+      ]),
+      findReferencedNftsByDropIds: jest.fn().mockResolvedValue([]),
+      findMetadataByDropIds: jest.fn().mockResolvedValue([]),
+      getDropMedia: jest.fn().mockResolvedValue([]),
+      getWinDecisionsForDrops: jest.fn().mockResolvedValue({}),
+      findDeletedDrops: jest.fn().mockResolvedValue({}),
+      findDropIdsOfWavesWhereNegativeVotesAreNotAllowed: jest
+        .fn()
+        .mockResolvedValue([]),
+      countBoostsOfGivenDrops: jest.fn().mockResolvedValue({})
+    };
+    const wavesApiDb = {
+      findWavesByIdsEligibleForRead: jest.fn().mockResolvedValue([
+        {
+          id: 'wave-2',
+          name: 'wave-2',
+          picture: null,
+          description_drop_id: 'description-drop-2',
+          last_drop_time: 42,
+          submission_type: null,
+          chat_enabled: true,
+          chat_group_id: null,
+          voting_group_id: null,
+          participation_group_id: null,
+          admin_group_id: null,
+          voting_credit_type: 'TDH',
+          voting_period_start: null,
+          voting_period_end: null,
+          visibility_group_id: null,
+          admin_drop_deletion_enabled: false,
+          forbid_negative_votes: false
+        }
+      ]),
+      whichOfWavesArePinnedByGivenProfile: jest
+        .fn()
+        .mockResolvedValue(new Set<string>())
+    };
+    const identitySubscriptionsDb = {
+      findIdentitySubscriptionActionsOfTargets: jest.fn().mockResolvedValue({})
+    };
+    const dropVotingDb = {
+      getParticipationDropsRealtimeRanks: jest.fn().mockResolvedValue({}),
+      findDropsTopContributors: jest.fn().mockResolvedValue({}),
+      getTallyForDrops: jest.fn().mockResolvedValue({}),
+      getWinningDropsTopRaters: jest.fn().mockResolvedValue({}),
+      getWinningDropsRatersCount: jest.fn().mockResolvedValue({}),
+      getWinningDropsRatingsByVoter: jest.fn().mockResolvedValue({}),
+      getTimeLockedDropsWeightedVotes: jest.fn().mockResolvedValue({}),
+      getWeightedDropRates: jest.fn().mockResolvedValue({})
+    };
+    const dropVotingService = {
+      findCreditLeftForVotingForDrops: jest.fn().mockResolvedValue({})
+    };
+    const reactionsDb = {
+      getByDropIds: jest.fn().mockResolvedValue(new Map())
+    };
+    const dropBookmarksDb = {
+      findBookmarkedDropIds: jest.fn().mockResolvedValue(new Set())
+    };
+    const curationsDb = {
+      findWaveCurationGroupsByWaveIds: jest.fn().mockResolvedValue([]),
+      findCuratedDropIdsByCurator: jest.fn().mockResolvedValue(new Set())
+    };
+    const dropNftLinksDb = {
+      findByDropIds: jest.fn().mockResolvedValue([])
+    };
+    const nftLinksDb = {
+      findByCanonicalIds: jest.fn().mockResolvedValue([])
+    };
+    const nftLinkResolvingService = {
+      refreshStaleTrackingForUrls: jest.fn()
+    };
+
+    const mapper = new DropsMappers(
+      userGroupsService as any,
+      identityFetcher as any,
+      dropsDb as any,
+      wavesApiDb as any,
+      identitySubscriptionsDb as any,
+      dropVotingDb as any,
+      dropVotingService as any,
+      reactionsDb as any,
+      dropBookmarksDb as any,
+      curationsDb as any,
+      dropNftLinksDb as any,
+      nftLinksDb as any,
+      nftLinkResolvingService as any
+    );
+
+    const dropEntity: DropEntity = {
+      id: 'drop-1',
+      serial_no: 1,
+      drop_type: DropType.CHAT,
+      wave_id: 'wave-1',
+      author_id: 'author-profile',
+      title: null,
+      reply_to_drop_id: null,
+      reply_to_part_id: null,
+      parts_count: 0,
+      created_at: 1,
+      updated_at: null,
+      signature: null,
+      hide_link_preview: false
+    } as DropEntity;
+    jest
+      .spyOn(
+        directMessageWaveDisplayService,
+        'resolveWaveDisplayByWaveIdForContext'
+      )
+      .mockResolvedValue({});
+
+    const drops = await mapper.convertToDropsWithoutWaves([dropEntity], {
+      connection: { connection: { id: 'tx' } } as any,
+      authenticationContext: new AuthenticationContext({
+        authenticatedWallet: null,
+        authenticatedProfileId: 'proxy-profile',
+        roleProfileId: 'author-profile',
+        activeProxyActions: []
+      })
+    });
+
+    expect(drops[0]?.mentioned_waves[0]?.wave).toEqual(
+      expect.objectContaining({
+        authenticated_user_eligible_to_vote: false,
+        authenticated_user_eligible_to_participate: false
+      })
     );
   });
 });

--- a/src/api-serverless/src/drops/drops.api.service.ts
+++ b/src/api-serverless/src/drops/drops.api.service.ts
@@ -47,8 +47,6 @@ import {
 import { ApiProfileMin } from '../generated/models/ApiProfileMin';
 import { ApiWaveVotersPage } from '../generated/models/ApiWaveVotersPage';
 import { ApiWaveVoter } from '../generated/models/ApiWaveVoter';
-import { ApiWaveCreditType as WaveCreditTypeApi } from '../generated/models/ApiWaveCreditType';
-import { ApiWaveParticipationSubmissionStrategyType } from '../generated/models/ApiWaveParticipationSubmissionStrategyType';
 import {
   identityFetcher,
   IdentityFetcher
@@ -72,20 +70,8 @@ import {
 } from '../ws/ws-listeners-notifier';
 import { giveReadReplicaTimeToCatchUp } from '../api-helpers';
 import { CurationsDb, curationsDb } from '@/api/curations/curations.db';
-import {
-  directMessageWaveDisplayService,
-  resolveWavePictureOverride
-} from '@/api/waves/direct-message-wave-display.service';
-
-const resolveWaveSubmissionType = (
-  submissionType?: string | null
-): ApiWaveParticipationSubmissionStrategyType | null =>
-  submissionType
-    ? (enums.resolve(
-        ApiWaveParticipationSubmissionStrategyType,
-        submissionType
-      ) ?? null)
-    : null;
+import { directMessageWaveDisplayService } from '@/api/waves/direct-message-wave-display.service';
+import { mapWaveEntityToApiWaveMin } from '@/api/waves/wave-min.mapper';
 
 export class DropsApiService {
   constructor(
@@ -136,7 +122,8 @@ export class DropsApiService {
       .convertToDropFulls(
         {
           dropEntities: [dropEntity],
-          contextProfileId: contextProfileId
+          contextProfileId: contextProfileId,
+          authenticationContext: ctx.authenticationContext
         },
         ctx.connection
       )
@@ -244,7 +231,8 @@ export class DropsApiService {
     );
     return await this.dropsMappers.convertToDropFulls({
       dropEntities: dropEntities,
-      contextProfileId: context_profile_id
+      contextProfileId: context_profile_id,
+      authenticationContext: ctx.authenticationContext
     });
   }
 
@@ -299,6 +287,28 @@ export class DropsApiService {
     return context_profile_id;
   }
 
+  private hasNoRightToVote(
+    authenticationContext?: AuthenticationContext
+  ): boolean {
+    return !!(
+      authenticationContext?.isAuthenticatedAsProxy() &&
+      !authenticationContext.activeProxyActions[
+        ProfileProxyActionType.RATE_WAVE_DROP
+      ]
+    );
+  }
+
+  private hasNoRightToParticipate(
+    authenticationContext?: AuthenticationContext
+  ): boolean {
+    return !!(
+      authenticationContext?.isAuthenticatedAsProxy() &&
+      !authenticationContext.activeProxyActions[
+        ProfileProxyActionType.CREATE_DROP_TO_WAVE
+      ]
+    );
+  }
+
   async findDropsByIdsOrThrow(
     dropIds: string[],
     authenticationContext: AuthenticationContext | undefined,
@@ -330,7 +340,8 @@ export class DropsApiService {
     return await this.dropsMappers
       .convertToDropFulls({
         dropEntities,
-        contextProfileId: authenticationContext?.getActingAsId()
+        contextProfileId: authenticationContext?.getActingAsId(),
+        authenticationContext
       })
       .then((drops) =>
         drops.reduce(
@@ -487,6 +498,10 @@ export class DropsApiService {
     const context_profile_id = this.getDropsReadContextProfileId(
       authenticationContext
     );
+    const noRightToVote = this.hasNoRightToVote(authenticationContext);
+    const noRightToParticipate = this.hasNoRightToParticipate(
+      authenticationContext
+    );
     const group_ids_user_is_eligible_for =
       !authenticationContext.isUserFullyAuthenticated() ||
       (authenticationContext.isAuthenticatedAsProxy() &&
@@ -520,44 +535,14 @@ export class DropsApiService {
         },
         ctx.connection
       );
-    const waveMin: ApiWaveMin = {
-      id: wave.id,
-      name: displayByWaveId[wave.id]?.name ?? wave.name,
-      picture: resolveWavePictureOverride(
-        wave.picture,
-        displayByWaveId[wave.id]
-      ),
-      description_drop_id: wave.description_drop_id,
-      last_drop_time: wave.last_drop_time,
-      submission_type: resolveWaveSubmissionType(wave.submission_type),
-      authenticated_user_eligible_to_vote:
-        wave.voting_group_id === null ||
-        group_ids_user_is_eligible_for.includes(wave.voting_group_id),
-      authenticated_user_eligible_to_participate:
-        wave.participation_group_id === null ||
-        group_ids_user_is_eligible_for.includes(wave.participation_group_id),
-      authenticated_user_eligible_to_chat:
-        wave.chat_enabled &&
-        (wave.chat_group_id === null ||
-          group_ids_user_is_eligible_for.includes(wave.chat_group_id)),
-      authenticated_user_admin:
-        wave.admin_group_id !== null &&
-        group_ids_user_is_eligible_for.includes(wave.admin_group_id),
-      voting_period_start: wave.voting_period_start,
-      voting_period_end: wave.voting_period_end,
-      voting_credit_type: enums.resolveOrThrow(
-        WaveCreditTypeApi,
-        wave.voting_credit_type
-      ),
-      visibility_group_id: wave.visibility_group_id,
-      participation_group_id: wave.participation_group_id,
-      admin_group_id: wave.admin_group_id,
-      chat_group_id: wave.chat_group_id,
-      voting_group_id: wave.voting_group_id,
-      admin_drop_deletion_enabled: wave.admin_drop_deletion_enabled,
-      forbid_negative_votes: wave.forbid_negative_votes,
-      pinned: pinnedWaveIds.has(wave_id)
-    };
+    const waveMin: ApiWaveMin = mapWaveEntityToApiWaveMin({
+      waveEntity: wave,
+      groupIdsUserIsEligibleFor: group_ids_user_is_eligible_for,
+      pinned: pinnedWaveIds.has(wave_id),
+      displayOverride: displayByWaveId[wave.id],
+      noRightToVote,
+      noRightToParticipate
+    });
     if (drop_id) {
       const dropEntity = await this.dropsDb.findDropByIdWithEligibilityCheck(
         drop_id,
@@ -657,6 +642,8 @@ export class DropsApiService {
       await this.userGroupsService.getGroupsUserIsEligibleFor(
         authenticatedProfileId
       );
+    const noRightToVote = this.hasNoRightToVote(authContext);
+    const noRightToParticipate = this.hasNoRightToParticipate(authContext);
     const [waveEntity, pinnedWaveIds] = await Promise.all([
       wavesApiDb.findWaveById(params.wave_id),
       wavesApiDb.whichOfWavesArePinnedByGivenProfile(
@@ -686,44 +673,17 @@ export class DropsApiService {
         ctx.connection
       );
     const votingPeriodEnd = waveEntity.voting_period_end;
-    const waveMin: ApiWaveMin = {
-      id: waveEntity.id,
-      name: displayByWaveId[waveEntity.id]?.name ?? waveEntity.name,
-      picture: resolveWavePictureOverride(
-        waveEntity.picture,
-        displayByWaveId[waveEntity.id]
-      ),
-      description_drop_id: waveEntity.description_drop_id,
-      last_drop_time: waveEntity.last_drop_time,
-      submission_type: resolveWaveSubmissionType(waveEntity.submission_type),
-      authenticated_user_eligible_to_vote:
-        waveEntity.voting_group_id === null ||
-        groupIdsUserIsEligibleFor.includes(waveEntity.voting_group_id),
-      authenticated_user_eligible_to_participate:
-        waveEntity.participation_group_id === null ||
-        groupIdsUserIsEligibleFor.includes(waveEntity.participation_group_id),
-      authenticated_user_eligible_to_chat:
-        waveEntity.chat_enabled &&
-        (waveEntity.chat_group_id === null ||
-          groupIdsUserIsEligibleFor.includes(waveEntity.chat_group_id)),
-      authenticated_user_admin:
-        waveEntity.admin_group_id !== null &&
-        groupIdsUserIsEligibleFor.includes(waveEntity.admin_group_id),
-      voting_period_start: waveEntity.voting_period_start,
-      voting_period_end: votingPeriodEnd,
-      voting_credit_type: enums.resolveOrThrow(
-        WaveCreditTypeApi,
-        waveEntity.voting_credit_type
-      ),
-      visibility_group_id: waveEntity.visibility_group_id,
-      participation_group_id: waveEntity.participation_group_id,
-      admin_group_id: waveEntity.admin_group_id,
-      chat_group_id: waveEntity.chat_group_id,
-      voting_group_id: waveEntity.voting_group_id,
-      admin_drop_deletion_enabled: waveEntity.admin_drop_deletion_enabled,
-      forbid_negative_votes: waveEntity.forbid_negative_votes,
-      pinned: pinnedWaveIds.has(params.wave_id)
-    };
+    const waveMin: ApiWaveMin = mapWaveEntityToApiWaveMin({
+      waveEntity: {
+        ...waveEntity,
+        voting_period_end: votingPeriodEnd
+      },
+      groupIdsUserIsEligibleFor,
+      pinned: pinnedWaveIds.has(params.wave_id),
+      displayOverride: displayByWaveId[waveEntity.id],
+      noRightToVote,
+      noRightToParticipate
+    });
     const isTimeLockedWave =
       waveEntity.time_lock_ms !== null && waveEntity.time_lock_ms > 0;
     let curatorIdsFilter: string[] | null = null;
@@ -1255,7 +1215,11 @@ export class DropsApiService {
         )
       ]);
       const apiDrops = await this.dropsMappers.convertToDropFulls(
-        { dropEntities: data, contextProfileId },
+        {
+          dropEntities: data,
+          contextProfileId,
+          authenticationContext: ctx.authenticationContext
+        },
         ctx.connection
       );
       return {

--- a/src/api-serverless/src/drops/drops.mappers.ts
+++ b/src/api-serverless/src/drops/drops.mappers.ts
@@ -47,13 +47,12 @@ import {
 import { ApiDropType } from '../generated/models/ApiDropType';
 import { dropVotingService, DropVotingService } from './drop-voting.service';
 import { dropVotingDb, DropVotingDb } from './drop-voting.db';
-import { ApiWaveCreditType as WaveCreditTypeApi } from '../generated/models/ApiWaveCreditType';
-import { ApiWaveParticipationSubmissionStrategyType } from '../generated/models/ApiWaveParticipationSubmissionStrategyType';
 import { WaveDecisionWinnerDropWithSaleEntity } from '@/entities/IWaveDecision';
 import { ApiDropWinningContext } from '../generated/models/ApiDropWinningContext';
 import { ApiWaveOutcomeType } from '../generated/models/ApiWaveOutcomeType';
 import { ApiWaveOutcomeSubType } from '../generated/models/ApiWaveOutcomeSubType';
 import { ApiWaveOutcomeCredit } from '../generated/models/ApiWaveOutcomeCredit';
+import { ProfileProxyActionType } from '@/entities/IProfileProxyAction';
 import { WinnerDropVoterVoteEntity } from '../../../entities/IWinnerDropVoterVote';
 import { ApiDropContextProfileContext } from '../generated/models/ApiDropContextProfileContext';
 import { ApiDropResolvedIdentityProfile } from '../generated/models/ApiDropResolvedIdentityProfile';
@@ -76,11 +75,8 @@ import {
   nftLinkResolvingService,
   NftLinkResolvingService
 } from '@/nft-links/nft-link-resolving.service';
-import {
-  directMessageWaveDisplayService,
-  resolveWavePictureOverride,
-  WaveDisplayOverride
-} from '@/api/waves/direct-message-wave-display.service';
+import { directMessageWaveDisplayService } from '@/api/waves/direct-message-wave-display.service';
+import { mapWaveEntityToApiWaveMin } from '@/api/waves/wave-min.mapper';
 
 export class DropsMappers {
   constructor(
@@ -185,18 +181,30 @@ export class DropsMappers {
   public async convertToDropFulls(
     {
       dropEntities,
-      contextProfileId
+      contextProfileId,
+      authenticationContext
     }: {
       dropEntities: DropEntity[];
       contextProfileId?: string | null;
+      authenticationContext?: AuthenticationContext;
     },
     connection?: ConnectionWrapper<any>
   ): Promise<ApiDrop[]> {
+    const effectiveAuthenticationContext =
+      authenticationContext ??
+      (contextProfileId
+        ? AuthenticationContext.fromProfileId(contextProfileId)
+        : AuthenticationContext.notAuthenticated());
+    const readScopedProfileId = this.getReadScopedProfileId(
+      effectiveAuthenticationContext
+    );
+    const noRightToVote = this.hasNoRightToVote(effectiveAuthenticationContext);
+    const noRightToParticipate = this.hasNoRightToParticipate(
+      effectiveAuthenticationContext
+    );
     const dWoW = await this.convertToDropsWithoutWaves(dropEntities, {
       connection,
-      authenticationContext: contextProfileId
-        ? AuthenticationContext.fromProfileId(contextProfileId)
-        : AuthenticationContext.notAuthenticated()
+      authenticationContext: effectiveAuthenticationContext
     });
     const dropIds = dropEntities.map((it) => it.id);
     const waveIds = collections.distinct(dropEntities.map((it) => it.wave_id));
@@ -205,7 +213,7 @@ export class DropsMappers {
       this.wavesApiDb.whichOfWavesArePinnedByGivenProfile(
         {
           waveIds,
-          profileId: contextProfileId
+          profileId: readScopedProfileId
         },
         { connection }
       )
@@ -217,22 +225,24 @@ export class DropsMappers {
             Object.values(waveOverviews),
             (it) => it.id
           ),
-          contextProfileId: contextProfileId ?? null
+          contextProfileId: readScopedProfileId
         },
         connection
       );
     const group_ids_user_is_eligible_for =
       await this.userGroupsService.getGroupsUserIsEligibleFor(
-        contextProfileId ?? null
+        readScopedProfileId
       );
     return dWoW.map<ApiDrop>((d) => {
       const wave = waveOverviews[d.id];
       const waveMin: ApiWaveMin | null = wave
-        ? this.mapWaveEntityToApiWaveMin({
+        ? mapWaveEntityToApiWaveMin({
             waveEntity: wave,
-            displayByWaveId: waveDisplayByWaveId,
+            displayOverride: waveDisplayByWaveId[wave.id],
             groupIdsUserIsEligibleFor: group_ids_user_is_eligible_for,
-            pinned: pinnedWaveIds.has(wave.id)
+            pinned: pinnedWaveIds.has(wave.id),
+            noRightToVote,
+            noRightToParticipate
           })
         : null;
       return {
@@ -470,7 +480,13 @@ export class DropsMappers {
     entities: DropEntity[],
     ctx: RequestContext
   ): Promise<ApiDropWithoutWave[]> {
-    const contextProfileId = ctx.authenticationContext?.getActingAsId() ?? null;
+    const contextProfileId = this.getReadScopedProfileId(
+      ctx.authenticationContext
+    );
+    const noRightToVote = this.hasNoRightToVote(ctx.authenticationContext);
+    const noRightToParticipate = this.hasNoRightToParticipate(
+      ctx.authenticationContext
+    );
     const {
       submissionDropsVotingRanges,
       mentions,
@@ -538,11 +554,13 @@ export class DropsMappers {
       );
     const mentionedWavesById = mentionedWaveEntities.reduce(
       (acc, wave) => {
-        acc[wave.id] = this.mapWaveEntityToApiWaveMin({
+        acc[wave.id] = mapWaveEntityToApiWaveMin({
           waveEntity: wave,
-          displayByWaveId: mentionedWaveDisplayByWaveId,
+          displayOverride: mentionedWaveDisplayByWaveId[wave.id],
           groupIdsUserIsEligibleFor,
-          pinned: pinnedMentionedWaveIds.has(wave.id)
+          pinned: pinnedMentionedWaveIds.has(wave.id),
+          noRightToVote,
+          noRightToParticipate
         });
         return acc;
       },
@@ -667,7 +685,8 @@ export class DropsMappers {
       active_main_stage_submission_ids: [],
       winner_main_stage_drop_ids: [],
       artist_of_prevote_cards: [],
-      is_wave_creator: false
+      is_wave_creator: false,
+      identity_wave: null
     };
     const profilesByIds = allProfileIds.reduce(
       (acc, profileId) => {
@@ -713,6 +732,43 @@ export class DropsMappers {
         rootDropIds
       });
     });
+  }
+
+  private getReadScopedProfileId(
+    authenticationContext?: AuthenticationContext
+  ): string | null {
+    if (!authenticationContext?.isUserFullyAuthenticated()) {
+      return null;
+    }
+    if (
+      authenticationContext.isAuthenticatedAsProxy() &&
+      !authenticationContext.hasProxyAction(ProfileProxyActionType.READ_WAVE)
+    ) {
+      return null;
+    }
+    return authenticationContext.getActingAsId();
+  }
+
+  private hasNoRightToVote(
+    authenticationContext?: AuthenticationContext
+  ): boolean {
+    return !!(
+      authenticationContext?.isAuthenticatedAsProxy() &&
+      !authenticationContext.activeProxyActions[
+        ProfileProxyActionType.RATE_WAVE_DROP
+      ]
+    );
+  }
+
+  private hasNoRightToParticipate(
+    authenticationContext?: AuthenticationContext
+  ): boolean {
+    return !!(
+      authenticationContext?.isAuthenticatedAsProxy() &&
+      !authenticationContext.activeProxyActions[
+        ProfileProxyActionType.CREATE_DROP_TO_WAVE
+      ]
+    );
   }
 
   private toDrop({
@@ -1058,80 +1114,6 @@ export class DropsMappers {
       nft_links: rootDropIds.has(dropEntity.id)
         ? (rootDropNftLinksByDropId[dropEntity.id] ?? [])
         : []
-    };
-  }
-
-  private mapWaveEntityToApiWaveMin({
-    waveEntity,
-    displayByWaveId,
-    groupIdsUserIsEligibleFor,
-    pinned
-  }: {
-    waveEntity: {
-      id: string;
-      name: string;
-      picture: string | null;
-      description_drop_id: string;
-      last_drop_time: number;
-      submission_type: string | null;
-      chat_enabled: boolean;
-      chat_group_id: string | null;
-      voting_group_id: string | null;
-      participation_group_id: string | null;
-      admin_group_id: string | null;
-      voting_credit_type: string;
-      voting_period_start: number | null;
-      voting_period_end: number | null;
-      visibility_group_id: string | null;
-      admin_drop_deletion_enabled: boolean;
-      forbid_negative_votes: boolean;
-    };
-    displayByWaveId: Record<string, WaveDisplayOverride>;
-    groupIdsUserIsEligibleFor: string[];
-    pinned: boolean;
-  }): ApiWaveMin {
-    return {
-      id: waveEntity.id,
-      name: displayByWaveId[waveEntity.id]?.name ?? waveEntity.name,
-      picture: resolveWavePictureOverride(
-        waveEntity.picture,
-        displayByWaveId[waveEntity.id]
-      ),
-      description_drop_id: waveEntity.description_drop_id,
-      last_drop_time: waveEntity.last_drop_time,
-      submission_type: waveEntity.submission_type
-        ? enums.resolveOrThrow(
-            ApiWaveParticipationSubmissionStrategyType,
-            waveEntity.submission_type
-          )
-        : null,
-      authenticated_user_eligible_to_chat:
-        waveEntity.chat_enabled &&
-        (waveEntity.chat_group_id === null ||
-          groupIdsUserIsEligibleFor.includes(waveEntity.chat_group_id)),
-      authenticated_user_eligible_to_vote:
-        waveEntity.voting_group_id === null ||
-        groupIdsUserIsEligibleFor.includes(waveEntity.voting_group_id),
-      authenticated_user_eligible_to_participate:
-        waveEntity.participation_group_id === null ||
-        groupIdsUserIsEligibleFor.includes(waveEntity.participation_group_id),
-      authenticated_user_admin:
-        waveEntity.admin_group_id !== null &&
-        groupIdsUserIsEligibleFor.includes(waveEntity.admin_group_id),
-      voting_credit_type: enums.resolveOrThrow(
-        WaveCreditTypeApi,
-        waveEntity.voting_credit_type
-      ),
-      voting_period_start: waveEntity.voting_period_start,
-      voting_period_end: waveEntity.voting_period_end,
-      visibility_group_id: waveEntity.visibility_group_id,
-      chat_group_id: waveEntity.chat_group_id,
-      admin_group_id: waveEntity.admin_group_id,
-      participation_group_id: waveEntity.participation_group_id,
-      voting_group_id: waveEntity.voting_group_id,
-      admin_drop_deletion_enabled: waveEntity.admin_drop_deletion_enabled,
-      forbid_negative_votes: waveEntity.forbid_negative_votes,
-      pinned
     };
   }
 }

--- a/src/api-serverless/src/generated/models/ApiDropResolvedIdentityProfile.ts
+++ b/src/api-serverless/src/generated/models/ApiDropResolvedIdentityProfile.ts
@@ -12,6 +12,7 @@
 
 import { ApiIdentitySubscriptionTargetAction } from '../models/ApiIdentitySubscriptionTargetAction';
 import { ApiProfileRepCategorySummary } from '../models/ApiProfileRepCategorySummary';
+import { ApiWaveMin } from '../models/ApiWaveMin';
 import { HttpFile } from '../http/http';
 
 export class ApiDropResolvedIdentityProfile {
@@ -34,6 +35,7 @@ export class ApiDropResolvedIdentityProfile {
     'winner_main_stage_drop_ids': Array<string>;
     'artist_of_prevote_cards': Array<number>;
     'is_wave_creator': boolean;
+    'identity_wave': ApiWaveMin;
     'bio': string | null;
     'top_rep_categories': Array<ApiProfileRepCategorySummary>;
 
@@ -152,6 +154,12 @@ export class ApiDropResolvedIdentityProfile {
             "name": "is_wave_creator",
             "baseName": "is_wave_creator",
             "type": "boolean",
+            "format": ""
+        },
+        {
+            "name": "identity_wave",
+            "baseName": "identity_wave",
+            "type": "ApiWaveMin",
             "format": ""
         },
         {

--- a/src/api-serverless/src/generated/models/ApiIdentity.ts
+++ b/src/api-serverless/src/generated/models/ApiIdentity.ts
@@ -12,6 +12,7 @@
 
 import { ApiProfileClassification } from '../models/ApiProfileClassification';
 import { ApiWallet } from '../models/ApiWallet';
+import { ApiWaveMin } from '../models/ApiWaveMin';
 import { HttpFile } from '../http/http';
 
 export class ApiIdentity {
@@ -39,6 +40,7 @@ export class ApiIdentity {
     'winner_main_stage_drop_ids': Array<string>;
     'artist_of_prevote_cards': Array<number>;
     'is_wave_creator': boolean;
+    'identity_wave': ApiWaveMin | null;
 
     static readonly discriminator: string | undefined = undefined;
 
@@ -185,6 +187,12 @@ export class ApiIdentity {
             "name": "is_wave_creator",
             "baseName": "is_wave_creator",
             "type": "boolean",
+            "format": ""
+        },
+        {
+            "name": "identity_wave",
+            "baseName": "identity_wave",
+            "type": "ApiWaveMin",
             "format": ""
         }    ];
 

--- a/src/api-serverless/src/generated/models/ApiProfileMin.ts
+++ b/src/api-serverless/src/generated/models/ApiProfileMin.ts
@@ -11,6 +11,7 @@
  */
 
 import { ApiIdentitySubscriptionTargetAction } from '../models/ApiIdentitySubscriptionTargetAction';
+import { ApiWaveMin } from '../models/ApiWaveMin';
 import { HttpFile } from '../http/http';
 
 export class ApiProfileMin {
@@ -33,6 +34,7 @@ export class ApiProfileMin {
     'winner_main_stage_drop_ids': Array<string>;
     'artist_of_prevote_cards': Array<number>;
     'is_wave_creator': boolean;
+    'identity_wave': ApiWaveMin | null;
 
     static readonly discriminator: string | undefined = undefined;
 
@@ -149,6 +151,12 @@ export class ApiProfileMin {
             "name": "is_wave_creator",
             "baseName": "is_wave_creator",
             "type": "boolean",
+            "format": ""
+        },
+        {
+            "name": "identity_wave",
+            "baseName": "identity_wave",
+            "type": "ApiWaveMin",
             "format": ""
         }    ];
 

--- a/src/api-serverless/src/generated/models/ObjectSerializer.ts
+++ b/src/api-serverless/src/generated/models/ObjectSerializer.ts
@@ -412,7 +412,7 @@ import { ApiGroupOwnsNft, ApiGroupOwnsNftNameEnum    } from '../models/ApiGroupO
 import { ApiGroupRepFilter      } from '../models/ApiGroupRepFilter';
 import { ApiGroupTdhFilter    } from '../models/ApiGroupTdhFilter';
 import { ApiGroupTdhInclusionStrategy } from '../models/ApiGroupTdhInclusionStrategy';
-import { ApiIdentity                         } from '../models/ApiIdentity';
+import { ApiIdentity                          } from '../models/ApiIdentity';
 import { ApiIdentityActivity } from '../models/ApiIdentityActivity';
 import { ApiIdentityAndSubscriptionActions } from '../models/ApiIdentityAndSubscriptionActions';
 import { ApiIdentitySubscriptionActions } from '../models/ApiIdentitySubscriptionActions';

--- a/src/api-serverless/src/identities/identities.service.ts
+++ b/src/api-serverless/src/identities/identities.service.ts
@@ -421,11 +421,13 @@ export class IdentitiesService {
       .map((it) => it.profile_id)
       .filter((it) => !!it) as string[];
     const [
+      identityWaves,
       mainStageSubmissions,
       mainStageWins,
       artistOfPrevoteCards,
       waveCreatorIds
     ] = await Promise.all([
+      this.identityFetcher.getIdentityWavesByIdentities(identityEntities, ctx),
       this.identitiesDb.getActiveMainStageDropIds(identityIds, ctx),
       this.identitiesDb.getMainStageWinnerDropIds(identityIds, ctx),
       this.identitiesDb.getArtistOfPrevoteCards(identityIds, ctx),
@@ -470,7 +472,10 @@ export class IdentitiesService {
           : [],
         is_wave_creator: it.profile_id
           ? waveCreatorIds.has(it.profile_id)
-          : false
+          : false,
+        identity_wave: it.profile_id
+          ? (identityWaves[it.profile_id] ?? null)
+          : null
       };
     });
   }
@@ -509,7 +514,8 @@ export class IdentitiesService {
           banner1: null,
           banner2: null,
           classification: null,
-          sub_classification: null
+          sub_classification: null,
+          wave_id: null
         })
       );
       if (newIdentities.length) {

--- a/src/api-serverless/src/identities/identity-fetcher.test.ts
+++ b/src/api-serverless/src/identities/identity-fetcher.test.ts
@@ -1,0 +1,228 @@
+import { AuthenticationContext } from '@/auth-context';
+import { userGroupsService } from '@/api/community-members/user-groups.service';
+import { wavesApiDb } from '@/api/waves/waves.api.db';
+import { IdentityFetcher } from '@/api/identities/identity.fetcher';
+import { anIdentity } from '@/tests/fixtures/identity.fixture';
+
+describe('IdentityFetcher identity waves', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function createFetcher(identityOverrides?: Record<string, any>) {
+    const identitiesDb = {
+      getIdentitiesByIds: jest
+        .fn()
+        .mockResolvedValue([anIdentity(identityOverrides ?? {}, undefined)]),
+      getActiveMainStageDropIds: jest.fn().mockResolvedValue({}),
+      getMainStageWinnerDropIds: jest.fn().mockResolvedValue({}),
+      getArtistOfPrevoteCards: jest.fn().mockResolvedValue({}),
+      getWaveCreatorProfileIds: jest.fn().mockResolvedValue(new Set<string>()),
+      getNewestVersionHandlesOfArchivedProfiles: jest.fn().mockResolvedValue([])
+    };
+    const identitySubscriptionsDb = {
+      findIdentitySubscriptionActionsOfTargets: jest.fn().mockResolvedValue({})
+    };
+    return new IdentityFetcher(
+      identitiesDb as any,
+      identitySubscriptionsDb as any,
+      jest.fn() as any
+    );
+  }
+
+  it('hydrates identity_wave for public waves', async () => {
+    const identity = anIdentity({
+      wave_id: 'wave-1'
+    });
+    const fetcher = createFetcher(identity);
+    jest
+      .spyOn(userGroupsService, 'getGroupsUserIsEligibleFor')
+      .mockResolvedValue([]);
+    jest.spyOn(wavesApiDb, 'findWavesByIdsEligibleForRead').mockResolvedValue([
+      {
+        id: 'wave-1',
+        name: 'wave-1',
+        picture: null,
+        description_drop_id: 'description-drop-1',
+        last_drop_time: 42,
+        submission_type: null,
+        chat_enabled: true,
+        chat_group_id: null,
+        voting_group_id: null,
+        participation_group_id: null,
+        admin_group_id: null,
+        voting_credit_type: 'TDH',
+        voting_period_start: null,
+        voting_period_end: null,
+        visibility_group_id: null,
+        admin_drop_deletion_enabled: false,
+        forbid_negative_votes: false
+      } as any
+    ]);
+    jest
+      .spyOn(wavesApiDb, 'whichOfWavesArePinnedByGivenProfile')
+      .mockResolvedValue(new Set(['wave-1']));
+
+    const overviews = await fetcher.getOverviewsByIds([identity.profile_id!], {
+      authenticationContext: AuthenticationContext.fromProfileId(
+        identity.profile_id!
+      ),
+      timer: undefined
+    });
+
+    expect(overviews[identity.profile_id!]?.identity_wave).toEqual(
+      expect.objectContaining({
+        id: 'wave-1',
+        pinned: true
+      })
+    );
+  });
+
+  it('returns null for private identity waves', async () => {
+    const identity = anIdentity({
+      wave_id: 'wave-1'
+    });
+    const fetcher = createFetcher(identity);
+    jest
+      .spyOn(userGroupsService, 'getGroupsUserIsEligibleFor')
+      .mockResolvedValue(['group-1']);
+    jest.spyOn(wavesApiDb, 'findWavesByIdsEligibleForRead').mockResolvedValue([
+      {
+        id: 'wave-1',
+        name: 'wave-1',
+        picture: null,
+        description_drop_id: 'description-drop-1',
+        last_drop_time: 42,
+        submission_type: null,
+        chat_enabled: true,
+        chat_group_id: null,
+        voting_group_id: null,
+        participation_group_id: null,
+        admin_group_id: null,
+        voting_credit_type: 'TDH',
+        voting_period_start: null,
+        voting_period_end: null,
+        visibility_group_id: 'group-1',
+        admin_drop_deletion_enabled: false,
+        forbid_negative_votes: false
+      } as any
+    ]);
+    jest
+      .spyOn(wavesApiDb, 'whichOfWavesArePinnedByGivenProfile')
+      .mockResolvedValue(new Set(['wave-1']));
+
+    const overviews = await fetcher.getOverviewsByIds([identity.profile_id!], {
+      authenticationContext: AuthenticationContext.fromProfileId(
+        identity.profile_id!
+      ),
+      timer: undefined
+    });
+
+    expect(overviews[identity.profile_id!]?.identity_wave).toBeNull();
+  });
+
+  it('does not overstate vote or participation rights for proxies', async () => {
+    const identity = anIdentity({
+      wave_id: 'wave-1'
+    });
+    const fetcher = createFetcher(identity);
+    jest
+      .spyOn(userGroupsService, 'getGroupsUserIsEligibleFor')
+      .mockResolvedValue([]);
+    jest.spyOn(wavesApiDb, 'findWavesByIdsEligibleForRead').mockResolvedValue([
+      {
+        id: 'wave-1',
+        name: 'wave-1',
+        picture: null,
+        description_drop_id: 'description-drop-1',
+        last_drop_time: 42,
+        submission_type: null,
+        chat_enabled: true,
+        chat_group_id: null,
+        voting_group_id: null,
+        participation_group_id: null,
+        admin_group_id: null,
+        voting_credit_type: 'TDH',
+        voting_period_start: null,
+        voting_period_end: null,
+        visibility_group_id: null,
+        admin_drop_deletion_enabled: false,
+        forbid_negative_votes: false
+      } as any
+    ]);
+    jest
+      .spyOn(wavesApiDb, 'whichOfWavesArePinnedByGivenProfile')
+      .mockResolvedValue(new Set(['wave-1']));
+
+    const overviews = await fetcher.getOverviewsByIds([identity.profile_id!], {
+      authenticationContext: new AuthenticationContext({
+        authenticatedWallet: null,
+        authenticatedProfileId: 'proxy-1',
+        roleProfileId: identity.profile_id!,
+        activeProxyActions: []
+      }),
+      timer: undefined
+    });
+
+    expect(overviews[identity.profile_id!]?.identity_wave).toEqual(
+      expect.objectContaining({
+        authenticated_user_eligible_to_vote: false,
+        authenticated_user_eligible_to_participate: false
+      })
+    );
+  });
+
+  it('treats proxies without READ_WAVE as anonymous for pin lookup', async () => {
+    const identity = anIdentity({
+      wave_id: 'wave-1'
+    });
+    const fetcher = createFetcher(identity);
+    jest.spyOn(wavesApiDb, 'findWavesByIdsEligibleForRead').mockResolvedValue([
+      {
+        id: 'wave-1',
+        name: 'wave-1',
+        picture: null,
+        description_drop_id: 'description-drop-1',
+        last_drop_time: 42,
+        submission_type: null,
+        chat_enabled: true,
+        chat_group_id: null,
+        voting_group_id: null,
+        participation_group_id: null,
+        admin_group_id: null,
+        voting_credit_type: 'TDH',
+        voting_period_start: null,
+        voting_period_end: null,
+        visibility_group_id: null,
+        admin_drop_deletion_enabled: false,
+        forbid_negative_votes: false
+      } as any
+    ]);
+    const pinnedLookup = jest
+      .spyOn(wavesApiDb, 'whichOfWavesArePinnedByGivenProfile')
+      .mockResolvedValue(new Set());
+
+    const overviews = await fetcher.getOverviewsByIds([identity.profile_id!], {
+      authenticationContext: new AuthenticationContext({
+        authenticatedWallet: null,
+        authenticatedProfileId: 'proxy-1',
+        roleProfileId: identity.profile_id!,
+        activeProxyActions: []
+      }),
+      timer: undefined
+    });
+
+    expect(pinnedLookup).toHaveBeenCalledWith(
+      {
+        waveIds: ['wave-1'],
+        profileId: null
+      },
+      expect.anything()
+    );
+    expect(overviews[identity.profile_id!]?.identity_wave).toEqual(
+      expect.objectContaining({
+        pinned: false
+      })
+    );
+  });
+});

--- a/src/api-serverless/src/identities/identity.fetcher.ts
+++ b/src/api-serverless/src/identities/identity.fetcher.ts
@@ -23,6 +23,11 @@ import { ApiProfileClassification } from '../generated/models/ApiProfileClassifi
 import { NotFoundException } from '../../../exceptions';
 import { ApiCommunityMemberMinimal } from '../generated/models/ApiCommunityMemberMinimal';
 import { enums } from '../../../enums';
+import { ApiWaveMin } from '@/api/generated/models/ApiWaveMin';
+import { ProfileProxyActionType } from '@/entities/IProfileProxyAction';
+import { userGroupsService } from '@/api/community-members/user-groups.service';
+import { wavesApiDb } from '@/api/waves/waves.api.db';
+import { mapWaveEntityToApiWaveMin } from '@/api/waves/wave-min.mapper';
 
 export class IdentityFetcher {
   constructor(
@@ -102,63 +107,77 @@ export class IdentityFetcher {
       this.identitiesDb.getArtistOfPrevoteCards(ids, ctx),
       this.identitiesDb.getWaveCreatorProfileIds(ids, ctx.connection)
     ]);
+    const identityWaves = await this.getIdentityWavesByIdentities(
+      identities,
+      ctx
+    );
     const notFoundProfileIds = ids.filter(
       (id) => !identities.find((p) => p.profile_id === id)
     );
-    const notArchivedProfiles = identities.map<ApiProfileMin>((p) => ({
-      id: p.profile_id!,
-      handle: p.handle,
-      banner1_color: p.banner1,
-      banner2_color: p.banner2,
-      cic: p.cic,
-      rep: p.rep,
-      tdh: p.tdh,
-      xtdh: p.xtdh,
-      xtdh_rate: p.xtdh_rate,
-      produced_xtdh: p.produced_xtdh,
-      granted_xtdh: p.granted_xtdh,
-      tdh_rate: p.basetdh_rate,
-      level: getLevelFromScore(p.level_raw),
-      pfp: p.pfp,
-      archived: false,
-      subscribed_actions: subscribedActions[p.profile_id!] ?? [],
-      primary_address: p.primary_address,
-      active_main_stage_submission_ids:
-        mainStageSubscriptions[p.profile_id!] ?? [],
-      winner_main_stage_drop_ids: mainStageWins[p.profile_id!] ?? [],
-      artist_of_prevote_cards: artistOfPrevoteCards[p.profile_id!] ?? [],
-      is_wave_creator: waveCreatorIds.has(p.profile_id!)
-    }));
+    const notArchivedProfiles = identities.reduce<ApiProfileMin[]>((acc, p) => {
+      const profileId = p.profile_id;
+      if (profileId === null) {
+        return acc;
+      }
+      const profile = {
+        id: profileId,
+        handle: p.handle,
+        banner1_color: p.banner1,
+        banner2_color: p.banner2,
+        cic: p.cic,
+        rep: p.rep,
+        tdh: p.tdh,
+        xtdh: p.xtdh,
+        xtdh_rate: p.xtdh_rate,
+        tdh_rate: p.basetdh_rate,
+        level: getLevelFromScore(p.level_raw),
+        pfp: p.pfp,
+        archived: false,
+        subscribed_actions: subscribedActions[profileId] ?? [],
+        primary_address: p.primary_address,
+        active_main_stage_submission_ids:
+          mainStageSubscriptions[profileId] ?? [],
+        winner_main_stage_drop_ids: mainStageWins[profileId] ?? [],
+        artist_of_prevote_cards: artistOfPrevoteCards[profileId] ?? [],
+        is_wave_creator: waveCreatorIds.has(profileId),
+        identity_wave: identityWaves[profileId] ?? null
+      };
+      acc.push(profile);
+      return acc;
+    }, []);
     const archivedProfiles = await this.identitiesDb
       .getNewestVersionHandlesOfArchivedProfiles(
         notFoundProfileIds,
         ctx.connection
       )
       .then((it) =>
-        it.map<ApiProfileMin>((p) => ({
-          id: p.external_id,
-          handle: p.handle,
-          banner1_color: p.banner1,
-          banner2_color: p.banner2,
-          cic: 0,
-          rep: 0,
-          tdh: 0,
-          xtdh: 0,
-          xtdh_rate: 0,
-          granted_xtdh: 0,
-          produced_xtdh: 0,
-          tdh_rate: 0,
-          level: 0,
-          primary_address: p.primary_address,
-          pfp: null,
-          archived: true,
-          subscribed_actions: subscribedActions[p.external_id] ?? [],
-          active_main_stage_submission_ids:
-            mainStageSubscriptions[p.external_id] ?? [],
-          winner_main_stage_drop_ids: mainStageWins[p.external_id] ?? [],
-          artist_of_prevote_cards: artistOfPrevoteCards[p.external_id] ?? [],
-          is_wave_creator: waveCreatorIds.has(p.external_id)
-        }))
+        it.reduce<ApiProfileMin[]>((acc, p) => {
+          const profile = {
+            id: p.external_id,
+            handle: p.handle,
+            banner1_color: p.banner1,
+            banner2_color: p.banner2,
+            cic: 0,
+            rep: 0,
+            tdh: 0,
+            xtdh: 0,
+            xtdh_rate: 0,
+            tdh_rate: 0,
+            level: 0,
+            primary_address: p.primary_address,
+            pfp: null,
+            archived: true,
+            subscribed_actions: subscribedActions[p.external_id] ?? [],
+            active_main_stage_submission_ids:
+              mainStageSubscriptions[p.external_id] ?? [],
+            winner_main_stage_drop_ids: mainStageWins[p.external_id] ?? [],
+            artist_of_prevote_cards: artistOfPrevoteCards[p.external_id] ?? [],
+            is_wave_creator: waveCreatorIds.has(p.external_id),
+            identity_wave: null
+          };
+          acc.push(profile);
+          return acc;
+        }, [])
       );
     return [...notArchivedProfiles, ...archivedProfiles].reduce(
       (acc, it) => {
@@ -256,6 +275,65 @@ export class IdentityFetcher {
     }
   }
 
+  public async getIdentityWavesByIdentities(
+    identities: Array<Pick<IdentityEntity, 'profile_id' | 'wave_id'>>,
+    ctx: RequestContext
+  ): Promise<Record<string, ApiWaveMin | null>> {
+    const profileIdsByWaveId = identities.reduce(
+      (acc, identity) => {
+        if (identity.profile_id && identity.wave_id) {
+          acc[identity.profile_id] = identity.wave_id;
+        }
+        return acc;
+      },
+      {} as Record<string, string>
+    );
+    const waveIds = Array.from(new Set(Object.values(profileIdsByWaveId)));
+    if (waveIds.length === 0) {
+      return {};
+    }
+    const readableWaveProfileId = this.getReadableWaveProfileId(ctx);
+    const [groupIdsUserIsEligibleFor, pinnedWaveIds] = await Promise.all([
+      this.getReadableWaveGroupIds(ctx),
+      wavesApiDb.whichOfWavesArePinnedByGivenProfile(
+        {
+          waveIds,
+          profileId: readableWaveProfileId
+        },
+        ctx
+      )
+    ]);
+    const noRightToVote = this.hasNoRightToVote(ctx);
+    const noRightToParticipate = this.hasNoRightToParticipate(ctx);
+    const waveEntities = await wavesApiDb.findWavesByIdsEligibleForRead(
+      waveIds,
+      groupIdsUserIsEligibleFor,
+      ctx.connection
+    );
+    const publicWavesById = waveEntities
+      .filter((waveEntity) => waveEntity.visibility_group_id === null)
+      .reduce(
+        (acc, waveEntity) => {
+          acc[waveEntity.id] = mapWaveEntityToApiWaveMin({
+            waveEntity,
+            groupIdsUserIsEligibleFor,
+            pinned: pinnedWaveIds.has(waveEntity.id),
+            noRightToVote,
+            noRightToParticipate
+          });
+          return acc;
+        },
+        {} as Record<string, ApiWaveMin>
+      );
+    return Object.entries(profileIdsByWaveId).reduce(
+      (acc, [profileId, waveId]) => {
+        acc[profileId] = publicWavesById[waveId] ?? null;
+        return acc;
+      },
+      {} as Record<string, ApiWaveMin | null>
+    );
+  }
+
   private async getSubscribedActions(
     {
       authenticatedProfileId,
@@ -285,6 +363,47 @@ export class IdentityFetcher {
             )
           )
       : {};
+  }
+
+  private async getReadableWaveGroupIds(
+    ctx: RequestContext
+  ): Promise<string[]> {
+    const readableWaveProfileId = this.getReadableWaveProfileId(ctx);
+    if (!readableWaveProfileId) {
+      return [];
+    }
+    return userGroupsService.getGroupsUserIsEligibleFor(
+      readableWaveProfileId,
+      ctx.timer
+    );
+  }
+
+  private getReadableWaveProfileId(ctx: RequestContext): string | null {
+    const authenticationContext = ctx.authenticationContext;
+    if (!authenticationContext?.hasRightsTo(ProfileProxyActionType.READ_WAVE)) {
+      return null;
+    }
+    return authenticationContext.getActingAsId();
+  }
+
+  private hasNoRightToVote(ctx: RequestContext): boolean {
+    const authenticationContext = ctx.authenticationContext;
+    return !!(
+      authenticationContext?.isAuthenticatedAsProxy() &&
+      !authenticationContext.activeProxyActions[
+        ProfileProxyActionType.RATE_WAVE_DROP
+      ]
+    );
+  }
+
+  private hasNoRightToParticipate(ctx: RequestContext): boolean {
+    const authenticationContext = ctx.authenticationContext;
+    return !!(
+      authenticationContext?.isAuthenticatedAsProxy() &&
+      !authenticationContext.activeProxyActions[
+        ProfileProxyActionType.CREATE_DROP_TO_WAVE
+      ]
+    );
   }
 
   private async getIdentityAndConsolidationsByHandle(
@@ -372,7 +491,8 @@ export class IdentityFetcher {
         active_main_stage_submission_ids: [],
         winner_main_stage_drop_ids: [],
         artist_of_prevote_cards: [],
-        is_wave_creator: false
+        is_wave_creator: false,
+        identity_wave: null
       };
     }
     return await this.mapToApiIdentity(identity, query, ctx);
@@ -478,6 +598,19 @@ export class IdentityFetcher {
           identity.classification as string
         ) ?? ApiProfileClassification.Pseudonym)
       : ApiProfileClassification.Pseudonym;
+    const identityWave = identity.profile_id
+      ? ((
+          await this.getIdentityWavesByIdentities(
+            [
+              {
+                profile_id: identity.profile_id,
+                wave_id: identity.wave_id
+              }
+            ],
+            ctx
+          )
+        )[identity.profile_id] ?? null)
+      : null;
     return {
       id: identity.profile_id,
       handle: identity.handle,
@@ -508,7 +641,8 @@ export class IdentityFetcher {
       artist_of_prevote_cards: artistOfPrevoteCards,
       is_wave_creator: identity.profile_id
         ? waveCreatorIds.has(identity.profile_id)
-        : false
+        : false,
+      identity_wave: identityWave
     };
   }
 

--- a/src/api-serverless/src/waves/wave-api-service.test.ts
+++ b/src/api-serverless/src/waves/wave-api-service.test.ts
@@ -45,6 +45,12 @@ describe('WaveApiService updateWave immutability', () => {
         .fn()
         .mockResolvedValue({ id: waveBeforeUpdate.id })
     };
+    const identityWavesService = {
+      assertWaveCanBeMadePrivate: jest.fn().mockResolvedValue(undefined),
+      clearIdentityWaveByWaveId: jest.fn().mockResolvedValue(undefined),
+      assertWaveCanBeIdentityWave: jest.fn().mockResolvedValue(undefined),
+      setIdentityWave: jest.fn().mockResolvedValue(undefined)
+    };
     const metricsRecorder = {
       recordActiveIdentity: jest.fn().mockResolvedValue(undefined)
     };
@@ -60,6 +66,7 @@ describe('WaveApiService updateWave immutability', () => {
       {} as any,
       {} as any,
       {} as any,
+      identityWavesService as any,
       metricsRecorder as any,
       {} as any,
       {} as any
@@ -71,6 +78,7 @@ describe('WaveApiService updateWave immutability', () => {
       service,
       wavesApiDb,
       waveMappers,
+      identityWavesService,
       metricsRecorder,
       ctx: {
         authenticationContext: AuthenticationContext.fromProfileId(
@@ -273,5 +281,111 @@ describe('WaveApiService updateWave immutability', () => {
 
     expect(wavesApiDb.deleteWave).toHaveBeenCalled();
     expect(waveMappers.createWaveToNewWaveEntity).toHaveBeenCalled();
+  });
+
+  it('rejects making an assigned identity wave private', async () => {
+    const waveBeforeUpdate = aWave(
+      {
+        type: WaveType.CHAT,
+        created_by: 'profile-1'
+      },
+      {
+        id: 'wave-1',
+        name: 'wave-1',
+        serial_no: 1
+      }
+    );
+    const { service, identityWavesService, wavesApiDb, ctx } = createService({
+      waveBeforeUpdate
+    });
+    identityWavesService.assertWaveCanBeMadePrivate.mockRejectedValue(
+      new Error(`A wave used as an identity wave cannot be made private`)
+    );
+
+    await expect(
+      service.updateWave(
+        'wave-1',
+        {
+          ...updateRequest({ type: ApiWaveType.Chat }),
+          visibility: {
+            scope: { group_id: 'group-1' }
+          }
+        },
+        ctx
+      )
+    ).rejects.toThrow(`A wave used as an identity wave cannot be made private`);
+
+    expect(wavesApiDb.deleteWave).not.toHaveBeenCalled();
+  });
+
+  it('sets identity wave for the authenticated profile', async () => {
+    const waveBeforeUpdate = aWave(
+      {
+        type: WaveType.CHAT,
+        created_by: 'profile-1'
+      },
+      {
+        id: 'wave-1',
+        name: 'wave-1',
+        serial_no: 1
+      }
+    );
+    const { service, identityWavesService, metricsRecorder, ctx } =
+      createService({
+        waveBeforeUpdate
+      });
+
+    await expect(
+      service.setIdentityWave({ waveId: 'wave-1' }, ctx)
+    ).resolves.toBeUndefined();
+
+    expect(
+      identityWavesService.assertWaveCanBeIdentityWave
+    ).toHaveBeenCalledWith(
+      {
+        waveId: 'wave-1',
+        profileId: 'profile-1'
+      },
+      expect.objectContaining({ connection: expect.anything() })
+    );
+    expect(identityWavesService.setIdentityWave).toHaveBeenCalledWith(
+      {
+        profileId: 'profile-1',
+        waveId: 'wave-1'
+      },
+      expect.objectContaining({ connection: expect.anything() })
+    );
+    expect(metricsRecorder.recordActiveIdentity).toHaveBeenCalledWith(
+      { identityId: 'profile-1' },
+      expect.objectContaining({ connection: expect.anything() })
+    );
+  });
+
+  it('rejects setting identity wave through a proxy', async () => {
+    const waveBeforeUpdate = aWave(
+      {
+        type: WaveType.CHAT,
+        created_by: 'profile-1'
+      },
+      {
+        id: 'wave-1',
+        name: 'wave-1',
+        serial_no: 1
+      }
+    );
+    const { service } = createService({ waveBeforeUpdate });
+    const ctx = {
+      authenticationContext: new AuthenticationContext({
+        authenticatedWallet: null,
+        authenticatedProfileId: 'proxy-1',
+        roleProfileId: 'profile-1',
+        activeProxyActions: []
+      }),
+      timer: undefined
+    } as any;
+
+    await expect(
+      service.setIdentityWave({ waveId: 'wave-1' }, ctx)
+    ).rejects.toThrow(`Proxies can't set identity waves`);
   });
 });

--- a/src/api-serverless/src/waves/wave-min.mapper.ts
+++ b/src/api-serverless/src/waves/wave-min.mapper.ts
@@ -1,0 +1,87 @@
+import { ApiWaveCreditType as WaveCreditTypeApi } from '@/api/generated/models/ApiWaveCreditType';
+import { ApiWaveMin } from '@/api/generated/models/ApiWaveMin';
+import { ApiWaveParticipationSubmissionStrategyType } from '@/api/generated/models/ApiWaveParticipationSubmissionStrategyType';
+import {
+  resolveWavePictureOverride,
+  WaveDisplayOverride
+} from '@/api/waves/direct-message-wave-display.service';
+import { enums } from '@/enums';
+
+export type WaveMinMappableEntity = {
+  id: string;
+  name: string;
+  picture: string | null;
+  description_drop_id: string;
+  last_drop_time: number;
+  submission_type: string | null;
+  chat_enabled: boolean;
+  chat_group_id: string | null;
+  voting_group_id: string | null;
+  participation_group_id: string | null;
+  admin_group_id: string | null;
+  voting_credit_type: string;
+  voting_period_start: number | null;
+  voting_period_end: number | null;
+  visibility_group_id: string | null;
+  admin_drop_deletion_enabled: boolean;
+  forbid_negative_votes: boolean;
+};
+
+export function mapWaveEntityToApiWaveMin({
+  waveEntity,
+  groupIdsUserIsEligibleFor,
+  pinned,
+  displayOverride,
+  noRightToVote = false,
+  noRightToParticipate = false
+}: {
+  waveEntity: WaveMinMappableEntity;
+  groupIdsUserIsEligibleFor: string[];
+  pinned: boolean;
+  displayOverride?: WaveDisplayOverride;
+  noRightToVote?: boolean;
+  noRightToParticipate?: boolean;
+}): ApiWaveMin {
+  return {
+    id: waveEntity.id,
+    name: displayOverride?.name ?? waveEntity.name,
+    picture: resolveWavePictureOverride(waveEntity.picture, displayOverride),
+    description_drop_id: waveEntity.description_drop_id,
+    last_drop_time: waveEntity.last_drop_time,
+    submission_type: waveEntity.submission_type
+      ? enums.resolveOrThrow(
+          ApiWaveParticipationSubmissionStrategyType,
+          waveEntity.submission_type
+        )
+      : null,
+    authenticated_user_eligible_to_chat:
+      waveEntity.chat_enabled &&
+      (waveEntity.chat_group_id === null ||
+        groupIdsUserIsEligibleFor.includes(waveEntity.chat_group_id)),
+    authenticated_user_eligible_to_vote:
+      !noRightToVote &&
+      (waveEntity.voting_group_id === null ||
+        groupIdsUserIsEligibleFor.includes(waveEntity.voting_group_id)),
+    authenticated_user_eligible_to_participate:
+      !noRightToParticipate &&
+      (waveEntity.participation_group_id === null ||
+        groupIdsUserIsEligibleFor.includes(waveEntity.participation_group_id)),
+    authenticated_user_admin:
+      waveEntity.admin_group_id !== null &&
+      groupIdsUserIsEligibleFor.includes(waveEntity.admin_group_id),
+    voting_credit_type: enums.resolveOrThrow(
+      WaveCreditTypeApi,
+      waveEntity.voting_credit_type
+    ),
+    voting_period_start: waveEntity.voting_period_start,
+    voting_period_end: waveEntity.voting_period_end,
+    visibility_group_id: waveEntity.visibility_group_id,
+    participation_group_id: waveEntity.participation_group_id,
+    chat_group_id: waveEntity.chat_group_id,
+    voting_group_id: waveEntity.voting_group_id,
+    admin_group_id: waveEntity.admin_group_id,
+    admin_drop_deletion_enabled: waveEntity.admin_drop_deletion_enabled,
+    forbid_negative_votes: waveEntity.forbid_negative_votes,
+    pinned
+  };
+}

--- a/src/api-serverless/src/waves/wave-quick-vote.api.service.ts
+++ b/src/api-serverless/src/waves/wave-quick-vote.api.service.ts
@@ -123,7 +123,8 @@ export class WaveQuickVoteApiService {
       .convertToDropFulls(
         {
           dropEntities: [drop],
-          contextProfileId: identityId
+          contextProfileId: identityId,
+          authenticationContext: ctx.authenticationContext
         },
         ctx.connection
       )

--- a/src/api-serverless/src/waves/wave.api.service.ts
+++ b/src/api-serverless/src/waves/wave.api.service.ts
@@ -69,6 +69,10 @@ import {
   identityFetcher
 } from '../identities/identity.fetcher';
 import {
+  IdentityWavesService,
+  identityWavesService
+} from '@/identities/identity-waves.service';
+import {
   identitySubscriptionsDb,
   IdentitySubscriptionsDb
 } from '../identity-subscriptions/identity-subscriptions.db';
@@ -100,6 +104,7 @@ export class WaveApiService {
     private readonly reactionsService: ReactionsService,
     private readonly userNotifier: UserNotifier,
     private readonly identityFetcher: IdentityFetcher,
+    private readonly identityWavesService: IdentityWavesService,
     private readonly metricsRecorder: MetricsRecorder,
     private readonly curationsDb: CurationsDb,
     private readonly dropsDb: DropsDb
@@ -1317,6 +1322,10 @@ export class WaveApiService {
         }
 
         await Promise.all([
+          this.identityWavesService.clearIdentityWaveByWaveId(
+            { waveId },
+            ctxWithConnection
+          ),
           this.wavesApiDb.deleteDropPartsByWaveId(waveId, ctxWithConnection),
           this.wavesApiDb.deleteDropMentionsByWaveId(waveId, ctxWithConnection),
           this.wavesApiDb.deleteDropMentionedWavesByWaveId(
@@ -1428,6 +1437,13 @@ export class WaveApiService {
           request,
           waveBeforeUpdate
         });
+        await this.identityWavesService.assertWaveCanBeMadePrivate(
+          {
+            waveId,
+            visibilityGroupId: request.visibility.scope.group_id
+          },
+          ctxWithConnection
+        );
         await this.validateWaveRelations(request, ctxWithConnection);
         await this.wavesApiDb.deleteWave(waveId, ctxWithConnection);
         const waveUpdateTime = Time.currentMillis();
@@ -1629,6 +1645,39 @@ export class WaveApiService {
     return subsequentDecisionPointer + 1;
   }
 
+  async setIdentityWave({ waveId }: { waveId: string }, ctx: RequestContext) {
+    const authenticationContext = this.getRequiredAuthenticationContext(ctx);
+    const actingAsId = this.getRequiredActingAsId(authenticationContext);
+    if (authenticationContext.isAuthenticatedAsProxy()) {
+      throw new ForbiddenException(`Proxies can't set identity waves`);
+    }
+    await this.wavesApiDb.executeNativeQueriesInTransaction(
+      async (connection) => {
+        const ctxWithConnection = { ...ctx, connection };
+        await this.identityWavesService.assertWaveCanBeIdentityWave(
+          {
+            waveId,
+            profileId: actingAsId
+          },
+          ctxWithConnection
+        );
+        await Promise.all([
+          this.identityWavesService.setIdentityWave(
+            {
+              profileId: actingAsId,
+              waveId
+            },
+            ctxWithConnection
+          ),
+          this.metricsRecorder.recordActiveIdentity(
+            { identityId: actingAsId },
+            ctxWithConnection
+          )
+        ]);
+      }
+    );
+  }
+
   async pinWave({ waveId }: { waveId: string }, ctx: RequestContext) {
     await this.wavesApiDb.executeNativeQueriesInTransaction(
       async (connection) => {
@@ -1795,6 +1844,7 @@ export const waveApiService = new WaveApiService(
   reactionsService,
   userNotifier,
   identityFetcher,
+  identityWavesService,
   metricsRecorder,
   curationsDb,
   dropsDb

--- a/src/api-serverless/src/waves/waves.api.db.ts
+++ b/src/api-serverless/src/waves/waves.api.db.ts
@@ -798,28 +798,35 @@ export class WavesApiDb extends LazyDbAccessCompatibleService {
     connection?: ConnectionWrapper<any>
   ): Promise<WaveEntity | null> {
     return this.db
-      .oneOrNull<WaveEntity>(
+      .oneOrNull<RawWaveEntity>(
         `
         select * from ${WAVES_TABLE} where id = :wave_id`,
         { wave_id },
         { wrappedConnection: connection }
       )
-      .then((it) =>
-        it
-          ? {
-              ...it,
-              participation_required_media: JSON.parse(
-                it.participation_required_media as any
-              ),
-              participation_required_metadata: JSON.parse(
-                it.participation_required_metadata as any
-              ),
-              decisions_strategy: it.decisions_strategy
-                ? JSON.parse(it.decisions_strategy as any)
-                : null
-            }
-          : null
+      .then((it) => (it ? this.parseWaveEntity(it) : null));
+  }
+
+  async lockById(
+    waveId: string,
+    ctx: RequestContext
+  ): Promise<WaveEntity | null> {
+    try {
+      ctx.timer?.start(`${this.constructor.name}->lockById`);
+      if (!ctx.connection) {
+        throw new Error(`Wave locking requires a transaction`);
+      }
+      const wave = await this.db.oneOrNull<RawWaveEntity>(
+        `
+          select * from ${WAVES_TABLE} where id = :waveId for update
+        `,
+        { waveId },
+        { wrappedConnection: ctx.connection }
       );
+      return wave ? this.parseWaveEntity(wave) : null;
+    } finally {
+      ctx.timer?.stop(`${this.constructor.name}->lockById`);
+    }
   }
 
   async deleteWave(waveId: string, ctx: RequestContext) {

--- a/src/api-serverless/src/waves/waves.routes.ts
+++ b/src/api-serverless/src/waves/waves.routes.ts
@@ -382,6 +382,22 @@ router.post('/:id/pins', needsAuthenticatedUser(), async (req, res) => {
 });
 
 router.post(
+  '/:id/identity-wave',
+  needsAuthenticatedUser(),
+  async (req, res) => {
+    await handleSimpleWaveAction(
+      req,
+      res,
+      (waveId, ctx) => waveApiService.setIdentityWave({ waveId }, ctx),
+      {
+        disallowProxy: true,
+        proxyErrorMessage: `Proxy is not allowed to set identity waves`
+      }
+    );
+  }
+);
+
+router.post(
   '/:id/pinned-drop',
   needsAuthenticatedUser(),
   async (

--- a/src/api-serverless/src/ws/ws-listeners-notifier.ts
+++ b/src/api-serverless/src/ws/ws-listeners-notifier.ts
@@ -210,7 +210,8 @@ export class WsListenersNotifier {
         mainStageSubscriptions[identityId] ?? [],
       winner_main_stage_drop_ids: mainStageWins[identityId] ?? [],
       artist_of_prevote_cards: artistOfPrevoteCards[identityId] ?? [],
-      is_wave_creator: waveCreatorIds.has(identityId)
+      is_wave_creator: waveCreatorIds.has(identityId),
+      identity_wave: null
     };
     const now = Time.currentMillis();
     await Promise.all(

--- a/src/drops/create-or-update-drop-use-case.test.ts
+++ b/src/drops/create-or-update-drop-use-case.test.ts
@@ -25,6 +25,9 @@ describe('CreateOrUpdateDropUseCase', () => {
   }: {
     existingNominations: Array<{ has_won: boolean }>;
   }) {
+    const identityWavesService = {
+      setIdentityWaveIfEligible: jest.fn().mockResolvedValue(false)
+    };
     return new CreateOrUpdateDropUseCase(
       {
         findIdentityNominationDropsForWave: jest
@@ -41,7 +44,8 @@ describe('CreateOrUpdateDropUseCase', () => {
       {} as any,
       {} as any,
       {} as any,
-      {} as any
+      {} as any,
+      identityWavesService as any
     );
   }
 
@@ -181,5 +185,126 @@ describe('CreateOrUpdateDropUseCase', () => {
       connection: {}
     });
     expect(mockResolveName).not.toHaveBeenCalled();
+  });
+
+  it('marks a newly created qualifying wave as the author identity wave', async () => {
+    const identityWavesService = {
+      setIdentityWaveIfEligible: jest.fn().mockResolvedValue(true)
+    };
+    const metricsRecorder = {
+      recordDrop: jest.fn().mockResolvedValue(undefined),
+      recordActiveIdentity: jest.fn().mockResolvedValue(undefined)
+    };
+    const useCase = new CreateOrUpdateDropUseCase(
+      {
+        findIdentityNominationDropsForWave: jest.fn(),
+        findDropById: jest.fn(),
+        executeNativeQueriesInTransaction: jest.fn(),
+        insertDrop: jest.fn(),
+        insertDropParts: jest.fn(),
+        insertDropMentions: jest.fn(),
+        insertDropMentionedWaves: jest.fn(),
+        insertDropReferencedNfts: jest.fn(),
+        insertDropMedia: jest.fn(),
+        insertDropMetadata: jest.fn(),
+        findNftDetailsByReferencedNfts: jest.fn().mockResolvedValue({})
+      } as any,
+      {} as any,
+      {
+        getGroupsUserIsEligibleFor: jest.fn().mockResolvedValue([])
+      } as any,
+      {
+        findById: jest.fn().mockResolvedValue({
+          id: 'wave-1',
+          type: 'CHAT',
+          chat_group_id: null,
+          chat_enabled: true,
+          participation_group_id: null,
+          participation_required_media: [],
+          participation_required_metadata: [],
+          submission_type: null,
+          participation_signature_required: false,
+          participation_period_start: null,
+          participation_period_end: null,
+          participation_max_applications_per_participant: null,
+          visibility_group_id: null
+        })
+      } as any,
+      {
+        notifyAllNotificationsSubscribers: jest
+          .fn()
+          .mockResolvedValue(undefined)
+      } as any,
+      {
+        recordDropCreated: jest.fn().mockResolvedValue(undefined)
+      } as any,
+      {
+        findWaveSubscribedAllSubscribers: jest.fn().mockResolvedValue([])
+      } as any,
+      {} as any,
+      {
+        execute: jest.fn().mockResolvedValue(undefined)
+      } as any,
+      metricsRecorder as any,
+      {
+        bulkDeleteForDrop: jest.fn().mockResolvedValue(undefined),
+        bulkInsert: jest.fn().mockResolvedValue(undefined)
+      } as any,
+      {
+        registerDrop: jest.fn().mockResolvedValue(undefined)
+      } as any,
+      identityWavesService as any
+    );
+
+    jest
+      .spyOn(useCase as any, 'validateReferences')
+      .mockImplementation(async (model) => model);
+    jest
+      .spyOn(useCase as any, 'insertAllDropComponents')
+      .mockResolvedValue(undefined);
+    jest.spyOn(useCase as any, 'buildDropNftLinks').mockReturnValue([]);
+
+    await expect(
+      (useCase as any).createOrUpdateDrop(
+        {
+          drop_id: null,
+          wave_id: 'wave-1',
+          reply_to: null,
+          title: null,
+          parts: [
+            {
+              content: 'hello',
+              quoted_drop: null,
+              media: []
+            }
+          ],
+          referenced_nfts: [],
+          mentioned_users: [],
+          mentioned_waves: [],
+          metadata: [],
+          author_identity: 'author-profile',
+          author_id: 'author-profile',
+          drop_type: DropType.CHAT,
+          mentions_all: false,
+          signature: null
+        },
+        false,
+        {
+          connection: {},
+          timer: undefined
+        }
+      )
+    ).resolves.toEqual({ drop_id: expect.any(String) });
+
+    expect(identityWavesService.setIdentityWaveIfEligible).toHaveBeenCalledWith(
+      {
+        profileId: 'author-profile',
+        waveId: 'wave-1'
+      },
+      {
+        timer: undefined,
+        connection: {}
+      }
+    );
   });
 });

--- a/src/drops/create-or-update-drop.use-case.ts
+++ b/src/drops/create-or-update-drop.use-case.ts
@@ -73,6 +73,10 @@ import {
   artCurationTokenWatchService,
   ArtCurationTokenWatchService
 } from '@/art-curation/art-curation-token-watch.service';
+import {
+  identityWavesService,
+  IdentityWavesService
+} from '@/identities/identity-waves.service';
 import { extractUrlCandidatesFromText } from '@/nft-links/nft-link-candidates';
 import { validateLinkUrl } from '@/nft-links/nft-link-resolver.validator';
 import { env } from '@/env';
@@ -102,7 +106,8 @@ export class CreateOrUpdateDropUseCase {
     private readonly deleteDropUseCase: DeleteDropUseCase,
     private readonly metricsRecorder: MetricsRecorder,
     private readonly dropNftLinksDb: DropNftLinksDb,
-    private readonly artCurationTokenWatchService: ArtCurationTokenWatchService
+    private readonly artCurationTokenWatchService: ArtCurationTokenWatchService,
+    private readonly identityWavesService: IdentityWavesService
   ) {}
 
   private getRequiredAuthorId(model: CreateOrUpdateDropModel): string {
@@ -343,6 +348,13 @@ export class CreateOrUpdateDropUseCase {
         { connection, timer }
       );
       await Promise.all([
+        this.identityWavesService.setIdentityWaveIfEligible(
+          {
+            profileId: authorId,
+            waveId: validatedModel.wave_id
+          },
+          { timer, connection }
+        ),
         this.metricsRecorder.recordDrop(
           {
             identityId: authorId,
@@ -1429,5 +1441,6 @@ export const createOrUpdateDrop = new CreateOrUpdateDropUseCase(
   deleteDrop,
   metricsRecorder,
   dropNftLinksDb,
-  artCurationTokenWatchService
+  artCurationTokenWatchService,
+  identityWavesService
 );

--- a/src/entities/IIdentity.ts
+++ b/src/entities/IIdentity.ts
@@ -53,6 +53,9 @@ export class IdentityEntity {
   @Column({ type: 'varchar', length: 255, nullable: true, default: null })
   public readonly sub_classification!: string | null;
 
+  @Column({ type: 'varchar', length: 100, nullable: true, default: null })
+  public readonly wave_id!: string | null;
+
   @Column({ type: 'double', nullable: false, default: 0 })
   readonly xtdh!: number;
 

--- a/src/identities/identities.db.ts
+++ b/src/identities/identities.db.ts
@@ -118,6 +118,7 @@ export class IdentitiesDb extends LazyDbAccessCompatibleService {
                                          primary_address,
                                          handle,
                                          normalised_handle,
+                                         wave_id,
                                          tdh,
                                          rep,
                                          cic,
@@ -135,6 +136,7 @@ export class IdentitiesDb extends LazyDbAccessCompatibleService {
                 :primary_address,
                 :handle,
                 :normalised_handle,
+                :wave_id,
                 :tdh,
                 :rep,
                 :cic,
@@ -276,6 +278,7 @@ export class IdentitiesDb extends LazyDbAccessCompatibleService {
       primary_address: identity.primary_address,
       handle: identity.handle ?? null,
       normalised_handle: identity.normalised_handle ?? null,
+      wave_id: identity.wave_id ?? null,
       tdh: identity.tdh ?? 0,
       rep: identity.rep ?? 0,
       cic: identity.cic ?? 0,
@@ -296,6 +299,7 @@ export class IdentitiesDb extends LazyDbAccessCompatibleService {
         'primary_address',
         'handle',
         'normalised_handle',
+        'wave_id',
         'tdh',
         'rep',
         'cic',
@@ -311,6 +315,7 @@ export class IdentitiesDb extends LazyDbAccessCompatibleService {
         'primary_address',
         'handle',
         'normalised_handle',
+        'wave_id',
         'tdh',
         'rep',
         'cic',
@@ -351,6 +356,58 @@ export class IdentitiesDb extends LazyDbAccessCompatibleService {
       { id },
       { wrappedConnection: connectionHolder }
     );
+  }
+
+  async updateIdentityWave(
+    {
+      profileId,
+      waveId
+    }: {
+      profileId: string;
+      waveId: string | null;
+    },
+    ctx: RequestContext
+  ) {
+    try {
+      ctx.timer?.start(`${this.constructor.name}->updateIdentityWave`);
+      await this.db.execute(
+        `update ${IDENTITIES_TABLE} set wave_id = :waveId where profile_id = :profileId`,
+        { profileId, waveId },
+        { wrappedConnection: ctx.connection }
+      );
+    } finally {
+      ctx.timer?.stop(`${this.constructor.name}->updateIdentityWave`);
+    }
+  }
+
+  async clearIdentityWaveByWaveId(waveId: string, ctx: RequestContext) {
+    try {
+      ctx.timer?.start(`${this.constructor.name}->clearIdentityWaveByWaveId`);
+      await this.db.execute(
+        `update ${IDENTITIES_TABLE} set wave_id = null where wave_id = :waveId`,
+        { waveId },
+        { wrappedConnection: ctx.connection }
+      );
+    } finally {
+      ctx.timer?.stop(`${this.constructor.name}->clearIdentityWaveByWaveId`);
+    }
+  }
+
+  async existsIdentityWithWaveId(
+    { waveId }: { waveId: string },
+    ctx: RequestContext
+  ): Promise<boolean> {
+    try {
+      ctx.timer?.start(`${this.constructor.name}->existsIdentityWithWaveId`);
+      const result = await this.db.oneOrNull<{ exists_count: number }>(
+        `select count(*) as exists_count from ${IDENTITIES_TABLE} where wave_id = :waveId`,
+        { waveId },
+        { wrappedConnection: ctx.connection }
+      );
+      return (result?.exists_count ?? 0) > 0;
+    } finally {
+      ctx.timer?.stop(`${this.constructor.name}->existsIdentityWithWaveId`);
+    }
   }
 
   async getIdentityByHandle(
@@ -785,6 +842,7 @@ export class IdentitiesDb extends LazyDbAccessCompatibleService {
       | 'granted_xtdh'
       | 'xtdh_rate'
       | 'basetdh_rate'
+      | 'wave_id'
     >,
     connection: ConnectionWrapper<any>
   ) {

--- a/src/identities/identity-waves.service.test.ts
+++ b/src/identities/identity-waves.service.test.ts
@@ -1,0 +1,104 @@
+import { IdentityWavesService } from '@/identities/identity-waves.service';
+import { WaveType } from '@/entities/IWave';
+
+describe('IdentityWavesService', () => {
+  const profileId = 'profile-1';
+  const waveId = 'wave-1';
+
+  function createService() {
+    const identitiesDb = {
+      updateIdentityWave: jest.fn().mockResolvedValue(undefined),
+      clearIdentityWaveByWaveId: jest.fn().mockResolvedValue(undefined),
+      existsIdentityWithWaveId: jest.fn().mockResolvedValue(false)
+    };
+    const wavesApiDb = {
+      lockById: jest.fn().mockResolvedValue({
+        id: waveId,
+        created_by: profileId,
+        type: WaveType.CHAT,
+        visibility_group_id: null
+      })
+    };
+
+    return {
+      service: new IdentityWavesService(identitiesDb as any, wavesApiDb as any),
+      identitiesDb,
+      wavesApiDb,
+      ctx: {
+        connection: {},
+        timer: undefined
+      } as any
+    };
+  }
+
+  it('locks the wave before auto-assigning an eligible identity wave', async () => {
+    const { service, identitiesDb, wavesApiDb, ctx } = createService();
+
+    await expect(
+      service.setIdentityWaveIfEligible({ profileId, waveId }, ctx)
+    ).resolves.toBe(true);
+
+    expect(wavesApiDb.lockById).toHaveBeenCalledWith(waveId, ctx);
+    expect(identitiesDb.updateIdentityWave).toHaveBeenCalledWith(
+      {
+        profileId,
+        waveId
+      },
+      ctx
+    );
+  });
+
+  it('returns false when the locked wave is not eligible', async () => {
+    const { service, identitiesDb, wavesApiDb, ctx } = createService();
+    wavesApiDb.lockById.mockResolvedValue({
+      id: waveId,
+      created_by: profileId,
+      type: WaveType.CHAT,
+      visibility_group_id: 'group-1'
+    });
+
+    await expect(
+      service.setIdentityWaveIfEligible({ profileId, waveId }, ctx)
+    ).resolves.toBe(false);
+
+    expect(identitiesDb.updateIdentityWave).not.toHaveBeenCalled();
+  });
+
+  it('locks the wave before allowing it to become private', async () => {
+    const { service, identitiesDb, wavesApiDb, ctx } = createService();
+    identitiesDb.existsIdentityWithWaveId.mockResolvedValue(true);
+
+    await expect(
+      service.assertWaveCanBeMadePrivate(
+        {
+          waveId,
+          visibilityGroupId: 'group-1'
+        },
+        ctx
+      )
+    ).rejects.toThrow(`A wave used as an identity wave cannot be made private`);
+
+    expect(wavesApiDb.lockById).toHaveBeenCalledWith(waveId, ctx);
+    expect(identitiesDb.existsIdentityWithWaveId).toHaveBeenCalledWith(
+      { waveId },
+      ctx
+    );
+  });
+
+  it('fails fast when the locked wave does not exist', async () => {
+    const { service, identitiesDb, wavesApiDb, ctx } = createService();
+    wavesApiDb.lockById.mockResolvedValue(null);
+
+    await expect(
+      service.assertWaveCanBeMadePrivate(
+        {
+          waveId,
+          visibilityGroupId: 'group-1'
+        },
+        ctx
+      )
+    ).rejects.toThrow(`Wave ${waveId} not found`);
+
+    expect(identitiesDb.existsIdentityWithWaveId).not.toHaveBeenCalled();
+  });
+});

--- a/src/identities/identity-waves.service.ts
+++ b/src/identities/identity-waves.service.ts
@@ -1,0 +1,150 @@
+import { WaveType } from '@/entities/IWave';
+import { BadRequestException, NotFoundException } from '@/exceptions';
+import { RequestContext } from '@/request.context';
+import { identitiesDb, IdentitiesDb } from '@/identities/identities.db';
+import { wavesApiDb, WavesApiDb } from '@/api/waves/waves.api.db';
+
+export class IdentityWavesService {
+  constructor(
+    private readonly identitiesDb: IdentitiesDb,
+    private readonly wavesApiDb: WavesApiDb
+  ) {}
+
+  public async setIdentityWave(
+    {
+      profileId,
+      waveId
+    }: {
+      profileId: string;
+      waveId: string;
+    },
+    ctx: RequestContext
+  ): Promise<void> {
+    await this.identitiesDb.updateIdentityWave({ profileId, waveId }, ctx);
+  }
+
+  public async clearIdentityWaveByWaveId(
+    { waveId }: { waveId: string },
+    ctx: RequestContext
+  ): Promise<void> {
+    await this.identitiesDb.clearIdentityWaveByWaveId(waveId, ctx);
+  }
+
+  public async setIdentityWaveIfEligible(
+    {
+      profileId,
+      waveId
+    }: {
+      profileId: string;
+      waveId: string;
+    },
+    ctx: RequestContext
+  ): Promise<boolean> {
+    try {
+      ctx.timer?.start(`${this.constructor.name}->setIdentityWaveIfEligible`);
+      const wave = await this.getLockedWaveById(waveId, ctx);
+      if (!wave || !this.isEligibleIdentityWave({ wave, profileId })) {
+        return false;
+      }
+      await this.identitiesDb.updateIdentityWave({ profileId, waveId }, ctx);
+      return true;
+    } finally {
+      ctx.timer?.stop(`${this.constructor.name}->setIdentityWaveIfEligible`);
+    }
+  }
+
+  public async assertWaveCanBeIdentityWave(
+    {
+      waveId,
+      profileId
+    }: {
+      waveId: string;
+      profileId: string;
+    },
+    ctx: RequestContext
+  ): Promise<void> {
+    try {
+      ctx.timer?.start(`${this.constructor.name}->assertWaveCanBeIdentityWave`);
+      const wave = await this.getLockedWaveById(waveId, ctx);
+      if (!wave) {
+        throw new NotFoundException(`Wave ${waveId} not found`);
+      }
+      if (!this.isEligibleIdentityWave({ wave, profileId })) {
+        if (wave.created_by !== profileId) {
+          throw new BadRequestException(
+            `Identity wave must be created by the authenticated profile`
+          );
+        }
+        if (wave.type !== WaveType.CHAT) {
+          throw new BadRequestException(`Identity wave must be of type CHAT`);
+        }
+        throw new BadRequestException(`Identity wave must be public`);
+      }
+    } finally {
+      ctx.timer?.stop(`${this.constructor.name}->assertWaveCanBeIdentityWave`);
+    }
+  }
+
+  public async assertWaveCanBeMadePrivate(
+    {
+      waveId,
+      visibilityGroupId
+    }: {
+      waveId: string;
+      visibilityGroupId: string | null;
+    },
+    ctx: RequestContext
+  ): Promise<void> {
+    try {
+      ctx.timer?.start(`${this.constructor.name}->assertWaveCanBeMadePrivate`);
+      if (visibilityGroupId === null) {
+        return;
+      }
+      const wave = await this.getLockedWaveById(waveId, ctx);
+      if (!wave) {
+        throw new NotFoundException(`Wave ${waveId} not found`);
+      }
+      const exists = await this.identitiesDb.existsIdentityWithWaveId(
+        { waveId },
+        ctx
+      );
+      if (exists) {
+        throw new BadRequestException(
+          `A wave used as an identity wave cannot be made private`
+        );
+      }
+    } finally {
+      ctx.timer?.stop(`${this.constructor.name}->assertWaveCanBeMadePrivate`);
+    }
+  }
+
+  private async getLockedWaveById(waveId: string, ctx: RequestContext) {
+    if (!ctx.connection) {
+      throw new Error(`Identity wave validation requires a transaction`);
+    }
+    return await this.wavesApiDb.lockById(waveId, ctx);
+  }
+
+  private isEligibleIdentityWave({
+    wave,
+    profileId
+  }: {
+    wave: {
+      created_by: string;
+      type: WaveType;
+      visibility_group_id: string | null;
+    };
+    profileId: string;
+  }): boolean {
+    return (
+      wave.created_by === profileId &&
+      wave.type === WaveType.CHAT &&
+      wave.visibility_group_id === null
+    );
+  }
+}
+
+export const identityWavesService = new IdentityWavesService(
+  identitiesDb,
+  wavesApiDb
+);

--- a/src/identity.ts
+++ b/src/identity.ts
@@ -134,7 +134,8 @@ export class IdentityConsolidationEffects extends LazyDbAccessCompatibleService 
                 sub_classification: null,
                 banner1: null,
                 banner2: null,
-                pfp: null
+                pfp: null,
+                wave_id: null
               };
               acc[profileId] = it;
               acc[newProfileId] = oldIdentitiesNewVersion;
@@ -189,7 +190,8 @@ export class IdentityConsolidationEffects extends LazyDbAccessCompatibleService 
       sub_classification: null,
       banner1: null,
       banner2: null,
-      pfp: null
+      pfp: null,
+      wave_id: null
     };
   }
 
@@ -934,6 +936,7 @@ export class IdentityConsolidationEffects extends LazyDbAccessCompatibleService 
                 profile_id: this.profileIdGenerator.generate(),
                 handle: null,
                 normalised_handle: null,
+                wave_id: null,
                 tdh: consolidation.tdh,
                 rep: 0,
                 cic: 0,
@@ -1060,6 +1063,7 @@ export class IdentityConsolidationEffects extends LazyDbAccessCompatibleService 
             profile_id: this.profileIdGenerator.generate(),
             handle: null,
             normalised_handle: null,
+            wave_id: null,
             tdh: 0,
             rep: 0,
             cic: 0,

--- a/src/profiles/profiles.service.ts
+++ b/src/profiles/profiles.service.ts
@@ -226,6 +226,7 @@ export class ProfilesService {
           banner2: null,
           classification: null,
           sub_classification: null,
+          wave_id: null,
           xtdh: 0,
           produced_xtdh: 0,
           granted_xtdh: 0,

--- a/src/rates/ratings.service.ts
+++ b/src/rates/ratings.service.ts
@@ -1041,6 +1041,7 @@ export class RatingsService {
                   pfp: null,
                   classification: null,
                   sub_classification: null,
+                  wave_id: null,
                   cic: 0,
                   rep: 0,
                   tdh: 0,

--- a/src/tests/fixtures/identity.fixture.ts
+++ b/src/tests/fixtures/identity.fixture.ts
@@ -24,6 +24,7 @@ const defaultBaseIdentity: BaseIdentity = {
   banner2: null,
   classification: ProfileClassification.PSEUDONYM,
   sub_classification: randomUUID(),
+  wave_id: null,
   xtdh: 0,
   produced_xtdh: 0,
   granted_xtdh: 0,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added authenticated POST /waves/{id}/identity-wave to set identity waves (proxy callers rejected).
  * Profiles and identity responses now include identity_wave; identity-wave mappings persisted, cleared on wave deletion, and can be auto-assigned when creating qualifying drops.
  * New identity-waves service and DB support (wave_id) to manage/validate assignments.

* **Bug Fixes**
  * Prevent making a wave private if it's used as an identity.

* **Tests**
  * Expanded tests for assignment, eligibility, proxy restrictions, and DB behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->