### PR TITLE
serial_nos param and optional wave field to /v2/drops

### DIFF
--- a/src/api-serverless/openapi.yaml
+++ b/src/api-serverless/openapi.yaml
@@ -2165,6 +2165,12 @@ paths:
           required: false
           schema:
             type: string
+        - name: ids
+          in: query
+          description: Comma-separated list of drop IDs to fetch.
+          required: false
+          schema:
+            type: string
         - name: page
           in: query
           required: false

--- a/src/api-serverless/openapi.yaml
+++ b/src/api-serverless/openapi.yaml
@@ -1112,6 +1112,12 @@ paths:
           required: false
           schema:
             type: string
+        - name: serial_nos
+          in: query
+          description: Comma-separated list of drop serial numbers to fetch
+          required: false
+          schema:
+            type: string
         - name: contains_media
           in: query
           description: >-
@@ -2150,6 +2156,12 @@ paths:
         - name: parent_drop_id
           in: query
           description: Return replies under this parent drop.
+          required: false
+          schema:
+            type: string
+        - name: serial_nos
+          in: query
+          description: Comma-separated list of drop serial numbers to fetch.
           required: false
           schema:
             type: string
@@ -10376,6 +10388,8 @@ components:
           $ref: "#/components/schemas/ApiSubmissionDropContext"
         context_profile_context:
           $ref: "#/components/schemas/ApiDropV2ContextProfileContext"
+        wave:
+          $ref: "#/components/schemas/ApiWaveOverview"
     ApiDropV2ContextProfileContext:
       type: object
       required:

