### PR TITLE
Make it so that wave creator is always counted as admin

### DIFF
--- a/src/api-serverless/src/drops/drops.api.service.ts
+++ b/src/api-serverless/src/drops/drops.api.service.ts
@@ -568,7 +568,8 @@ export class DropsApiService {
       noRightToVote,
       noRightToParticipate,
       pinned: pinnedWaveIds.has(wave_id),
-      identityWave: identityWaveIds.has(wave_id)
+      identityWave: identityWaveIds.has(wave_id),
+      authenticatedProfileId: context_profile_id
     });
     if (drop_id) {
       const dropEntity = await this.dropsDb.findDropByIdWithEligibilityCheck(
@@ -840,7 +841,8 @@ export class DropsApiService {
       noRightToVote,
       noRightToParticipate,
       pinned: pinnedWaveIds.has(params.wave_id),
-      identityWave: identityWaveIds.has(params.wave_id)
+      identityWave: identityWaveIds.has(params.wave_id),
+      authenticatedProfileId
     });
     const isTimeLockedWave =
       waveEntity.time_lock_ms !== null && waveEntity.time_lock_ms > 0;

--- a/src/api-serverless/src/drops/drops.mappers.ts
+++ b/src/api-serverless/src/drops/drops.mappers.ts
@@ -255,7 +255,8 @@ export class DropsMappers {
             noRightToVote,
             noRightToParticipate,
             pinned: pinnedWaveIds.has(wave.id),
-            identityWave: identityWaveIds.has(wave.id)
+            identityWave: identityWaveIds.has(wave.id),
+            authenticatedProfileId: readContextProfileId
           })
         : null;
       return {
@@ -590,7 +591,8 @@ export class DropsMappers {
           noRightToVote,
           noRightToParticipate,
           pinned: pinnedMentionedWaveIds.has(wave.id),
-          identityWave: identityWaveIds.has(wave.id)
+          identityWave: identityWaveIds.has(wave.id),
+          authenticatedProfileId: contextProfileId
         });
         return acc;
       },

--- a/src/api-serverless/src/waves/wave-api-service.test.ts
+++ b/src/api-serverless/src/waves/wave-api-service.test.ts
@@ -19,6 +19,7 @@ import {
   WaveSubmissionType,
   WaveType
 } from '@/entities/IWave';
