### PR TITLE
Temporary revert to excluding 'only' groups

### DIFF
--- a/src/api-serverless/src/community-members/user-groups.routes.ts
+++ b/src/api-serverless/src/community-members/user-groups.routes.ts
@@ -74,7 +74,7 @@ router.get(
       groupName,
       authorId,
       createdAtLessThan,
-      query.include_profile_groups,
+      true,
       { authenticationContext, timer }
     );
     res.send(response);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * User group search results now consistently include profile groups in all queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->