### PR TITLE
Get single drop v2 endpoint

### DIFF
--- a/src/api-serverless/openapi.yaml
+++ b/src/api-serverless/openapi.yaml
@@ -1996,6 +1996,27 @@ paths:
                 $ref: "#/components/schemas/ApiCompleteMultipartUploadResponse"
         "400":
           description: Invalid request
+  /v2/drops/{id}:
+    get:
+      tags:
+        - DropsV2
+      summary: Get V2 drop by ID.
+      operationId: getDropV2ById
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiDropAndWave"
+        "404":
+          description: Drop not found
   /feed:
     get:
       tags:

--- a/src/api-serverless/src/api-v2.router.ts
+++ b/src/api-serverless/src/api-v2.router.ts
@@ -1,0 +1,8 @@
+import { asyncRouter } from '@/api/async.router';
+import dropsRoutes from './drops/drops-v2.routes';
+
+const router = asyncRouter();
+
+router.use('/drops', dropsRoutes);
+
+export default router;

--- a/src/api-serverless/src/app.ts
+++ b/src/api-serverless/src/app.ts
@@ -4,6 +4,7 @@ import { ids } from '@/ids';
 import * as http from 'node:http';
 import WebSocket, { WebSocketServer } from 'ws';
 import aggregatedActivityRoutes from './aggregated-activity/api.aggregated-activity.routes';
+import apiV2Routes from './api-v2.router';
 import authRoutes from './auth/auth.routes';
 import attachmentsRoutes from './attachments/attachments.routes';
 import communityMembersRoutes from './community-members/community-members.routes';
