### PR TITLE
v2 profile drops api and deprecation of all old alternatives

### DIFF
--- a/src/api-serverless/openapi.yaml
+++ b/src/api-serverless/openapi.yaml
@@ -996,11 +996,13 @@ paths:
       tags:
         - Drops
       summary: Get curated profile wave drops
+      deprecated: true
       description: >-
-        Returns drops from effective profile-wave curations across all public
-        profile waves, newest drops first. If a profile wave has an explicit
-        profile curation it is used; otherwise the oldest curation in the
-        profile wave is used. Reply drops are included when curated.
+        Deprecated. Use GET /v2/curated-profile-wave-drops instead. Returns
+        drops from effective profile-wave curations across all public profile
+        waves, newest drops first. If a profile wave has an explicit profile
+        curation it is used; otherwise the oldest curation in the profile wave
+        is used. Reply drops are included when curated.
       operationId: getCuratedProfileWaveDrops
       parameters:
         - name: page
@@ -1032,6 +1034,8 @@ paths:
       tags:
         - Drops
       summary: Get latest drops.
+      deprecated: true
+      description: Deprecated. Use GET /v2/drops instead.
       operationId: getLatestDrops
       parameters:
         - name: limit
@@ -1197,6 +1201,8 @@ paths:
       tags:
         - Drops
       summary: Get boosted drops.
+      deprecated: true
+      description: Deprecated. Use GET /v2/boosted-drops instead.
       operationId: getBoostedDrops
       parameters:
         - name: author
@@ -1277,6 +1283,8 @@ paths:
       tags:
         - Drops
       summary: Get drop boosts by Drop ID.
+      deprecated: true
+      description: Deprecated. Use GET /v2/drops/{id}/boosts instead.
       operationId: getDropBoostsById
       parameters:
         - name: dropId
@@ -1450,6 +1458,8 @@ paths:
       tags:
         - Drops
       summary: Get drop by ID.
+      deprecated: true
+      description: Deprecated. Use GET /v2/drops/{id} instead.
       operationId: getDropById
       parameters:
         - name: dropId
@@ -2076,6 +2086,42 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiDropV2Page"
+  /v2/curated-profile-wave-drops:
+    get:
+      tags:
+        - DropsV2
+      summary: Get V2 curated profile wave drops
+      description: >-
+        Returns V2 drops from effective profile-wave curations across all public
+        profile waves, newest drops first. If a profile wave has an explicit
+        profile curation it is used; otherwise the oldest curation in the
+        profile wave is used. Reply drops are included when curated.
+      operationId: getCuratedProfileWaveDropsV2
+      parameters:
+        - name: page
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int64
+            minimum: 1
+            default: 1
+        - name: page_size
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int64
+            minimum: 1
+            maximum: 2000
+            default: 50
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiDropV2PageWithoutCount"
   /v2/drops:
     get:
       tags:
@@ -3388,6 +3434,8 @@ paths:
       tags:
         - Notifications
       summary: Get notifications for authenticated user.
+      deprecated: true
+      description: Deprecated. Use GET /v2/notifications instead.
       operationId: getNotifications
       parameters:
         - name: limit
@@ -5756,6 +5804,8 @@ paths:
       tags:
         - Waves
       summary: Get already decided wave decision outcomes
+      deprecated: true
+      description: Deprecated. Use GET /v2/waves/{id}/decisions instead.
       operationId: getWaveDecisions
       parameters:
         - name: id
@@ -5871,6 +5921,8 @@ paths:
       tags:
         - Waves
       summary: Search for drops in wave by content
+      deprecated: true
+      description: Deprecated. Use GET /v2/waves/{waveId}/search instead.
       operationId: searchDropsInWave
       parameters:
         - name: waveId
@@ -5936,6 +5988,8 @@ paths:
       tags:
         - Waves
       summary: Get overview of waves by different criteria.
+      deprecated: true
+      description: Deprecated. Use GET /v2/waves?view=OVERVIEW instead.
       operationId: getWavesOverview
       parameters:
         - name: limit
@@ -5996,10 +6050,12 @@ paths:
       tags:
         - Waves
       summary: Get waves where a profile has written the most messages.
+      deprecated: true
       description: >-
-        Returns non-DM waves ranked by how many chat messages the resolved
-        profile has written in them. Results only include waves the requester
-        can access.
+        Deprecated. Use GET /v2/waves?view=FAVOURITES&identity={identityKey}
+        instead. Returns non-DM waves ranked by how many chat messages the
+        resolved profile has written in them. Results only include waves the
+        requester can access.
       operationId: getFavouriteWavesOfIdentity
       parameters:
         - name: identityKey
@@ -6040,7 +6096,10 @@ paths:
       tags:
         - Waves
       summary: Get hot waves overview.
