### PR TITLE
Added announcments_wave_id to seize settings

### DIFF
--- a/src/api-serverless/openapi.yaml
+++ b/src/api-serverless/openapi.yaml
@@ -10893,6 +10893,7 @@ components:
         - curation_wave_id
         - distribution_admin_wallets
         - claims_admin_wallets
+        - announcements_wave_id
       properties:
         rememes_submission_tdh_threshold:
           type: integer
@@ -10914,6 +10915,9 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/ApiEthereumAddress"
+        announcements_wave_id:
+          type: string
+          nullable: true
     ApiSetPinnedDropRequest:
       type: object
       required:

--- a/src/api-serverless/src/generated/models/ApiSeizeSettings.ts
+++ b/src/api-serverless/src/generated/models/ApiSeizeSettings.ts
@@ -19,6 +19,7 @@ export class ApiSeizeSettings {
     'curation_wave_id': string | null;
     'distribution_admin_wallets': Array<string>;
     'claims_admin_wallets': Array<string>;
+    'announcements_wave_id': string | null;
 
     static readonly discriminator: string | undefined = undefined;
 
@@ -57,6 +58,12 @@ export class ApiSeizeSettings {
             "name": "claims_admin_wallets",
             "baseName": "claims_admin_wallets",
             "type": "Array<string>",
+            "format": ""
+        },
+        {
+            "name": "announcements_wave_id",
+            "baseName": "announcements_wave_id",
+            "type": "string",
             "format": ""
         }    ];
 

--- a/src/api-serverless/src/seize-settings.ts
+++ b/src/api-serverless/src/seize-settings.ts
@@ -23,6 +23,7 @@ export const seizeSettings = (): ApiSeizeSettings => {
 
   const memes_wave_id = env.getStringOrNull('MAIN_STAGE_WAVE_ID');
   const curation_wave_id = env.getStringOrNull('CURATION_WAVE_ID');
+  const announcements_wave_id = env.getStringOrNull('ANNOUNCEMENTS_WAVE_ID');
   const distribution_admin_wallets = getDistributionAdminWallets();
   const claims_admin_wallets = getClaimsAdminWallets();
 
@@ -32,6 +33,7 @@ export const seizeSettings = (): ApiSeizeSettings => {
     memes_wave_id,
     curation_wave_id,
     distribution_admin_wallets,
-    claims_admin_wallets
+    claims_admin_wallets,
+    announcements_wave_id
   };
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The seize settings API now includes a new announcements wave identifier field, enabling users to configure and manage announcement wave identifiers alongside existing wave-id settings. The field is nullable and accessible through the updated seize settings endpoint, providing enhanced flexibility for wave-id configuration and management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->