### PR TITLE
Waveless light-drops + more fields to response

### DIFF
--- a/src/api-serverless/openapi.yaml
+++ b/src/api-serverless/openapi.yaml
@@ -963,7 +963,7 @@ paths:
         - name: wave_id
           in: query
           description: Drops in wave with given ID
-          required: true
+          required: false
           schema:
             type: string
       responses:
@@ -9338,6 +9338,10 @@ components:
       type: object
       required:
         - id
+        - wave_id
+        - wave_name
+        - author
+        - created_at
         - serial_no
         - drop_type
         - part_1_text
@@ -9348,6 +9352,15 @@ components:
       properties:
         id:
           type: string
+        wave_id:
+          type: string
+        wave_name:
+          type: string
+        author:
+          type: string
+        created_at:
+          type: number
+          format: int64
         serial_no:
           description: Sequence number of the drop in Seize
           type: number

--- a/src/api-serverless/src/drops/drops-api-service.test.ts
+++ b/src/api-serverless/src/drops/drops-api-service.test.ts
@@ -41,7 +41,10 @@ describe('DropsApiService', () => {
   } = {}) {
     const dropsDb = {
       findLatestDrops: jest.fn().mockResolvedValue([]),
-      findLatestDropsSimple: jest.fn().mockResolvedValue([])
+      findLatestDropsSimple: jest.fn().mockResolvedValue([]),
+      findLatestLightDropIdsByWave: jest.fn().mockResolvedValue([]),
+      findLatestVisibleLightDropIds: jest.fn().mockResolvedValue([]),
+      findLightDropsByIds: jest.fn().mockResolvedValue([])
     };
     const dropsMappers = {
       convertToDropFulls: jest.fn().mockResolvedValue([]),
@@ -216,5 +219,126 @@ describe('DropsApiService', () => {
       }),
       ctx
     );
+  });
+
+  it('uses the wave-scoped light drop selector when wave id is provided', async () => {
+    const { service, dropsDb, ctx, userGroupsService } = createService();
+    dropsDb.findLatestLightDropIdsByWave.mockResolvedValue([
+      { id: 'drop-1', serial_no: 2 }
+    ]);
+    dropsDb.findLightDropsByIds.mockResolvedValue([
+      {
+        id: 'drop-1',
+        wave_id: 'wave-1',
+        wave_name: 'Wave 1',
+        author: 'alice',
+        created_at: 123,
+        serial_no: 2,
+        drop_type: 'CHAT',
+        title: null,
+        reply_to_drop_id: null,
+        part_content: 'hello',
+        part_quoted_drop_id: null,
+        medias_json: null
+      }
+    ]);
+    userGroupsService.getGroupsUserIsEligibleFor.mockResolvedValue(['group-1']);
+
+    await expect(
+      service.findLatestLightDrops(
+        {
+          waveId: 'wave-1',
+          limit: 10,
+          max_serial_no: 20
+        },
+        ctx
+      )
+    ).resolves.toEqual([
+      expect.objectContaining({
+        id: 'drop-1',
+        wave_id: 'wave-1',
+        wave_name: 'Wave 1',
+        author: 'alice',
+        created_at: 123,
+        serial_no: 2,
+        part_1_text: 'hello',
+        part_1_medias: []
+      })
+    ]);
+
+    expect(dropsDb.findLatestLightDropIdsByWave).toHaveBeenCalledWith(
+      {
+        limit: 10,
+        max_serial_no: 20,
+        group_ids_user_is_eligible_for: ['group-1'],
+        wave_id: 'wave-1'
+      },
+      ctx
+    );
+    expect(dropsDb.findLatestVisibleLightDropIds).not.toHaveBeenCalled();
+    expect(dropsDb.findLightDropsByIds).toHaveBeenCalledWith(['drop-1'], ctx);
+  });
+
+  it('uses the global light drop selector when wave id is omitted', async () => {
+    const { service, dropsDb, ctx, userGroupsService } = createService();
+    dropsDb.findLatestVisibleLightDropIds.mockResolvedValue([
+      { id: 'drop-2', serial_no: 3 }
+    ]);
+    dropsDb.findLightDropsByIds.mockResolvedValue([
+      {
+        id: 'drop-2',
+        wave_id: 'wave-2',
+        wave_name: 'Wave 2',
+        author: 'bob',
+        created_at: 456,
+        serial_no: 3,
+        drop_type: 'CHAT',
+        title: 'Title',
+        reply_to_drop_id: 'parent-1',
+        part_content: null,
+        part_quoted_drop_id: 'quoted-1',
+        medias_json:
+          '[{"url":"https://example.com/drop-2.png","mime_type":"image/png"}]'
+      }
+    ]);
+    userGroupsService.getGroupsUserIsEligibleFor.mockResolvedValue([]);
+
+    await expect(
+      service.findLatestLightDrops(
+        {
+          waveId: null,
+          limit: 5,
+          max_serial_no: null
+        },
+        ctx
+      )
+    ).resolves.toEqual([
+      expect.objectContaining({
+        id: 'drop-2',
+        wave_id: 'wave-2',
+        wave_name: 'Wave 2',
+        author: 'bob',
+        created_at: 456,
+        has_quote: true,
+        is_reply_drop: true,
+        part_1_medias: [
+          {
+            url: 'https://example.com/drop-2.png',
+            mime_type: 'image/png'
+          }
+        ]
+      })
+    ]);
+
+    expect(dropsDb.findLatestVisibleLightDropIds).toHaveBeenCalledWith(
+      {
+        limit: 5,
+        max_serial_no: null,
+        group_ids_user_is_eligible_for: []
+      },
+      ctx
+    );
+    expect(dropsDb.findLatestLightDropIdsByWave).not.toHaveBeenCalled();
+    expect(dropsDb.findLightDropsByIds).toHaveBeenCalledWith(['drop-2'], ctx);
   });
 });

