### PR TITLE
Exclude pure profile groups from groups search

### DIFF
--- a/src/api-serverless/openapi.yaml
+++ b/src/api-serverless/openapi.yaml
@@ -1887,6 +1887,13 @@ paths:
           schema:
             type: number
             format: int64
+        - name: include_profile_groups
+          description: Include pure profile groups in search results
+          in: query
+          required: false
+          schema:
+            type: boolean
+            default: false
       responses:
         "200":
           description: successful operation

--- a/src/api-serverless/src/community-members/user-groups.routes.test.ts
+++ b/src/api-serverless/src/community-members/user-groups.routes.test.ts
@@ -1,0 +1,32 @@
+jest.mock('passport', () => ({
+  authenticate: jest.fn(
+    () => (_req: unknown, _res: unknown, next: () => void) => next()
+  )
+}));
+
+import { getValidatedByJoiOrThrow } from '../validation';
+import {
+  SearchUserGroupsQuery,
+  SearchUserGroupsQuerySchema
+} from './user-groups.routes';
+
+describe('user groups search query validation', () => {
+  it('normalizes blank optional filters to their legacy defaults', () => {
+    const result = getValidatedByJoiOrThrow<SearchUserGroupsQuery>(
+      {
+        group_name: '',
+        author_identity: '',
+        created_at_less_than: '',
+        include_profile_groups: ''
+      } as unknown as SearchUserGroupsQuery,
+      SearchUserGroupsQuerySchema
+    );
+
+    expect(result).toEqual({
+      group_name: null,
+      author_identity: null,
+      created_at_less_than: null,
+      include_profile_groups: false
+    });
+  });
+});

--- a/src/api-serverless/src/community-members/user-groups.routes.ts
+++ b/src/api-serverless/src/community-members/user-groups.routes.ts
@@ -31,40 +31,38 @@ import { Timer } from '../../../time';
 import { RequestContext } from '../../../request.context';
 import { identityFetcher } from '../identities/identity.fetcher';
 import { enums } from '../../../enums';
-import { numbers } from '../../../numbers';
 import { collections } from '../../../collections';
 import { WALLET_REGEX } from '@/constants';
 import { ApiGroupTdhInclusionStrategy } from '../generated/models/ApiGroupTdhInclusionStrategy';
 
 const router = asyncRouter();
 