-      description: Returns up to 25 public waves ranked by activity in the last 24 hours.
+      deprecated: true
+      description: >-
+        Deprecated. Use GET /v2/waves?view=HOT instead. Returns up to 25 public
+        waves ranked by activity in the last 24 hours.
       operationId: getHotWavesOverview
       parameters:
         - name: exclude_followed
@@ -6065,6 +6124,8 @@ paths:
       tags:
         - Waves
       summary: Get waves.
+      deprecated: true
+      description: Deprecated. Use GET /v2/waves?view=SEARCH instead.
       operationId: getWaves
       parameters:
         - name: name
@@ -6233,6 +6294,8 @@ paths:
       tags:
         - Waves
       summary: Get drops related to wave or parent drop
+      deprecated: true
+      description: Deprecated. Use GET /v2/waves/{id}/drops instead.
       operationId: getDropsOfWave
       parameters:
         - name: id
@@ -6449,6 +6512,8 @@ paths:
       tags:
         - Waves
       summary: Get waves leaderboard
+      deprecated: true
+      description: Deprecated. Use GET /v2/waves/{id}/leaderboard instead.
       operationId: getWaveLeaderboard
       parameters:
         - name: id
@@ -6595,6 +6660,10 @@ paths:
       tags:
         - Waves
       summary: List drops in a curation for wave
+      deprecated: true
+      description: >-
+        Deprecated. Use GET /v2/waves/{id}/curations/{curation_id}/drops
+        instead.
       operationId: listWaveCurationDrops
       parameters:
         - name: id

--- a/src/api-serverless/src/api-v2.router.ts
+++ b/src/api-serverless/src/api-v2.router.ts
@@ -1,5 +1,6 @@
 import { asyncRouter } from '@/api/async.router';
 import boostedDropsRoutes from '@/api/drops/boosted-drops-v2.routes';
+import curatedProfileWaveDropsRoutes from '@/api/drops/curated-profile-wave-drops-v2.routes';
 import notificationsRoutes from '@/api/notifications/notifications-v2.routes';
 import dropsRoutes from './drops/drops-v2.routes';
 import wavesRoutes from '@/api/waves/waves-v2.routes';
@@ -7,6 +8,7 @@ import wavesRoutes from '@/api/waves/waves-v2.routes';
 const router = asyncRouter();
 
 router.use('/boosted-drops', boostedDropsRoutes);
+router.use('/curated-profile-wave-drops', curatedProfileWaveDropsRoutes);
 router.use('/drops', dropsRoutes);
 router.use('/notifications', notificationsRoutes);
 router.use('/waves', wavesRoutes);