+import { Time } from '@/time';
 
 describe('WaveApiService updateWave immutability', () => {
   function createService({
@@ -279,6 +280,95 @@ describe('WaveApiService updateWave immutability', () => {
 
     expect(wavesApiDb.deleteWave).toHaveBeenCalled();
     expect(waveMappers.createWaveToNewWaveEntity).toHaveBeenCalled();
+  });
+});
+
+describe('WaveApiService wave pause authorization', () => {
+  it('allows admin group members to create wave pauses when they are not the wave creator', async () => {
+    const replicaCatchupDelay = process.env.REPLICA_CATCHUP_DELAY_AFTER_WRITE;
+    process.env.REPLICA_CATCHUP_DELAY_AFTER_WRITE = '0';
+    const nextDecisionTime = Time.currentMillis() + 60_000;
+    const wave = aWave(
+      {
+        type: WaveType.RANK,
+        created_by: 'creator-profile',
+        admin_group_id: 'admin-group',
+        decisions_strategy: {
+          first_decision_time: nextDecisionTime,
+          subsequent_decisions: [],
+          is_rolling: false
+        },
+        next_decision_time: nextDecisionTime
+      },
+      {
+        id: 'wave-1',
+        name: 'wave-1',
+        serial_no: 1
+      }
+    );
+    const connection = {} as any;
+    const wavesApiDb = {
+      findById: jest.fn().mockResolvedValue(wave),
+      getWavePauses: jest.fn().mockResolvedValue([]),
+      executeNativeQueriesInTransaction: jest.fn(async (fn) => fn(connection)),
+      insertPause: jest.fn().mockResolvedValue(undefined),
+      deletePause: jest.fn().mockResolvedValue(undefined)
+    };
+    const userGroupsService = {
+      getGroupsUserIsEligibleFor: jest.fn().mockResolvedValue(['admin-group'])
+    };
+    const service = new WaveApiService(
+      wavesApiDb as any,
+      userGroupsService as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any,
+      {} as any
+    );
+    jest
+      .spyOn(service, 'findWaveByIdOrThrow')
+      .mockResolvedValue({ id: 'wave-1' } as any);
+
+    try {
+      await expect(
+        service.createOrUpdateWavePause(
+          'wave-1',
+          {
+            id: null,
+            start_time: nextDecisionTime + 1_000,
+            end_time: nextDecisionTime + 2_000
+          },
+          {
+            authenticationContext:
+              AuthenticationContext.fromProfileId('admin-profile')
+          } as any
+        )
+      ).resolves.toEqual({ id: 'wave-1' });
+
+      expect(wavesApiDb.insertPause).toHaveBeenCalledWith(
+        {
+          startTime: nextDecisionTime + 1_000,
+          endTime: nextDecisionTime + 2_000,
+          waveId: 'wave-1'
+        },
+        connection
+      );
+    } finally {
+      if (replicaCatchupDelay === undefined) {
+        delete process.env.REPLICA_CATCHUP_DELAY_AFTER_WRITE;
+      } else {
+        process.env.REPLICA_CATCHUP_DELAY_AFTER_WRITE = replicaCatchupDelay;
+      }
+    }
   });
 });
 

--- a/src/api-serverless/src/waves/wave-min-helpers.test.ts
+++ b/src/api-serverless/src/waves/wave-min-helpers.test.ts
@@ -1,0 +1,45 @@
+import {
+  mapWaveToApiWaveMin,
+  WaveMinSource
+} from '@/api/waves/wave-min.helpers';
+
+describe('mapWaveToApiWaveMin', () => {
+  function wave(overrides: Partial<WaveMinSource> = {}): WaveMinSource {
+    return {
+      id: 'wave-1',
+      name: 'Wave 1',
+      picture: null,
+      description_drop_id: 'description-drop',
+      created_by: 'creator',
+      last_drop_time: 0,
+      submission_type: null,
+      chat_enabled: true,
+      chat_group_id: null,
+      voting_group_id: null,
+      participation_group_id: null,
+      admin_group_id: null,
+      voting_credit_type: 'TDH',
+      voting_period_start: null,
+      voting_period_end: null,
+      visibility_group_id: null,
+      admin_drop_deletion_enabled: false,
+      forbid_negative_votes: false,
+      ...overrides
+    };
+  }
+
+  it('sets authenticated_user_admin when the authenticated user created the wave', () => {
+    const mapped = mapWaveToApiWaveMin({
+      wave: wave(),
+      displayByWaveId: {},
+      groupIdsUserIsEligibleFor: [],
+      noRightToVote: false,
+      noRightToParticipate: false,
+      pinned: false,
+      identityWave: false,
+      authenticatedProfileId: 'creator'
+    });
+
+    expect(mapped.authenticated_user_admin).toBe(true);
+  });
+});

--- a/src/api-serverless/src/waves/wave-min.helpers.ts
+++ b/src/api-serverless/src/waves/wave-min.helpers.ts
@@ -8,12 +8,14 @@ import {
   resolveWavePictureOverride,
   WaveDisplayOverride
 } from '@/api/waves/direct-message-wave-display.service';
+import { isWaveCreatorOrAdmin } from '@/waves/wave-admin.helpers';
 
 export type WaveMinSource = {
   id: string;
   name: string;
   picture: string | null;
   description_drop_id: string;
+  created_by: string;
   last_drop_time: number;
   submission_type: string | null;
   chat_enabled: boolean;
@@ -63,7 +65,8 @@ export function mapWaveToApiWaveMin({
   noRightToVote,
   noRightToParticipate,
   pinned,
-  identityWave
+  identityWave,
+  authenticatedProfileId
 }: {
   wave: WaveMinSource;
   displayByWaveId: Record<string, WaveDisplayOverride>;
@@ -72,6 +75,7 @@ export function mapWaveToApiWaveMin({
   noRightToParticipate: boolean;
   pinned: boolean;
   identityWave: boolean;
+  authenticatedProfileId: string | null | undefined;
 }): ApiWaveMin {
   return {
     id: wave.id,
@@ -92,9 +96,11 @@ export function mapWaveToApiWaveMin({
       wave.chat_enabled &&
       (wave.chat_group_id === null ||
         groupIdsUserIsEligibleFor.includes(wave.chat_group_id)),
-    authenticated_user_admin:
-      wave.admin_group_id !== null &&
-      groupIdsUserIsEligibleFor.includes(wave.admin_group_id),
+    authenticated_user_admin: isWaveCreatorOrAdmin({
+      authenticatedProfileId,
+      wave,
+      groupIdsUserIsEligibleFor
+    }),
     voting_period_start: wave.voting_period_start,
     voting_period_end: wave.voting_period_end,
     voting_credit_type: enums.resolveOrThrow(

--- a/src/api-serverless/src/waves/wave.api.service.ts
+++ b/src/api-serverless/src/waves/wave.api.service.ts
@@ -568,7 +568,7 @@ export class WaveApiService {
       }
       const isUserInAdminGroup = await this.userGroupsService
         .getGroupsUserIsEligibleFor(authenticatedUserId, ctx.timer)
-        .then((it) => it.includes(authenticatedUserId));
+        .then((it) => it.includes(adminGroupId));
       if (!isUserInAdminGroup) {
         throw new ForbiddenException(
           `Wave modification not allowed for authenticated user`

--- a/src/api-serverless/src/waves/waves.mappers.ts
+++ b/src/api-serverless/src/waves/waves.mappers.ts
@@ -59,6 +59,7 @@ import { InsertWaveEntity, wavesApiDb, WavesApiDb } from './waves.api.db';
 import { enums } from '../../../enums';
 import { collections } from '../../../collections';
 import { profileWavesDb } from '@/profiles/profile-waves.db';
+import { isWaveCreatorOrAdmin } from '@/waves/wave-admin.helpers';
 
 type WaveMappingRelatedData = {
   contributors: Record<
@@ -79,6 +80,7 @@ type WaveMappingRelatedData = {
   wavePauses: Record<string, WaveDecisionPauseEntity[]>;
   pinnedWaveIds: Set<string>;
   identityWaveIds: Set<string>;
+  authenticatedUserId: string | null;
 };
 
 export class WavesMappers {
@@ -351,10 +353,11 @@ export class WavesMappers {
           groupIdsUserIsEligibleFor.includes(waveEntity.chat_group_id)) &&
         waveEntity.chat_enabled
     };
-    const authenticatedUserEligibleForAdmin = !!(
-      waveEntity.admin_group_id &&
-      groupIdsUserIsEligibleFor.includes(waveEntity.admin_group_id)
-    );
+    const authenticatedUserEligibleForAdmin = isWaveCreatorOrAdmin({
+      authenticatedProfileId: relatedData.authenticatedUserId,
+      wave: waveEntity,
+      groupIdsUserIsEligibleFor
+    });
     const waveConf: ApiWaveConfig = {
       type: enums.resolveOrThrow(WaveTypeApi, waveEntity.type),
       winning_thresholds: {
@@ -433,7 +436,8 @@ export class WavesMappers {
   ): Promise<WaveMappingRelatedData> {
     ctx.timer?.start('wavesMappers->getRelatedData');
     const waveIds = waveEntities.map((it) => it.id);
-    const authenticatedUserId = ctx.authenticationContext?.getActingAsId();
+    const authenticatedUserId =
+      ctx.authenticationContext?.getActingAsId() ?? null;
     ctx.timer?.start('dropsService->findDropsByIdsOrThrow');
     ctx.timer?.start(
       'identitySubscriptionsDb->findIdentitySubscriptionActionsOfTargets'
@@ -616,7 +620,8 @@ export class WavesMappers {
       firstUnreadDropSerialNoByWaveId,
       wavePauses,
       pinnedWaveIds,
-      identityWaveIds
+      identityWaveIds,
+      authenticatedUserId
     };
   }
 }

--- a/src/drops/delete-drop-use-case.test.ts
+++ b/src/drops/delete-drop-use-case.test.ts
@@ -1,4 +1,5 @@
 import { identityFetcher } from '@/api-serverless/src/identities/identity.fetcher';
+import { userGroupsService } from '@/api-serverless/src/community-members/user-groups.service';
 import { DropType } from '@/entities/IDrop';
 import { DeleteDropUseCase } from './delete-drop.use-case';
 
@@ -157,5 +158,94 @@ describe('DeleteDropUseCase', () => {
       },
       { timer, connection }
     );
+  });
+
+  it("allows wave creators to delete another user's drop when admin drop deletion is enabled", async () => {
+    const connection = {} as any;
+    const drop = {
+      id: 'drop-1',
+      wave_id: 'wave-1',
+      serial_no: 7,
+      created_at: 123,
+      author_id: 'drop-author',
+      drop_type: DropType.PARTICIPATORY
+    };
+    const wave = {
+      description_drop_id: 'description-drop',
+      visibility_group_id: 'group-1',
+      created_by: 'wave-creator',
+      admin_group_id: null,
+      admin_drop_deletion_enabled: true
+    };
+    const { useCase, dropsDb } = createUseCase({ drop, wave });
+    const getGroupsUserIsEligibleForSpy = jest.spyOn(
+      userGroupsService,
+      'getGroupsUserIsEligibleFor'
+    );
+
+    await expect(
+      useCase.execute(
+        {
+          drop_id: 'drop-1',
+          deleter_id: 'wave-creator',
+          deletion_purpose: 'DELETE'
+        },
+        { connection }
+      )
+    ).resolves.toEqual({
+      id: 'drop-1',
+      serial_no: 7,
+      visibility_group_id: 'group-1',
+      wave_id: 'wave-1'
+    });
+
+    expect(getGroupsUserIsEligibleForSpy).not.toHaveBeenCalled();
+    expect(dropsDb.insertDeletedDrop).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'drop-1',
+        wave_id: 'wave-1',
+        author_id: 'drop-author'
+      }),
+      { timer: undefined, connection }
+    );
+  });
+
+  it("allows admin group members to delete another user's drop when admin drop deletion is enabled", async () => {
+    const connection = {} as any;
+    const drop = {
+      id: 'drop-1',
+      wave_id: 'wave-1',
+      serial_no: 7,
+      created_at: 123,
+      author_id: 'drop-author',
+      drop_type: DropType.PARTICIPATORY
+    };
+    const wave = {
+      description_drop_id: 'description-drop',
+      visibility_group_id: 'group-1',
+      created_by: 'wave-creator',
+      admin_group_id: 'admin-group',
+      admin_drop_deletion_enabled: true
+    };
+    const { useCase } = createUseCase({ drop, wave });
+    jest
+      .spyOn(userGroupsService, 'getGroupsUserIsEligibleFor')
+      .mockResolvedValue(['admin-group']);
+
+    await expect(
+      useCase.execute(
+        {
+          drop_id: 'drop-1',
+          deleter_id: 'admin-profile',
+          deletion_purpose: 'DELETE'
+        },
+        { connection }
+      )
+    ).resolves.toEqual({
+      id: 'drop-1',
+      serial_no: 7,
+      visibility_group_id: 'group-1',
+      wave_id: 'wave-1'
+    });
   });
 });

--- a/src/drops/delete-drop.use-case.ts
+++ b/src/drops/delete-drop.use-case.ts
@@ -187,11 +187,17 @@ export class DeleteDropUseCase {
     timer?: Timer;
   }) {
     if (drop.author_id !== deleterId) {
+      if (
+        !wave?.admin_drop_deletion_enabled ||
+        model.deletion_purpose !== 'DELETE'
+      ) {
+        throw new ForbiddenException('User is not allowed to delete this drop');
+      }
+      if (wave.created_by === deleterId) {
+        return;
+      }
       const adminGroupId = wave?.admin_group_id;
-      const adminDropDeletionEnabled = !!(
-        wave?.admin_drop_deletion_enabled && adminGroupId
-      );
-      if (!adminDropDeletionEnabled || model.deletion_purpose !== 'DELETE') {
+      if (!adminGroupId) {
         throw new ForbiddenException('User is not allowed to delete this drop');
       }
       const groupsUserIsEligibleIn =

--- a/src/waves/wave-admin-helpers.test.ts
+++ b/src/waves/wave-admin-helpers.test.ts
@@ -1,0 +1,42 @@
+import { isWaveCreatorOrAdmin } from './wave-admin.helpers';
+
+describe('isWaveCreatorOrAdmin', () => {
+  it('counts wave creators as admins even without admin group membership', () => {
+    expect(
+      isWaveCreatorOrAdmin({
+        authenticatedProfileId: 'creator',
+        wave: {
+          created_by: 'creator',
+          admin_group_id: 'admin-group'
+        },
+        groupIdsUserIsEligibleFor: []
+      })
+    ).toBe(true);
+  });
+
+  it('counts admin group members as admins', () => {
+    expect(
+      isWaveCreatorOrAdmin({
+        authenticatedProfileId: 'admin',
+        wave: {
+          created_by: 'creator',
+          admin_group_id: 'admin-group'
+        },
+        groupIdsUserIsEligibleFor: ['admin-group']
+      })
+    ).toBe(true);
+  });
+
+  it('rejects users who are neither creator nor admin group member', () => {
+    expect(
+      isWaveCreatorOrAdmin({
+        authenticatedProfileId: 'outsider',
+        wave: {
+          created_by: 'creator',
+          admin_group_id: 'admin-group'
+        },
+        groupIdsUserIsEligibleFor: []
+      })
+    ).toBe(false);
+  });
+});

--- a/src/waves/wave-admin.helpers.ts
+++ b/src/waves/wave-admin.helpers.ts
@@ -1,0 +1,18 @@
+export function isWaveCreatorOrAdmin({
+  authenticatedProfileId,
+  wave,
+  groupIdsUserIsEligibleFor
+}: {
+  authenticatedProfileId: string | null | undefined;
+  wave: {
+    readonly created_by: string;
+    readonly admin_group_id: string | null;
+  };
+  groupIdsUserIsEligibleFor: readonly string[];
+}): boolean {
+  return (
+    (!!authenticatedProfileId && wave.created_by === authenticatedProfileId) ||
+    (wave.admin_group_id !== null &&
+      groupIdsUserIsEligibleFor.includes(wave.admin_group_id))
+  );
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced authorization for wave pause management to correctly identify and grant permissions to wave creators and admin group members.
  * Refined drop deletion permissions to allow authorized users (creators and admin group members) to delete drops when the feature is enabled.
  * Improved access control logic across wave management to properly distinguish between wave creators and those with admin group membership.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->