### PR TITLE
Don't send out subscribed_to_every_drop notifications when wave has more than 15 followers

### DIFF
--- a/src/api-serverless/src/identity-subscriptions/identity-subscriptions.db.ts
+++ b/src/api-serverless/src/identity-subscriptions/identity-subscriptions.db.ts
@@ -268,7 +268,10 @@ export class IdentitySubscriptionsDb extends LazyDbAccessCompatibleService {
       .then((it) => it?.cnt ?? 0);
   }
 
-  async countWaveSubscribers(waveId: string) {
+  async countWaveSubscribers(
+    waveId: string,
+    connection?: ConnectionWrapper<any>
+  ) {
     return this.db
       .oneOrNull<{
         cnt: number;
@@ -282,7 +285,8 @@ export class IdentitySubscriptionsDb extends LazyDbAccessCompatibleService {
           waveId,
           targetType: ActivityEventTargetType.WAVE,
           targetAction: ActivityEventAction.DROP_CREATED
-        }
+        },
+        connection ? { wrappedConnection: connection } : undefined
       )
       .then((it) => it?.cnt ?? 0);
   }

--- a/src/drops/create-or-update-drop-use-case.test.ts
+++ b/src/drops/create-or-update-drop-use-case.test.ts
@@ -12,6 +12,7 @@ import { identitiesDb } from '@/identities/identities.db';
 import { DropType } from '@/entities/IDrop';
 import { DropGroupMention } from '@/entities/IWaveGroupNotificationSubscription';
 import { WaveIdentitySubmissionDuplicates } from '@/entities/IWave';
+import { env } from '@/env';
 import { profilesService } from '@/profiles/profiles.service';
 import { CreateOrUpdateDropUseCase } from './create-or-update-drop.use-case';
 
@@ -50,6 +51,8 @@ describe('CreateOrUpdateDropUseCase', () => {
     overrides: {
       dropsDb?: any;
       wavesApiDb?: any;
+      userNotifier?: any;
+      identitySubscriptionsDb?: any;
       deleteDropUseCase?: any;
       artCurationTokenWatchService?: any;
     } = {}
@@ -59,9 +62,9 @@ describe('CreateOrUpdateDropUseCase', () => {
       {} as any,
       {} as any,
       overrides.wavesApiDb ?? ({} as any),
+      overrides.userNotifier ?? ({} as any),
       {} as any,
-      {} as any,
-      {} as any,
+      overrides.identitySubscriptionsDb ?? ({} as any),
       {} as any,
       overrides.deleteDropUseCase ?? ({} as any),
       {} as any,
@@ -284,5 +287,137 @@ describe('CreateOrUpdateDropUseCase', () => {
         groupIdsUserIsEligibleFor: ['admins']
       })
     ).toThrow(`Group mentions can only be used when creating a drop`);
+  });
+
+  it('skips all-drops notifications once the wave reaches the subscriber cap', async () => {
+    jest.spyOn(env, 'getIntOrNull').mockReturnValue(15);
+    const identitySubscriptionsDb = {
+      findWaveFollowersEligibleForDropNotifications: jest
+        .fn()
+        .mockResolvedValue([
+          {
+            identity_id: 'all-drops-1',
+            subscribed_to_all_drops: true,
+            has_group_mention: false
+          },
+          {
+            identity_id: 'group-mention-1',
+            subscribed_to_all_drops: false,
+            has_group_mention: true
+          },
+          {
+            identity_id: 'both-1',
+            subscribed_to_all_drops: true,
+            has_group_mention: true
+          }
+        ]),
+      countWaveSubscribers: jest.fn().mockResolvedValue(15),
+      findMutedWaveReaders: jest.fn().mockResolvedValue(['direct-muted'])
+    };
+    const userNotifier = {
+      notifyWaveDropCreatedRecipients: jest.fn().mockResolvedValue([101])
+    };
+    const useCase = createUseCaseWithMocks({
+      identitySubscriptionsDb,
+      userNotifier
+    });
+
+    await expect(
+      (useCase as any).notifyWaveDropRecipients(
+        {
+          model: {
+            drop_id: 'drop-1',
+            author_id: 'author-1',
+            mentioned_groups: [DropGroupMention.ALL]
+          },
+          wave: {
+            id: 'wave-1',
+            visibility_group_id: null
+          },
+          directlyMentionedIdentityIds: ['direct-1', 'direct-muted']
+        },
+        { connection: {} }
+      )
+    ).resolves.toEqual([101]);
+
+    expect(identitySubscriptionsDb.countWaveSubscribers).toHaveBeenCalledWith(
+      'wave-1',
+      {}
+    );
+    expect(userNotifier.notifyWaveDropCreatedRecipients).toHaveBeenCalledWith(
+      {
+        waveId: 'wave-1',
+        dropId: 'drop-1',
+        relatedIdentityId: 'author-1',
+        mentionedIdentityIds: ['direct-1', 'group-mention-1', 'both-1'],
+        allDropsSubscriberIds: []
+      },
+      null,
+      { timer: undefined, connection: {} }
+    );
+  });
+
+  it('keeps all-drops notifications below the subscriber cap while deduplicating @all mentions', async () => {
+    jest.spyOn(env, 'getIntOrNull').mockReturnValue(15);
+    const identitySubscriptionsDb = {
+      findWaveFollowersEligibleForDropNotifications: jest
+        .fn()
+        .mockResolvedValue([
+          {
+            identity_id: 'all-drops-1',
+            subscribed_to_all_drops: true,
+            has_group_mention: false
+          },
+          {
+            identity_id: 'group-mention-1',
+            subscribed_to_all_drops: false,
+            has_group_mention: true
+          },
+          {
+            identity_id: 'both-1',
+            subscribed_to_all_drops: true,
+            has_group_mention: true
+          }
+        ]),
+      countWaveSubscribers: jest.fn().mockResolvedValue(14),
+      findMutedWaveReaders: jest.fn().mockResolvedValue([])
+    };
+    const userNotifier = {
+      notifyWaveDropCreatedRecipients: jest.fn().mockResolvedValue([102])
+    };
+    const useCase = createUseCaseWithMocks({
+      identitySubscriptionsDb,
+      userNotifier
+    });
+
+    await expect(
+      (useCase as any).notifyWaveDropRecipients(
+        {
+          model: {
+            drop_id: 'drop-1',
+            author_id: 'author-1',
+            mentioned_groups: [DropGroupMention.ALL]
+          },
+          wave: {
+            id: 'wave-1',
+            visibility_group_id: null
+          },
+          directlyMentionedIdentityIds: ['direct-1']
+        },
+        { connection: {} }
+      )
+    ).resolves.toEqual([102]);
+
+    expect(userNotifier.notifyWaveDropCreatedRecipients).toHaveBeenCalledWith(
+      {
+        waveId: 'wave-1',
+        dropId: 'drop-1',
+        relatedIdentityId: 'author-1',
+        mentionedIdentityIds: ['direct-1', 'group-mention-1', 'both-1'],
+        allDropsSubscriberIds: ['all-drops-1']
+      },
+      null,
+      { timer: undefined, connection: {} }
+    );
   });
 });