@@ -1598,6 +1599,7 @@ async function initializeApp() {
   apiRouter.use(`/push-notifications`, pushNotificationsRoutes);
   apiRouter.use(`/xtdh`, xtdhRoutes);
   apiRouter.use(`/nft-link`, nftLinksRoutes);
+  apiRouter.use(`/v2`, apiV2Routes);
 
   rootRouter.use(BASE_PATH, apiRouter);
   rootRouter.use(`/desktop`, desktopRoutes);

--- a/src/api-serverless/src/drops/api-drop-v2-service.test.ts
+++ b/src/api-serverless/src/drops/api-drop-v2-service.test.ts
@@ -1,0 +1,181 @@
+import { AuthenticationContext } from '@/auth-context';
+import { DropEntity, DropType } from '@/entities/IDrop';
+import { WaveCreditType, WaveEntity, WaveType } from '@/entities/IWave';
+import { NotFoundException } from '@/exceptions';
+import { ApiDropV2Service } from './api-drop-v2.service';
+
+function makeDrop(overrides: Partial<DropEntity> = {}): DropEntity {
+  return {
+    serial_no: 1,
+    id: 'drop-1',
+    wave_id: 'wave-1',
+    author_id: 'author-1',
+    created_at: 100,
+    updated_at: null,
+    title: null,
+    parts_count: 1,
+    reply_to_drop_id: null,
+    reply_to_part_id: null,
+    drop_type: DropType.CHAT,
+    signature: null,
+    hide_link_preview: false,
+    ...overrides
+  };
+}
+
+function makeWave(overrides: Partial<WaveEntity> = {}): WaveEntity {
+  return {
+    id: 'wave-1',
+    serial_no: 1,
+    name: 'Wave 1',
+    picture: null,
+    description_drop_id: 'description-drop-1',
+    created_at: 100,
+    updated_at: null,
+    created_by: 'creator-1',
+    voting_group_id: null,
+    admin_group_id: null,
+    voting_credit_type: WaveCreditType.TDH,
+    voting_credit_category: null,
+    voting_credit_creditor: null,
+    voting_signature_required: false,
+    voting_period_start: null,
+    voting_period_end: null,
+    visibility_group_id: null,
+    participation_group_id: null,
+    chat_enabled: true,
+    chat_group_id: null,
+    participation_max_applications_per_participant: null,
+    participation_required_metadata: [],
+    participation_required_media: [],
+    submission_type: null,
+    identity_submission_strategy: null,
+    identity_submission_duplicates: null,
+    participation_period_start: null,
+    participation_period_end: null,
+    participation_signature_required: false,
+    participation_terms: null,
+    type: WaveType.CHAT,
+    winning_min_threshold: null,
+    winning_max_threshold: null,
+    max_winners: null,
+    max_votes_per_identity_to_drop: null,
+    time_lock_ms: null,
+    decisions_strategy: null,
+    next_decision_time: null,
+    forbid_negative_votes: false,
+    admin_drop_deletion_enabled: false,
+    is_direct_message: false,
+    ...overrides
+  };
+}
+
+function createService() {
+  const dropsDb = {
+    findDropByIdWithEligibilityCheck: jest.fn().mockResolvedValue(makeDrop()),
+    findWaveByIdOrNull: jest.fn().mockResolvedValue(makeWave())
+  };
+  const userGroupsService = {
+    getGroupsUserIsEligibleFor: jest.fn().mockResolvedValue(['group-1'])
+  };
+  const apiDropMapper = {
+    mapDrops: jest.fn().mockResolvedValue({
+      'drop-1': { id: 'drop-1' }
+    })
+  };
+  const apiWaveOverviewMapper = {
+    mapWaves: jest.fn().mockResolvedValue({
+      'wave-1': { id: 'wave-1' }
+    })
+  };
+
+  return {
+    service: new ApiDropV2Service(
+      dropsDb as any,
+      userGroupsService as any,
+      apiDropMapper as any,
+      apiWaveOverviewMapper as any
+    ),
+    deps: {
+      dropsDb,
+      userGroupsService,
+      apiDropMapper,
+      apiWaveOverviewMapper
+    }
+  };
+}
+
+describe('ApiDropV2Service', () => {
+  it('finds visible drop and maps it with wave overview', async () => {
+    const { service, deps } = createService();
+    const drop = makeDrop();
+    const wave = makeWave();
+    const authenticationContext =
+      AuthenticationContext.fromProfileId('viewer-1');
+    const connection = {} as any;
+    deps.dropsDb.findDropByIdWithEligibilityCheck.mockResolvedValue(drop);
+    deps.dropsDb.findWaveByIdOrNull.mockResolvedValue(wave);
+
+    const result = await service.findWithWaveByIdOrThrow('drop-1', {
+      authenticationContext,
+      connection
+    });
+
+    expect(result).toEqual({
+      drop: { id: 'drop-1' },
+      wave: { id: 'wave-1' }
+    });
+    expect(
+      deps.userGroupsService.getGroupsUserIsEligibleFor
+    ).toHaveBeenCalledWith('viewer-1', undefined);
+    expect(deps.dropsDb.findDropByIdWithEligibilityCheck).toHaveBeenCalledWith(
+      'drop-1',
+      ['group-1'],
+      connection
+    );
+    expect(deps.dropsDb.findWaveByIdOrNull).toHaveBeenCalledWith(
+      'wave-1',
+      connection
+    );
+    expect(deps.apiDropMapper.mapDrops).toHaveBeenCalledWith([drop], {
+      authenticationContext,
+      connection
+    });
+    expect(deps.apiWaveOverviewMapper.mapWaves).toHaveBeenCalledWith([wave], {
+      authenticationContext,
+      connection
+    });
+  });
+
+  it('throws when drop is missing or not visible', async () => {
+    const { service, deps } = createService();
+    deps.dropsDb.findDropByIdWithEligibilityCheck.mockResolvedValue(null);
+
+    await expect(
+      service.findWithWaveByIdOrThrow('missing-drop', {
+        authenticationContext: AuthenticationContext.notAuthenticated()
+      })
+    ).rejects.toThrow(NotFoundException);
+
+    expect(
+      deps.userGroupsService.getGroupsUserIsEligibleFor
+    ).toHaveBeenCalledWith(null, undefined);
+    expect(deps.dropsDb.findWaveByIdOrNull).not.toHaveBeenCalled();
+    expect(deps.apiDropMapper.mapDrops).not.toHaveBeenCalled();
+    expect(deps.apiWaveOverviewMapper.mapWaves).not.toHaveBeenCalled();
+  });
+
+  it('throws when owning wave is missing', async () => {
+    const { service, deps } = createService();
+    deps.dropsDb.findWaveByIdOrNull.mockResolvedValue(null);
+
+    await expect(
+      service.findWithWaveByIdOrThrow('drop-1', {
+        authenticationContext: AuthenticationContext.fromProfileId('viewer-1')
+      })
+    ).rejects.toThrow(NotFoundException);
+
+    expect(deps.apiDropMapper.mapDrops).toHaveBeenCalled();
+    expect(deps.apiWaveOverviewMapper.mapWaves).not.toHaveBeenCalled();
+  });
+});

--- a/src/api-serverless/src/drops/api-drop-v2.service.ts
+++ b/src/api-serverless/src/drops/api-drop-v2.service.ts
@@ -1,0 +1,80 @@
+import { NotFoundException } from '@/exceptions';
+import { RequestContext } from '@/request.context';
+import { dropsDb, DropsDb } from '@/drops/drops.db';
+import {
+  userGroupsService,
+  UserGroupsService
+} from '@/api/community-members/user-groups.service';
+import { ApiDropAndWave } from '@/api/generated/models/ApiDropAndWave';
+import { apiDropMapper, ApiDropMapper } from '@/api/drops/api-drop.mapper';
+import {
+  apiWaveOverviewMapper,
+  ApiWaveOverviewMapper
+} from '@/api/waves/api-wave-overview.mapper';
+import { getWaveReadContextProfileId } from '@/api/waves/wave-access.helpers';
+
+export type ApiDropWithWave = ApiDropAndWave;
+
+export class ApiDropV2Service {
+  constructor(
+    private readonly dropsDb: DropsDb,
+    private readonly userGroupsService: UserGroupsService,
+    private readonly apiDropMapper: ApiDropMapper,
+    private readonly apiWaveOverviewMapper: ApiWaveOverviewMapper
+  ) {}
+
+  public async findWithWaveByIdOrThrow(
+    id: string,
+    ctx: RequestContext
+  ): Promise<ApiDropWithWave> {
+    const timerKey = `${this.constructor.name}->findWithWaveByIdOrThrow`;
+    ctx.timer?.start(timerKey);
+    try {
+      const contextProfileId = getWaveReadContextProfileId(
+        ctx.authenticationContext
+      );
+      const groupIdsUserIsEligibleFor =
+        await this.userGroupsService.getGroupsUserIsEligibleFor(
+          contextProfileId,
+          ctx.timer
+        );
+      const dropEntity = await this.dropsDb.findDropByIdWithEligibilityCheck(
+        id,
+        groupIdsUserIsEligibleFor,
+        ctx.connection
+      );
+      if (!dropEntity) {
+        throw new NotFoundException(`Drop ${id} not found`);
+      }
+
+      const apiDropByIdPromise = this.apiDropMapper.mapDrops([dropEntity], ctx);
+      const apiWaveByIdPromise = this.dropsDb
+        .findWaveByIdOrNull(dropEntity.wave_id, ctx.connection)
+        .then((waveEntity) => {
+          if (!waveEntity) {
+            throw new NotFoundException(`Drop ${id} not found`);
+          }
+          return this.apiWaveOverviewMapper.mapWaves([waveEntity], ctx);
+        });
+
+      const [apiDropById, apiWaveById] = await Promise.all([
+        apiDropByIdPromise,
+        apiWaveByIdPromise
+      ]);
+
+      return {
+        drop: apiDropById[dropEntity.id],
+        wave: apiWaveById[dropEntity.wave_id]
+      };
+    } finally {
+      ctx.timer?.stop(timerKey);
+    }
+  }
+}
+
+export const apiDropV2Service = new ApiDropV2Service(
+  dropsDb,
+  userGroupsService,
+  apiDropMapper,
+  apiWaveOverviewMapper
+);

--- a/src/api-serverless/src/drops/drops-v2.routes.ts
+++ b/src/api-serverless/src/drops/drops-v2.routes.ts
@@ -1,0 +1,32 @@
+import { asyncRouter } from '@/api/async.router';
+import { Request, Response } from 'express';
+import {
+  getAuthenticationContext,
+  maybeAuthenticatedUser
+} from '@/api/auth/auth';
+import { ApiResponse } from '@/api/api-response';
+import { Timer } from '@/time';
+import { ApiDropAndWave } from '@/api/generated/models/ApiDropAndWave';
+import { apiDropV2Service } from '@/api/drops/api-drop-v2.service';
+
+const router = asyncRouter();
+
+router.get(
+  '/:drop_id',
+  maybeAuthenticatedUser(),
+  async (
+    req: Request<{ drop_id: string }, any, any, any, any>,
+    res: Response<ApiResponse<ApiDropAndWave>>
+  ) => {
+    const timer = Timer.getFromRequest(req);
+    const authenticationContext = await getAuthenticationContext(req, timer);
+    const dropId = req.params.drop_id;
+    const drop = await apiDropV2Service.findWithWaveByIdOrThrow(dropId, {
+      timer,
+      authenticationContext
+    });
+    res.send(drop);
+  }
+);
+
+export default router;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `/api/v2/drops/{id}` endpoint to retrieve drop details with associated wave information.
  * Endpoint includes authentication-aware eligibility checks and returns a `404` response when drops are not found.

* **Tests**
  * Added test coverage for the drops v2 service with fixtures for drop and wave entities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->