### PR TITLE
Curations priority order

### DIFF
--- a/migrations/20260413110000-backfill-wave-curation-priority-order.js
+++ b/migrations/20260413110000-backfill-wave-curation-priority-order.js
@@ -1,0 +1,39 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(
+    __dirname,
+    'sqls',
+    '20260413110000-backfill-wave-curation-priority-order-up.sql'
+  );
+  return new Promise(function(resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function(err, data) {
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  }).then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {};
+
+exports._meta = {
+  version: 1
+};

--- a/migrations/sqls/20260413110000-backfill-wave-curation-priority-order-up.sql
+++ b/migrations/sqls/20260413110000-backfill-wave-curation-priority-order-up.sql
@@ -1,0 +1,11 @@
+UPDATE wave_curation_groups wc
+JOIN (
+  SELECT
+    id,
+    ROW_NUMBER() OVER (
+      PARTITION BY wave_id
+      ORDER BY created_at ASC, id ASC
+    ) AS priority_order
+  FROM wave_curation_groups
+) ranked ON ranked.id = wc.id
+SET wc.priority_order = ranked.priority_order;

--- a/src/api-serverless/openapi.yaml
+++ b/src/api-serverless/openapi.yaml
@@ -971,7 +971,9 @@ paths:
         - name: older_first
           in: query
           required: false
-          description: By default this endpoint orders things newer first, but if you set it to true then it starts from older drops.
+          description: >-
+            By default this endpoint orders things newer first, but if you set
+            it to true then it starts from older drops.
           schema:
             type: boolean
         - name: wave_id
@@ -11549,6 +11551,7 @@ components:
         - group_id
         - created_at
         - updated_at
+        - priority_order
       properties:
         id:
           type: string
@@ -11564,6 +11567,10 @@ components:
         updated_at:
           type: number
           format: int64
+        priority_order:
+          type: integer
+          format: int32
+          minimum: 1
     ApiWaveCurationRequest:
       type: object
       required:
@@ -11576,6 +11583,10 @@ components:
           maxLength: 50
         group_id:
           type: string
+        priority_order:
+          type: integer
+          format: int32
+          minimum: 1
     ApiWaveDecision:
       type: object
       required:

--- a/src/api-serverless/src/curations/curations-api-service.test.ts
+++ b/src/api-serverless/src/curations/curations-api-service.test.ts
@@ -27,7 +27,8 @@ describe('CurationsApiService', () => {
         community_group_id: 'community-group-1',
         name: 'Featured',
         created_at: 1,
-        updated_at: 1
+        updated_at: 1,
+        priority_order: 1
       }
     ]
   }: {
@@ -39,6 +40,21 @@ describe('CurationsApiService', () => {
     waveCurations?: Record<string, unknown>[];
   } = {}) {
     const connection = { id: 'tx' } as any;
+    const storedWaveCurations = waveCurations.map((curation) => ({
+      ...curation
+    }));
+    const getSortedWaveCurations = () =>
+      [...storedWaveCurations].sort((a, b) => {
+        const aPriority =
+          (a.priority_order as number | null) ?? Number.MAX_SAFE_INTEGER;
+        const bPriority =
+          (b.priority_order as number | null) ?? Number.MAX_SAFE_INTEGER;
+        return (
+          aPriority - bPriority ||
+          (a.created_at as number) - (b.created_at as number) ||
+          String(a.id).localeCompare(String(b.id))
+        );
+      });
     const curationsDb = {
       executeNativeQueriesInTransaction: jest.fn(async (fn) => fn(connection)),
       findCommunityGroupById: jest
@@ -46,17 +62,81 @@ describe('CurationsApiService', () => {
         .mockResolvedValue({ id: 'community-group-1', is_private: false }),
       findWaveCurationById: jest
         .fn()
-        .mockResolvedValue(waveCurations[0] ?? null),
+        .mockImplementation(
+          async ({ id }) =>
+            storedWaveCurations.find((curation) => curation.id === id) ?? null
+        ),
       findWaveCurationByName: jest.fn().mockResolvedValue(null),
-      insertWaveCuration: jest.fn().mockResolvedValue(undefined),
-      findWaveCurationsByWaveId: jest.fn().mockResolvedValue(waveCurations),
+      insertWaveCuration: jest.fn().mockImplementation(async (entity) => {
+        storedWaveCurations.push({ ...entity });
+      }),
+      updateWaveCuration: jest.fn().mockImplementation(async (param) => {
+        const target = storedWaveCurations.find(
+          (curation) => curation.id === param.id
+        );
+        if (target) {
+          Object.assign(target, {
+            name: param.name,
+            community_group_id: param.community_group_id,
+            updated_at: param.updated_at,
+            priority_order: param.priority_order
+          });
+        }
+      }),
+      lockWaveCurationsByWaveId: jest
+        .fn()
+        .mockImplementation(async () => getSortedWaveCurations()),
+      incrementWaveCurationPriorityOrderRange: jest
+        .fn()
+        .mockImplementation(
+          async ({ from_priority_order, to_priority_order }) => {
+            for (const curation of storedWaveCurations) {
+              const priorityOrder = curation.priority_order as number | null;
+              if (
+                priorityOrder !== null &&
+                priorityOrder >= from_priority_order &&
+                (to_priority_order === undefined ||
+                  priorityOrder <= to_priority_order)
+              ) {
+                curation.priority_order = priorityOrder + 1;
+              }
+            }
+          }
+        ),
+      decrementWaveCurationPriorityOrderRange: jest
+        .fn()
+        .mockImplementation(
+          async ({ from_priority_order, to_priority_order }) => {
+            for (const curation of storedWaveCurations) {
+              const priorityOrder = curation.priority_order as number | null;
+              if (
+                priorityOrder !== null &&
+                priorityOrder >= from_priority_order &&
+                (to_priority_order === undefined ||
+                  priorityOrder <= to_priority_order)
+              ) {
+                curation.priority_order = priorityOrder - 1;
+              }
+            }
+          }
+        ),
+      findWaveCurationsByWaveId: jest
+        .fn()
+        .mockImplementation(async () => getSortedWaveCurations()),
       findCurationIdsForDropId: jest
         .fn()
         .mockResolvedValue(new Set(curatedCurationIds)),
       upsertDropCuration: jest.fn().mockResolvedValue(undefined),
       deleteDropCuration: jest.fn().mockResolvedValue(undefined),
       deleteDropCurationsByCurationId: jest.fn().mockResolvedValue(undefined),
-      deleteWaveCuration: jest.fn().mockResolvedValue(undefined)
+      deleteWaveCuration: jest.fn().mockImplementation(async ({ id }) => {
+        const targetIndex = storedWaveCurations.findIndex(
+          (curation) => curation.id === id
+        );
+        if (targetIndex !== -1) {
+          storedWaveCurations.splice(targetIndex, 1);
+        }
+      })
     };
     const wavesApiDb = {
       findWaveById: jest.fn().mockResolvedValue(wave)
@@ -76,6 +156,7 @@ describe('CurationsApiService', () => {
         userGroupsService as any
       ),
       curationsDb,
+      storedWaveCurations,
       ctx: {
         authenticationContext,
         timer: undefined
@@ -83,7 +164,65 @@ describe('CurationsApiService', () => {
     };
   }
 
-  it('creates curations for chat waves', async () => {
+  it('creates curations for chat waves at max+1 when priority_order is omitted', async () => {
+    const { service, curationsDb, ctx } = createService({
+      waveCurations: [
+        {
+          id: 'curation-1',
+          wave_id: 'wave-1',
+          community_group_id: 'community-group-1',
+          name: 'Featured',
+          created_at: 1,
+          updated_at: 1,
+          priority_order: 1
+        },
+        {
+          id: 'curation-2',
+          wave_id: 'wave-1',
+          community_group_id: 'community-group-1',
+          name: 'Team Picks',
+          created_at: 2,
+          updated_at: 2,
+          priority_order: 2
+        }
+      ]
+    });
+
+    await expect(
+      service.createWaveCuration(
+        'wave-1',
+        {
+          name: '  Editor Picks  ',
+          group_id: 'community-group-1'
+        } as any,
+        ctx
+      )
+    ).resolves.toEqual(
+      expect.objectContaining({
+        name: 'Editor Picks',
+        wave_id: 'wave-1',
+        group_id: 'community-group-1',
+        priority_order: 3
+      })
+    );
+
+    expect(
+      curationsDb.incrementWaveCurationPriorityOrderRange
+    ).not.toHaveBeenCalled();
+    expect(curationsDb.insertWaveCuration).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Editor Picks',
+        wave_id: 'wave-1',
+        community_group_id: 'community-group-1',
+        priority_order: 3
+      }),
+      expect.objectContaining({
+        connection: expect.anything()
+      })
+    );
+  });
+
+  it('creates curations at an explicit priority and shifts later curations', async () => {
     const { service, curationsDb, ctx } = createService();
 
     await expect(
@@ -91,7 +230,8 @@ describe('CurationsApiService', () => {
         'wave-1',
         {
           name: '  Featured  ',
-          group_id: 'community-group-1'
+          group_id: 'community-group-1',
+          priority_order: 1
         } as any,
         ctx
       )
@@ -99,15 +239,28 @@ describe('CurationsApiService', () => {
       expect.objectContaining({
         name: 'Featured',
         wave_id: 'wave-1',
-        group_id: 'community-group-1'
+        group_id: 'community-group-1',
+        priority_order: 1
       })
     );
 
+    expect(
+      curationsDb.incrementWaveCurationPriorityOrderRange
+    ).toHaveBeenCalledWith(
+      {
+        wave_id: 'wave-1',
+        from_priority_order: 1
+      },
+      expect.objectContaining({
+        connection: expect.anything()
+      })
+    );
     expect(curationsDb.insertWaveCuration).toHaveBeenCalledWith(
       expect.objectContaining({
         name: 'Featured',
         wave_id: 'wave-1',
-        community_group_id: 'community-group-1'
+        community_group_id: 'community-group-1',
+        priority_order: 1
       }),
       expect.objectContaining({
         connection: expect.anything()
@@ -184,7 +337,8 @@ describe('CurationsApiService', () => {
           community_group_id: 'community-group-1',
           name: 'Featured',
           created_at: 1,
-          updated_at: 1
+          updated_at: 1,
+          priority_order: 2
         },
         {
           id: 'curation-2',
@@ -192,25 +346,64 @@ describe('CurationsApiService', () => {
           community_group_id: 'community-group-2',
           name: 'Team Picks',
           created_at: 2,
-          updated_at: 2
+          updated_at: 2,
+          priority_order: 1
         }
       ]
     });
 
     await expect(service.findDropCurations('drop-1', ctx)).resolves.toEqual([
       expect.objectContaining({
-        id: 'curation-1',
-        wave_id: 'wave-1',
-        group_id: 'community-group-1',
-        drop_included: true,
-        authenticated_user_can_curate: false
-      }),
-      expect.objectContaining({
         id: 'curation-2',
         wave_id: 'wave-1',
         group_id: 'community-group-2',
+        priority_order: 1,
         drop_included: false,
         authenticated_user_can_curate: true
+      }),
+      expect.objectContaining({
+        id: 'curation-1',
+        wave_id: 'wave-1',
+        group_id: 'community-group-1',
+        priority_order: 2,
+        drop_included: true,
+        authenticated_user_can_curate: false
+      })
+    ]);
+  });
+
+  it('returns wave curations ordered by priority_order', async () => {
+    const { service, ctx } = createService({
+      waveCurations: [
+        {
+          id: 'curation-1',
+          wave_id: 'wave-1',
+          community_group_id: 'community-group-1',
+          name: 'Featured',
+          created_at: 1,
+          updated_at: 1,
+          priority_order: 2
+        },
+        {
+          id: 'curation-2',
+          wave_id: 'wave-1',
+          community_group_id: 'community-group-1',
+          name: 'Team Picks',
+          created_at: 2,
+          updated_at: 2,
+          priority_order: 1
+        }
+      ]
+    });
+
+    await expect(service.findWaveCurations('wave-1', ctx)).resolves.toEqual([
+      expect.objectContaining({
+        id: 'curation-2',
+        priority_order: 1
+      }),
+      expect.objectContaining({
+        id: 'curation-1',
+        priority_order: 2
       })
     ]);
   });
@@ -255,7 +448,28 @@ describe('CurationsApiService', () => {
   });
 
   it('deletes persisted memberships when a curation is deleted', async () => {
-    const { service, curationsDb, ctx } = createService();
+    const { service, curationsDb, storedWaveCurations, ctx } = createService({
+      waveCurations: [
+        {
+          id: 'curation-1',
+          wave_id: 'wave-1',
+          community_group_id: 'community-group-1',
+          name: 'Featured',
+          created_at: 1,
+          updated_at: 1,
+          priority_order: 1
+        },
+        {
+          id: 'curation-2',
+          wave_id: 'wave-1',
+          community_group_id: 'community-group-1',
+          name: 'Team Picks',
+          created_at: 2,
+          updated_at: 2,
+          priority_order: 2
+        }
+      ]
+    });
 
     await expect(
       service.deleteWaveCuration('wave-1', 'curation-1', ctx)
@@ -263,6 +477,17 @@ describe('CurationsApiService', () => {
 
     expect(curationsDb.deleteDropCurationsByCurationId).toHaveBeenCalledWith(
       'curation-1',
+      expect.objectContaining({
+        connection: expect.anything()
+      })
+    );
+    expect(
+      curationsDb.decrementWaveCurationPriorityOrderRange
+    ).toHaveBeenCalledWith(
+      {
+        wave_id: 'wave-1',
+        from_priority_order: 2
+      },
       expect.objectContaining({
         connection: expect.anything()
       })
@@ -276,5 +501,249 @@ describe('CurationsApiService', () => {
         connection: expect.anything()
       })
     );
+    expect(storedWaveCurations).toEqual([
+      expect.objectContaining({
+        id: 'curation-2',
+        priority_order: 1
+      })
+    ]);
+  });
+
+  it('keeps the current priority_order on update when not provided', async () => {
+    const { service, curationsDb, ctx } = createService();
+
+    await service.updateWaveCuration(
+      'wave-1',
+      'curation-1',
+      {
+        name: 'Updated',
+        group_id: 'community-group-1'
+      } as any,
+      ctx
+    );
+
+    expect(
+      curationsDb.incrementWaveCurationPriorityOrderRange
+    ).not.toHaveBeenCalled();
+    expect(
+      curationsDb.decrementWaveCurationPriorityOrderRange
+    ).not.toHaveBeenCalled();
+    expect(curationsDb.updateWaveCuration).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'curation-1',
+        priority_order: 1
+      }),
+      expect.objectContaining({
+        connection: expect.anything()
+      })
+    );
+  });
+
+  it('moves a curation earlier on update and shifts the displaced range', async () => {
+    const { service, curationsDb, storedWaveCurations, ctx } = createService({
+      waveCurations: [
+        {
+          id: 'curation-1',
+          wave_id: 'wave-1',
+          community_group_id: 'community-group-1',
+          name: 'A',
+          created_at: 1,
+          updated_at: 1,
+          priority_order: 1
+        },
+        {
+          id: 'curation-2',
+          wave_id: 'wave-1',
+          community_group_id: 'community-group-1',
+          name: 'B',
+          created_at: 2,
+          updated_at: 2,
+          priority_order: 2
+        },
+        {
+          id: 'curation-3',
+          wave_id: 'wave-1',
+          community_group_id: 'community-group-1',
+          name: 'C',
+          created_at: 3,
+          updated_at: 3,
+          priority_order: 3
+        }
+      ]
+    });
+
+    await service.updateWaveCuration(
+      'wave-1',
+      'curation-3',
+      {
+        name: 'C',
+        group_id: 'community-group-1',
+        priority_order: 1
+      } as any,
+      ctx
+    );
+
+    expect(
+      curationsDb.incrementWaveCurationPriorityOrderRange
+    ).toHaveBeenCalledWith(
+      {
+        wave_id: 'wave-1',
+        from_priority_order: 1,
+        to_priority_order: 2
+      },
+      expect.objectContaining({
+        connection: expect.anything()
+      })
+    );
+    expect(storedWaveCurations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'curation-1', priority_order: 2 }),
+        expect.objectContaining({ id: 'curation-2', priority_order: 3 }),
+        expect.objectContaining({ id: 'curation-3', priority_order: 1 })
+      ])
+    );
+  });
+
+  it('moves a curation later on update and shifts the displaced range', async () => {
+    const { service, curationsDb, storedWaveCurations, ctx } = createService({
+      waveCurations: [
+        {
+          id: 'curation-1',
+          wave_id: 'wave-1',
+          community_group_id: 'community-group-1',
+          name: 'A',
+          created_at: 1,
+          updated_at: 1,
+          priority_order: 1
+        },
+        {
+          id: 'curation-2',
+          wave_id: 'wave-1',
+          community_group_id: 'community-group-1',
+          name: 'B',
+          created_at: 2,
+          updated_at: 2,
+          priority_order: 2
+        },
+        {
+          id: 'curation-3',
+          wave_id: 'wave-1',
+          community_group_id: 'community-group-1',
+          name: 'C',
+          created_at: 3,
+          updated_at: 3,
+          priority_order: 3
+        }
+      ]
+    });
+
+    await service.updateWaveCuration(
+      'wave-1',
+      'curation-1',
+      {
+        name: 'A',
+        group_id: 'community-group-1',
+        priority_order: 3
+      } as any,
+      ctx
+    );
+
+    expect(
+      curationsDb.decrementWaveCurationPriorityOrderRange
+    ).toHaveBeenCalledWith(
+      {
+        wave_id: 'wave-1',
+        from_priority_order: 2,
+        to_priority_order: 3
+      },
+      expect.objectContaining({
+        connection: expect.anything()
+      })
+    );
+    expect(storedWaveCurations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'curation-1', priority_order: 3 }),
+        expect.objectContaining({ id: 'curation-2', priority_order: 1 }),
+        expect.objectContaining({ id: 'curation-3', priority_order: 2 })
+      ])
+    );
+  });
+
+  it('allows count+1 on update as an alias for move to end', async () => {
+    const { service, curationsDb, storedWaveCurations, ctx } = createService({
+      waveCurations: [
+        {
+          id: 'curation-1',
+          wave_id: 'wave-1',
+          community_group_id: 'community-group-1',
+          name: 'A',
+          created_at: 1,
+          updated_at: 1,
+          priority_order: 1
+        },
+        {
+          id: 'curation-2',
+          wave_id: 'wave-1',
+          community_group_id: 'community-group-1',
+          name: 'B',
+          created_at: 2,
+          updated_at: 2,
+          priority_order: 2
+        },
+        {
+          id: 'curation-3',
+          wave_id: 'wave-1',
+          community_group_id: 'community-group-1',
+          name: 'C',
+          created_at: 3,
+          updated_at: 3,
+          priority_order: 3
+        }
+      ]
+    });
+
+    await service.updateWaveCuration(
+      'wave-1',
+      'curation-1',
+      {
+        name: 'A',
+        group_id: 'community-group-1',
+        priority_order: 4
+      } as any,
+      ctx
+    );
+
+    expect(curationsDb.updateWaveCuration).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'curation-1',
+        priority_order: 3
+      }),
+      expect.objectContaining({
+        connection: expect.anything()
+      })
+    );
+    expect(storedWaveCurations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'curation-1', priority_order: 3 }),
+        expect.objectContaining({ id: 'curation-2', priority_order: 1 }),
+        expect.objectContaining({ id: 'curation-3', priority_order: 2 })
+      ])
+    );
+  });
+
+  it('rejects out of range priority_order values', async () => {
+    const { service, ctx } = createService();
+
+    await expect(
+      service.createWaveCuration(
+        'wave-1',
+        {
+          name: 'Featured',
+          group_id: 'community-group-1',
+          priority_order: 3
+        } as any,
+        ctx
+      )
+    ).rejects.toThrow(`Curation priority_order must be between 1 and 2`);
   });
 });

