### PR TITLE
Add CSV export for V2 drop voters

### DIFF
--- a/src/api-serverless/openapi.yaml
+++ b/src/api-serverless/openapi.yaml
@@ -2344,6 +2344,7 @@ paths:
             text/csv:
               schema:
                 type: string
+                format: binary
         "404":
           description: Drop not found
   /v2/drops/{id}/votes/logs:

--- a/src/api-serverless/openapi.yaml
+++ b/src/api-serverless/openapi.yaml
@@ -2325,6 +2325,27 @@ paths:
           description: Invalid request
         "404":
           description: Drop not found
+  /v2/drops/{id}/votes/download:
+    get:
+      tags:
+        - DropsV2
+      summary: Download V2 drop voters by drop ID as CSV.
+      operationId: downloadDropV2VotersById
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: successful operation
+          content:
+            text/csv:
+              schema:
+                type: string
+        "404":
+          description: Drop not found
   /v2/drops/{id}/votes/logs:
     get:
       tags:

--- a/src/api-serverless/src/drops/api-drop-v2-service.test.ts
+++ b/src/api-serverless/src/drops/api-drop-v2-service.test.ts
@@ -208,8 +208,10 @@ function createService() {
     countBoostedDrops: jest.fn().mockResolvedValue(0),
     findDropVoteEditLogEntities: jest.fn().mockResolvedValue([]),
     findDropVotersByAbsoluteVote: jest.fn().mockResolvedValue([]),
+    findAllDropVotersByVoteDesc: jest.fn().mockResolvedValue([]),
     countDropVotersByAbsoluteVote: jest.fn().mockResolvedValue(0),
     getWinnerDropVoters: jest.fn().mockResolvedValue([]),
+    getAllWinnerDropVotersByVoteDesc: jest.fn().mockResolvedValue([]),
     countWinnerDropVoters: jest.fn().mockResolvedValue(0)
   };
   const userGroupsService = {
@@ -1352,6 +1354,148 @@ describe('ApiDropV2Service', () => {
     });
     expect(deps.dropsDb.findDropVotersByAbsoluteVote).toHaveBeenCalled();
     expect(deps.dropsDb.countDropVotersByAbsoluteVote).toHaveBeenCalled();
+    expect(
+      deps.identityFetcher.getApiIdentityOverviewsByIds
+    ).not.toHaveBeenCalled();
+  });
+
+  it('exports all visible drop voters sorted by signed vote descending', async () => {
+    const { service, deps } = createService();
+    const authenticationContext =
+      AuthenticationContext.fromProfileId('viewer-1');
+    const connection = {} as any;
+    deps.dropsDb.findAllDropVotersByVoteDesc.mockResolvedValue([
+      {
+        voter_id: 'voter-1',
+        vote: 12
+      },
+      {
+        voter_id: 'voter-2',
+        vote: -3
+      }
+    ]);
+    deps.identityFetcher.getApiIdentityOverviewsByIds.mockResolvedValue({
+      'voter-1': {
+        id: 'voter-1',
+        handle: 'alice',
+        primary_address: '0x1',
+        level: 5,
+        classification: 'PSEUDONYM',
+        badges: {
+          artist_of_main_stage_submissions: 0,
+          artist_of_memes: 0
+        }
+      },
+      'voter-2': {
+        id: 'voter-2',
+        handle: 'bob',
+        primary_address: '0x2',
+        level: 2,
+        classification: 'PSEUDONYM',
+        badges: {
+          artist_of_main_stage_submissions: 0,
+          artist_of_memes: 0
+        }
+      }
+    });
+
+    const result = await service.findVotersCsvByDropIdOrThrow('drop-1', {
+      authenticationContext,
+      connection
+    });
+
+    expect(result).toEqual([
+      {
+        handle: 'alice',
+        level: 5,
+        primary_address: '0x1',
+        vote: 12
+      },
+      {
+        handle: 'bob',
+        level: 2,
+        primary_address: '0x2',
+        vote: -3
+      }
+    ]);
+    expect(deps.dropsDb.findAllDropVotersByVoteDesc).toHaveBeenCalledWith(
+      {
+        wave_id: 'wave-1',
+        drop_id: 'drop-1'
+      },
+      {
+        authenticationContext,
+        connection
+      }
+    );
+    expect(
+      deps.dropsDb.getAllWinnerDropVotersByVoteDesc
+    ).not.toHaveBeenCalled();
+    expect(
+      deps.identityFetcher.getApiIdentityOverviewsByIds
+    ).toHaveBeenCalledWith(['voter-1', 'voter-2'], {
+      authenticationContext,
+      connection
+    });
+  });
+
+  it('exports all visible winner drop voters from winner votes', async () => {
+    const { service, deps } = createService();
+    deps.dropsDb.findDropByIdWithEligibilityCheck.mockResolvedValue(
+      makeDrop({ drop_type: DropType.WINNER })
+    );
+    deps.dropsDb.getAllWinnerDropVotersByVoteDesc.mockResolvedValue([
+      {
+        voter_id: 'voter-1',
+        drop_id: 'drop-1',
+        wave_id: 'wave-1',
+        votes: 8
+      }
+    ]);
+    deps.identityFetcher.getApiIdentityOverviewsByIds.mockResolvedValue({
+      'voter-1': {
+        id: 'voter-1',
+        handle: 'alice',
+        primary_address: '0x1',
+        level: 5,
+        classification: 'PSEUDONYM',
+        badges: {
+          artist_of_main_stage_submissions: 0,
+          artist_of_memes: 0
+        }
+      }
+    });
+
+    const result = await service.findVotersCsvByDropIdOrThrow('drop-1', {
+      authenticationContext: AuthenticationContext.fromProfileId('viewer-1')
+    });
+
+    expect(result).toEqual([
+      {
+        handle: 'alice',
+        level: 5,
+        primary_address: '0x1',
+        vote: 8
+      }
+    ]);
+    expect(deps.dropsDb.getAllWinnerDropVotersByVoteDesc).toHaveBeenCalledWith(
+      'drop-1',
+      {
+        authenticationContext: AuthenticationContext.fromProfileId('viewer-1')
+      }
+    );
+    expect(deps.dropsDb.findAllDropVotersByVoteDesc).not.toHaveBeenCalled();
+  });
+
+  it('exports empty voters without resolving identities', async () => {
+    const { service, deps } = createService();
+    deps.dropsDb.findAllDropVotersByVoteDesc.mockResolvedValue([]);
+
+    const result = await service.findVotersCsvByDropIdOrThrow('drop-1', {
+      authenticationContext: AuthenticationContext.fromProfileId('viewer-1')
+    });
+
+    expect(result).toEqual([]);
     expect(
       deps.identityFetcher.getApiIdentityOverviewsByIds
     ).not.toHaveBeenCalled();

--- a/src/api-serverless/src/drops/api-drop-v2-service.test.ts
+++ b/src/api-serverless/src/drops/api-drop-v2-service.test.ts
@@ -1466,8 +1466,10 @@ describe('ApiDropV2Service', () => {
       }
     });
 
+    const authenticationContext =
+      AuthenticationContext.fromProfileId('viewer-1');
     const result = await service.findVotersCsvByDropIdOrThrow('drop-1', {
-      authenticationContext: AuthenticationContext.fromProfileId('viewer-1')
+      authenticationContext
     });
 
     expect(result).toEqual([
@@ -1481,7 +1483,7 @@ describe('ApiDropV2Service', () => {
     expect(deps.dropsDb.getAllWinnerDropVotersByVoteDesc).toHaveBeenCalledWith(
       'drop-1',
       {
-        authenticationContext: AuthenticationContext.fromProfileId('viewer-1')
+        authenticationContext
       }
     );
     expect(deps.dropsDb.findAllDropVotersByVoteDesc).not.toHaveBeenCalled();

--- a/src/api-serverless/src/drops/api-drop-v2.service.ts
+++ b/src/api-serverless/src/drops/api-drop-v2.service.ts
@@ -40,6 +40,13 @@ export type DropVotersSearchParams = {
   sort_direction: PageSortDirection;
 };
 
+export type DropVotersCsvRow = {
+  handle: string;
+  level: number;
+  primary_address: string;
+  vote: number;
+};
+
 export type DropVoteEditLogsSearchParams = {
   offset: number;
   limit: number;
@@ -545,6 +552,57 @@ export class ApiDropV2Service {
           vote: Number(row.vote)
         }))
       };
+    } finally {
+      ctx.timer?.stop(timerKey);
+    }
+  }
+
+  public async findVotersCsvByDropIdOrThrow(
+    id: string,
+    ctx: RequestContext
+  ): Promise<DropVotersCsvRow[]> {
+    const timerKey = `${this.constructor.name}->findVotersCsvByDropIdOrThrow`;
+    ctx.timer?.start(timerKey);
+    try {
+      const dropEntity = await this.findVisibleDropByIdOrThrow(id, ctx);
+
+      const rows =
+        dropEntity.drop_type === DropType.WINNER
+          ? await this.dropsDb
+              .getAllWinnerDropVotersByVoteDesc(id, ctx)
+              .then((voters) =>
+                voters.map((voter) => ({
+                  voter_id: voter.voter_id,
+                  vote: voter.votes
+                }))
+              )
+          : await this.dropsDb.findAllDropVotersByVoteDesc(
+              {
+                wave_id: dropEntity.wave_id,
+                drop_id: id
+              },
+              ctx
+            );
+
+      if (!rows.length) {
+        return [];
+      }
+
+      const votersById =
+        await this.identityFetcher.getApiIdentityOverviewsByIds(
+          rows.map((row) => row.voter_id),
+          ctx
+        );
+
+      return rows.map((row) => {
+        const voter = votersById[row.voter_id];
+        return {
+          handle: voter?.handle ?? '',
+          level: voter?.level ?? 0,
+          primary_address: voter?.primary_address ?? '',
+          vote: Number(row.vote)
+        };
+      });
     } finally {
       ctx.timer?.stop(timerKey);
     }

--- a/src/api-serverless/src/drops/api-drop-v2.service.ts
+++ b/src/api-serverless/src/drops/api-drop-v2.service.ts
@@ -600,7 +600,7 @@ export class ApiDropV2Service {
           handle: voter?.handle ?? '',
           level: voter?.level ?? 0,
           primary_address: voter?.primary_address ?? '',
-          vote: Number(row.vote)
+          vote: this.parseVoteValue(row.vote)
         };
       });
     } finally {

--- a/src/api-serverless/src/drops/drops-v2.routes.ts
+++ b/src/api-serverless/src/drops/drops-v2.routes.ts
@@ -32,11 +32,19 @@ type DropPartPathParams = {
   part_no: number;
 };
 
+type DropIdPathParams = {
+  drop_id: string;
+};
+
 const DropPartPathParamsSchema: Joi.ObjectSchema<DropPartPathParams> =
   Joi.object({
     drop_id: Joi.string().required(),
     part_no: Joi.number().integer().min(1).required()
   });
+
+const DropIdPathParamsSchema: Joi.ObjectSchema<DropIdPathParams> = Joi.object({
+  drop_id: Joi.string().required()
+});
 
 const DropVoteEditLogsQuerySchema: Joi.ObjectSchema<DropVoteEditLogsSearchParams> =
   Joi.object({
@@ -231,12 +239,18 @@ router.get(
   ) => {
     const timer = Timer.getFromRequest(req);
     const authenticationContext = await getAuthenticationContext(req, timer);
-    const dropId = req.params.drop_id;
-    const voters = await apiDropV2Service.findVotersCsvByDropIdOrThrow(dropId, {
-      timer,
-      authenticationContext
-    });
-    return returnCSVResult(`drop-${dropId}-votes`, voters, res);
+    const { drop_id } = getValidatedByJoiOrThrow(
+      req.params,
+      DropIdPathParamsSchema
+    );
+    const voters = await apiDropV2Service.findVotersCsvByDropIdOrThrow(
+      drop_id,
+      {
+        timer,
+        authenticationContext
+      }
+    );
+    return returnCSVResult(`drop-${drop_id}-votes`, voters, res);
   }
 );
 

--- a/src/api-serverless/src/drops/drops-v2.routes.ts
+++ b/src/api-serverless/src/drops/drops-v2.routes.ts
@@ -23,6 +23,7 @@ import { PageSortDirection } from '@/api/page-request';
 import { ApiDropVotersPage } from '@/api/generated/models/ApiDropVotersPage';
 import { ApiDropReactionV2 } from '@/api/generated/models/ApiDropReactionV2';
 import { ApiDropV2PageWithoutCount } from '@/api/generated/models/ApiDropV2PageWithoutCount';
+import { returnCSVResult } from '@/api/api-helpers';
 
 const router = asyncRouter();
 
@@ -218,6 +219,24 @@ router.get(
       }
     );
     res.send(voters);
+  }
+);
+
+router.get(
+  '/:drop_id/votes/download',
+  maybeAuthenticatedUser(),
+  async (
+    req: Request<{ drop_id: string }, any, any, any, any>,
+    res: Response<string>
+  ) => {
+    const timer = Timer.getFromRequest(req);
+    const authenticationContext = await getAuthenticationContext(req, timer);
+    const dropId = req.params.drop_id;
+    const voters = await apiDropV2Service.findVotersCsvByDropIdOrThrow(dropId, {
+      timer,
+      authenticationContext
+    });
+    return returnCSVResult(`drop-${dropId}-votes`, voters, res);
   }
 );
 

