### PR TITLE
fix for opensea price detection

### DIFF
--- a/src/nft-links/adapters/opensea.test.ts
+++ b/src/nft-links/adapters/opensea.test.ts
@@ -1,0 +1,203 @@
+import { formatUnits } from 'ethers';
+import fc from 'fast-check';
+import { fetchJsonWithTimeout } from '../lib/http';
+import { OpenSeaAdapter } from './opensea';
+import { CanonicalLink } from '@/nft-links/types';
+
+jest.mock('../lib/http', () => ({
+  fetchJsonWithTimeout: jest.fn()
+}));
+
+const fetchJsonMock = fetchJsonWithTimeout as jest.MockedFunction<
+  typeof fetchJsonWithTimeout
+>;
+
+const originalEnv = { ...process.env };
+
+const canonical: CanonicalLink = {
+  platform: 'OPENSEA',
+  viewUrl:
+    'https://opensea.io/assets/ethereum/0x1111111111111111111111111111111111111111/1',
+  canonicalId: 'OPENSEA:eth:0x1111111111111111111111111111111111111111:1',
+  identifiers: {
+    kind: 'TOKEN',
+    chain: 'eth',
+    contract: '0x1111111111111111111111111111111111111111',
+    tokenId: '1'
+  },
+  originalUrl:
+    'https://opensea.io/assets/ethereum/0x1111111111111111111111111111111111111111/1'
+};
+
+function nftResponse() {
+  return {
+    nft: {
+      name: 'Edition #1',
+      image_url: 'https://example.com/image.png',
+      collection: {
+        name: 'Test Collection',
+        slug: 'test-collection'
+      }
+    }
+  };
+}
+
+function legacyOrder({
+  currentPrice,
+  quantity
+}: {
+  currentPrice: bigint;
+  quantity: number;
+}) {
+  return {
+    current_price: currentPrice.toString(),
+    remaining_quantity: String(quantity),
+    payment_token: {
+      symbol: 'ETH'
+    }
+  };
+}
+
+async function resolveWithLegacyOrders(orders: any[]) {
+  fetchJsonMock
+    .mockResolvedValueOnce(nftResponse())
+    .mockRejectedValueOnce(new Error('best listing unavailable'))
+    .mockResolvedValueOnce({ orders });
+
+  const result = await new OpenSeaAdapter().resolveFast(canonical);
+  return (result?.patch as any).market.price;
+}
+
+describe('OpenSeaAdapter', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    process.env.OPENSEA_API_KEY = 'test-key';
+    delete process.env.OPENSEA_API_BASE;
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('prefers the NFT-specific best listing endpoint', async () => {
+    fetchJsonMock.mockResolvedValueOnce(nftResponse()).mockResolvedValueOnce({
+      listing: {
+        price: {
+          current: {
+            value: '50000000000000000',
+            currency: 'ETH',
+            decimals: 18
+          }
+        }
+      }
+    });
+
+    const result = await new OpenSeaAdapter().resolveFast(canonical);
+    const price = (result?.patch as any).market.price;
+
+    expect(price).toEqual({
+      amount: '0.05',
+      currency: 'ETH'
+    });
+    expect(fetchJsonMock).toHaveBeenCalledTimes(2);
+    expect(fetchJsonMock.mock.calls[1]?.[0]).toContain(
+      '/api/v2/listings/collection/test-collection/nfts/1/best'
+    );
+  });
+
+  it('normalizes structured best listing aggregate price to unit price', async () => {
+    fetchJsonMock.mockResolvedValueOnce(nftResponse()).mockResolvedValueOnce({
+      listing: {
+        quantity: 5,
+        price: {
+          current: {
+            value: '250000000000000000',
+            currency: 'ETH',
+            decimals: 18
+          }
+        }
+      }
+    });
+
+    const result = await new OpenSeaAdapter().resolveFast(canonical);
+    const price = (result?.patch as any).market.price;
+
+    expect(price).toEqual({
+      amount: '0.05',
+      currency: 'ETH'
+    });
+  });
+
+  it('normalizes legacy ERC1155 aggregate price to unit price', async () => {
+    const price = await resolveWithLegacyOrders([
+      legacyOrder({
+        currentPrice: BigInt('250000000000000000'),
+        quantity: 5
+      })
+    ]);
+
+    expect(price).toEqual({
+      amount: '0.05',
+      currency: 'ETH'
+    });
+  });
+
+  it('chooses the lowest normalized unit price from legacy listings', async () => {
+    const price = await resolveWithLegacyOrders([
+      legacyOrder({
+        currentPrice: BigInt('120000000000000000'),
+        quantity: 2
+      }),
+      legacyOrder({
+        currentPrice: BigInt('250000000000000000'),
+        quantity: 5
+      })
+    ]);
+
+    expect(price).toEqual({
+      amount: '0.05',
+      currency: 'ETH'
+    });
+  });
+
+  it('keeps single quantity legacy listing price unchanged', async () => {
+    const price = await resolveWithLegacyOrders([
+      legacyOrder({
+        currentPrice: BigInt('50000000000000000'),
+        quantity: 1
+      })
+    ]);
+
+    expect(price).toEqual({
+      amount: '0.05',
+      currency: 'ETH'
+    });
+  });
+
+  it('normalizes generated legacy ERC1155 aggregate prices by quantity', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.integer({ min: 1, max: 1000000 }),
+        fc.integer({ min: 2, max: 25 }),
+        async (unitWeiNumber, quantity) => {
+          fetchJsonMock.mockReset();
+          const unitWei = BigInt(unitWeiNumber);
+          const totalWei = unitWei * BigInt(quantity);
+
+          const price = await resolveWithLegacyOrders([
+            legacyOrder({
+              currentPrice: totalWei,
+              quantity
+            })
+          ]);
+
+          expect(price).toEqual({
+            amount: formatUnits(unitWei, 18),
+            currency: 'ETH'
+          });
+        }
+      ),
+      { numRuns: 25 }
+    );
+  });
+});