--- a/src/api-serverless/src/drops/api-drop-v2-service.test.ts
+++ b/src/api-serverless/src/drops/api-drop-v2-service.test.ts
@@ -305,6 +305,7 @@ describe('ApiDropV2Service', () => {
       {
         parent_drop_id: 'parent-drop',
         serial_nos: null,
+        ids: null,
         page_size: 2,
         page: 2
       },
@@ -323,6 +324,7 @@ describe('ApiDropV2Service', () => {
       {
         parent_drop_id: 'parent-drop',
         serial_nos: null,
+        ids: null,
         group_ids_user_is_eligible_for: ['group-1'],
         limit: 3,
         offset: 2
@@ -361,6 +363,7 @@ describe('ApiDropV2Service', () => {
         {
           parent_drop_id: 'missing-parent',
           serial_nos: null,
+          ids: null,
           page_size: 50,
           page: 1
         },
@@ -396,6 +399,7 @@ describe('ApiDropV2Service', () => {
       {
         parent_drop_id: null,
         serial_nos: [10, 8],
+        ids: null,
         page_size: 50,
         page: 1
       },
@@ -409,6 +413,64 @@ describe('ApiDropV2Service', () => {
       {
         parent_drop_id: null,
         serial_nos: [10, 8],
+        ids: null,
+        group_ids_user_is_eligible_for: ['group-1'],
+        limit: 51,
+        offset: 0
+      },
+      { authenticationContext }
+    );
+    expect(deps.wavesApiDb.findWavesByIdsEligibleForRead).toHaveBeenCalledWith(
+      ['wave-1', 'wave-2'],
+      ['group-1'],
+      undefined
+    );
+    expect(result).toEqual({
+      data: [
+        { id: 'drop-1', wave: { id: 'wave-1' } },
+        { id: 'drop-2', wave: { id: 'wave-2' } }
+      ],
+      page: 1,
+      next: false
+    });
+  });
+
+  it('finds visible V2 drops by ids', async () => {
+    const { service, deps } = createService();
+    const firstDrop = makeDrop({ id: 'drop-1', serial_no: 10 });
+    const secondDrop = makeDrop({
+      id: 'drop-2',
+      serial_no: 8,
+      wave_id: 'wave-2'
+    });
+    const authenticationContext =
+      AuthenticationContext.fromProfileId('viewer-1');
+    deps.dropsDb.findVisibleDrops.mockResolvedValue([firstDrop, secondDrop]);
+    deps.wavesApiDb.findWavesByIdsEligibleForRead.mockResolvedValue([
+      makeWave(),
+      makeWave({ id: 'wave-2', name: 'Wave 2' })
+    ]);
+    deps.apiWaveOverviewMapper.mapWaves.mockResolvedValue({
+      'wave-1': { id: 'wave-1' },
+      'wave-2': { id: 'wave-2' }
+    });
+
+    const result = await service.findDrops(
+      {
+        parent_drop_id: null,
+        serial_nos: null,
+        ids: ['drop-1', 'drop-2'],
+        page_size: 50,
+        page: 1
+      },
+      { authenticationContext }
+    );
+
+    expect(deps.dropsDb.findVisibleDrops).toHaveBeenCalledWith(
+      {
+        parent_drop_id: null,
+        serial_nos: null,
+        ids: ['drop-1', 'drop-2'],
         group_ids_user_is_eligible_for: ['group-1'],
         limit: 51,
         offset: 0

--- a/src/api-serverless/src/drops/api-drop-v2-service.test.ts
+++ b/src/api-serverless/src/drops/api-drop-v2-service.test.ts
@@ -217,6 +217,9 @@ function createService() {
   const userGroupsService = {
     getGroupsUserIsEligibleFor: jest.fn().mockResolvedValue(['group-1'])
   };
+  const wavesApiDb = {
+    findWavesByIdsEligibleForRead: jest.fn().mockResolvedValue([makeWave()])
+  };
   const apiDropMapper = {
     mapDrops: jest.fn().mockImplementation(async (drops: DropEntity[]) =>
       drops.reduce(
@@ -252,6 +255,7 @@ function createService() {
     service: new ApiDropV2Service(
       dropsDb as any,
       userGroupsService as any,
+      wavesApiDb as any,
       apiDropMapper as any,
       apiWaveOverviewMapper as any,
       identityFetcher as any,
@@ -261,6 +265,7 @@ function createService() {
     deps: {
       dropsDb,
       userGroupsService,
+      wavesApiDb,
       apiDropMapper,
       apiWaveOverviewMapper,
       identityFetcher,
@@ -299,6 +304,7 @@ describe('ApiDropV2Service', () => {
     const result = await service.findDrops(
       {
         parent_drop_id: 'parent-drop',
+        serial_nos: null,
         page_size: 2,
         page: 2
       },
@@ -316,6 +322,7 @@ describe('ApiDropV2Service', () => {
     expect(deps.dropsDb.findVisibleDrops).toHaveBeenCalledWith(
       {
         parent_drop_id: 'parent-drop',
+        serial_nos: null,
         group_ids_user_is_eligible_for: ['group-1'],
         limit: 3,
         offset: 2
@@ -326,8 +333,20 @@ describe('ApiDropV2Service', () => {
       [firstReply, secondReply],
       { authenticationContext, connection }
     );
+    expect(deps.wavesApiDb.findWavesByIdsEligibleForRead).toHaveBeenCalledWith(
+      ['wave-1'],
+      ['group-1'],
+      connection
+    );
+    expect(deps.apiWaveOverviewMapper.mapWaves).toHaveBeenCalledWith(
+      [makeWave()],
+      { authenticationContext, connection }
+    );
     expect(result).toEqual({
-      data: [{ id: 'reply-1' }, { id: 'reply-2' }],
+      data: [
+        { id: 'reply-1', wave: { id: 'wave-1' } },
+        { id: 'reply-2', wave: { id: 'wave-1' } }
+      ],
       page: 2,
       next: true
     });
@@ -341,6 +360,7 @@ describe('ApiDropV2Service', () => {
       service.findDrops(
         {
           parent_drop_id: 'missing-parent',
+          serial_nos: null,
           page_size: 50,
           page: 1
         },
@@ -350,6 +370,64 @@ describe('ApiDropV2Service', () => {
 
     expect(deps.dropsDb.findVisibleDrops).not.toHaveBeenCalled();
     expect(deps.apiDropMapper.mapDrops).not.toHaveBeenCalled();
+  });
+
+  it('finds visible V2 drops by serial numbers', async () => {
+    const { service, deps } = createService();
+    const firstDrop = makeDrop({ id: 'drop-1', serial_no: 10 });
+    const secondDrop = makeDrop({
+      id: 'drop-2',
+      serial_no: 8,
+      wave_id: 'wave-2'
+    });
+    const authenticationContext =
+      AuthenticationContext.fromProfileId('viewer-1');
+    deps.dropsDb.findVisibleDrops.mockResolvedValue([firstDrop, secondDrop]);
+    deps.wavesApiDb.findWavesByIdsEligibleForRead.mockResolvedValue([
+      makeWave(),
+      makeWave({ id: 'wave-2', name: 'Wave 2' })
+    ]);
+    deps.apiWaveOverviewMapper.mapWaves.mockResolvedValue({
+      'wave-1': { id: 'wave-1' },
+      'wave-2': { id: 'wave-2' }
+    });
+
+    const result = await service.findDrops(
+      {
+        parent_drop_id: null,
+        serial_nos: [10, 8],
+        page_size: 50,
+        page: 1
+      },
+      { authenticationContext }
+    );
+
+    expect(
+      deps.dropsDb.findDropByIdWithEligibilityCheck
+    ).not.toHaveBeenCalled();
+    expect(deps.dropsDb.findVisibleDrops).toHaveBeenCalledWith(
+      {
+        parent_drop_id: null,
+        serial_nos: [10, 8],
+        group_ids_user_is_eligible_for: ['group-1'],
+        limit: 51,
+        offset: 0
+      },
+      { authenticationContext }
+    );
+    expect(deps.wavesApiDb.findWavesByIdsEligibleForRead).toHaveBeenCalledWith(
+      ['wave-1', 'wave-2'],
+      ['group-1'],
+      undefined
+    );
+    expect(result).toEqual({
+      data: [
+        { id: 'drop-1', wave: { id: 'wave-1' } },
+        { id: 'drop-2', wave: { id: 'wave-2' } }
+      ],
+      page: 1,
+      next: false
+    });
   });
 
   it('finds curated profile wave drops and maps them with V2 models', async () => {

--- a/src/api-serverless/src/drops/api-drop-v2.service.ts
+++ b/src/api-serverless/src/drops/api-drop-v2.service.ts
@@ -32,6 +32,7 @@ import { ApiDropVotersPage } from '@/api/generated/models/ApiDropVotersPage';
 import { DropEntity, DropType } from '@/entities/IDrop';
 import { ApiDropReactionV2 } from '@/api/generated/models/ApiDropReactionV2';
 import { reactionsDb, ReactionsDb } from '@/api/drops/reactions.db';
+import { wavesApiDb, WavesApiDb } from '@/api/waves/waves.api.db';
 
 export type ApiDropWithWave = ApiDropAndWave;
 export type DropVotersSearchParams = {
@@ -55,6 +56,7 @@ export type DropVoteEditLogsSearchParams = {
 
 export interface FindDropsV2Request {
   parent_drop_id: string | null;
+  serial_nos: number[] | null;
   page_size: number;
   page: number;
 }
@@ -80,6 +82,7 @@ export class ApiDropV2Service {
   constructor(
     private readonly dropsDb: DropsDb,
     private readonly userGroupsService: UserGroupsService,
+    private readonly wavesApiDb: WavesApiDb,
     private readonly apiDropMapper: ApiDropMapper,
     private readonly apiWaveOverviewMapper: ApiWaveOverviewMapper,
     private readonly identityFetcher: IdentityFetcher,
@@ -115,6 +118,7 @@ export class ApiDropV2Service {
       const dropEntities = await this.dropsDb.findVisibleDrops(
         {
           parent_drop_id: req.parent_drop_id,
+          serial_nos: req.serial_nos,
           group_ids_user_is_eligible_for: groupIdsUserIsEligibleFor,
           limit: req.page_size + 1,
           offset: req.page_size * (req.page - 1)
@@ -122,12 +126,33 @@ export class ApiDropV2Service {
         ctx
       );
       const pageDropEntities = dropEntities.slice(0, req.page_size);
-      const dropsById = await this.apiDropMapper.mapDrops(
+      const waveIds = Array.from(
+        new Set(pageDropEntities.map((drop) => drop.wave_id))
+      );
+      const dropsByIdPromise = this.apiDropMapper.mapDrops(
         pageDropEntities,
         ctx
       );
+      const wavesByIdPromise = this.wavesApiDb
+        .findWavesByIdsEligibleForRead(
+          waveIds,
+          groupIdsUserIsEligibleFor,
+          ctx.connection
+        )
+        .then((waves) => this.apiWaveOverviewMapper.mapWaves(waves, ctx));
+      const [dropsById, wavesById] = await Promise.all([
+        dropsByIdPromise,
+        wavesByIdPromise
+      ]);
       return {
-        data: pageDropEntities.map((drop) => dropsById[drop.id]),
+        data: pageDropEntities.map((drop) => {
+          const apiDrop = dropsById[drop.id];
+          const wave = wavesById[drop.wave_id];
+          if (wave) {
+            apiDrop.wave = wave;
+          }
+          return apiDrop;
+        }),
         page: req.page,
         next: dropEntities.length > req.page_size
       };
@@ -683,6 +708,7 @@ export class ApiDropV2Service {
 export const apiDropV2Service = new ApiDropV2Service(
   dropsDb,
   userGroupsService,
+  wavesApiDb,
   apiDropMapper,
   apiWaveOverviewMapper,
   identityFetcher,

--- a/src/api-serverless/src/drops/api-drop-v2.service.ts
+++ b/src/api-serverless/src/drops/api-drop-v2.service.ts
@@ -57,6 +57,7 @@ export type DropVoteEditLogsSearchParams = {
 export interface FindDropsV2Request {
   parent_drop_id: string | null;
   serial_nos: number[] | null;
+  ids: string[] | null;
   page_size: number;
   page: number;
 }
@@ -119,6 +120,7 @@ export class ApiDropV2Service {
         {
           parent_drop_id: req.parent_drop_id,
           serial_nos: req.serial_nos,
+          ids: req.ids,
           group_ids_user_is_eligible_for: groupIdsUserIsEligibleFor,
           limit: req.page_size + 1,
           offset: req.page_size * (req.page - 1)

--- a/src/api-serverless/src/drops/drop.validator.ts
+++ b/src/api-serverless/src/drops/drop.validator.ts
@@ -14,6 +14,28 @@ import { ApiAddReactionToDropRequest } from '../generated/models/ApiAddReactionT
 import { ApiDropGroupMention } from '../generated/models/ApiDropGroupMention';
 import { ApiDropAttachmentReference } from '../generated/models/ApiDropAttachmentReference';
 
+function parseSerialNos(value: string, helpers: Joi.CustomHelpers): number[] {
+  const parts = value.split(',').map((part) => part.trim());
+  const serialNos = parts.map((part) => Number(part));
+  if (
+    parts.some((part) => !part) ||
+    serialNos.some((serialNo) => !Number.isInteger(serialNo) || serialNo < 1)
+  ) {
+    return helpers.error('serialNos.invalid') as unknown as number[];
+  }
+  return Array.from(new Set(serialNos));
+}
+
+export const SerialNosQueryParamSchema = Joi.string()
+  .trim()
+  .empty('')
+  .custom(parseSerialNos)
+  .default(null)
+  .messages({
+    'serialNos.invalid':
+      '"serial_nos" must be a comma-separated list of positive integers'
+  });
+
 export const ApiDropRatingRequestSchema: Joi.ObjectSchema<ApiDropRatingRequest> =
   Joi.object({
     rating: Joi.number().integer().required(),

--- a/src/api-serverless/src/drops/drop.validator.ts
+++ b/src/api-serverless/src/drops/drop.validator.ts
@@ -26,6 +26,14 @@ function parseSerialNos(value: string, helpers: Joi.CustomHelpers): number[] {
   return Array.from(new Set(serialNos));
 }
 
+function parseDropIds(value: string, helpers: Joi.CustomHelpers): string[] {
+  const dropIds = value.split(',').map((part) => part.trim());
+  if (dropIds.some((dropId) => !dropId || dropId.length > 100)) {
+    return helpers.error('dropIds.invalid') as unknown as string[];
+  }
+  return Array.from(new Set(dropIds));
+}
+
 export const SerialNosQueryParamSchema = Joi.string()
   .trim()
   .empty('')
@@ -34,6 +42,16 @@ export const SerialNosQueryParamSchema = Joi.string()
   .messages({
     'serialNos.invalid':
       '"serial_nos" must be a comma-separated list of positive integers'
+  });
+
+export const DropIdsQueryParamSchema = Joi.string()
+  .trim()
+  .empty('')
+  .custom(parseDropIds)
+  .default(null)
+  .messages({
+    'dropIds.invalid':
+      '"ids" must be a comma-separated list of non-empty drop IDs'
   });
 
 export const ApiDropRatingRequestSchema: Joi.ObjectSchema<ApiDropRatingRequest> =

--- a/src/api-serverless/src/drops/drops-api-service.test.ts
+++ b/src/api-serverless/src/drops/drops-api-service.test.ts
@@ -137,6 +137,7 @@ describe('DropsApiService', () => {
           include_replies: false,
           drop_type: null,
           ids: null,
+          serial_nos: null,
           contains_media: false
         },
         ctx
@@ -226,6 +227,7 @@ describe('DropsApiService', () => {
           include_replies: false,
           drop_type: null,
           ids: null,
+          serial_nos: null,
           contains_media: false
         },
         ctx
@@ -272,6 +274,7 @@ describe('DropsApiService', () => {
           include_replies: false,
           drop_type: null,
           ids: null,
+          serial_nos: null,
           contains_media: false
         },
         ctx
@@ -297,6 +300,7 @@ describe('DropsApiService', () => {
           include_replies: false,
           drop_type: null,
           ids: null,
+          serial_nos: null,
           contains_media: false
         },
         ctx
@@ -330,6 +334,7 @@ describe('DropsApiService', () => {
           include_replies: false,
           drop_type: null,
           ids: null,
+          serial_nos: null,
           contains_media: false
         },
         ctx

--- a/src/api-serverless/src/drops/drops-v2-handlers.test.ts
+++ b/src/api-serverless/src/drops/drops-v2-handlers.test.ts
@@ -225,6 +225,7 @@ describe('drops v2 handlers', () => {
       expect(mockFindDrops).toHaveBeenCalledWith(
         {
           parent_drop_id: null,
+          serial_nos: null,
           page_size: 50,
           page: 1
         },
@@ -239,6 +240,7 @@ describe('drops v2 handlers', () => {
       const req = {
         query: {
           parent_drop_id: '',
+          serial_nos: '7, 5,7',
           page_size: '25',
           page: '2'
         }
@@ -249,6 +251,7 @@ describe('drops v2 handlers', () => {
       expect(mockFindDrops).toHaveBeenCalledWith(
         {
           parent_drop_id: null,
+          serial_nos: [7, 5],
           page_size: 25,
           page: 2
         },
@@ -264,6 +267,15 @@ describe('drops v2 handlers', () => {
 
       await expect(handleGetDropsV2(req)).rejects.toThrow(
         '"page_size" must be less than or equal to 100'
+      );
+      expect(mockFindDrops).not.toHaveBeenCalled();
+    });
+
+    it('rejects invalid serial numbers', async () => {
+      const req = { query: { serial_nos: '10, nope' } } as any;
+
+      await expect(handleGetDropsV2(req)).rejects.toThrow(
+        '"serial_nos" must be a comma-separated list of positive integers'
       );
       expect(mockFindDrops).not.toHaveBeenCalled();
     });

--- a/src/api-serverless/src/drops/drops-v2-handlers.test.ts
+++ b/src/api-serverless/src/drops/drops-v2-handlers.test.ts
@@ -226,6 +226,7 @@ describe('drops v2 handlers', () => {
         {
           parent_drop_id: null,
           serial_nos: null,
+          ids: null,
           page_size: 50,
           page: 1
         },
@@ -241,6 +242,7 @@ describe('drops v2 handlers', () => {
         query: {
           parent_drop_id: '',
           serial_nos: '7, 5,7',
+          ids: 'drop-1, drop-2,drop-1',
           page_size: '25',
           page: '2'
         }
@@ -252,6 +254,7 @@ describe('drops v2 handlers', () => {
         {
           parent_drop_id: null,
           serial_nos: [7, 5],
+          ids: ['drop-1', 'drop-2'],
           page_size: 25,
           page: 2
         },
@@ -276,6 +279,15 @@ describe('drops v2 handlers', () => {
 
       await expect(handleGetDropsV2(req)).rejects.toThrow(
         '"serial_nos" must be a comma-separated list of positive integers'
+      );
+      expect(mockFindDrops).not.toHaveBeenCalled();
+    });
+
+    it('rejects invalid drop ids', async () => {
+      const req = { query: { ids: 'drop-1,,drop-2' } } as any;
+
+      await expect(handleGetDropsV2(req)).rejects.toThrow(
+        '"ids" must be a comma-separated list of non-empty drop IDs'
       );
       expect(mockFindDrops).not.toHaveBeenCalled();
     });

--- a/src/api-serverless/src/drops/drops-v2.handlers.ts
+++ b/src/api-serverless/src/drops/drops-v2.handlers.ts
@@ -40,6 +40,7 @@ import { getValidatedByJoiOrThrow } from '@/api/validation';
 import { Timer } from '@/time';
 import { Response } from 'express';
 import * as Joi from 'joi';
+import { SerialNosQueryParamSchema } from '@/api/drops/drop.validator';
 
 const FindBoostedDropsV2RequestSchema: Joi.ObjectSchema<FindBoostedDropsV2Request> =
   Joi.object<FindBoostedDropsV2Request>({
@@ -72,14 +73,12 @@ const FindCuratedProfileWaveDropsV2RequestSchema: Joi.ObjectSchema<FindCuratedPr
       .min(1)
   });
 
-const FindDropsV2QuerySchema: Joi.ObjectSchema<FindDropsV2Request> = Joi.object<
-  FindDropsV2Request,
-  true
->({
+const FindDropsV2QuerySchema = Joi.object({
   parent_drop_id: Joi.string().trim().empty('').optional().default(null),
+  serial_nos: SerialNosQueryParamSchema,
   page_size: Joi.number().integer().min(1).max(100).default(50),
   page: Joi.number().integer().min(1).default(1)
-});
+}) as Joi.ObjectSchema<FindDropsV2Request>;
 
 type GetDropV2ByIdPathParams = {
   id: string;

--- a/src/api-serverless/src/drops/drops-v2.handlers.ts
+++ b/src/api-serverless/src/drops/drops-v2.handlers.ts
@@ -40,7 +40,10 @@ import { getValidatedByJoiOrThrow } from '@/api/validation';
 import { Timer } from '@/time';
 import { Response } from 'express';
 import * as Joi from 'joi';
-import { SerialNosQueryParamSchema } from '@/api/drops/drop.validator';
+import {
+  DropIdsQueryParamSchema,
+  SerialNosQueryParamSchema
+} from '@/api/drops/drop.validator';
 
 const FindBoostedDropsV2RequestSchema: Joi.ObjectSchema<FindBoostedDropsV2Request> =
   Joi.object<FindBoostedDropsV2Request>({
@@ -76,6 +79,7 @@ const FindCuratedProfileWaveDropsV2RequestSchema: Joi.ObjectSchema<FindCuratedPr
 const FindDropsV2QuerySchema = Joi.object({
   parent_drop_id: Joi.string().trim().empty('').optional().default(null),
   serial_nos: SerialNosQueryParamSchema,
+  ids: DropIdsQueryParamSchema,
   page_size: Joi.number().integer().min(1).max(100).default(50),
   page: Joi.number().integer().min(1).default(1)
 }) as Joi.ObjectSchema<FindDropsV2Request>;

--- a/src/api-serverless/src/drops/drops.api.service.ts
+++ b/src/api-serverless/src/drops/drops.api.service.ts
@@ -232,6 +232,7 @@ export class DropsApiService {
       include_replies,
       drop_type,
       ids,
+      serial_nos,
       contains_media
     }: {
       group_id: string | null;
@@ -244,6 +245,7 @@ export class DropsApiService {
       include_replies: boolean;
       drop_type: ApiDropType | null;
       ids: string[] | null;
+      serial_nos: number[] | null;
       contains_media: boolean;
     },
     ctx: RequestContext
@@ -282,6 +284,7 @@ export class DropsApiService {
         include_replies,
         drop_type: drop_type ? enums.resolveOrThrow(DropType, drop_type) : null,
         ids,
+        serial_nos,
         contains_media
       },
       ctx

--- a/src/api-serverless/src/drops/drops.routes.ts
+++ b/src/api-serverless/src/drops/drops.routes.ts
@@ -36,6 +36,7 @@ import {
   ApiAddReactionToDropRequestSchema,
   ApiDropRatingRequestSchema,
   NewDropSchema,
+  SerialNosQueryParamSchema,
   UpdateDropSchema
 } from './drop.validator';
 import { dropsService, GetDropsBoostsRequest } from './drops.api.service';
@@ -50,6 +51,12 @@ import { ApiDropCuration } from '@/api/generated/models/ApiDropCuration';
 import { ApiDropCurationRequest } from '@/api/generated/models/ApiDropCurationRequest';
 
 const router = asyncRouter();
+
+const LatestDropsSerialNosQuerySchema: Joi.ObjectSchema<{
+  serial_nos: number[] | null;
+}> = Joi.object({
+  serial_nos: SerialNosQueryParamSchema
+});
 
 router.get(
   '/',
@@ -70,6 +77,7 @@ router.get(
         include_replies?: string;
         drop_type?: ApiDropType;
         ids?: string;
+        serial_nos?: string;
         contains_media?: string;
       },
       any
@@ -88,6 +96,7 @@ router.get(
       include_replies,
       drop_type,
       ids,
+      serial_nos,
       contains_media
     } = await prepLatestDropsSearchQuery(req);
     const latestDrops = await dropsService.findLatestDrops(
@@ -104,6 +113,7 @@ router.get(
         include_replies,
         drop_type,
         ids,
+        serial_nos,
         contains_media
       },
       { timer, authenticationContext }
@@ -745,6 +755,7 @@ export async function prepLatestDropsSearchQuery(
       include_replies?: string;
       drop_type?: ApiDropType;
       ids?: string;
+      serial_nos?: string;
       contains_media?: string;
     },
     any
@@ -770,6 +781,10 @@ export async function prepLatestDropsSearchQuery(
         .map((id) => id.trim())
         .filter((id) => id.length > 0)
     : null;
+  const { serial_nos } = getValidatedByJoiOrThrow(
+    { serial_nos: req.query.serial_nos },
+    LatestDropsSerialNosQuerySchema
+  );
   const contains_media = req.query.contains_media === 'true';
   return {
     limit,
@@ -781,6 +796,7 @@ export async function prepLatestDropsSearchQuery(
     include_replies,
     drop_type: drop_type_enum,
     ids,
+    serial_nos,
     contains_media
   };
 }

--- a/src/api-serverless/src/generated/models/ApiDropV2.ts
+++ b/src/api-serverless/src/generated/models/ApiDropV2.ts
@@ -24,6 +24,7 @@ import { ApiIdentityOverview } from '../models/ApiIdentityOverview';
 import { ApiMentionedWaveV2 } from '../models/ApiMentionedWaveV2';
 import { ApiReplyToDropV2 } from '../models/ApiReplyToDropV2';
 import { ApiSubmissionDropContext } from '../models/ApiSubmissionDropContext';
+import { ApiWaveOverview } from '../models/ApiWaveOverview';
 import { HttpFile } from '../http/http';
 
 export class ApiDropV2 {
@@ -51,6 +52,7 @@ export class ApiDropV2 {
     'reply_to_drop'?: ApiReplyToDropV2;
     'submission_context'?: ApiSubmissionDropContext;
     'context_profile_context'?: ApiDropV2ContextProfileContext;
+    'wave'?: ApiWaveOverview;
 
     static readonly discriminator: string | undefined = undefined;
 
@@ -199,6 +201,12 @@ export class ApiDropV2 {
             "name": "context_profile_context",
             "baseName": "context_profile_context",
             "type": "ApiDropV2ContextProfileContext",
+            "format": ""
+        },
+        {
+            "name": "wave",
+            "baseName": "wave",
+            "type": "ApiWaveOverview",
             "format": ""
         }    ];
 

--- a/src/api-serverless/src/generated/models/ObjectSerializer.ts
+++ b/src/api-serverless/src/generated/models/ObjectSerializer.ts
@@ -484,7 +484,7 @@ import { ApiDropSubscriptionActions } from '../models/ApiDropSubscriptionActions
 import { ApiDropSubscriptionTargetAction } from '../models/ApiDropSubscriptionTargetAction';
 import { ApiDropTraceItem } from '../models/ApiDropTraceItem';
 import { ApiDropType } from '../models/ApiDropType';
-import { ApiDropV2                         } from '../models/ApiDropV2';
+import { ApiDropV2                          } from '../models/ApiDropV2';
 import { ApiDropV2ContextProfileContext } from '../models/ApiDropV2ContextProfileContext';
 import { ApiDropV2Page } from '../models/ApiDropV2Page';
 import { ApiDropV2PageWithoutCount } from '../models/ApiDropV2PageWithoutCount';

--- a/src/api-serverless/src/generated/routes/operations.ts
+++ b/src/api-serverless/src/generated/routes/operations.ts
@@ -62,6 +62,7 @@ export type GetDropsV2PathParams = Record<string, never>;
 export interface GetDropsV2Query {
   "parent_drop_id"?: string;
   "serial_nos"?: string;
+  "ids"?: string;
   "page"?: number;
   "page_size"?: number;
 }

--- a/src/api-serverless/src/generated/routes/operations.ts
+++ b/src/api-serverless/src/generated/routes/operations.ts
@@ -61,6 +61,7 @@ export type GetDropsV2PathParams = Record<string, never>;
 
 export interface GetDropsV2Query {
   "parent_drop_id"?: string;
+  "serial_nos"?: string;
   "page"?: number;
   "page_size"?: number;
 }

--- a/src/drops/drops.db.test.ts
+++ b/src/drops/drops.db.test.ts
@@ -666,6 +666,7 @@ describeWithSeed(
               offset: 0,
               parent_drop_id: 'drop-parent',
               serial_nos: null,
+              ids: null,
               group_ids_user_is_eligible_for: []
             },
             ctx
@@ -681,6 +682,7 @@ describeWithSeed(
               offset: 0,
               parent_drop_id: 'drop-parent',
               serial_nos: null,
+              ids: null,
               group_ids_user_is_eligible_for: ['group-1']
             },
             ctx
@@ -698,6 +700,7 @@ describeWithSeed(
               offset: 0,
               parent_drop_id: null,
               serial_nos: [104, 103, 102, 101],
+              ids: null,
               group_ids_user_is_eligible_for: []
             },
             ctx
@@ -717,6 +720,7 @@ describeWithSeed(
               offset: 0,
               parent_drop_id: null,
               serial_nos: [104, 103, 102, 101],
+              ids: null,
               group_ids_user_is_eligible_for: ['group-1']
             },
             ctx
@@ -727,6 +731,44 @@ describeWithSeed(
         'drop-public-a-new',
         'drop-private',
         'drop-public-a-old'
+      ]);
+    });
+
+    it('finds visible drops by ids across waves', async () => {
+      await expect(
+        repo
+          .findVisibleDrops(
+            {
+              limit: 10,
+              offset: 0,
+              parent_drop_id: null,
+              serial_nos: null,
+              ids: ['drop-public-b', 'drop-private', 'drop-public-a-new'],
+              group_ids_user_is_eligible_for: []
+            },
+            ctx
+          )
+          .then((drops) => drops.map((drop) => drop.id))
+      ).resolves.toEqual(['drop-public-b', 'drop-public-a-new']);
+
+      await expect(
+        repo
+          .findVisibleDrops(
+            {
+              limit: 10,
+              offset: 0,
+              parent_drop_id: null,
+              serial_nos: null,
+              ids: ['drop-public-b', 'drop-private', 'drop-public-a-new'],
+              group_ids_user_is_eligible_for: ['group-1']
+            },
+            ctx
+          )
+          .then((drops) => drops.map((drop) => drop.id))
+      ).resolves.toEqual([
+        'drop-public-b',
+        'drop-public-a-new',
+        'drop-private'
       ]);
     });
 

--- a/src/drops/drops.db.test.ts
+++ b/src/drops/drops.db.test.ts
@@ -665,6 +665,7 @@ describeWithSeed(
               limit: 10,
               offset: 0,
               parent_drop_id: 'drop-parent',
+              serial_nos: null,
               group_ids_user_is_eligible_for: []
             },
             ctx
@@ -679,12 +680,54 @@ describeWithSeed(
               limit: 10,
               offset: 0,
               parent_drop_id: 'drop-parent',
+              serial_nos: null,
               group_ids_user_is_eligible_for: ['group-1']
             },
             ctx
           )
           .then((drops) => drops.map((drop) => drop.id))
       ).resolves.toEqual(['drop-public-a-new', 'drop-private']);
+    });
+
+    it('finds visible drops by serial numbers across waves', async () => {
+      await expect(
+        repo
+          .findVisibleDrops(
+            {
+              limit: 10,
+              offset: 0,
+              parent_drop_id: null,
+              serial_nos: [104, 103, 102, 101],
+              group_ids_user_is_eligible_for: []
+            },
+            ctx
+          )
+          .then((drops) => drops.map((drop) => drop.id))
+      ).resolves.toEqual([
+        'drop-public-b',
+        'drop-public-a-new',
+        'drop-public-a-old'
+      ]);
+
+      await expect(
+        repo
+          .findVisibleDrops(
+            {
+              limit: 10,
+              offset: 0,
+              parent_drop_id: null,
+              serial_nos: [104, 103, 102, 101],
+              group_ids_user_is_eligible_for: ['group-1']
+            },
+            ctx
+          )
+          .then((drops) => drops.map((drop) => drop.id))
+      ).resolves.toEqual([
+        'drop-public-b',
+        'drop-public-a-new',
+        'drop-private',
+        'drop-public-a-old'
+      ]);
     });
 
     it('does not include private waves for admin-group-only eligibility in the global selector', async () => {
@@ -736,6 +779,7 @@ describeWithSeed(
           include_replies: false,
           drop_type: null,
           ids: null,
+          serial_nos: null,
           contains_media: false
         },
         ctx
@@ -761,12 +805,66 @@ describeWithSeed(
           include_replies: false,
           drop_type: null,
           ids: null,
+          serial_nos: null,
           contains_media: false
         },
         ctx
       );
 
       expect(results).toEqual([]);
+    });
+
+    it('finds latest drops by serial numbers across eligible waves', async () => {
+      const resultsWithoutPrivate = await repo.findLatestDrops(
+        {
+          amount: 10,
+          serial_no_less_than: null,
+          group_ids_user_is_eligible_for: [],
+          group_id: null,
+          wave_id: null,
+          curation_id: null,
+          curation_name: null,
+          author_id: null,
+          include_replies: false,
+          drop_type: null,
+          ids: null,
+          serial_nos: [104, 103, 102, 101],
+          contains_media: false
+        },
+        ctx
+      );
+
+      expect(resultsWithoutPrivate.map((it) => it.id)).toEqual([
+        'drop-public-b',
+        'drop-public-a-new',
+        'drop-public-a-old'
+      ]);
+
+      const resultsWithPrivate = await repo.findLatestDrops(
+        {
+          amount: 10,
+          serial_no_less_than: null,
+          group_ids_user_is_eligible_for: ['group-1'],
+          group_id: null,
+          wave_id: null,
+          curation_id: null,
+          curation_name: null,
+          author_id: null,
+          include_replies: false,
+          drop_type: null,
+          ids: null,
+          serial_nos: [104, 103, 102, 101],
+          contains_media: false
+        },
+        ctx
+      );
+
+      expect(resultsWithPrivate.map((it) => it.id)).toEqual([
+        'drop-public-b',
+        'drop-public-a-new',
+        'drop-private',
+        'drop-public-a-old'
+      ]);
     });
 
     it('does not find a private drop by id through admin-group-only eligibility', async () => {

--- a/src/drops/drops.db.ts
+++ b/src/drops/drops.db.ts
@@ -796,12 +796,14 @@ export class DropsDb extends LazyDbAccessCompatibleService {
       offset,
       parent_drop_id,
       serial_nos,
+      ids,
       group_ids_user_is_eligible_for
     }: {
       limit: number;
       offset: number;
       parent_drop_id: string | null;
       serial_nos: number[] | null;
+      ids: string[] | null;
       group_ids_user_is_eligible_for: string[];
     },
     ctx: RequestContext
@@ -821,11 +823,12 @@ export class DropsDb extends LazyDbAccessCompatibleService {
              : ``
          }
          where ${
-           parent_drop_id || serial_nos?.length
+           parent_drop_id || serial_nos?.length || ids?.length
              ? ``
              : `d.reply_to_drop_id is null and`
          }
-           ${serial_nos?.length ? `d.serial_no in (:serial_nos) and` : ``}
+          ${serial_nos?.length ? `d.serial_no in (:serial_nos) and` : ``}
+          ${ids?.length ? `d.id in (:ids) and` : ``}
            exists (
              select 1
              from ${WAVES_TABLE} w
@@ -839,6 +842,7 @@ export class DropsDb extends LazyDbAccessCompatibleService {
           offset,
           parent_drop_id,
           serial_nos,
+          ids,
           groupsUserIsEligibleFor: group_ids_user_is_eligible_for
         },
         { wrappedConnection: ctx.connection }

--- a/src/drops/drops.db.ts
+++ b/src/drops/drops.db.ts
@@ -612,6 +612,7 @@ export class DropsDb extends LazyDbAccessCompatibleService {
       include_replies,
       drop_type,
       ids,
+      serial_nos,
       contains_media
     }: {
       group_id: string | null;
@@ -625,6 +626,7 @@ export class DropsDb extends LazyDbAccessCompatibleService {
       include_replies: boolean;
       drop_type: DropType | null;
       ids: string[] | null;
+      serial_nos: number[] | null;
       contains_media: boolean;
     },
     ctx: RequestContext
@@ -660,10 +662,12 @@ export class DropsDb extends LazyDbAccessCompatibleService {
          where ${
            drop_type ? ` d.drop_type = :drop_type and ` : ``
          } d.serial_no < :serialNoLessThan ${
-           !include_replies ? `and reply_to_drop_id is null` : ``
+           !include_replies && !serial_nos?.length
+             ? `and reply_to_drop_id is null`
+             : ``
          } ${author_id ? ` and d.author_id = :author_id ` : ``}${
            ids?.length ? ` and d.id in (:ids) ` : ``
-         }${
+         }${serial_nos?.length ? ` and d.serial_no in (:serial_nos) ` : ``}${
            contains_media
              ? ` and exists (select 1 from ${DROP_MEDIA_TABLE} dm where dm.drop_id = d.id) `
              : ``
@@ -677,7 +681,8 @@ export class DropsDb extends LazyDbAccessCompatibleService {
       curation_id: curation_id ?? null,
       curation_name: curation_name ?? null,
       drop_type,
-      ids
+      ids,
+      serial_nos
     };
     return this.db.execute<DropEntity>(sql, params);
   }
@@ -790,11 +795,13 @@ export class DropsDb extends LazyDbAccessCompatibleService {
       limit,
       offset,
       parent_drop_id,
+      serial_nos,
       group_ids_user_is_eligible_for
     }: {
       limit: number;
       offset: number;
       parent_drop_id: string | null;
+      serial_nos: number[] | null;
       group_ids_user_is_eligible_for: string[];
     },
     ctx: RequestContext
@@ -813,7 +820,12 @@ export class DropsDb extends LazyDbAccessCompatibleService {
              ? `join ${DROP_RELATIONS_TABLE} dr on dr.child_id = d.id and dr.parent_id = :parent_drop_id`
              : ``
          }
-         where ${parent_drop_id ? `` : `d.reply_to_drop_id is null and`}
+         where ${
+           parent_drop_id || serial_nos?.length
+             ? ``
+             : `d.reply_to_drop_id is null and`
+         }
+           ${serial_nos?.length ? `d.serial_no in (:serial_nos) and` : ``}
            exists (
              select 1
              from ${WAVES_TABLE} w
@@ -826,6 +838,7 @@ export class DropsDb extends LazyDbAccessCompatibleService {
           limit,
           offset,
           parent_drop_id,
+          serial_nos,
           groupsUserIsEligibleFor: group_ids_user_is_eligible_for
         },
         { wrappedConnection: ctx.connection }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added serial_nos query parameter to GET /drops and GET /v2/drops to filter results by comma-separated serial numbers.
  * V2 drop responses now include a wave field showing the associated wave overview.
* **Enhancements**
  * Request validation tightened: malformed serial_nos or ids are rejected with proper validation errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/6529-Collections/6529seize-backend/pull/1566)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->