--- a/src/drops/drops.db.ts
+++ b/src/drops/drops.db.ts
@@ -2788,6 +2788,30 @@ export class DropsDb extends LazyDbAccessCompatibleService {
     }
   }
 
+  async findAllDropVotersByVoteDesc(
+    params: Pick<DropVotersByAbsoluteVoteParams, 'wave_id' | 'drop_id'>,
+    ctx: RequestContext
+  ): Promise<DropVoterVoteFromDb[]> {
+    const timerKey = `${this.constructor.name}->findAllDropVotersByVoteDesc`;
+    ctx.timer?.start(timerKey);
+    try {
+      return await this.db.execute<DropVoterVoteFromDb>(
+        `
+        select voter_id, votes as vote
+        from ${DROP_VOTER_STATE_TABLE}
+        where wave_id = :wave_id
+          and drop_id = :drop_id
+          and votes <> 0
+        order by votes desc
+      `,
+        params,
+        { wrappedConnection: ctx.connection }
+      );
+    } finally {
+      ctx.timer?.stop(timerKey);
+    }
+  }
+
   async countDropVotersByAbsoluteVote(
     params: Pick<DropVotersByAbsoluteVoteParams, 'wave_id' | 'drop_id'>,
     ctx: RequestContext
@@ -2925,6 +2949,17 @@ export class DropsDb extends LazyDbAccessCompatibleService {
         { wrappedConnection: ctx.connection }
       )
       .then((res) => res?.cnt ?? 0);
+  }
+
+  async getAllWinnerDropVotersByVoteDesc(
+    dropId: string,
+    ctx: RequestContext
+  ): Promise<WinnerDropVoterVoteEntity[]> {
+    return await this.db.execute<WinnerDropVoterVoteEntity>(
+      `select * from ${WINNER_DROP_VOTER_VOTES_TABLE} where drop_id = :dropId and votes <> 0 order by votes desc`,
+      { dropId },
+      { wrappedConnection: ctx.connection }
+    );
   }
 
   async searchDropsContainingPhraseInWave(

--- a/src/drops/drops.db.ts
+++ b/src/drops/drops.db.ts
@@ -2955,11 +2955,17 @@ export class DropsDb extends LazyDbAccessCompatibleService {
     dropId: string,
     ctx: RequestContext
   ): Promise<WinnerDropVoterVoteEntity[]> {
-    return await this.db.execute<WinnerDropVoterVoteEntity>(
-      `select * from ${WINNER_DROP_VOTER_VOTES_TABLE} where drop_id = :dropId and votes <> 0 order by votes desc`,
-      { dropId },
-      { wrappedConnection: ctx.connection }
-    );
+    const timerKey = `${this.constructor.name}->getAllWinnerDropVotersByVoteDesc`;
+    ctx.timer?.start(timerKey);
+    try {
+      return await this.db.execute<WinnerDropVoterVoteEntity>(
+        `select * from ${WINNER_DROP_VOTER_VOTES_TABLE} where drop_id = :dropId and votes <> 0 order by votes desc`,
+        { dropId },
+        { wrappedConnection: ctx.connection }
+      );
+    } finally {
+      ctx.timer?.stop(timerKey);
+    }
   }
 
   async searchDropsContainingPhraseInWave(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CSV download endpoint for drop voter data (returns CSV or 404 for missing drops).
  * Export includes voter handle, level, primary address, and numeric vote.
  * CSV responses use a drop-specific filename for easy downloading.

* **Tests**
  * Added unit tests covering winner/non-winner exports and empty-result behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/6529-Collections/6529seize-backend/pull/1560)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->