+interface SearchUserGroupsQuery {
+  group_name: string | null;
+  author_identity: string | null;
+  created_at_less_than: number | null;
+  include_profile_groups: boolean;
+}
+
 router.get(
   '/',
   maybeAuthenticatedUser(),
   async (
-    req: Request<
-      any,
-      any,
-      {
-        group_name: string;
-        author_identity: string;
-        created_at_less_than?: string;
-      },
-      any,
-      any
-    >,
+    req: Request<any, any, any, SearchUserGroupsQuery, any>,
     res: Response<ApiResponse<ApiGroupFull[]>>
   ) => {
     const timer = Timer.getFromRequest(req);
     const authenticationContext = await getAuthenticationContext(req, timer);
-    const groupName = req.query.group_name ?? null;
-    const createdAtLessThan = numbers.parseIntOrNull(
-      req.query.created_at_less_than
+    const query = getValidatedByJoiOrThrow<SearchUserGroupsQuery>(
+      req.query,
+      SearchUserGroupsQuerySchema
     );
+    const groupName = query.group_name;
+    const createdAtLessThan = query.created_at_less_than;
     let authorId: string | null = null;
-    if (req.query.author_identity) {
+    if (query.author_identity) {
       authorId = await identityFetcher.getProfileIdByIdentityKey(
-        { identityKey: req.query.author_identity },
+        { identityKey: query.author_identity },
         {}
       );
       if (!authorId) {
@@ -76,6 +74,7 @@ router.get(
       groupName,
       authorId,
       createdAtLessThan,
+      query.include_profile_groups,
       { authenticationContext, timer }
     );
     res.send(response);
@@ -308,6 +307,14 @@ const NullableStringSchema: Joi.StringSchema = Joi.string()
   .optional()
   .allow(null)
   .default(null);
+
+const SearchUserGroupsQuerySchema: Joi.ObjectSchema<SearchUserGroupsQuery> =
+  Joi.object<SearchUserGroupsQuery>({
+    group_name: NullableStringSchema,
+    author_identity: NullableStringSchema,
+    created_at_less_than: NullableIntegerSchema,
+    include_profile_groups: Joi.boolean().optional().default(false)
+  });
 
 const GroupTdhFilterSchema: Joi.ObjectSchema<ApiGroupTdhFilter> =
   Joi.object<ApiGroupTdhFilter>({

--- a/src/api-serverless/src/community-members/user-groups.routes.ts
+++ b/src/api-serverless/src/community-members/user-groups.routes.ts
@@ -37,7 +37,7 @@ import { ApiGroupTdhInclusionStrategy } from '../generated/models/ApiGroupTdhInc
 
 const router = asyncRouter();
 
-interface SearchUserGroupsQuery {
+export interface SearchUserGroupsQuery {
   group_name: string | null;
   author_identity: string | null;
   created_at_less_than: number | null;
@@ -308,12 +308,25 @@ const NullableStringSchema: Joi.StringSchema = Joi.string()
   .allow(null)
   .default(null);
 
-const SearchUserGroupsQuerySchema: Joi.ObjectSchema<SearchUserGroupsQuery> =
+const SearchNullableStringSchema: Joi.StringSchema = Joi.string()
+  .empty('')
+  .optional()
+  .allow(null)
+  .default(null);
+
+const SearchNullableIntegerSchema: Joi.NumberSchema = Joi.number()
+  .integer()
+  .empty('')
+  .optional()
+  .allow(null)
+  .default(null);
+
+export const SearchUserGroupsQuerySchema: Joi.ObjectSchema<SearchUserGroupsQuery> =
   Joi.object<SearchUserGroupsQuery>({
-    group_name: NullableStringSchema,
-    author_identity: NullableStringSchema,
-    created_at_less_than: NullableIntegerSchema,
-    include_profile_groups: Joi.boolean().optional().default(false)
+    group_name: SearchNullableStringSchema,
+    author_identity: SearchNullableStringSchema,
+    created_at_less_than: SearchNullableIntegerSchema,
+    include_profile_groups: Joi.boolean().empty('').optional().default(false)
   });
 
 const GroupTdhFilterSchema: Joi.ObjectSchema<ApiGroupTdhFilter> =

--- a/src/api-serverless/src/community-members/user-groups.service.ts
+++ b/src/api-serverless/src/community-members/user-groups.service.ts
@@ -74,7 +74,7 @@ import { xTdhGrantApiConverter } from '../xtdh/grants/xtdh-grant.api-converter';
 
 export type NewUserGroupEntity = Omit<
   UserGroupEntity,
-  'id' | 'created_at' | 'created_by'
+  'id' | 'created_at' | 'created_by' | 'is_pure_profile_group'
 >;
 
 type GClean = Omit<
@@ -1245,6 +1245,7 @@ export class UserGroupsService {
     name: string | null,
     authorId: string | null,
     createdAtLessThan: number | null,
+    includeProfileGroups: boolean,
     ctx: RequestContext
   ): Promise<ApiGroupFull[]> {
     ctx.timer?.start('userGroupsService->searchByNameOrAuthor');
@@ -1259,6 +1260,7 @@ export class UserGroupsService {
       name,
       authorId,
       createdAtLessThan,
+      includeProfileGroups,
       authenticatedUserId,
       eligibleGroupIds,
       ctx

--- a/src/entities/IUserGroup.ts
+++ b/src/entities/IUserGroup.ts
@@ -7,6 +7,27 @@ export enum GroupTdhInclusionStrategy {
   BOTH = 'BOTH'
 }
 
+const IS_PURE_PROFILE_GROUP_EXPRESSION = `
+  profile_group_id IS NOT NULL
+  AND excluded_profile_group_id IS NULL
+  AND tdh_min IS NULL
+  AND tdh_max IS NULL
+  AND level_min IS NULL
+  AND level_max IS NULL
+  AND rep_min IS NULL
+  AND rep_max IS NULL
+  AND cic_min IS NULL
+  AND cic_max IS NULL
+  AND cic_user IS NULL
+  AND rep_user IS NULL
+  AND rep_category IS NULL
+  AND is_beneficiary_of_grant_id IS NULL
+  AND COALESCE(owns_meme, 0) = 0
+  AND COALESCE(owns_gradient, 0) = 0
+  AND COALESCE(owns_nextgen, 0) = 0
+  AND COALESCE(owns_lab, 0) = 0
+`;
+
 @Entity(USER_GROUPS_TABLE)
 @Index(['id', 'visible'])
 @Index(['profile_group_id', 'visible', 'id'])
@@ -76,6 +97,15 @@ export class UserGroupEntity {
   readonly profile_group_id!: string | null;
   @Column({ type: 'varchar', length: 50, nullable: true, default: null })
   readonly excluded_profile_group_id!: string | null;
+  @Column({
+    type: 'tinyint',
+    nullable: false,
+    insert: false,
+    update: false,
+    generatedType: 'STORED',
+    asExpression: IS_PURE_PROFILE_GROUP_EXPRESSION
+  })
+  readonly is_pure_profile_group!: boolean;
   @Index('idx_user_group_is_private')
   @Column({ type: 'boolean', nullable: false, default: false })
   readonly is_private!: boolean;

--- a/src/groups/user-group-predicates.test.ts
+++ b/src/groups/user-group-predicates.test.ts
@@ -22,6 +22,7 @@ import {
   isGroupTotalRepByUserOutgoing,
   isGroupTotalRepForCategoryIncoming,
   isGroupTotalRepForCategoryOutgoing,
+  isPureProfileGroup,
   isGroupViolatingAnySpecificCicCriteria,
   isGroupViolatingAnySpecificRepCriteria,
   isProfileHavingContractTokenOwningsMisMatch,
@@ -53,6 +54,15 @@ import {
   MEMES_CONTRACT
 } from '@/constants';
 import { RateMatter } from '../entities/IRating';
+
+function withDerivedFields(
+  group: Omit<UserGroupEntity, 'is_pure_profile_group'>
+): UserGroupEntity {
+  return {
+    ...group,
+    is_pure_profile_group: isPureProfileGroup(group as UserGroupEntity)
+  };
+}
 
 function aProfile({
   tdh,
@@ -130,7 +140,7 @@ function aGroup({
   excluded_profile_group_id?: string | null;
   is_beneficiary_of_grant_id?: string | null;
 }): UserGroupEntity {
-  return {
+  return withDerivedFields({
     id: 'a-group-id',
     name: 'A Group',
     cic_min: cic_min ?? null,
@@ -164,7 +174,7 @@ function aGroup({
     is_private: false,
     is_direct_message: false,
     is_beneficiary_of_grant_id: is_beneficiary_of_grant_id ?? null
-  };
+  });
 }
 
 describe('UserGroupPredicates', () => {
@@ -391,6 +401,40 @@ describe('UserGroupPredicates', () => {
           aGroup({ owns_nextgen: false }),
           aGroup({ owns_nextgen: false })
         ])
+      ).toBe(false);
+    });
+  });
+
+  describe('isPureProfileGroup', () => {
+    it('should return true when profile_group_id is the only meaningful criteria', () => {
+      expect(
+        isPureProfileGroup(aGroup({ profile_group_id: 'a-profile-group-id' }))
+      ).toBe(true);
+    });
+
+    it('should return false when profile_group_id is not set', () => {
+      expect(isPureProfileGroup(aGroup({}))).toBe(false);
+    });
+
+    it('should return false when excluded_profile_group_id is set', () => {
+      expect(
+        isPureProfileGroup(
+          aGroup({
+            profile_group_id: 'a-profile-group-id',
+            excluded_profile_group_id: 'another-profile-group-id'
+          })
+        )
+      ).toBe(false);
+    });
+
+    it('should return false when another meaningful criteria is set', () => {
+      expect(
+        isPureProfileGroup(
+          aGroup({
+            profile_group_id: 'a-profile-group-id',
+            tdh_min: 1
+          })
+        )
       ).toBe(false);
     });
   });

--- a/src/groups/user-group-predicates.ts
+++ b/src/groups/user-group-predicates.ts
@@ -454,6 +454,14 @@ export const hasGroupGotAnyNonIdentityConditions = (
   );
 };
 
+export const isPureProfileGroup = (entity: UserGroupEntity) => {
+  return (
+    entity.profile_group_id !== null &&
+    entity.excluded_profile_group_id === null &&
+    !hasGroupGotAnyNonIdentityConditions(entity)
+  );
+};
+
 export const isProfileViolatingGroupsProfileTdhCriteria = (
   profile: ProfileSimpleMetrics,
   entity: UserGroupEntity

--- a/src/tests/fixtures/user-group.fixture.ts
+++ b/src/tests/fixtures/user-group.fixture.ts
@@ -72,9 +72,12 @@ export function aUserGroup(
 export function withUserGroups(entities: UserGroupEntity[]): Seed {
   return {
     table: USER_GROUPS_TABLE,
-    rows: entities.map(({ is_pure_profile_group, ...entity }) => {
-      void is_pure_profile_group;
-      return entity as PersistedUserGroup;
+    rows: entities.map((entity) => {
+      const persistedEntity = {
+        ...entity
+      } as PersistedUserGroup & { is_pure_profile_group?: boolean };
+      delete persistedEntity.is_pure_profile_group;
+      return persistedEntity;
     })
   };
 }

--- a/src/tests/fixtures/user-group.fixture.ts
+++ b/src/tests/fixtures/user-group.fixture.ts
@@ -2,12 +2,17 @@ import {
   GroupTdhInclusionStrategy,
   UserGroupEntity
 } from '../../entities/IUserGroup';
+import { isPureProfileGroup } from '@/groups/user-group-predicates';
 import { Time } from '../../time';
 import { randomUUID } from 'node:crypto';
 import { Seed } from '../_setup/seed';
 import { USER_GROUPS_TABLE } from '@/constants';
 
-type BaseUserGroup = Omit<UserGroupEntity, 'id' | 'name'>;
+type BaseUserGroup = Omit<
+  UserGroupEntity,
+  'id' | 'name' | 'is_pure_profile_group'
+>;
+type PersistedUserGroup = Omit<UserGroupEntity, 'is_pure_profile_group'>;
 
 const aDefaultUserGroup: BaseUserGroup = {
   cic_min: null,
@@ -53,16 +58,23 @@ export function aUserGroup(
     id: randomUUID(),
     name: randomUUID()
   };
-  return {
+  const entity = {
     ...key,
     ...aDefaultUserGroup,
     ...params
+  };
+  return {
+    ...entity,
+    is_pure_profile_group: isPureProfileGroup(entity as UserGroupEntity)
   };
 }
 
 export function withUserGroups(entities: UserGroupEntity[]): Seed {
   return {
     table: USER_GROUPS_TABLE,
-    rows: entities
+    rows: entities.map(({ is_pure_profile_group, ...entity }) => {
+      void is_pure_profile_group;
+      return entity as PersistedUserGroup;
+    })
   };
 }

--- a/src/tests/user-groups.integration.test.ts
+++ b/src/tests/user-groups.integration.test.ts
@@ -34,6 +34,9 @@ const profileGroupWithTdh11Identity2 = aProfileGroup({
 const minTdh20Group = aUserGroup({ tdh_min: 20 });
 const maxTdh10Group = aUserGroup({ tdh_max: 10 });
 const tdhBetween15And25Group = aUserGroup({ tdh_min: 15, tdh_max: 20 });
+const pureProfileGroup = aUserGroup({
+  profile_group_id: profileGroupWithTdh11Identity1.profile_group_id
+});
 
 const minTdh20AndTdh11Identity1Group = aUserGroup({
   profile_group_id: profileGroupWithTdh11Identity1.profile_group_id,
@@ -71,6 +74,7 @@ describeWithSeed(
       minTdh20Group,
       maxTdh10Group,
       tdhBetween15And25Group,
+      pureProfileGroup,
       minTdh20AndTdh11Identity1Group,
       minTdh10AndTdh11Identity1ExcludedGroup,
       onlyInclusionAndExclusionGroupWhereSameIdentityIsIncludedAndExcluded,
@@ -81,6 +85,7 @@ describeWithSeed(
         minTdh20Group,
         maxTdh10Group,
         tdhBetween15And25Group,
+        pureProfileGroup,
         minTdh20AndTdh11Identity1Group,
         minTdh10AndTdh11Identity1ExcludedGroup,
         onlyInclusionAndExclusionGroupWhereSameIdentityIsIncludedAndExcluded,
@@ -135,6 +140,7 @@ describeWithSeed(
 
       it('tdh11Identity1 gets its groups', async () => {
         await expectIdentityToBeInExactGroups(tdh11Identity1, [
+          pureProfileGroup,
           minTdh20AndTdh11Identity1Group
         ]);
       });
@@ -199,6 +205,12 @@ describeWithSeed(
         ]);
       });
 
+      it('identities of pureProfileGroup ', async () => {
+        await expectGroupToContainExactIdentities(pureProfileGroup, [
+          tdh11Identity1
+        ]);
+      });
+
       it('identities of minTdh20AndTdh11Identity1Group ', async () => {
         await expectGroupToContainExactIdentities(
           minTdh20AndTdh11Identity1Group,
@@ -224,6 +236,33 @@ describeWithSeed(
           minTdh10GroupWhereTdh11Identity1IsIncludedAndExcluded,
           [tdh10Identity, tdh20Identity, tdh11Identity2]
         );
+      });
+    });
+
+    describe('is_pure_profile_group', () => {
+      it('is computed from the stored criteria', async () => {
+        const groups = await new UserGroupsDb(() => sqlExecutor).getByIds(
+          [
+            pureProfileGroup.id,
+            minTdh20AndTdh11Identity1Group.id,
+            onlyInclusionAndExclusionGroupWhereSameIdentityIsIncludedAndExcluded.id
+          ],
+          {}
+        );
+        const pureProfileGroupById = Object.fromEntries(
+          groups.map((group) => [group.id, group.is_pure_profile_group])
+        );
+
+        expect(pureProfileGroupById[pureProfileGroup.id]).toBe(true);
+        expect(pureProfileGroupById[minTdh20AndTdh11Identity1Group.id]).toBe(
+          false
+        );
+        expect(
+          pureProfileGroupById[
+            onlyInclusionAndExclusionGroupWhereSameIdentityIsIncludedAndExcluded
+              .id
+          ]
+        ).toBe(false);
       });
     });
   }

--- a/src/user-groups/user-groups-db.test.ts
+++ b/src/user-groups/user-groups-db.test.ts
@@ -1,0 +1,83 @@
+import 'reflect-metadata';
+import { randomUUID } from 'node:crypto';
+import { UserGroupsDb } from './user-groups.db';
+import { RequestContext } from '@/request.context';
+import { sqlExecutor } from '@/sql-executor';
+import { describeWithSeed } from '@/tests/_setup/seed';
+import {
+  aUserGroup,
+  withUserGroups
+} from '@/tests/fixtures/user-group.fixture';
+
+const pureProfileGroup = aUserGroup(
+  {
+    profile_group_id: randomUUID(),
+    is_direct_message: false
+  },
+  {
+    id: 'pure-profile-group',
+    name: 'Search Group Profile'
+  }
+);
+
+const criteriaGroup = aUserGroup(
+  {
+    tdh_min: 1,
+    is_direct_message: false
+  },
+  {
+    id: 'criteria-group',
+    name: 'Search Group Criteria'
+  }
+);
+
+const unrelatedGroup = aUserGroup(
+  {
+    is_direct_message: false
+  },
+  {
+    id: 'unrelated-group',
+    name: 'Another Group'
+  }
+);
+
+describeWithSeed(
+  'UserGroupsDb searchByNameOrAuthor',
+  withUserGroups([pureProfileGroup, criteriaGroup, unrelatedGroup]),
+  () => {
+    const repo = new UserGroupsDb(() => sqlExecutor);
+    const ctx: RequestContext = { timer: undefined };
+
+    it('excludes pure profile groups when includeProfileGroups is false', async () => {
+      const results = await repo.searchByNameOrAuthor(
+        'Search Group',
+        null,
+        null,
+        false,
+        null,
+        [],
+        ctx
+      );
+
+      expect(results.map((group) => group.id).sort()).toEqual([
+        criteriaGroup.id
+      ]);
+    });
+
+    it('includes pure profile groups when includeProfileGroups is true', async () => {
+      const results = await repo.searchByNameOrAuthor(
+        'Search Group',
+        null,
+        null,
+        true,
+        null,
+        [],
+        ctx
+      );
+
+      expect(results.map((group) => group.id).sort()).toEqual(
+        [criteriaGroup.id, pureProfileGroup.id].sort()
+      );
+    });
+  }
+);

--- a/src/user-groups/user-groups.db.ts
+++ b/src/user-groups/user-groups.db.ts
@@ -31,7 +31,10 @@ import { DbPoolName } from '../db-query.options';
 const mysql = require('mysql');
 
 export class UserGroupsDb extends LazyDbAccessCompatibleService {
-  async save(entity: UserGroupEntity, connection: ConnectionWrapper<any>) {
+  async save(
+    entity: Omit<UserGroupEntity, 'is_pure_profile_group'>,
+    connection: ConnectionWrapper<any>
+  ) {
     await this.db.execute(
       `
           insert into ${USER_GROUPS_TABLE} (id,
@@ -212,6 +215,7 @@ export class UserGroupsDb extends LazyDbAccessCompatibleService {
     name: string | null,
     authorId: string | null,
     created_at_less_than: number | null,
+    includeProfileGroups: boolean,
     authenticatedUserId: string | null,
     eligibleGroupIds: string[],
     ctx: RequestContext
@@ -224,6 +228,9 @@ export class UserGroupsDb extends LazyDbAccessCompatibleService {
       authenticatedUserId,
       eligibleGroupIds
     };
+    if (!includeProfileGroups) {
+      sql += ` and is_pure_profile_group is false `;
+    }
     if (name) {
       sql += ` and name like :name `;
       params.name = `%${name}%`;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional include_profile_groups query parameter to GET /groups and GET /aggregated-activity so searches can optionally include "pure profile" groups (defaults to false, preserving current results).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->