--- a/src/nft-links/adapters/opensea.test.ts
+++ b/src/nft-links/adapters/opensea.test.ts
@@ -142,7 +142,7 @@ describe('OpenSeaAdapter', () => {
     });
   });
 
-  it('chooses the lowest normalized unit price from legacy listings', async () => {
+  it('respects server ordering for legacy listings', async () => {
     const price = await resolveWithLegacyOrders([
       legacyOrder({
         currentPrice: BigInt('120000000000000000'),
@@ -155,7 +155,7 @@ describe('OpenSeaAdapter', () => {
     ]);
 
     expect(price).toEqual({
-      amount: '0.05',
+      amount: '0.06',
       currency: 'ETH'
     });
   });

--- a/src/nft-links/adapters/opensea.ts
+++ b/src/nft-links/adapters/opensea.ts
@@ -19,6 +19,12 @@ function toOpenSeaApiChain(chain: string): string {
 }
 
 type AnyObj = Record<string, any>;
+type ParsedListingPrice = {
+  amount: string;
+  currency: string;
+  rawAmount?: bigint;
+  decimals?: number;
+};
 
 function getApiKeyHeader(): Record<string, string> {
   const key = env.getStringOrNull('OPENSEA_API_KEY');
@@ -68,13 +74,16 @@ function parseMetadata(meta: AnyObj): {
     meta.creator?.username
   );
 
-  const collectionName = pick<string>(
-    nft.collection?.name,
-    meta.collection?.name
-  );
+  const collection = nft.collection ?? meta.collection;
+  const collectionName =
+    collection && typeof collection === 'object'
+      ? pick<string>(collection.name, meta.collection?.name)
+      : undefined;
   const collectionSlug = pick<string>(
-    nft.collection?.slug,
-    meta.collection?.slug
+    typeof collection === 'string' ? collection : undefined,
+    collection?.slug,
+    nft.collection_slug,
+    meta.collection_slug
   );
 
   return {
@@ -96,37 +105,152 @@ function parseCollectionSlug(res: AnyObj): string | undefined {
   return undefined;
 }
 
-function parseBestListing(
-  res: AnyObj
-): { amount?: string; currency?: string } | undefined {
+function parseIntegerLike(value: any): bigint | undefined {
+  if (value == null) return undefined;
+  if (typeof value === 'bigint') return value;
+  if (typeof value === 'number') {
+    if (!Number.isInteger(value) || value < 0) return undefined;
+    return BigInt(value);
+  }
+  const asString = String(value).trim();
+  const match = /^(\d+)(?:\.0+)?$/.exec(asString);
+  if (!match) return undefined;
+  return BigInt(match[1]);
+}
+
+function parseDecimals(value: any): number | undefined {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 0 || parsed > 255) {
+    return undefined;
+  }
+  return parsed;
+}
+
+function getListingQuantity(listing: AnyObj): bigint | undefined {
+  const quantity = parseIntegerLike(
+    pick<any>(
+      listing?.remaining_quantity,
+      listing?.quantity,
+      listing?.protocol_data?.parameters?.offer?.[0]?.startAmount
+    )
+  );
+  if (!quantity || quantity <= BigInt(1)) {
+    return undefined;
+  }
+  return quantity;
+}
+
+function formatRawTokenAmount(amount: bigint, decimals: number): string {
+  return formatTokenAmount(amount, decimals);
+}
+
+function parseBestListing(res: AnyObj): ParsedListingPrice | undefined {
   // The shape changes over time; be permissive.
   const listing = res.listing ?? res.best_listing ?? res;
-  const price =
-    listing?.price ??
+  const structuredPrice = listing?.price?.current ?? listing?.price;
+
+  const structuredAmount = pick<any>(
+    structuredPrice?.value,
+    structuredPrice?.amount
+  );
+  const structuredCurrency = pick<any>(
+    structuredPrice?.currency,
+    structuredPrice?.currency_symbol
+  );
+  if (structuredAmount != null && structuredCurrency != null) {
+    const rawAmount = parseIntegerLike(structuredAmount);
+    const quantity =
+      rawAmount == null ? undefined : getListingQuantity(listing);
+    const normalizedRawAmount =
+      quantity && quantity > BigInt(1) ? rawAmount! / quantity : rawAmount;
+    return {
+      amount:
+        normalizedRawAmount == null
+          ? String(structuredAmount)
+          : normalizedRawAmount.toString(),
+      currency: String(structuredCurrency),
+      rawAmount: normalizedRawAmount,
+      decimals: parseDecimals(structuredPrice?.decimals)
+    };
+  }
+
+  const legacyPrice =
     listing?.current_price ??
     listing?.protocol_data?.parameters?.consideration?.[0];
 
   // Common patterns
   const amount = pick<any>(
-    price?.amount,
-    price?.value,
-    listing?.price?.current?.value,
-    listing?.price?.value,
+    legacyPrice?.amount,
+    legacyPrice?.value,
     listing?.current_price
   );
   const currency = pick<any>(
-    price?.currency,
-    price?.currency_symbol,
-    listing?.price?.current?.currency,
+    legacyPrice?.currency,
+    legacyPrice?.currency_symbol,
     listing?.payment_token?.symbol,
-    listing?.protocol_data?.payment_token?.symbol
+    listing?.protocol_data?.payment_token?.symbol,
+    listing?.taker_asset_bundle?.assets?.[0]?.asset_contract?.symbol
   );
 
-  if (amount == null && currency == null) return undefined;
+  if (amount == null || currency == null) return undefined;
+  const rawAmount = parseIntegerLike(amount);
+  const quantity = rawAmount == null ? undefined : getListingQuantity(listing);
+  const normalizedRawAmount =
+    quantity && quantity > BigInt(1) ? rawAmount! / quantity : rawAmount;
   return {
-    amount: amount == null ? undefined : String(amount),
-    currency: currency == null ? undefined : String(currency)
+    amount:
+      normalizedRawAmount == null
+        ? String(amount)
+        : normalizedRawAmount.toString(),
+    currency: String(currency),
+    rawAmount: normalizedRawAmount,
+    decimals:
+      String(currency).toUpperCase() === 'ETH'
+        ? ETH_DEFAULT_DECIMALS
+        : undefined
   };
+}
+
+function toMarketPrice(
+  parsed: ParsedListingPrice
+): { amount: string; currency: string } | undefined {
+  if (!parsed.amount || !parsed.currency) {
+    return undefined;
+  }
+  const currency = parsed.currency;
+  if (parsed.rawAmount != null && parsed.decimals != null) {
+    return {
+      amount: formatRawTokenAmount(parsed.rawAmount, parsed.decimals),
+      currency
+    };
+  }
+  if (currency.toUpperCase() === 'ETH' && parsed.rawAmount != null) {
+    return {
+      amount: formatRawTokenAmount(parsed.rawAmount, ETH_DEFAULT_DECIMALS),
+      currency
+    };
+  }
+  return {
+    amount: parsed.amount,
+    currency
+  };
+}
+
+function selectBestListingPrice(
+  listings: AnyObj[]
+): ParsedListingPrice | undefined {
+  const parsedListings = listings
+    .map((listing) => parseBestListing(listing))
+    .filter((it): it is ParsedListingPrice => !!it?.amount && !!it?.currency);
+  const ethListingsWithRawAmount = parsedListings.filter(
+    (it) => it.currency.toUpperCase() === 'ETH' && it.rawAmount != null
+  );
+  if (ethListingsWithRawAmount.length) {
+    return ethListingsWithRawAmount.reduce((best, current) =>
+      current.rawAmount! < best.rawAmount! ? current : best
+    );
+  }
+  return parsedListings[0];
 }
 
 export class OpenSeaAdapter implements PlatformAdapter {
@@ -159,81 +283,70 @@ export class OpenSeaAdapter implements PlatformAdapter {
 
     const m = parseMetadata(meta);
 
-    // Listings: use Seaport orders endpoint (best-effort; shape may evolve)
+    // Listings: prefer the NFT-specific best-listing endpoint. The legacy
+    // orders endpoint reports ERC1155 aggregate prices, so keep it as fallback.
     let price: { amount: string; currency: string } | undefined;
     let saleType: 'FIXED' | 'UNKNOWN' = 'UNKNOWN';
 
-    const ordersUrl = new URL(
-      `${apiBase}/api/v2/orders/${encodeURIComponent(apiChain)}/seaport/listings`
-    );
-    ordersUrl.searchParams.set('asset_contract_address', contract);
-    ordersUrl.searchParams.set('token_ids', tokenId);
-    ordersUrl.searchParams.set('limit', '1');
-    // Prefer lowest price when server supports ordering
-    ordersUrl.searchParams.set('order_by', 'eth_price');
-    ordersUrl.searchParams.set('order_direction', 'asc');
-
-    try {
-      const orders = await fetchJsonWithTimeout<AnyObj>(ordersUrl.toString(), {
-        timeoutMs,
-        headers
-      });
-      const first = orders?.orders?.[0];
-      const parsed = first ? parseBestListing(first) : undefined;
-      if (parsed?.amount && parsed?.currency) {
-        price = {
-          amount:
-            parsed?.currency === 'ETH'
-              ? formatTokenAmount(BigInt(parsed.amount), ETH_DEFAULT_DECIMALS)
-              : parsed.amount,
-          currency: parsed.currency
-        };
-        saleType = 'FIXED';
+    let collectionSlug = m.collectionSlug;
+    if (!collectionSlug) {
+      try {
+        const collectionUrl = `${apiBase}/api/v2/chain/${encodeURIComponent(apiChain)}/contract/${encodeURIComponent(contract)}/nfts/${encodeURIComponent(tokenId)}/collection`;
+        const col = await fetchJsonWithTimeout<AnyObj>(collectionUrl, {
+          timeoutMs,
+          headers
+        });
+        collectionSlug = parseCollectionSlug(col);
+      } catch {
+        // ignore
       }
-    } catch {
-      // ignore
     }
 
-    // Backward-compatible fallback: best listing by collection slug
-    if (!price) {
-      let collectionSlug = m.collectionSlug;
-      if (!collectionSlug) {
-        try {
-          const collectionUrl = `${apiBase}/api/v2/chain/${encodeURIComponent(apiChain)}/contract/${encodeURIComponent(contract)}/nfts/${encodeURIComponent(tokenId)}/collection`;
-          const col = await fetchJsonWithTimeout<AnyObj>(collectionUrl, {
-            timeoutMs,
-            headers
-          });
-          collectionSlug = parseCollectionSlug(col);
-        } catch {
-          // ignore
+    if (collectionSlug) {
+      const bestUrl = `${apiBase}/api/v2/listings/collection/${encodeURIComponent(collectionSlug)}/nfts/${encodeURIComponent(tokenId)}/best`;
+      try {
+        const best = await fetchJsonWithTimeout<AnyObj>(bestUrl, {
+          timeoutMs,
+          headers
+        });
+        const parsed = parseBestListing(best);
+        const marketPrice = parsed ? toMarketPrice(parsed) : undefined;
+        if (marketPrice) {
+          price = marketPrice;
+          saleType = 'FIXED';
         }
+      } catch {
+        // ignore
       }
+    }
 
-      if (collectionSlug) {
-        const bestUrl = `${apiBase}/api/v2/listings/collection/${encodeURIComponent(collectionSlug)}/nfts/${encodeURIComponent(tokenId)}/best`;
-        try {
-          const best = await fetchJsonWithTimeout<AnyObj>(bestUrl, {
+    if (!price) {
+      const ordersUrl = new URL(
+        `${apiBase}/api/v2/orders/${encodeURIComponent(apiChain)}/seaport/listings`
+      );
+      ordersUrl.searchParams.set('asset_contract_address', contract);
+      ordersUrl.searchParams.set('token_ids', tokenId);
+      ordersUrl.searchParams.set('limit', '200');
+      // Prefer lowest price when server supports ordering
+      ordersUrl.searchParams.set('order_by', 'eth_price');
+      ordersUrl.searchParams.set('order_direction', 'asc');
+
+      try {
+        const orders = await fetchJsonWithTimeout<AnyObj>(
+          ordersUrl.toString(),
+          {
             timeoutMs,
             headers
-          });
-          const parsed = parseBestListing(best);
-          if (parsed?.amount && parsed?.currency) {
-            price = {
-              amount:
-                parsed?.currency === 'ETH'
-                  ? formatTokenAmount(
-                      BigInt(parsed.amount),
-                      ETH_DEFAULT_DECIMALS
-                    )
-                  : parsed.amount,
-              currency: parsed.currency
-            };
-            saleType = 'FIXED';
           }
-        } catch {
-          // ignore
+        );
+        const parsed = selectBestListingPrice(orders?.orders ?? []);
+        const marketPrice = parsed ? toMarketPrice(parsed) : undefined;
+        if (marketPrice) {
+          price = marketPrice;
+          saleType = 'FIXED';
         }
+      } catch {
+        // ignore
       }
     }
 

--- a/src/nft-links/adapters/opensea.ts
+++ b/src/nft-links/adapters/opensea.ts
@@ -25,9 +25,6 @@ type ParsedListingPrice = {
   rawAmount?: bigint;
   decimals?: number;
 };
-type ParsedListingPriceWithRawAmount = ParsedListingPrice & {
-  rawAmount: bigint;
-};
 
 function getApiKeyHeader(): Record<string, string> {
   const key = env.getStringOrNull('OPENSEA_API_KEY');
@@ -248,26 +245,12 @@ function toMarketPrice(
   };
 }
 
-function hasEthRawAmount(
-  listing: ParsedListingPrice
-): listing is ParsedListingPriceWithRawAmount {
-  return listing.currency.toUpperCase() === 'ETH' && listing.rawAmount != null;
-}
-
 function selectBestListingPrice(
   listings: AnyObj[]
 ): ParsedListingPrice | undefined {
   const parsedListings = listings
     .map((listing) => parseBestListing(listing))
     .filter((it): it is ParsedListingPrice => !!it?.amount && !!it?.currency);
-  const ethListingsWithRawAmount = parsedListings.filter(hasEthRawAmount);
-  if (ethListingsWithRawAmount.length) {
-    const [first, ...rest] = ethListingsWithRawAmount;
-    return rest.reduce(
-      (best, current) => (current.rawAmount < best.rawAmount ? current : best),
-      first
-    );
-  }
   return parsedListings[0];
 }
 

--- a/src/nft-links/adapters/opensea.ts
+++ b/src/nft-links/adapters/opensea.ts
@@ -25,6 +25,9 @@ type ParsedListingPrice = {
   rawAmount?: bigint;
   decimals?: number;
 };
+type ParsedListingPriceWithRawAmount = ParsedListingPrice & {
+  rawAmount: bigint;
+};
 
 function getApiKeyHeader(): Record<string, string> {
   const key = env.getStringOrNull('OPENSEA_API_KEY');
@@ -140,6 +143,20 @@ function getListingQuantity(listing: AnyObj): bigint | undefined {
   return quantity;
 }
 
+function normalizeAggregateRawAmount(
+  rawAmount: bigint | undefined,
+  listing: AnyObj
+): bigint | undefined {
+  if (rawAmount == null) {
+    return undefined;
+  }
+  const quantity = getListingQuantity(listing);
+  if (quantity && quantity > BigInt(1)) {
+    return rawAmount / quantity;
+  }
+  return rawAmount;
+}
+
 function formatRawTokenAmount(amount: bigint, decimals: number): string {
   return formatTokenAmount(amount, decimals);
 }
@@ -159,10 +176,7 @@ function parseBestListing(res: AnyObj): ParsedListingPrice | undefined {
   );
   if (structuredAmount != null && structuredCurrency != null) {
     const rawAmount = parseIntegerLike(structuredAmount);
-    const quantity =
-      rawAmount == null ? undefined : getListingQuantity(listing);
-    const normalizedRawAmount =
-      quantity && quantity > BigInt(1) ? rawAmount! / quantity : rawAmount;
+    const normalizedRawAmount = normalizeAggregateRawAmount(rawAmount, listing);
     return {
       amount:
         normalizedRawAmount == null
@@ -194,9 +208,7 @@ function parseBestListing(res: AnyObj): ParsedListingPrice | undefined {
 
   if (amount == null || currency == null) return undefined;
   const rawAmount = parseIntegerLike(amount);
-  const quantity = rawAmount == null ? undefined : getListingQuantity(listing);
-  const normalizedRawAmount =
-    quantity && quantity > BigInt(1) ? rawAmount! / quantity : rawAmount;
+  const normalizedRawAmount = normalizeAggregateRawAmount(rawAmount, listing);
   return {
     amount:
       normalizedRawAmount == null
@@ -236,20 +248,23 @@ function toMarketPrice(
   };
 }
 
+function hasEthRawAmount(
+  listing: ParsedListingPrice
+): listing is ParsedListingPriceWithRawAmount {
+  return listing.currency.toUpperCase() === 'ETH' && listing.rawAmount != null;
+}
+
 function selectBestListingPrice(
   listings: AnyObj[]
 ): ParsedListingPrice | undefined {
   const parsedListings = listings
     .map((listing) => parseBestListing(listing))
     .filter((it): it is ParsedListingPrice => !!it?.amount && !!it?.currency);
-  const ethListingsWithRawAmount = parsedListings.filter(
-    (it) => it.currency.toUpperCase() === 'ETH' && it.rawAmount != null
-  );
+  const ethListingsWithRawAmount = parsedListings.filter(hasEthRawAmount);
   if (ethListingsWithRawAmount.length) {
     const [first, ...rest] = ethListingsWithRawAmount;
     return rest.reduce(
-      (best, current) =>
-        current.rawAmount! < best.rawAmount! ? current : best,
+      (best, current) => (current.rawAmount < best.rawAmount ? current : best),
       first
     );
   }

--- a/src/nft-links/adapters/opensea.ts
+++ b/src/nft-links/adapters/opensea.ts
@@ -246,8 +246,11 @@ function selectBestListingPrice(
     (it) => it.currency.toUpperCase() === 'ETH' && it.rawAmount != null
   );
   if (ethListingsWithRawAmount.length) {
-    return ethListingsWithRawAmount.reduce((best, current) =>
-      current.rawAmount! < best.rawAmount! ? current : best
+    const [first, ...rest] = ethListingsWithRawAmount;
+    return rest.reduce(
+      (best, current) =>
+        current.rawAmount! < best.rawAmount! ? current : best,
+      first
     );
   }
   return parsedListings[0];


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved price parsing and normalization so aggregate and legacy multi-unit listings are converted to accurate per-unit prices and per-unit pricing is preserved when quantity is 1.
  * Prefer collection-scoped “best” pricing when available, falling back to broader listings; when multiple legacy listings exist the adapter follows server ordering rather than picking the lowest unit price.
  * More robust extraction of collection metadata from varied API responses.

* **Refactor**
  * Rewrote listing-price parsing and selection pipeline for more reliable normalization and validation.

* **Tests**
  * Added comprehensive tests, including property-based checks, covering price normalization and endpoint selection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/6529-Collections/6529seize-backend/pull/1567)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->