--- a/src/api-serverless/src/curations/curations.api.service.ts
+++ b/src/api-serverless/src/curations/curations.api.service.ts
@@ -49,9 +49,7 @@ export class CurationsApiService {
     );
     return await this.curationsDb
       .findWaveCurationsByWaveId(waveId, ctx.connection)
-      .then((entities) =>
-        entities.map((entity) => this.waveCurationToApi(entity))
-      );
+      .then((entities) => this.waveCurationsToApi(entities));
   }
 
   public async createWaveCuration(
@@ -72,6 +70,21 @@ export class CurationsApiService {
           },
           txCtx
         );
+        const lockedCurations =
+          await this.curationsDb.lockWaveCurationsByWaveId(wave.id, txCtx);
+        const priorityOrder = this.resolveRequestedPriorityOrderOrThrow({
+          requestedPriorityOrder: request.priority_order,
+          maxPriorityOrder: lockedCurations.length + 1
+        });
+        if (priorityOrder <= lockedCurations.length) {
+          await this.curationsDb.incrementWaveCurationPriorityOrderRange(
+            {
+              wave_id: wave.id,
+              from_priority_order: priorityOrder
+            },
+            txCtx
+          );
+        }
         const now = Time.currentMillis();
         const entity: WaveCurationEntity = {
           id: randomUUID(),
@@ -79,7 +92,8 @@ export class CurationsApiService {
           wave_id: wave.id,
           community_group_id: request.group_id,
           created_at: now,
-          updated_at: now
+          updated_at: now,
+          priority_order: priorityOrder
         };
         await this.curationsDb.insertWaveCuration(entity, txCtx);
         return this.waveCurationToApi(entity);
@@ -97,13 +111,18 @@ export class CurationsApiService {
       async (connection) => {
         const txCtx: RequestContext = { ...ctx, connection };
         const { wave } = await this.assertCanManageWaveCurations(waveId, txCtx);
-        const targetCuration = await this.curationsDb.findWaveCurationById(
-          { id: curationId, wave_id: wave.id },
-          connection
+        const lockedCurations =
+          await this.curationsDb.lockWaveCurationsByWaveId(wave.id, txCtx);
+        const targetCuration = lockedCurations.find(
+          (curation) => curation.id === curationId
         );
         if (!targetCuration) {
           throw new NotFoundException(`Curation ${curationId} not found`);
         }
+        const currentPriorityOrder = this.resolveCurrentPriorityOrder(
+          targetCuration,
+          lockedCurations
+        );
         const validatedName = this.validateNameOrThrow(request.name);
         await this.assertCommunityGroupCanBeUsed(request.group_id, txCtx);
         await this.assertCurationNameIsUniqueInWave(
@@ -114,13 +133,44 @@ export class CurationsApiService {
           },
           txCtx
         );
+        const requestedPriorityOrder = request.priority_order;
+        if (requestedPriorityOrder !== undefined) {
+          this.assertPriorityOrderWithinBoundariesOrThrow({
+            priorityOrder: requestedPriorityOrder,
+            maxPriorityOrder: lockedCurations.length + 1
+          });
+        }
+        const nextPriorityOrder =
+          requestedPriorityOrder === undefined
+            ? currentPriorityOrder
+            : Math.min(requestedPriorityOrder, lockedCurations.length);
+        if (nextPriorityOrder < currentPriorityOrder) {
+          await this.curationsDb.incrementWaveCurationPriorityOrderRange(
+            {
+              wave_id: wave.id,
+              from_priority_order: nextPriorityOrder,
+              to_priority_order: currentPriorityOrder - 1
+            },
+            txCtx
+          );
+        } else if (nextPriorityOrder > currentPriorityOrder) {
+          await this.curationsDb.decrementWaveCurationPriorityOrderRange(
+            {
+              wave_id: wave.id,
+              from_priority_order: currentPriorityOrder + 1,
+              to_priority_order: nextPriorityOrder
+            },
+            txCtx
+          );
+        }
         await this.curationsDb.updateWaveCuration(
           {
             id: curationId,
             wave_id: wave.id,
             name: validatedName,
             community_group_id: request.group_id,
-            updated_at: Time.currentMillis()
+            updated_at: Time.currentMillis(),
+            priority_order: nextPriorityOrder
           },
           txCtx
         );
@@ -145,13 +195,18 @@ export class CurationsApiService {
       async (connection) => {
         const txCtx: RequestContext = { ...ctx, connection };
         const { wave } = await this.assertCanManageWaveCurations(waveId, txCtx);
-        const targetCuration = await this.curationsDb.findWaveCurationById(
-          { id: curationId, wave_id: wave.id },
-          connection
+        const lockedCurations =
+          await this.curationsDb.lockWaveCurationsByWaveId(wave.id, txCtx);
+        const targetCuration = lockedCurations.find(
+          (curation) => curation.id === curationId
         );
         if (!targetCuration) {
           throw new NotFoundException(`Curation ${curationId} not found`);
         }
+        const currentPriorityOrder = this.resolveCurrentPriorityOrder(
+          targetCuration,
+          lockedCurations
+        );
         await this.curationsDb.deleteDropCurationsByCurationId(
           curationId,
           txCtx
@@ -160,6 +215,15 @@ export class CurationsApiService {
           { id: curationId, wave_id: wave.id },
           txCtx
         );
+        if (currentPriorityOrder < lockedCurations.length) {
+          await this.curationsDb.decrementWaveCurationPriorityOrderRange(
+            {
+              wave_id: wave.id,
+              from_priority_order: currentPriorityOrder + 1
+            },
+            txCtx
+          );
+        }
       }
     );
   }
@@ -233,12 +297,13 @@ export class CurationsApiService {
         this.curationsDb.findCurationIdsForDropId(drop.id, ctx.connection),
         this.getEligibleGroupIdsForAuthenticatedCurator(ctx)
       ]);
-    return waveCurations.map((entity) =>
+    return waveCurations.map((entity, index) =>
       this.dropCurationToApi(entity, {
         dropIncluded: dropCurationIds.has(entity.id),
         authenticatedUserCanCurate: curatorEligibleGroupIds.includes(
           entity.community_group_id
-        )
+        ),
+        fallbackPriorityOrder: index + 1
       })
     );
   }
@@ -394,14 +459,70 @@ export class CurationsApiService {
     }
   }
 
-  private waveCurationToApi(entity: WaveCurationEntity): ApiWaveCuration {
+  private resolveRequestedPriorityOrderOrThrow(param: {
+    requestedPriorityOrder: number | undefined;
+    maxPriorityOrder: number;
+  }): number {
+    const priorityOrder =
+      param.requestedPriorityOrder ?? param.maxPriorityOrder;
+    this.assertPriorityOrderWithinBoundariesOrThrow({
+      priorityOrder,
+      maxPriorityOrder: param.maxPriorityOrder
+    });
+    return priorityOrder;
+  }
+
+  private assertPriorityOrderWithinBoundariesOrThrow(param: {
+    priorityOrder: number;
+    maxPriorityOrder: number;
+  }): void {
+    if (
+      !Number.isInteger(param.priorityOrder) ||
+      param.priorityOrder < 1 ||
+      param.priorityOrder > param.maxPriorityOrder
+    ) {
+      throw new BadRequestException(
+        `Curation priority_order must be between 1 and ${param.maxPriorityOrder}`
+      );
+    }
+  }
+
+  private resolveCurrentPriorityOrder(
+    targetCuration: WaveCurationEntity,
+    orderedCurations: WaveCurationEntity[]
+  ): number {
+    return (
+      targetCuration.priority_order ??
+      orderedCurations.findIndex(
+        (curation) => curation.id === targetCuration.id
+      ) + 1
+    );
+  }
+
+  private waveCurationsToApi(
+    entities: WaveCurationEntity[]
+  ): ApiWaveCuration[] {
+    return entities.map((entity, index) =>
+      this.waveCurationToApi(entity, index + 1)
+    );
+  }
+
+  private waveCurationToApi(
+    entity: WaveCurationEntity,
+    fallbackPriorityOrder?: number
+  ): ApiWaveCuration {
+    const priorityOrder = entity.priority_order ?? fallbackPriorityOrder;
+    if (priorityOrder === undefined) {
+      throw new Error(`Curation ${entity.id} is missing priority_order`);
+    }
     return {
       id: entity.id,
       name: entity.name,
       wave_id: entity.wave_id,
       group_id: entity.community_group_id,
       created_at: entity.created_at,
-      updated_at: entity.updated_at
+      updated_at: entity.updated_at,
+      priority_order: priorityOrder
     };
   }
 
@@ -410,10 +531,11 @@ export class CurationsApiService {
     param: {
       dropIncluded: boolean;
       authenticatedUserCanCurate: boolean;
+      fallbackPriorityOrder?: number;
     }
   ): ApiDropCuration {
     return {
-      ...this.waveCurationToApi(entity),
+      ...this.waveCurationToApi(entity, param.fallbackPriorityOrder),
       drop_included: param.dropIncluded,
       authenticated_user_can_curate: param.authenticatedUserCanCurate
     };

--- a/src/api-serverless/src/curations/curations.db.ts
+++ b/src/api-serverless/src/curations/curations.db.ts
@@ -14,6 +14,10 @@ import { RequestContext } from '@/request.context';
 import { Time } from '@/time';
 
 export class CurationsDb extends LazyDbAccessCompatibleService {
+  private readonly waveCurationOrderBy = `
+      order by (priority_order is null) asc, priority_order asc, created_at asc, id asc
+    `;
+
   public async findWaveCurationById(
     param: { id: string; wave_id?: string },
     connection?: ConnectionWrapper<any>
@@ -36,7 +40,7 @@ export class CurationsDb extends LazyDbAccessCompatibleService {
       `
       select * from ${WAVE_CURATIONS_TABLE}
       where wave_id = :waveId
-      order by created_at asc
+      ${this.waveCurationOrderBy}
       `,
       { waveId },
       connection ? { wrappedConnection: connection } : undefined
@@ -54,6 +58,7 @@ export class CurationsDb extends LazyDbAccessCompatibleService {
       `
       select * from ${WAVE_CURATIONS_TABLE}
       where wave_id in (:waveIds)
+      ${this.waveCurationOrderBy}
       `,
       { waveIds },
       connection ? { wrappedConnection: connection } : undefined
@@ -83,9 +88,9 @@ export class CurationsDb extends LazyDbAccessCompatibleService {
       await this.db.execute(
         `
         insert into ${WAVE_CURATIONS_TABLE}
-        (id, name, wave_id, community_group_id, created_at, updated_at)
+        (id, name, wave_id, community_group_id, created_at, updated_at, priority_order)
         values
-        (:id, :name, :wave_id, :community_group_id, :created_at, :updated_at)
+        (:id, :name, :wave_id, :community_group_id, :created_at, :updated_at, :priority_order)
       `,
         entity,
         { wrappedConnection: ctx.connection }
@@ -102,6 +107,7 @@ export class CurationsDb extends LazyDbAccessCompatibleService {
       name: string;
       community_group_id: string;
       updated_at: number;
+      priority_order: number;
     },
     ctx: RequestContext
   ): Promise<void> {
@@ -110,7 +116,11 @@ export class CurationsDb extends LazyDbAccessCompatibleService {
       await this.db.execute(
         `
         update ${WAVE_CURATIONS_TABLE}
-        set name = :name, community_group_id = :community_group_id, updated_at = :updated_at
+        set
+          name = :name,
+          community_group_id = :community_group_id,
+          updated_at = :updated_at,
+          priority_order = :priority_order
         where id = :id and wave_id = :wave_id
       `,
         param,
@@ -118,6 +128,95 @@ export class CurationsDb extends LazyDbAccessCompatibleService {
       );
     } finally {
       ctx.timer?.stop(`${this.constructor.name}->updateWaveCuration`);
+    }
+  }
+
+  public async lockWaveCurationsByWaveId(
+    waveId: string,
+    ctx: RequestContext
+  ): Promise<WaveCurationEntity[]> {
+    try {
+      ctx.timer?.start(`${this.constructor.name}->lockWaveCurationsByWaveId`);
+      return await this.db.execute<WaveCurationEntity>(
+        `
+        select * from ${WAVE_CURATIONS_TABLE}
+        where wave_id = :waveId
+        ${this.waveCurationOrderBy}
+        for update
+        `,
+        { waveId },
+        { wrappedConnection: ctx.connection }
+      );
+    } finally {
+      ctx.timer?.stop(`${this.constructor.name}->lockWaveCurationsByWaveId`);
+    }
+  }
+
+  public async incrementWaveCurationPriorityOrderRange(
+    param: {
+      wave_id: string;
+      from_priority_order: number;
+      to_priority_order?: number;
+    },
+    ctx: RequestContext
+  ): Promise<void> {
+    try {
+      ctx.timer?.start(
+        `${this.constructor.name}->incrementWaveCurationPriorityOrderRange`
+      );
+      await this.db.execute(
+        `
+        update ${WAVE_CURATIONS_TABLE}
+        set priority_order = priority_order + 1
+        where wave_id = :wave_id
+          and priority_order >= :from_priority_order
+          ${
+            param.to_priority_order === undefined
+              ? ''
+              : 'and priority_order <= :to_priority_order'
+          }
+      `,
+        param,
+        { wrappedConnection: ctx.connection }
+      );
+    } finally {
+      ctx.timer?.stop(
+        `${this.constructor.name}->incrementWaveCurationPriorityOrderRange`
+      );
+    }
+  }
+
+  public async decrementWaveCurationPriorityOrderRange(
+    param: {
+      wave_id: string;
+      from_priority_order: number;
+      to_priority_order?: number;
+    },
+    ctx: RequestContext
+  ): Promise<void> {
+    try {
+      ctx.timer?.start(
+        `${this.constructor.name}->decrementWaveCurationPriorityOrderRange`
+      );
+      await this.db.execute(
+        `
+        update ${WAVE_CURATIONS_TABLE}
+        set priority_order = priority_order - 1
+        where wave_id = :wave_id
+          and priority_order >= :from_priority_order
+          ${
+            param.to_priority_order === undefined
+              ? ''
+              : 'and priority_order <= :to_priority_order'
+          }
+      `,
+        param,
+        { wrappedConnection: ctx.connection }
+      );
+    } finally {
+      ctx.timer?.stop(
+        `${this.constructor.name}->decrementWaveCurationPriorityOrderRange`
+      );
     }
   }
 
@@ -251,7 +350,11 @@ export class CurationsDb extends LazyDbAccessCompatibleService {
       from ${WAVE_CURATIONS_TABLE} wcg
       join ${DROP_CURATIONS_TABLE} dc on dc.curation_id = wcg.id
       where dc.drop_id = :dropId
-      order by wcg.created_at asc, wcg.id asc
+      order by
+        (wcg.priority_order is null) asc,
+        wcg.priority_order asc,
+        wcg.created_at asc,
+        wcg.id asc
       `,
       { dropId },
       connection ? { wrappedConnection: connection } : undefined

--- a/src/api-serverless/src/generated/models/ApiDropCuration.ts
+++ b/src/api-serverless/src/generated/models/ApiDropCuration.ts
@@ -21,6 +21,7 @@ export class ApiDropCuration {
     'group_id': string;
     'created_at': number;
     'updated_at': number;
+    'priority_order': number;
 
     static readonly discriminator: string | undefined = undefined;
 
@@ -72,6 +73,12 @@ export class ApiDropCuration {
             "baseName": "updated_at",
             "type": "number",
             "format": "int64"
+        },
+        {
+            "name": "priority_order",
+            "baseName": "priority_order",
+            "type": "number",
+            "format": "int32"
         }    ];
 
     static getAttributeTypeMap() {

--- a/src/api-serverless/src/generated/models/ApiWaveCuration.ts
+++ b/src/api-serverless/src/generated/models/ApiWaveCuration.ts
@@ -19,6 +19,7 @@ export class ApiWaveCuration {
     'group_id': string;
     'created_at': number;
     'updated_at': number;
+    'priority_order': number;
 
     static readonly discriminator: string | undefined = undefined;
 
@@ -58,6 +59,12 @@ export class ApiWaveCuration {
             "baseName": "updated_at",
             "type": "number",
             "format": "int64"
+        },
+        {
+            "name": "priority_order",
+            "baseName": "priority_order",
+            "type": "number",
+            "format": "int32"
         }    ];
 
     static getAttributeTypeMap() {

--- a/src/api-serverless/src/generated/models/ApiWaveCurationRequest.ts
+++ b/src/api-serverless/src/generated/models/ApiWaveCurationRequest.ts
@@ -15,6 +15,7 @@ import { HttpFile } from '../http/http';
 export class ApiWaveCurationRequest {
     'name': string;
     'group_id': string;
+    'priority_order'?: number;
 
     static readonly discriminator: string | undefined = undefined;
 
@@ -30,6 +31,12 @@ export class ApiWaveCurationRequest {
             "baseName": "group_id",
             "type": "string",
             "format": ""
+        },
+        {
+            "name": "priority_order",
+            "baseName": "priority_order",
+            "type": "number",
+            "format": "int32"
         }    ];
 
     static getAttributeTypeMap() {

--- a/src/api-serverless/src/waves/waves.routes.ts
+++ b/src/api-serverless/src/waves/waves.routes.ts
@@ -93,7 +93,8 @@ const router = asyncRouter();
 
 const WaveCurationSchema = Joi.object<ApiWaveCurationRequest>({
   name: Joi.string().trim().min(1).max(50).required(),
-  group_id: Joi.string().required()
+  group_id: Joi.string().required(),
+  priority_order: Joi.number().integer().min(1).optional()
 });
 
 async function handleSimpleWaveAction(

--- a/src/entities/IWaveCuration.ts
+++ b/src/entities/IWaveCuration.ts
@@ -26,4 +26,7 @@ export class WaveCurationEntity {
 
   @Column({ type: 'bigint', nullable: false })
   readonly updated_at!: number;
+
+  @Column({ type: 'int', nullable: true })
+  readonly priority_order!: number | null;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Wave curations now support priority ordering. Users can specify a priority order when creating or updating curations, allowing them to control the sequence in which curations appear within a wave. The system automatically handles reordering when curations are added, moved, or removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->