### PR TITLE
Allow some wave changes after decision made

### DIFF
--- a/src/api-serverless/src/waves/wave-api-service.test.ts
+++ b/src/api-serverless/src/waves/wave-api-service.test.ts
@@ -6,6 +6,7 @@ import {
 import { aWave } from '@/tests/fixtures/wave.fixture';
 import { ApiCreateNewWave } from '../generated/models/ApiCreateNewWave';
 import { ApiUpdateWaveRequest } from '../generated/models/ApiUpdateWaveRequest';
+import { ApiWaveDecisionsStrategy } from '../generated/models/ApiWaveDecisionsStrategy';
 import { ApiWaveCreditType } from '../generated/models/ApiWaveCreditType';
 import { ApiWaveParticipationIdentitySubmissionAllowDuplicates } from '../generated/models/ApiWaveParticipationIdentitySubmissionAllowDuplicates';
 import { ApiWaveParticipationIdentitySubmissionWhoCanBeSubmitted } from '../generated/models/ApiWaveParticipationIdentitySubmissionWhoCanBeSubmitted';
@@ -94,12 +95,14 @@ describe('WaveApiService updateWave immutability', () => {
     name = 'updated-wave',
     type = ApiWaveType.Rank,
     submissionStrategy,
-    maxVotesPerIdentityToDrop
+    maxVotesPerIdentityToDrop,
+    decisionsStrategy = null
   }: {
     name?: string;
     type?: ApiWaveType;
     submissionStrategy?: ApiUpdateWaveRequest['participation']['submission_strategy'];
     maxVotesPerIdentityToDrop?: number | null;
+    decisionsStrategy?: ApiWaveDecisionsStrategy | null;
   }): ApiUpdateWaveRequest {
     return {
       name,
@@ -137,7 +140,7 @@ describe('WaveApiService updateWave immutability', () => {
         max_votes_per_identity_to_drop: maxVotesPerIdentityToDrop,
         time_lock_ms: null,
         admin_group: { group_id: null },
-        decisions_strategy: null,
+        decisions_strategy: decisionsStrategy,
         admin_drop_deletion_enabled: false
       }
     };
@@ -285,6 +288,122 @@ describe('WaveApiService updateWave immutability', () => {
 
     expect(wavesApiDb.deleteWave).toHaveBeenCalled();
     expect(waveMappers.createWaveToNewWaveEntity).toHaveBeenCalled();
+  });
+
+  it('allows renaming an ended wave with an existing past decision strategy', async () => {
+    const existingDecisionStrategy = {
+      first_decision_time: Time.currentMillis() - Time.hours(2).toMillis(),
+      subsequent_decisions: [Time.hours(1).toMillis()],
+      is_rolling: false
+    };
+    const waveBeforeUpdate = aWave(
+      {
+        type: WaveType.RANK,
+        created_by: 'profile-1',
+        decisions_strategy: existingDecisionStrategy,
+        next_decision_time: null
+      },
+      {
+        id: 'wave-1',
+        name: 'wave-1',
+        serial_no: 1
+      }
+    );
+    const { service, wavesApiDb, waveMappers, ctx } = createService({
+      waveBeforeUpdate
+    });
+
+    await expect(
+      service.updateWave(
+        'wave-1',
+        updateRequest({
+          name: 'renamed-ended-wave',
+          decisionsStrategy: existingDecisionStrategy
+        }),
+        ctx
+      )
+    ).resolves.toEqual({ id: 'wave-1' });
+
+    expect(wavesApiDb.deleteWave).toHaveBeenCalled();
+    expect(waveMappers.createWaveToNewWaveEntity).toHaveBeenCalled();
+  });
+
+  it('preserves pending future decision time when the decision strategy is unchanged', async () => {
+    const currentMillis = Time.currentMillis();
+    const existingDecisionStrategy = {
+      first_decision_time: currentMillis - Time.hours(5).toMillis(),
+      subsequent_decisions: [Time.hours(10).toMillis()],
+      is_rolling: false
+    };
+    const pendingDecisionTime = currentMillis + Time.hours(2).toMillis();
+    const waveBeforeUpdate = aWave(
+      {
+        type: WaveType.RANK,
+        created_by: 'profile-1',
+        decisions_strategy: existingDecisionStrategy,
+        next_decision_time: pendingDecisionTime
+      },
+      {
+        id: 'wave-1',
+        name: 'wave-1',
+        serial_no: 1
+      }
+    );
+    const { service, waveMappers, ctx } = createService({
+      waveBeforeUpdate
+    });
+
+    await expect(
+      service.updateWave(
+        'wave-1',
+        updateRequest({
+          name: 'renamed-wave',
+          decisionsStrategy: existingDecisionStrategy
+        }),
+        ctx
+      )
+    ).resolves.toEqual({ id: 'wave-1' });
+
+    expect(waveMappers.createWaveToNewWaveEntity).toHaveBeenCalledWith(
+      expect.objectContaining({ nextDecisionTime: pendingDecisionTime })
+    );
+  });
+
+  it('rejects changing a decision strategy to start in the past', async () => {
+    const waveBeforeUpdate = aWave(
+      {
+        type: WaveType.RANK,
+        created_by: 'profile-1',
+        decisions_strategy: {
+          first_decision_time: Time.currentMillis() + Time.hours(1).toMillis(),
+          subsequent_decisions: [],
+          is_rolling: false
+        }
+      },
+      {
+        id: 'wave-1',
+        name: 'wave-1',
+        serial_no: 1
+      }
+    );
+    const { service, wavesApiDb, ctx } = createService({ waveBeforeUpdate });
+
+    await expect(
+      service.updateWave(
+        'wave-1',
+        updateRequest({
+          decisionsStrategy: {
+            first_decision_time:
+              Time.currentMillis() - Time.hours(2).toMillis(),
+            subsequent_decisions: [],
+            is_rolling: false
+          }
+        }),
+        ctx
+      )
+    ).rejects.toThrow(`first_decision_time must be in the future`);
+
+    expect(wavesApiDb.deleteWave).not.toHaveBeenCalled();
   });
 
   it('rejects lowering approve max_winners below existing decisions count', async () => {

--- a/src/api-serverless/src/waves/wave.api.service.ts
+++ b/src/api-serverless/src/waves/wave.api.service.ts
@@ -101,6 +101,13 @@ import { sendIdentityPushNotifications } from '@/api/push-notifications/push-not
 const CARD_SET_TDH_SUPPORTED_CONTRACTS = new Set(
   [MEMES_CONTRACT, GRADIENT_CONTRACT].map((contract) => contract.toLowerCase())
 );
+const FIRST_DECISION_TIME_IN_FUTURE_ERROR =
+  'first_decision_time must be in the future';
+
+type ComparableDecisionStrategy = Pick<
+  ApiWaveDecisionsStrategy,
+  'first_decision_time' | 'subsequent_decisions' | 'is_rolling'
+>;
 
 export class WaveApiService {
   constructor(
@@ -220,6 +227,78 @@ export class WaveApiService {
         `max_votes_per_identity_to_drop can only be increased after creation`
       );
     }
+  }
+
+  private assertChangedDecisionStrategyStartsInFuture({
+    request,
+    waveBeforeUpdate,
+    currentMillis
+  }: {
+    request: ApiUpdateWaveRequest;
+    waveBeforeUpdate: Pick<WaveEntity, 'decisions_strategy'>;
+    currentMillis: number;
+  }) {
+    const requestedDecisionStrategy = request.wave.decisions_strategy ?? null;
+    if (
+      this.areDecisionStrategiesEqual(
+        requestedDecisionStrategy,
+        waveBeforeUpdate.decisions_strategy
+      )
+    ) {
+      return;
+    }
+    if (
+      requestedDecisionStrategy !== null &&
+      requestedDecisionStrategy.first_decision_time < currentMillis
+    ) {
+      throw new BadRequestException(FIRST_DECISION_TIME_IN_FUTURE_ERROR);
+    }
+  }
+
+  private areDecisionStrategiesEqual(
+    left: ComparableDecisionStrategy | null,
+    right: ComparableDecisionStrategy | null
+  ): boolean {
+    if (left === null || right === null) {
+      return left === right;
+    }
+    if (
+      left.first_decision_time !== right.first_decision_time ||
+      left.is_rolling !== right.is_rolling ||
+      left.subsequent_decisions.length !== right.subsequent_decisions.length
+    ) {
+      return false;
+    }
+    return left.subsequent_decisions.every(
+      (decisionGap, index) => decisionGap === right.subsequent_decisions[index]
+    );
+  }
+
+  private getNextDecisionTimeForWaveUpdate({
+    request,
+    waveBeforeUpdate,
+    waveUpdateTime
+  }: {
+    request: ApiUpdateWaveRequest;
+    waveBeforeUpdate: Pick<
+      WaveEntity,
+      'decisions_strategy' | 'next_decision_time'
+    >;
+    waveUpdateTime: number;
+  }): number | null {
+    const requestedDecisionStrategy = request.wave.decisions_strategy ?? null;
+    if (
+      this.areDecisionStrategiesEqual(
+        requestedDecisionStrategy,
+        waveBeforeUpdate.decisions_strategy
+      )
+    ) {
+      return waveBeforeUpdate.next_decision_time;
+    }
+    return this.calculateNextDecisionTimeRelativeToNow(
+      waveUpdateTime,
+      requestedDecisionStrategy
+    );
   }
 
   public async createWave(
@@ -1571,9 +1650,10 @@ export class WaveApiService {
         if (!waveBeforeUpdate) {
           throw new NotFoundException(`Wave ${waveId} not found`);
         }
+        const currentMillis = Time.currentMillis();
         if (
           waveBeforeUpdate.next_decision_time !== null &&
-          waveBeforeUpdate.next_decision_time < Time.currentMillis()
+          waveBeforeUpdate.next_decision_time < currentMillis
         ) {
           throw new ForbiddenException(
             `Wave has unresolved decisions and can't be edited at the moment. Try again later`
@@ -1615,6 +1695,11 @@ export class WaveApiService {
           request,
           waveBeforeUpdate
         });
+        this.assertChangedDecisionStrategyStartsInFuture({
+          request,
+          waveBeforeUpdate,
+          currentMillis
+        });
         this.assertImmutableWaveUpdateFieldsUnchanged({
           request,
           waveBeforeUpdate
@@ -1630,10 +1715,11 @@ export class WaveApiService {
           request,
           created_by: waveBeforeUpdate.created_by,
           descriptionDropId: waveBeforeUpdate.description_drop_id,
-          nextDecisionTime: this.calculateNextDecisionTimeRelativeToNow(
-            waveUpdateTime,
-            request.wave.decisions_strategy
-          ),
+          nextDecisionTime: this.getNextDecisionTimeForWaveUpdate({
+            request,
+            waveBeforeUpdate,
+            waveUpdateTime
+          }),
           isDirectMessage: waveBeforeUpdate.is_direct_message ?? false,
           existingSubmissionStrategy: waveBeforeUpdate,
           existingWaveSettings: waveBeforeUpdate

--- a/src/api-serverless/src/waves/waves-routes.test.ts
+++ b/src/api-serverless/src/waves/waves-routes.test.ts
@@ -1,0 +1,106 @@
+jest.mock('passport', () => ({
+  authenticate: jest.fn(
+    () => (_req: unknown, _res: unknown, next: () => void) => next()
+  )
+}));
+
+import { ApiCreateNewWave } from '../generated/models/ApiCreateNewWave';
+import { ApiUpdateWaveRequest } from '../generated/models/ApiUpdateWaveRequest';
+import { ApiWaveCreditType } from '../generated/models/ApiWaveCreditType';
+import { ApiWaveType } from '../generated/models/ApiWaveType';
+import {
+  CreateWaveDecisionsStrategySchema,
+  UpdateWaveSchema
+} from './waves.routes';
+import { Time } from '@/time';
+
+describe('waves route validation', () => {
+  const emptyPeriod = { min: null, max: null };
+
+  function updateWaveRequest(firstDecisionTime: number): ApiUpdateWaveRequest {
+    return {
+      name: 'updated-wave',
+      picture: null,
+      voting: {
+        scope: { group_id: null },
+        credit_type: ApiWaveCreditType.Tdh,
+        credit_category: null,
+        creditor_id: null,
+        signature_required: false,
+        period: emptyPeriod,
+        forbid_negative_votes: false
+      },
+      visibility: {
+        scope: { group_id: null }
+      },
+      participation: {
+        scope: { group_id: null },
+        no_of_applications_allowed_per_participant: null,
+        required_metadata: [],
+        required_media: [],
+        signature_required: false,
+        period: emptyPeriod,
+        terms: null
+      },
+      chat: {
+        scope: { group_id: null },
+        enabled: true
+      },
+      wave: {
+        type: ApiWaveType.Rank,
+        winning_threshold: null,
+        max_winners: null,
+        max_votes_per_identity_to_drop: null,
+        time_lock_ms: null,
+        admin_group: { group_id: null },
+        decisions_strategy: {
+          first_decision_time: firstDecisionTime,
+          subsequent_decisions: [],
+          is_rolling: false
+        },
+        admin_drop_deletion_enabled: false
+      }
+    };
+  }
+
+  it('rejects creating a wave with a past first decision time', () => {
+    const result = CreateWaveDecisionsStrategySchema.validate({
+      first_decision_time: Time.currentMillis() - Time.hours(1).toMillis(),
+      subsequent_decisions: [],
+      is_rolling: false
+    } satisfies ApiCreateNewWave['wave']['decisions_strategy']);
+
+    expect(result.error?.message).toContain(
+      'first_decision_time must be in the future'
+    );
+  });
+
+  it('checks first decision time against validation time', () => {
+    const firstDecisionTime = Time.currentMillis() + Time.hours(1).toMillis();
+    const currentMillisSpy = jest
+      .spyOn(Time, 'currentMillis')
+      .mockReturnValue(firstDecisionTime + 1);
+
+    try {
+      const result = CreateWaveDecisionsStrategySchema.validate({
+        first_decision_time: firstDecisionTime,
+        subsequent_decisions: [],
+        is_rolling: false
+      } satisfies ApiCreateNewWave['wave']['decisions_strategy']);
+
+      expect(result.error?.message).toContain(
+        'first_decision_time must be in the future'
+      );
+    } finally {
+      currentMillisSpy.mockRestore();
+    }
+  });
+
+  it('allows updating a wave with an existing past first decision time', () => {
+    const result = UpdateWaveSchema.validate(
+      updateWaveRequest(Time.currentMillis() - Time.hours(1).toMillis())
+    );
+
+    expect(result.error).toBeUndefined();
+  });
+});

--- a/src/api-serverless/src/waves/waves.routes.ts
+++ b/src/api-serverless/src/waves/waves.routes.ts
@@ -1185,57 +1185,101 @@ const WaveChatSchema = Joi.object<ApiCreateNewWaveChatConfig>({
     .min(Time.seconds(1).toMillis())
 });
 
-const WaveDecisionsStrategySchema = Joi.object<ApiWaveDecisionsStrategy>({
-  first_decision_time: Joi.number()
-    .integer()
-    .required()
-    .min(Time.currentMillis())
-    .message('first_decision_time must be in the future'),
-  subsequent_decisions: Joi.array()
-    .required()
-    .items(Joi.number().integer().min(Time.hours(1).toMillis())),
-  is_rolling: Joi.boolean().required()
+function createWaveDecisionsStrategySchema({
+  requireFutureFirstDecisionTime
+}: {
+  requireFutureFirstDecisionTime: boolean;
+}): Joi.ObjectSchema<ApiWaveDecisionsStrategy> {
+  const firstDecisionTimeSchema = requireFutureFirstDecisionTime
+    ? Joi.number()
+        .integer()
+        .required()
+        .custom((value, helpers) => {
+          if (value <= Time.currentMillis()) {
+            return helpers.error('firstDecisionTime.future');
+          }
+          return value;
+        }, 'future time check')
+        .messages({
+          'firstDecisionTime.future':
+            'first_decision_time must be in the future'
+        })
+    : Joi.number().integer().required();
+
+  return Joi.object<ApiWaveDecisionsStrategy>({
+    first_decision_time: firstDecisionTimeSchema,
+    subsequent_decisions: Joi.array()
+      .required()
+      .items(Joi.number().integer().min(Time.hours(1).toMillis())),
+    is_rolling: Joi.boolean().required()
+  });
+}
+
+export const CreateWaveDecisionsStrategySchema =
+  createWaveDecisionsStrategySchema({
+    requireFutureFirstDecisionTime: true
+  });
+
+const UpdateWaveDecisionsStrategySchema = createWaveDecisionsStrategySchema({
+  requireFutureFirstDecisionTime: false
 });
 
-const WaveConfigSchema = Joi.object<
+function createWaveConfigSchema(
+  decisionsStrategySchema: Joi.ObjectSchema<ApiWaveDecisionsStrategy>
+): Joi.ObjectSchema<
   ApiWaveConfig & {
     period?: ApiIntRange | null;
     winning_thresholds?: unknown[] | null;
   }
->({
-  type: Joi.string()
-    .required()
-    .valid(...Object.values(ApiWaveType)),
-  // Accept the legacy field from old clients and strip it before service code.
-  winning_thresholds: Joi.alternatives()
-    .try(Joi.array(), Joi.valid(null))
-    .optional()
-    .strip(),
-  winning_threshold: Joi.when('type', {
-    is: Joi.string().valid(ApiWaveType.Approve),
-    then: Joi.number().integer().required().min(1),
-    otherwise: Joi.valid(null).default(null)
-  }),
-  max_winners: Joi.when('type', {
-    is: Joi.string().valid(ApiWaveType.Approve),
-    then: Joi.number().integer().required().allow(null).min(1),
-    otherwise: Joi.valid(null).default(null)
-  }),
-  max_votes_per_identity_to_drop: Joi.when('type', {
-    is: Joi.string().valid(ApiWaveType.Approve, ApiWaveType.Rank),
-    then: Joi.number().integer().optional().allow(null).min(1),
-    otherwise: Joi.valid(null).optional()
-  }),
-  time_lock_ms: Joi.number()
-    .integer()
-    .required()
-    .allow(null)
-    .min(Time.minutes(5).toMillis()),
-  period: IntRangeSchema.optional(),
-  admin_group: WaveScopeSchema.required(),
-  decisions_strategy: WaveDecisionsStrategySchema.optional().allow(null),
-  admin_drop_deletion_enabled: Joi.boolean().optional().default(false)
-});
+> {
+  return Joi.object<
+    ApiWaveConfig & {
+      period?: ApiIntRange | null;
+      winning_thresholds?: unknown[] | null;
+    }
+  >({
+    type: Joi.string()
+      .required()
+      .valid(...Object.values(ApiWaveType)),
+    // Accept the legacy field from old clients and strip it before service code.
+    winning_thresholds: Joi.alternatives()
+      .try(Joi.array(), Joi.valid(null))
+      .optional()
+      .strip(),
+    winning_threshold: Joi.when('type', {
+      is: Joi.string().valid(ApiWaveType.Approve),
+      then: Joi.number().integer().required().min(1),
+      otherwise: Joi.valid(null).default(null)
+    }),
+    max_winners: Joi.when('type', {
+      is: Joi.string().valid(ApiWaveType.Approve),
+      then: Joi.number().integer().required().allow(null).min(1),
+      otherwise: Joi.valid(null).default(null)
+    }),
+    max_votes_per_identity_to_drop: Joi.when('type', {
+      is: Joi.string().valid(ApiWaveType.Approve, ApiWaveType.Rank),
+      then: Joi.number().integer().optional().allow(null).min(1),
+      otherwise: Joi.valid(null).optional()
+    }),
+    time_lock_ms: Joi.number()
+      .integer()
+      .required()
+      .allow(null)
+      .min(Time.minutes(5).toMillis()),
+    period: IntRangeSchema.optional(),
+    admin_group: WaveScopeSchema.required(),
+    decisions_strategy: decisionsStrategySchema.optional().allow(null),
+    admin_drop_deletion_enabled: Joi.boolean().optional().default(false)
+  });
+}
+
+const WaveConfigSchema = createWaveConfigSchema(
+  CreateWaveDecisionsStrategySchema
+);
+
+const UpdateWaveConfigSchema = createWaveConfigSchema(
+  UpdateWaveDecisionsStrategySchema
+);
 
 const WaveOutcomeDistributionItemSchema =
   Joi.object<ApiWaveOutcomeDistributionItem>({
@@ -1301,15 +1345,16 @@ const waveSchemaBaseValidations = {
   wave: WaveConfigSchema.required()
 };
 
-const WaveSchema = Joi.object<ApiCreateNewWave>({
+export const WaveSchema = Joi.object<ApiCreateNewWave>({
   ...waveSchemaBaseValidations,
   description_drop: NewWaveDropSchema.required(),
   outcomes: Joi.array().required().min(0).items(WaveOutcomeSchema)
 });
 
-const UpdateWaveSchema = Joi.object<ApiUpdateWaveRequest>({
+export const UpdateWaveSchema = Joi.object<ApiUpdateWaveRequest>({
   ...waveSchemaBaseValidations,
-  participation: UpdateWaveParticipationSchema.required()
+  participation: UpdateWaveParticipationSchema.required(),
+  wave: UpdateWaveConfigSchema.required()
 });
 
 const SetPinnedDropSchema = Joi.object<ApiSetPinnedDropRequest>({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stricter validation for wave decision-strategy updates: changing a strategy now requires a future start time; preserves existing next-decision timing when strategy is unchanged; improved error messages for invalid decision times.
  * Validation schemas refined so create vs. update rules differ (creates enforce future first_decision_time, updates allow past values).

* **Tests**
  * Added comprehensive tests covering decision-strategy validation, update immutability rules, and time-relative validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/6529-Collections/6529seize-backend/pull/1570)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->