--- a/src/api-serverless/src/drops/api-drop-v2-service.test.ts
+++ b/src/api-serverless/src/drops/api-drop-v2-service.test.ts
@@ -203,6 +203,7 @@ function createService() {
     findDropPartMedia: jest.fn().mockResolvedValue([]),
     findDropBoostsByDropId: jest.fn().mockResolvedValue([]),
     findVisibleDrops: jest.fn().mockResolvedValue([]),
+    findCuratedProfileWaveDrops: jest.fn().mockResolvedValue([]),
     findBoostedDrops: jest.fn().mockResolvedValue([]),
     countBoostedDrops: jest.fn().mockResolvedValue(0),
     findDropVoteEditLogEntities: jest.fn().mockResolvedValue([]),
@@ -347,6 +348,46 @@ describe('ApiDropV2Service', () => {
 
     expect(deps.dropsDb.findVisibleDrops).not.toHaveBeenCalled();
     expect(deps.apiDropMapper.mapDrops).not.toHaveBeenCalled();
+  });
+
+  it('finds curated profile wave drops and maps them with V2 models', async () => {
+    const { service, deps } = createService();
+    const firstDrop = makeDrop({ id: 'drop-1' });
+    const secondDrop = makeDrop({ id: 'drop-2' });
+    const overflowDrop = makeDrop({ id: 'drop-3' });
+    const authenticationContext =
+      AuthenticationContext.fromProfileId('viewer-1');
+    const connection = {} as any;
+    deps.dropsDb.findCuratedProfileWaveDrops.mockResolvedValue([
+      firstDrop,
+      secondDrop,
+      overflowDrop
+    ]);
+
+    const result = await service.findCuratedProfileWaveDrops(
+      {
+        page_size: 2,
+        page: 3
+      },
+      { authenticationContext, connection }
+    );
+
+    expect(deps.dropsDb.findCuratedProfileWaveDrops).toHaveBeenCalledWith(
+      {
+        limit: 3,
+        offset: 4
+      },
+      { authenticationContext, connection }
+    );
+    expect(deps.apiDropMapper.mapDrops).toHaveBeenCalledWith(
+      [firstDrop, secondDrop],
+      { authenticationContext, connection }
+    );
+    expect(result).toEqual({
+      data: [{ id: 'drop-1' }, { id: 'drop-2' }],
+      page: 3,
+      next: true
+    });
   });
 
   it('finds visible drop and maps it with wave overview', async () => {

--- a/src/api-serverless/src/drops/api-drop-v2.service.ts
+++ b/src/api-serverless/src/drops/api-drop-v2.service.ts
@@ -64,6 +64,11 @@ export interface FindBoostedDropsV2Request {
   sort: 'last_boosted_at' | 'first_boosted_at' | 'drop_created_at' | 'boosts';
 }
 
+export interface FindCuratedProfileWaveDropsV2Request {
+  page_size: number;
+  page: number;
+}
+
 export class ApiDropV2Service {
   constructor(
     private readonly dropsDb: DropsDb,
@@ -104,6 +109,35 @@ export class ApiDropV2Service {
         {
           parent_drop_id: req.parent_drop_id,
           group_ids_user_is_eligible_for: groupIdsUserIsEligibleFor,
+          limit: req.page_size + 1,
+          offset: req.page_size * (req.page - 1)
+        },
+        ctx
+      );
+      const pageDropEntities = dropEntities.slice(0, req.page_size);
+      const dropsById = await this.apiDropMapper.mapDrops(
+        pageDropEntities,
+        ctx
+      );
+      return {
+        data: pageDropEntities.map((drop) => dropsById[drop.id]),
+        page: req.page,
+        next: dropEntities.length > req.page_size
+      };
+    } finally {
+      ctx.timer?.stop(timerKey);
+    }
+  }
+
+  public async findCuratedProfileWaveDrops(
+    req: FindCuratedProfileWaveDropsV2Request,
+    ctx: RequestContext
+  ): Promise<ApiDropV2PageWithoutCount> {
+    const timerKey = `${this.constructor.name}->findCuratedProfileWaveDrops`;
+    ctx.timer?.start(timerKey);
+    try {
+      const dropEntities = await this.dropsDb.findCuratedProfileWaveDrops(
+        {
           limit: req.page_size + 1,
           offset: req.page_size * (req.page - 1)
         },

--- a/src/api-serverless/src/drops/curated-profile-wave-drops-v2.routes.ts
+++ b/src/api-serverless/src/drops/curated-profile-wave-drops-v2.routes.ts
@@ -1,0 +1,52 @@
+import { Request, Response } from 'express';
+import * as Joi from 'joi';
+import { Timer } from '@/time';
+import { ApiResponse } from '@/api/api-response';
+import { asyncRouter } from '@/api/async.router';
+import {
+  getAuthenticationContext,
+  maybeAuthenticatedUser
+} from '@/api/auth/auth';
+import { ApiDropV2PageWithoutCount } from '@/api/generated/models/ApiDropV2PageWithoutCount';
+import { DEFAULT_MAX_SIZE, DEFAULT_PAGE_SIZE } from '@/api/page-request';
+import { getValidatedByJoiOrThrow } from '@/api/validation';
+import {
+  apiDropV2Service,
+  FindCuratedProfileWaveDropsV2Request
+} from '@/api/drops/api-drop-v2.service';
+
+const router = asyncRouter();
+
+const FindCuratedProfileWaveDropsV2RequestSchema: Joi.ObjectSchema<FindCuratedProfileWaveDropsV2Request> =
+  Joi.object({
+    page: Joi.number().integer().default(1).min(1),
+    page_size: Joi.number()
+      .integer()
+      .default(DEFAULT_PAGE_SIZE)
+      .max(DEFAULT_MAX_SIZE)
+      .min(1)
+  });
+
+router.get(
+  '/',
+  maybeAuthenticatedUser(),
+  async (
+    req: Request<any, any, any, Partial<FindCuratedProfileWaveDropsV2Request>>,
+    res: Response<ApiResponse<ApiDropV2PageWithoutCount>>
+  ) => {
+    const timer = Timer.getFromRequest(req);
+    const authenticationContext = await getAuthenticationContext(req, timer);
+    const request =
+      getValidatedByJoiOrThrow<FindCuratedProfileWaveDropsV2Request>(
+        req.query as FindCuratedProfileWaveDropsV2Request,
+        FindCuratedProfileWaveDropsV2RequestSchema
+      );
+    const result = await apiDropV2Service.findCuratedProfileWaveDrops(request, {
+      authenticationContext,
+      timer
+    });
+    res.send(result);
+  }
+);
+
+export default router;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new API endpoint for retrieving curated profile wave drops with page-based pagination and customizable page size configuration.

* **Deprecations**
  * Multiple legacy Drops, Notifications, and Waves endpoints are now marked as deprecated. Integrations should plan to migrate to their corresponding v2 endpoint versions to maintain compatibility and ensure continued access to platform resources.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/6529-Collections/6529seize-backend/pull/1556)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->