### PR TITLE
Never render drops in cases where user is in admin group but not in view group

### DIFF
--- a/src/api-serverless/src/waves/waves-api-db.test.ts
+++ b/src/api-serverless/src/waves/waves-api-db.test.ts
@@ -1,0 +1,129 @@
+import 'reflect-metadata';
+import { WAVE_DROPPER_METRICS_TABLE } from '@/constants';
+import { RequestContext } from '@/request.context';
+import { sqlExecutor } from '@/sql-executor';
+import { describeWithSeed } from '@/tests/_setup/seed';
+import { anIdentity, withIdentities } from '@/tests/fixtures/identity.fixture';
+import { aWave, withWaves } from '@/tests/fixtures/wave.fixture';
+import { WavesApiDb } from './waves.api.db';
+
+const repo = new WavesApiDb(() => sqlExecutor);
+const ctx: RequestContext = { timer: undefined };
+
+const author = anIdentity(
+  {},
+  {
+    consolidation_key: 'identity-wave-author',
+    profile_id: 'profile-wave-author',
+    primary_address: 'wallet-wave-author',
+    handle: 'wave-author'
+  }
+);
+
+const publicWave = aWave(
+  {
+    created_by: author.profile_id!
+  },
+  { id: 'wave-public', serial_no: 1, name: 'Public Wave' }
+);
+
+const privateWave = aWave(
+  {
+    created_by: author.profile_id!,
+    visibility_group_id: 'visibility-group',
+    admin_group_id: 'admin-group'
+  },
+  { id: 'wave-private', serial_no: 2, name: 'Private Wave' }
+);
+
+describeWithSeed(
+  'WavesApiDb read visibility',
+  [
+    withIdentities([author]),
+    withWaves([publicWave, privateWave]),
+    {
+      table: WAVE_DROPPER_METRICS_TABLE,
+      rows: [
+        {
+          wave_id: publicWave.id,
+          dropper_id: author.profile_id!,
+          drops_count: 1,
+          participatory_drops_count: 0,
+          latest_drop_timestamp: 1001
+        },
+        {
+          wave_id: privateWave.id,
+          dropper_id: author.profile_id!,
+          drops_count: 2,
+          participatory_drops_count: 0,
+          latest_drop_timestamp: 1002
+        }
+      ]
+    }
+  ],
+  () => {
+    it('does not read private waves through admin-group-only eligibility by ids', async () => {
+      const adminOnlyResults = await repo.findWavesByIdsEligibleForRead(
+        [publicWave.id, privateWave.id],
+        ['admin-group'],
+        undefined
+      );
+      expect(adminOnlyResults.map((wave) => wave.id)).toEqual([publicWave.id]);
+
+      const visibilityResults = await repo.findWavesByIdsEligibleForRead(
+        [publicWave.id, privateWave.id],
+        ['visibility-group'],
+        undefined
+      );
+      expect(visibilityResults.map((wave) => wave.id).sort()).toEqual([
+        privateWave.id,
+        publicWave.id
+      ]);
+    });
+
+    it('does not search private waves through admin-group-only eligibility', async () => {
+      const baseParams = {
+        limit: 10,
+        direct_message: false
+      };
+
+      await expect(
+        repo.searchWaves(baseParams, ['admin-group'], ctx)
+      ).resolves.toEqual([expect.objectContaining({ id: publicWave.id })]);
+      await expect(
+        repo.searchWaves(baseParams, ['visibility-group'], ctx)
+      ).resolves.toEqual([
+        expect.objectContaining({ id: privateWave.id }),
+        expect.objectContaining({ id: publicWave.id })
+      ]);
+    });
+
+    it('does not return favorite private waves through admin-group-only eligibility', async () => {
+      await expect(
+        repo.findFavouriteWavesOfIdentity(
+          {
+            identityId: author.profile_id!,
+            eligibleGroups: ['admin-group'],
+            limit: 10,
+            offset: 0
+          },
+          ctx
+        )
+      ).resolves.toEqual([expect.objectContaining({ id: publicWave.id })]);
+      await expect(
+        repo.findFavouriteWavesOfIdentity(
+          {
+            identityId: author.profile_id!,
+            eligibleGroups: ['visibility-group'],
+            limit: 10,
+            offset: 0
+          },
+          ctx
+        )
+      ).resolves.toEqual([
+        expect.objectContaining({ id: privateWave.id }),
+        expect.objectContaining({ id: publicWave.id })
+      ]);
+    });
+  }
+);