--- a/src/api-serverless/src/drops/drops.api.service.ts
+++ b/src/api-serverless/src/drops/drops.api.service.ts
@@ -142,7 +142,7 @@ export class DropsApiService {
       waveId,
       limit,
       max_serial_no
-    }: { waveId: string; limit: number; max_serial_no: number | null },
+    }: { waveId: string | null; limit: number; max_serial_no: number | null },
     ctx: RequestContext
   ): Promise<ApiLightDrop[]> {
     const authenticationContext = ctx.authenticationContext;
@@ -153,13 +153,26 @@ export class DropsApiService {
       await this.userGroupsService.getGroupsUserIsEligibleFor(
         context_profile_id
       );
-    const entities = await this.dropsDb.findLatestDropsWithPartsAndMedia(
-      {
-        limit,
-        max_serial_no,
-        group_ids_user_is_eligible_for,
-        wave_id: waveId
-      },
+    const lightDropIds = waveId
+      ? await this.dropsDb.findLatestLightDropIdsByWave(
+          {
+            limit,
+            max_serial_no,
+            group_ids_user_is_eligible_for,
+            wave_id: waveId
+          },
+          ctx
+        )
+      : await this.dropsDb.findLatestVisibleLightDropIds(
+          {
+            limit,
+            max_serial_no,
+            group_ids_user_is_eligible_for
+          },
+          ctx
+        );
+    const entities = await this.dropsDb.findLightDropsByIds(
+      lightDropIds.map((it) => it.id),
       ctx
     );
     const apiLightDrops = Object.values(
@@ -167,6 +180,10 @@ export class DropsApiService {
         (acc, it) => {
           acc[it.id] = {
             id: it.id,
+            wave_id: it.wave_id,
+            wave_name: it.wave_name,
+            author: it.author,
+            created_at: it.created_at,
             serial_no: it.serial_no,
             drop_type: enums.resolveOrThrow(
               ApiDropType,

--- a/src/api-serverless/src/drops/light-drops.routes.ts
+++ b/src/api-serverless/src/drops/light-drops.routes.ts
@@ -18,7 +18,7 @@ router.get(
       any,
       any,
       any,
-      { wave_id: string; limit: number; max_serial_no: number | null },
+      { wave_id?: string; limit: number; max_serial_no: number | null },
       any
     >,
     res: Response<ApiResponse<ApiLightDrop[]>>
@@ -26,9 +26,6 @@ router.get(
     const timer = Timer.getFromRequest(req);
     const authenticationContext = await getAuthenticationContext(req, timer);
     const { wave_id, limit, max_serial_no } = req.query;
-    if (!wave_id) {
-      throw new BadRequestException('wave_id must be provided');
-    }
     if (!limit) {
       throw new BadRequestException('limit must be provided');
     }
@@ -39,7 +36,7 @@ router.get(
     const maxSerialNo = numbers.parseIntOrNull(max_serial_no);
     const latestDrops = await dropsService.findLatestLightDrops(
       {
-        waveId: wave_id,
+        waveId: wave_id ?? null,
         limit: parsedLimit,
         max_serial_no: maxSerialNo
       },

--- a/src/api-serverless/src/generated/models/ApiLightDrop.ts
+++ b/src/api-serverless/src/generated/models/ApiLightDrop.ts
@@ -16,6 +16,10 @@ import { HttpFile } from '../http/http';
 
 export class ApiLightDrop {
     'id': string;
+    'wave_id': string;
+    'wave_name': string;
+    'author': string;
+    'created_at': number;
     /**
     * Sequence number of the drop in Seize
     */
@@ -35,6 +39,30 @@ export class ApiLightDrop {
             "baseName": "id",
             "type": "string",
             "format": ""
+        },
+        {
+            "name": "wave_id",
+            "baseName": "wave_id",
+            "type": "string",
+            "format": ""
+        },
+        {
+            "name": "wave_name",
+            "baseName": "wave_name",
+            "type": "string",
+            "format": ""
+        },
+        {
+            "name": "author",
+            "baseName": "author",
+            "type": "string",
+            "format": ""
+        },
+        {
+            "name": "created_at",
+            "baseName": "created_at",
+            "type": "number",
+            "format": "int64"
         },
         {
             "name": "serial_no",

--- a/src/api-serverless/src/generated/models/ObjectSerializer.ts
+++ b/src/api-serverless/src/generated/models/ObjectSerializer.ts
@@ -425,7 +425,7 @@ import { ApiIdentitySubscriptionTargetAction } from '../models/ApiIdentitySubscr
 import { ApiIdentitySubscriptionTargetType } from '../models/ApiIdentitySubscriptionTargetType';
 import { ApiIncomingIdentitySubscriptionsPage } from '../models/ApiIncomingIdentitySubscriptionsPage';
 import { ApiIntRange } from '../models/ApiIntRange';
-import { ApiLightDrop         } from '../models/ApiLightDrop';
+import { ApiLightDrop             } from '../models/ApiLightDrop';
 import { ApiLoginRequest } from '../models/ApiLoginRequest';
 import { ApiLoginResponse } from '../models/ApiLoginResponse';
 import { ApiMarkDropUnreadResponse } from '../models/ApiMarkDropUnreadResponse';

--- a/src/drops/drops.db.test.ts
+++ b/src/drops/drops.db.test.ts
@@ -1,0 +1,321 @@
+import 'reflect-metadata';
+import { DROP_MEDIA_TABLE, DROPS_PARTS_TABLE, DROPS_TABLE } from '@/constants';
+import { DropType } from '@/entities/IDrop';
+import { RequestContext } from '@/request.context';
+import { sqlExecutor } from '@/sql-executor';
+import { describeWithSeed } from '@/tests/_setup/seed';
+import { anIdentity, withIdentities } from '@/tests/fixtures/identity.fixture';
+import { aWave, withWaves } from '@/tests/fixtures/wave.fixture';
+import { DropsDb } from './drops.db';
+
+const repo = new DropsDb(() => sqlExecutor);
+const ctx: RequestContext = { timer: undefined };
+
+const publicWaveA = aWave(
+  { visibility_group_id: null },
+  { id: 'wave-public-a', serial_no: 1, name: 'Public A' }
+);
+const publicWaveB = aWave(
+  { visibility_group_id: null },
+  { id: 'wave-public-b', serial_no: 2, name: 'Public B' }
+);
+const privateWave = aWave(
+  { visibility_group_id: 'group-1' },
+  { id: 'wave-private', serial_no: 3, name: 'Private Wave' }
+);
+
+const authorAlice = anIdentity(
+  {},
+  {
+    consolidation_key: 'identity-alice',
+    profile_id: 'profile-alice',
+    primary_address: 'wallet-alice',
+    handle: 'alice'
+  }
+);
+const authorBob = anIdentity(
+  {},
+  {
+    consolidation_key: 'identity-bob',
+    profile_id: 'profile-bob',
+    primary_address: 'wallet-bob',
+    handle: 'bob'
+  }
+);
+const authorCarol = anIdentity(
+  {},
+  {
+    consolidation_key: 'identity-carol',
+    profile_id: 'profile-carol',
+    primary_address: 'wallet-carol',
+    handle: 'carol'
+  }
+);
+const authorDave = anIdentity(
+  {},
+  {
+    consolidation_key: 'identity-dave',
+    profile_id: 'profile-dave',
+    primary_address: 'wallet-dave',
+    handle: 'dave'
+  }
+);
+
+function aDropRow({
+  id,
+  serial_no,
+  wave_id,
+  author_id,
+  created_at,
+  title = null,
+  reply_to_drop_id = null
+}: {
+  id: string;
+  serial_no: number;
+  wave_id: string;
+  author_id: string;
+  created_at: number;
+  title?: string | null;
+  reply_to_drop_id?: string | null;
+}) {
+  return {
+    id,
+    serial_no,
+    wave_id,
+    author_id,
+    created_at,
+    title,
+    parts_count: 2,
+    drop_type: DropType.CHAT,
+    reply_to_drop_id
+  };
+}
+
+function aDropPartRow({
+  drop_id,
+  drop_part_id,
+  content,
+  quoted_drop_id = null
+}: {
+  drop_id: string;
+  drop_part_id: number;
+  content: string;
+  quoted_drop_id?: string | null;
+}) {
+  return {
+    drop_id,
+    drop_part_id,
+    content,
+    quoted_drop_id
+  };
+}
+
+function aDropMediaRow({
+  drop_id,
+  drop_part_id,
+  url,
+  mime_type
+}: {
+  drop_id: string;
+  drop_part_id: number;
+  url: string;
+  mime_type: string;
+}) {
+  return {
+    drop_id,
+    drop_part_id,
+    url,
+    mime_type
+  };
+}
+
+describeWithSeed(
+  'DropsDb light drops',
+  [
+    withWaves([publicWaveA, publicWaveB, privateWave]),
+    withIdentities([authorAlice, authorBob, authorCarol, authorDave]),
+    {
+      table: DROPS_TABLE,
+      rows: [
+        aDropRow({
+          id: 'drop-public-a-old',
+          serial_no: 101,
+          wave_id: publicWaveA.id,
+          author_id: authorAlice.profile_id!,
+          created_at: 1001,
+          title: 'Old public A'
+        }),
+        aDropRow({
+          id: 'drop-private',
+          serial_no: 102,
+          wave_id: privateWave.id,
+          author_id: authorDave.profile_id!,
+          created_at: 1002
+        }),
+        aDropRow({
+          id: 'drop-public-a-new',
+          serial_no: 103,
+          wave_id: publicWaveA.id,
+          author_id: authorBob.profile_id!,
+          created_at: 1003,
+          reply_to_drop_id: 'drop-parent'
+        }),
+        aDropRow({
+          id: 'drop-public-b',
+          serial_no: 104,
+          wave_id: publicWaveB.id,
+          author_id: authorCarol.profile_id!,
+          created_at: 1004
+        })
+      ]
+    },
+    {
+      table: DROPS_PARTS_TABLE,
+      rows: [
+        aDropPartRow({
+          drop_id: 'drop-public-a-old',
+          drop_part_id: 1,
+          content: 'Old public A part 1'
+        }),
+        aDropPartRow({
+          drop_id: 'drop-private',
+          drop_part_id: 1,
+          content: 'Private part 1'
+        }),
+        aDropPartRow({
+          drop_id: 'drop-public-a-new',
+          drop_part_id: 1,
+          content: 'Newest public A part 1',
+          quoted_drop_id: 'quoted-drop-1'
+        }),
+        aDropPartRow({
+          drop_id: 'drop-public-a-new',
+          drop_part_id: 2,
+          content: 'Newest public A part 2'
+        }),
+        aDropPartRow({
+          drop_id: 'drop-public-b',
+          drop_part_id: 1,
+          content: 'Public B part 1'
+        })
+      ]
+    },
+    {
+      table: DROP_MEDIA_TABLE,
+      rows: [
+        aDropMediaRow({
+          drop_id: 'drop-public-a-new',
+          drop_part_id: 1,
+          url: 'https://example.com/new-public-a-1.png',
+          mime_type: 'image/png'
+        }),
+        aDropMediaRow({
+          drop_id: 'drop-public-a-new',
+          drop_part_id: 2,
+          url: 'https://example.com/new-public-a-2.mp4',
+          mime_type: 'video/mp4'
+        }),
+        aDropMediaRow({
+          drop_id: 'drop-private',
+          drop_part_id: 1,
+          url: 'https://example.com/private.png',
+          mime_type: 'image/png'
+        })
+      ]
+    }
+  ],
+  () => {
+    it('finds the latest visible ids within a wave and respects max serial', async () => {
+      await expect(
+        repo.findLatestLightDropIdsByWave(
+          {
+            limit: 10,
+            max_serial_no: 103,
+            group_ids_user_is_eligible_for: [],
+            wave_id: publicWaveA.id
+          },
+          ctx
+        )
+      ).resolves.toEqual([
+        { id: 'drop-public-a-new', serial_no: 103 },
+        { id: 'drop-public-a-old', serial_no: 101 }
+      ]);
+    });
+
+    it('returns no wave-scoped rows when the wave is not visible', async () => {
+      await expect(
+        repo.findLatestLightDropIdsByWave(
+          {
+            limit: 10,
+            max_serial_no: null,
+            group_ids_user_is_eligible_for: [],
+            wave_id: privateWave.id
+          },
+          ctx
+        )
+      ).resolves.toEqual([]);
+    });
+
+    it('finds the latest visible ids globally and skips private waves without membership', async () => {
+      await expect(
+        repo.findLatestVisibleLightDropIds(
+          {
+            limit: 10,
+            max_serial_no: null,
+            group_ids_user_is_eligible_for: []
+          },
+          ctx
+        )
+      ).resolves.toEqual([
+        { id: 'drop-public-b', serial_no: 104 },
+        { id: 'drop-public-a-new', serial_no: 103 },
+        { id: 'drop-public-a-old', serial_no: 101 }
+      ]);
+    });
+
+    it('includes eligible private waves in the global selector', async () => {
+      await expect(
+        repo.findLatestVisibleLightDropIds(
+          {
+            limit: 10,
+            max_serial_no: null,
+            group_ids_user_is_eligible_for: ['group-1']
+          },
+          ctx
+        )
+      ).resolves.toEqual([
+        { id: 'drop-public-b', serial_no: 104 },
+        { id: 'drop-public-a-new', serial_no: 103 },
+        { id: 'drop-private', serial_no: 102 },
+        { id: 'drop-public-a-old', serial_no: 101 }
+      ]);
+    });
+
+    it('hydrates wave, author, first part and first-part media only', async () => {
+      const results = await repo.findLightDropsByIds(
+        ['drop-public-a-old', 'drop-public-a-new'],
+        ctx
+      );
+
+      expect(results.map((it) => it.id)).toEqual([
+        'drop-public-a-new',
+        'drop-public-a-old'
+      ]);
+      expect(results[0]).toMatchObject({
+        id: 'drop-public-a-new',
+        wave_name: 'Public A',
+        author: 'bob',
+        created_at: 1003,
+        part_drop_part_id: 1,
+        part_content: 'Newest public A part 1',
+        part_quoted_drop_id: 'quoted-drop-1'
+      });
+      expect(JSON.parse(results[0].medias_json ?? '[]')).toEqual([
+        {
+          url: 'https://example.com/new-public-a-1.png',
+          mime_type: 'image/png'
+        }
+      ]);
+    });
+  }
+);

--- a/src/drops/drops.db.ts
+++ b/src/drops/drops.db.ts
@@ -7,16 +7,16 @@ import { PageSortDirection } from '../api-serverless/src/page-request';
 import { assertUnreachable } from '../assertions';
 import { collections } from '../collections';
 import {
+  ACTIVITY_EVENTS_TABLE,
   ART_CURATION_TOKEN_WATCH_DROPS_TABLE,
   ART_CURATION_TOKEN_WATCHES_TABLE,
-  ACTIVITY_EVENTS_TABLE,
   DELETED_DROPS_TABLE,
   DROP_BOOSTS_TABLE,
   DROP_CURATIONS_TABLE,
-  DROP_NFT_LINKS_TABLE,
   DROP_MEDIA_TABLE,
   DROP_MENTIONED_WAVES_TABLE,
   DROP_METADATA_TABLE,
+  DROP_NFT_LINKS_TABLE,
   DROP_REAL_VOTER_VOTE_IN_TIME_TABLE,
   DROP_REFERENCED_NFTS_TABLE,
   DROP_RELATIONS_TABLE,
@@ -81,6 +81,20 @@ export class DropsDb extends LazyDbAccessCompatibleService {
       },
       connection ? { wrappedConnection: connection } : undefined
     );
+  }
+
+  private getVisibleWaveFilterSql(groupIdsUserIsEligibleFor: string[]): string {
+    return [
+      'w.visibility_group_id is null',
+      groupIdsUserIsEligibleFor.length
+        ? `w.visibility_group_id in (:groupsUserIsEligibleFor)`
+        : null,
+      groupIdsUserIsEligibleFor.length
+        ? `w.admin_group_id in (:groupsUserIsEligibleFor)`
+        : null
+    ]
+      .filter((it): it is string => !!it)
+      .join(' or ');
   }
 
   async insertDrop(
@@ -465,7 +479,7 @@ export class DropsDb extends LazyDbAccessCompatibleService {
     return this.db.execute<DropEntity>(sql, params);
   }
 
-  async findLatestDropsWithPartsAndMedia(
+  async findLatestLightDropIdsByWave(
     {
       limit,
       max_serial_no,
@@ -475,16 +489,105 @@ export class DropsDb extends LazyDbAccessCompatibleService {
       limit: number;
       max_serial_no: number | null;
       group_ids_user_is_eligible_for: string[];
-      wave_id: string | null;
+      wave_id: string;
     },
     ctx: RequestContext
-  ): Promise<DropWithMediaAndPart[]> {
+  ): Promise<LightDropIdRow[]> {
+    const timerLabel = `${this.constructor.name}->findLatestLightDropIdsByWave`;
+    ctx.timer?.start(timerLabel);
     const maxSerialNo = max_serial_no ?? Number.MAX_SAFE_INTEGER;
-    const sql = `select d.*, 
+    const visibleWaveFilter = this.getVisibleWaveFilterSql(
+      group_ids_user_is_eligible_for
+    );
+    try {
+      return await this.db.execute<LightDropIdRow>(
+        `select d.id, d.serial_no
+         from ${DROPS_TABLE} d FORCE INDEX (idx_drop_wave_serial_no)
+         where d.wave_id = :wave_id
+           and d.serial_no <= :maxSerialNo
+           and exists (
+             select 1
+             from ${WAVES_TABLE} w
+             where w.id = :wave_id
+               and (${visibleWaveFilter})
+           )
+         order by d.serial_no desc
+         limit :limit`,
+        {
+          limit,
+          maxSerialNo,
+          groupsUserIsEligibleFor: group_ids_user_is_eligible_for,
+          wave_id
+        },
+        { wrappedConnection: ctx.connection }
+      );
+    } finally {
+      ctx.timer?.stop(timerLabel);
+    }
+  }
+
+  async findLatestVisibleLightDropIds(
+    {
+      limit,
+      max_serial_no,
+      group_ids_user_is_eligible_for
+    }: {
+      limit: number;
+      max_serial_no: number | null;
+      group_ids_user_is_eligible_for: string[];
+    },
+    ctx: RequestContext
+  ): Promise<LightDropIdRow[]> {
+    const timerLabel = `${this.constructor.name}->findLatestVisibleLightDropIds`;
+    ctx.timer?.start(timerLabel);
+    const maxSerialNo = max_serial_no ?? Number.MAX_SAFE_INTEGER;
+    const visibleWaveFilter = this.getVisibleWaveFilterSql(
+      group_ids_user_is_eligible_for
+    );
+    try {
+      return await this.db.execute<LightDropIdRow>(
+        `select d.id, d.serial_no
+         from ${DROPS_TABLE} d FORCE INDEX (PRIMARY)
+         where d.serial_no <= :maxSerialNo
+           and exists (
+             select 1
+             from ${WAVES_TABLE} w
+             where w.id = d.wave_id
+               and (${visibleWaveFilter})
+           )
+         order by d.serial_no desc
+         limit :limit`,
+        {
+          limit,
+          maxSerialNo,
+          groupsUserIsEligibleFor: group_ids_user_is_eligible_for
+        },
+        { wrappedConnection: ctx.connection }
+      );
+    } finally {
+      ctx.timer?.stop(timerLabel);
+    }
+  }
+
+  async findLightDropsByIds(
+    dropIds: string[],
+    ctx: RequestContext
+  ): Promise<DropWithMediaAndPart[]> {
+    if (!dropIds.length) {
+      return [];
+    }
+
+    const timerLabel = `${this.constructor.name}->findLightDropsByIds`;
+    ctx.timer?.start(timerLabel);
+    try {
+      return await this.db.execute<DropWithMediaAndPart>(
+        `select d.*, 
     dp.drop_part_id as part_drop_part_id,
     dp.content as part_content,
     dp.quoted_drop_id as part_quoted_drop_id,
-    dm.medias_json as medias_json
+    dm.medias_json as medias_json,
+    w.name as wave_name,
+    COALESCE(i.handle, '') as author
     from ${DROPS_TABLE} d
          left join ${DROPS_PARTS_TABLE} dp on dp.drop_id = d.id and dp.drop_part_id = 1
          LEFT JOIN (
@@ -497,24 +600,19 @@ export class DropsDb extends LazyDbAccessCompatibleService {
                     ) AS medias_json
             FROM    ${DROP_MEDIA_TABLE}
             WHERE   drop_part_id = 1
+              and drop_id in (:dropIds)
             GROUP BY drop_id
         ) dm ON dm.drop_id = d.id
-         join ${WAVES_TABLE} w on d.wave_id = w.id and (${
-           group_ids_user_is_eligible_for.length
-             ? `w.visibility_group_id in (:groupsUserIsEligibleFor) or w.admin_group_id in (:groupsUserIsEligibleFor) or`
-             : ``
-         } w.visibility_group_id is null) ${wave_id ? `and w.id = :wave_id` : ``}
-         where d.serial_no <= :maxSerialNo 
-          order by d.serial_no desc limit :limit`;
-    const params: Record<string, any> = {
-      limit,
-      maxSerialNo: maxSerialNo,
-      groupsUserIsEligibleFor: group_ids_user_is_eligible_for,
-      wave_id
-    };
-    return await this.db.execute<DropWithMediaAndPart>(sql, params, {
-      wrappedConnection: ctx.connection
-    });
+         join ${WAVES_TABLE} w on d.wave_id = w.id
+         join ${IDENTITIES_TABLE} i on i.profile_id = d.author_id
+         where d.id in (:dropIds)
+         order by d.serial_no desc`,
+        { dropIds },
+        { wrappedConnection: ctx.connection }
+      );
+    } finally {
+      ctx.timer?.stop(timerLabel);
+    }
   }
 
   async findLatestDropsSimple(
@@ -2680,11 +2778,18 @@ export interface DropVotersStatsParams {
   readonly sort: DropVotersStatsSort;
 }
 
+export interface LightDropIdRow {
+  readonly id: string;
+  readonly serial_no: number;
+}
+
 export type DropWithMediaAndPart = DropEntity & {
   part_drop_part_id: number | null;
   part_content: string | null;
   part_quoted_drop_id: string | null;
   medias_json: string | null;
+  wave_name: string;
+  author: string;
 };
 
 export interface IdentityNominationDrop {

--- a/src/entities/IDrop.ts
+++ b/src/entities/IDrop.ts
@@ -24,6 +24,7 @@ export enum DropType {
 
 @Entity(DROPS_TABLE)
 @Index('idx_drop_wave_author', ['wave_id', 'author_id'])
+@Index('idx_drop_wave_serial_no', ['wave_id', 'serial_no'])
 @Index('idx_drop_wave_type_author', ['wave_id', 'drop_type', 'author_id'])
 @Index('idx_drop_wave_created_at', ['wave_id', 'created_at'])
 export class DropEntity {
@@ -150,6 +151,7 @@ export class DropMetadataEntity {
 }
 
 @Entity(DROP_MEDIA_TABLE)
+@Index('idx_drop_media_drop_part', ['drop_id', 'drop_part_id'])
 export class DropMediaEntity {
   @PrimaryGeneratedColumn('increment', { type: 'bigint' })
   readonly id!: string;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Light drops API now supports browsing across all visible waves (optional wave filtering).
  * API responses now include wave name, author, and creation timestamp for each light drop.

* **Bug Fixes**
  * Fixed query parameter validation to allow flexible wave selection in the light drops endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->