### PR TITLE
Added subscribed field to drop reactors in notification (for subscribe all)

### DIFF
--- a/src/api-serverless/openapi.yaml
+++ b/src/api-serverless/openapi.yaml
@@ -11921,8 +11921,8 @@ components:
           type: string
       description: >-
         Notification-specific additional context. For DROP_REACTED notifications
-        this includes reaction and reactors, where each reactor only has handle
-        and pfp.
+        this includes reaction and reactors, where each reactor only has handle,
+        pfp, and subscribed.
     ApiNotificationCause:
       type: string
       enum:
@@ -11940,11 +11940,15 @@ components:
         - PRIORITY_ALERT
     ApiNotificationDropReactedReactor:
       type: object
+      required:
+        - subscribed
       properties:
         handle:
           type: string
         pfp:
           type: string
+        subscribed:
+          type: boolean
     ApiNotificationsResponse:
       type: object
       required:

--- a/src/api-serverless/src/generated/models/ApiNotificationAdditionalContextV2.ts
+++ b/src/api-serverless/src/generated/models/ApiNotificationAdditionalContextV2.ts
@@ -14,7 +14,7 @@ import { ApiNotificationDropReactedReactor } from '../models/ApiNotificationDrop
 import { HttpFile } from '../http/http';
 
 /**
-* Notification-specific additional context. For DROP_REACTED notifications this includes reaction and reactors, where each reactor only has handle and pfp.
+* Notification-specific additional context. For DROP_REACTED notifications this includes reaction and reactors, where each reactor only has handle, pfp, and subscribed.
 */
 export class ApiNotificationAdditionalContextV2 {
     'amount'?: number;

--- a/src/api-serverless/src/generated/models/ApiNotificationDropReactedReactor.ts
+++ b/src/api-serverless/src/generated/models/ApiNotificationDropReactedReactor.ts
@@ -15,6 +15,7 @@ import { HttpFile } from '../http/http';
 export class ApiNotificationDropReactedReactor {
     'handle'?: string;
     'pfp'?: string;
+    'subscribed': boolean;
 
     static readonly discriminator: string | undefined = undefined;
 
@@ -31,6 +32,12 @@ export class ApiNotificationDropReactedReactor {
             "name": "pfp",
             "baseName": "pfp",
             "type": "string",
+            "format": ""
+        },
+        {
+            "name": "subscribed",
+            "baseName": "subscribed",
+            "type": "boolean",
             "format": ""
         }    ];
 

--- a/src/api-serverless/src/notifications/notifications-api-service.test.ts
+++ b/src/api-serverless/src/notifications/notifications-api-service.test.ts
@@ -10,7 +10,12 @@ describe('NotificationsApiService V2 notifications', () => {
     jest.restoreAllMocks();
   });
 
-  function makeIdentity(id: string, handle: string, pfp: string) {
+  function makeIdentity(
+    id: string,
+    handle: string,
+    pfp: string,
+    subscribed?: boolean
+  ) {
     return {
       id,
       handle,
@@ -21,7 +26,9 @@ describe('NotificationsApiService V2 notifications', () => {
       badges: {
         artist_of_main_stage_submissions: 0,
         artist_of_memes: 0
-      }
+      },
+      context_profile_context:
+        subscribed === undefined ? undefined : { subscribed }
     };
   }
 
@@ -235,8 +242,8 @@ describe('NotificationsApiService V2 notifications', () => {
       reactionsDb
     } = createService();
     const drop = { id: 'drop-1', content: 'v2 drop' };
-    const reactorOne = makeIdentity('reactor-1', 'alice', 'alice.png');
-    const reactorTwo = makeIdentity('reactor-2', 'bob', 'bob.png');
+    const reactorOne = makeIdentity('reactor-1', 'alice', 'alice.png', true);
+    const reactorTwo = makeIdentity('reactor-2', 'bob', 'bob.png', false);
     const reactorForOtherReaction = makeIdentity(
       'reactor-3',
       'carol',
@@ -312,8 +319,8 @@ describe('NotificationsApiService V2 notifications', () => {
           additional_context: {
             reaction: 'LIKE',
             reactors: [
-              { handle: 'alice', pfp: 'alice.png' },
-              { handle: 'bob', pfp: 'bob.png' }
+              { handle: 'alice', pfp: 'alice.png', subscribed: true },
+              { handle: 'bob', pfp: 'bob.png', subscribed: false }
             ]
           }
         }
@@ -322,7 +329,7 @@ describe('NotificationsApiService V2 notifications', () => {
     });
     const reactors = result.notifications[0].additional_context.reactors ?? [];
     expect(reactors).toHaveLength(2);
-    expect(Object.keys(reactors[0])).toEqual(['handle', 'pfp']);
+    expect(Object.keys(reactors[0])).toEqual(['handle', 'pfp', 'subscribed']);
   });
 
   it('skips V2 notifications when a related drop is missing', async () => {

--- a/src/api-serverless/src/notifications/notifications.api.service.ts
+++ b/src/api-serverless/src/notifications/notifications.api.service.ts
@@ -63,6 +63,7 @@ interface DropReactedNotificationAdditionalContextV2 {
   reactors: Array<{
     handle?: string;
     pfp?: string;
+    subscribed: boolean;
   }>;
 }
 
@@ -729,7 +730,8 @@ export class NotificationsApiService {
       .filter((profile): profile is ApiIdentityOverview => !!profile)
       .map((profile) => ({
         handle: profile.handle,
-        pfp: profile.pfp
+        pfp: profile.pfp,
+        subscribed: profile.context_profile_context?.subscribed ?? false
       }));
     return {
       reaction,


### PR DESCRIPTION
…e all)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Drop reaction notifications now display subscription status for each reactor, showing whether users who react are subscribed to your content. This feature provides creators with significantly enhanced insight into their audience composition and engagement patterns, helping identify active subscribers among those who react to their drops and improving community understanding.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/6529-Collections/6529seize-backend/pull/1568)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->