--- a/src/drops/create-or-update-drop.use-case.ts
+++ b/src/drops/create-or-update-drop.use-case.ts
@@ -126,6 +126,10 @@ export class CreateOrUpdateDropUseCase {
     return dropId;
   }
 
+  private getAllDropsNotificationsSubscribersLimit(): number {
+    return env.getIntOrNull('ALL_DROPS_NOTIFICATIONS_SUBSCRIBERS_LIMIT') ?? 15;
+  }
+
   public async execute(
     model: CreateOrUpdateDropModel,
     isDescriptionDrop: boolean,
@@ -1451,15 +1455,17 @@ export class CreateOrUpdateDropUseCase {
     timer?.start(`${CreateOrUpdateDropUseCase.name}->notifyWaveDropRecipients`);
     const dropId = this.getRequiredDropId(model);
     const authorId = this.getRequiredAuthorId(model);
-    const followerRecipients =
-      await this.identitySubscriptionsDb.findWaveFollowersEligibleForDropNotifications(
+    const [followerRecipients, waveSubscribersCount] = await Promise.all([
+      this.identitySubscriptionsDb.findWaveFollowersEligibleForDropNotifications(
         {
           waveId: wave.id,
           authorId,
           mentionedGroups: model.mentioned_groups
         },
         connection
-      );
+      ),
+      this.identitySubscriptionsDb.countWaveSubscribers(wave.id, connection)
+    ]);
     const mutedDirectMentionedIdentityIds = new Set(
       await this.identitySubscriptionsDb.findMutedWaveReaders(
         wave.id,
@@ -1481,13 +1487,16 @@ export class CreateOrUpdateDropUseCase {
         .map((recipient) => recipient.identity_id)
     ]);
     const mentionedIdentityIdsSet = new Set(mentionedIdentityIds);
-    const allDropsSubscriberIds = followerRecipients
-      .filter(
-        (recipient) =>
-          recipient.subscribed_to_all_drops &&
-          !mentionedIdentityIdsSet.has(recipient.identity_id)
-      )
-      .map((recipient) => recipient.identity_id);
+    const allDropsSubscriberIds =
+      waveSubscribersCount < this.getAllDropsNotificationsSubscribersLimit()
+        ? followerRecipients
+            .filter(
+              (recipient) =>
+                recipient.subscribed_to_all_drops &&
+                !mentionedIdentityIdsSet.has(recipient.identity_id)
+            )
+            .map((recipient) => recipient.identity_id)
+        : [];
 
     const pendingPushNotificationIds =
       await this.userNotifier.notifyWaveDropCreatedRecipients(


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Drop notifications now enforce a subscriber limit cap for "@all drops" recipients, controlling the scale of notification distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->