--- a/src/api-serverless/src/waves/waves.api.db.ts
+++ b/src/api-serverless/src/waves/waves.api.db.ts
@@ -144,7 +144,7 @@ export class WavesApiDb extends LazyDbAccessCompatibleService {
          LEFT JOIN ${WAVE_METRICS_TABLE} wm ON wm.wave_id = w.id
          WHERE w.id in (:ids) and (w.visibility_group_id is null ${
            groupIdsUserIsEligibleFor.length
-             ? `or w.visibility_group_id in (:groupIdsUserIsEligibleFor) or w.admin_group_id in (:groupIdsUserIsEligibleFor)`
+             ? `or w.visibility_group_id in (:groupIdsUserIsEligibleFor)`
              : ``
          })`,
         { ids, groupIdsUserIsEligibleFor },
@@ -383,7 +383,7 @@ export class WavesApiDb extends LazyDbAccessCompatibleService {
              : ``
          }(${
            groupsUserIsEligibleFor.length
-             ? `w.visibility_group_id in (:groupsUserIsEligibleFor) or w.admin_group_id in (:groupsUserIsEligibleFor) or`
+             ? `w.visibility_group_id in (:groupsUserIsEligibleFor) or`
              : ``
          } w.visibility_group_id is null) and w.serial_no < :serialNoLessThan order by w.serial_no desc limit ${
            searchParams.limit
@@ -702,8 +702,7 @@ export class WavesApiDb extends LazyDbAccessCompatibleService {
                 w.visibility_group_id is null
                 ${
                   eligibleGroups.length
-                    ? `or w.visibility_group_id in (:eligibleGroups)
-                       or w.admin_group_id in (:eligibleGroups)`
+                    ? `or w.visibility_group_id in (:eligibleGroups)`
                     : ``
                 }
               )

--- a/src/drops/drops.db.test.ts
+++ b/src/drops/drops.db.test.ts
@@ -26,7 +26,7 @@ const publicWaveB = aWave(
   { id: 'wave-public-b', serial_no: 2, name: 'Public B' }
 );
 const privateWave = aWave(
-  { visibility_group_id: 'group-1' },
+  { visibility_group_id: 'group-1', admin_group_id: 'admin-group' },
   { id: 'wave-private', serial_no: 3, name: 'Private Wave' }
 );
 
@@ -392,6 +392,41 @@ describeWithSeed(
       ]);
     });
 
+    it('does not include private waves for admin-group-only eligibility in the global selector', async () => {
+      await expect(
+        repo.findVisibleLightDropIds(
+          {
+            limit: 10,
+            min_serial_no: null,
+            max_serial_no: null,
+            older_first: false,
+            group_ids_user_is_eligible_for: ['admin-group']
+          },
+          ctx
+        )
+      ).resolves.toEqual([
+        { id: 'drop-public-b', serial_no: 104 },
+        { id: 'drop-public-a-new', serial_no: 103 },
+        { id: 'drop-public-a-old', serial_no: 101 }
+      ]);
+    });
+
+    it('does not include private wave-scoped rows for admin-group-only eligibility', async () => {
+      await expect(
+        repo.findLightDropIdsByWave(
+          {
+            limit: 10,
+            max_serial_no: null,
+            min_serial_no: null,
+            older_first: false,
+            group_ids_user_is_eligible_for: ['admin-group'],
+            wave_id: privateWave.id
+          },
+          ctx
+        )
+      ).resolves.toEqual([]);
+    });
+
     it('finds latest drops by curation name across visible waves', async () => {
       const results = await repo.findLatestDrops(
         {
@@ -415,6 +450,72 @@ describeWithSeed(
         'drop-public-b',
         'drop-public-a-old'
       ]);
+    });
+
+    it('does not find latest drops by author through admin-group-only eligibility', async () => {
+      const results = await repo.findLatestDrops(
+        {
+          amount: 10,
+          serial_no_less_than: null,
+          group_ids_user_is_eligible_for: ['admin-group'],
+          group_id: null,
+          wave_id: null,
+          curation_id: null,
+          curation_name: null,
+          author_id: authorDave.profile_id,
+          include_replies: false,
+          drop_type: null,
+          ids: null,
+          contains_media: false
+        },
+        ctx
+      );
+
+      expect(results).toEqual([]);
+    });
+
+    it('does not find a private drop by id through admin-group-only eligibility', async () => {
+      await expect(
+        repo.findDropByIdWithEligibilityCheck(
+          'drop-private',
+          ['admin-group'],
+          undefined
+        )
+      ).resolves.toBeNull();
+      await expect(
+        repo.findDropByIdWithEligibilityCheck(
+          'drop-private',
+          ['group-1'],
+          undefined
+        )
+      ).resolves.toMatchObject({ id: 'drop-private' });
+    });
+
+    it('does not find private drop ids in a wave range through admin-group-only eligibility', async () => {
+      await expect(
+        repo.findDropIdsInWaveRange(
+          {
+            wave_id: privateWave.id,
+            min_serial_no: 0,
+            max_serial_no: 200,
+            limit: 10,
+            group_ids_user_is_eligible_for: ['admin-group']
+          },
+          ctx
+        )
+      ).resolves.toEqual([]);
+      await expect(
+        repo.findDropIdsInWaveRange(
+          {
+            wave_id: privateWave.id,
+            min_serial_no: 0,
+            max_serial_no: 200,
+            limit: 10,
+            group_ids_user_is_eligible_for: ['group-1']
+          },
+          ctx
+        )
+      ).resolves.toEqual([{ id: 'drop-private', serial_no: 102 }]);
     });
 
     it('finds drops in a curation by priority order', async () => {

--- a/src/drops/drops.db.ts
+++ b/src/drops/drops.db.ts
@@ -96,9 +96,6 @@ export class DropsDb extends LazyDbAccessCompatibleService {
       'w.visibility_group_id is null',
       groupIdsUserIsEligibleFor.length
         ? `w.visibility_group_id in (:groupsUserIsEligibleFor)`
-        : null,
-      groupIdsUserIsEligibleFor.length
-        ? `w.admin_group_id in (:groupsUserIsEligibleFor)`
         : null
     ]
       .filter((it): it is string => !!it)
@@ -404,7 +401,7 @@ export class DropsDb extends LazyDbAccessCompatibleService {
         select d.* from ${DROPS_TABLE} d
          join waves w on d.wave_id = w.id and (${
            group_ids_user_is_eligible_for.length
-             ? `w.visibility_group_id in (:group_ids_user_is_eligible_for) or w.admin_group_id in (:group_ids_user_is_eligible_for) or`
+             ? `w.visibility_group_id in (:group_ids_user_is_eligible_for) or`
              : ``
          } w.visibility_group_id is null)
          where d.id = :id
@@ -491,7 +488,7 @@ export class DropsDb extends LazyDbAccessCompatibleService {
          } cm on cm.profile_id = d.author_id
          join ${WAVES_TABLE} w on d.wave_id = w.id and (${
            group_ids_user_is_eligible_for.length
-             ? `w.visibility_group_id in (:groupsUserIsEligibleFor) or w.admin_group_id in (:groupsUserIsEligibleFor) or`
+             ? `w.visibility_group_id in (:groupsUserIsEligibleFor) or`
              : ``
          } w.visibility_group_id is null) ${wave_id ? `and w.id = :wave_id` : ``}
          where ${
@@ -748,7 +745,7 @@ export class DropsDb extends LazyDbAccessCompatibleService {
       from ${DROPS_TABLE} d
       join ${WAVES_TABLE} w on d.wave_id = w.id and (${
         group_ids_user_is_eligible_for.length
-          ? `w.visibility_group_id in (:groupsUserIsEligibleFor) or w.admin_group_id in (:groupsUserIsEligibleFor) or`
+          ? `w.visibility_group_id in (:groupsUserIsEligibleFor) or`
           : ``
       } w.visibility_group_id is null)
       where d.wave_id = :wave_id


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed permission handling where admin users could access private and visibility-restricted content. Access to restricted content is now exclusively controlled by visibility group membership assignments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->