### PR TITLE
Increase claims Arweave upload limit

### DIFF
--- a/src/claimsMediaArweaveUploader/index.ts
+++ b/src/claimsMediaArweaveUploader/index.ts
@@ -24,8 +24,11 @@ function buildUploadErrorWithContext(
   const contextualError = new Error(
     `Failed to upload claim media to Arweave for contract=${contract} claim_id=${claimId}: ${errorMessage}`
   );
-  if (error instanceof Error && error.stack) {
-    contextualError.stack = error.stack;
+  if (error instanceof Error) {
+    contextualError.name = error.name;
+    if (error.stack) {
+      contextualError.stack = `${contextualError.name}: ${contextualError.message}\nCaused by: ${error.stack}`;
+    }
   }
   return contextualError;
 }

--- a/src/claimsMediaArweaveUploader/index.ts
+++ b/src/claimsMediaArweaveUploader/index.ts
@@ -15,6 +15,21 @@ import type { SQSHandler } from 'aws-lambda';
 const logger = Logger.get('CLAIMS_MEDIA_ARWEAVE_UPLOADER');
 const ALERT_TITLE = 'Claims Media Arweave Uploader';
 
+function buildUploadErrorWithContext(
+  contract: string,
+  claimId: number,
+  error: unknown
+): Error {
+  const errorMessage = error instanceof Error ? error.message : String(error);
+  const contextualError = new Error(
+    `Failed to upload claim media to Arweave for contract=${contract} claim_id=${claimId}: ${errorMessage}`
+  );
+  if (error instanceof Error && error.stack) {
+    contextualError.stack = error.stack;
+  }
+  return contextualError;
+}
+
 function parseRecordBody(body: string): { contract: string; claim_id: number } {
   const parsed = JSON.parse(body) as { contract?: unknown; claim_id?: unknown };
   const contract =
@@ -85,7 +100,10 @@ async function processMintingClaimUpload(
         rollbackError
       });
     }
-    await priorityAlertsContext.sendPriorityAlert(ALERT_TITLE, error);
+    await priorityAlertsContext.sendPriorityAlert(
+      ALERT_TITLE,
+      buildUploadErrorWithContext(contract, claimId, error)
+    );
     throw error;
   }
 }

--- a/src/minting-claims/claims-media-arweave-upload.ts
+++ b/src/minting-claims/claims-media-arweave-upload.ts
@@ -8,6 +8,7 @@ import { BadRequestException } from '@/exceptions';
 import { fetchPublicUrlToBuffer } from '@/http/safe-fetch';
 import { Logger } from '@/logging';
 import { isMemesContract } from '@/minting-claims/external-url';
+import { MAX_MINTING_CLAIM_MEDIA_BYTES } from '@/minting-claims/media-limits';
 import { normalizeIpfsUri } from '@/nft-links/lib/uri';
 import { createHash } from 'node:crypto';
 
@@ -15,7 +16,6 @@ const logger = Logger.get('claims-media-arweave-upload');
 export const MIN_EDITION_SIZE = 300;
 
 const FETCH_MEDIA_TIMEOUT_MS = 60_000;
-const MAX_ARWEAVE_UPLOAD_BYTES = 200 * 1024 * 1024;
 const ARWEAVE_METADATA_CREATED_BY = '6529 Collections';
 const ARWEAVE_POINTS_TRAIT_PREFIX = 'Points - ';
 const TYPE_MEME_TRAIT = 'Type - Meme';
@@ -151,7 +151,7 @@ async function fetchUrlToBuffer(
 ): Promise<{ buffer: Buffer; contentType: string }> {
   const { buffer, contentType } = await fetchPublicUrlToBuffer(url, {
     timeoutMs: FETCH_MEDIA_TIMEOUT_MS,
-    maxBytes: MAX_ARWEAVE_UPLOAD_BYTES,
+    maxBytes: MAX_MINTING_CLAIM_MEDIA_BYTES,
     headers: {
       'User-Agent':
         'Mozilla/5.0 (compatible; 6529ArweaveUpload/1.0; +https://6529.io)',

--- a/src/minting-claims/claims-media-arweave-upload.ts
+++ b/src/minting-claims/claims-media-arweave-upload.ts
@@ -15,7 +15,7 @@ const logger = Logger.get('claims-media-arweave-upload');
 export const MIN_EDITION_SIZE = 300;
 
 const FETCH_MEDIA_TIMEOUT_MS = 60_000;
-const MAX_ARWEAVE_UPLOAD_BYTES = 100 * 1024 * 1024;
+const MAX_ARWEAVE_UPLOAD_BYTES = 200 * 1024 * 1024;
 const ARWEAVE_METADATA_CREATED_BY = '6529 Collections';
 const ARWEAVE_POINTS_TRAIT_PREFIX = 'Points - ';
 const TYPE_MEME_TRAIT = 'Type - Meme';

--- a/src/minting-claims/media-inspector.ts
+++ b/src/minting-claims/media-inspector.ts
@@ -6,6 +6,7 @@ import type {
   MintingClaimImageDetails
 } from '@/entities/IMintingClaim';
 import { fetchPublicUrlToBuffer } from '@/http/safe-fetch';
+import { MAX_MINTING_CLAIM_MEDIA_BYTES } from '@/minting-claims/media-limits';
 import { imageSize } from 'image-size';
 import * as MP4Box from 'mp4box';
 
@@ -37,7 +38,6 @@ function sniffKindAndFormat(
 }
 
 const FETCH_TIMEOUT_MS = 30_000;
-const MAX_MEDIA_BYTES = 100 * 1024 * 1024;
 const FETCH_HEADERS = {
   'User-Agent':
     'Mozilla/5.0 (compatible; 6529ArweaveUpload/1.0; +https://6529.io)',
@@ -49,7 +49,7 @@ async function fetchUrlToBuffer(
 ): Promise<{ buffer: Buffer; contentType: string | null }> {
   const { buffer, contentType } = await fetchPublicUrlToBuffer(url, {
     timeoutMs: FETCH_TIMEOUT_MS,
-    maxBytes: MAX_MEDIA_BYTES,
+    maxBytes: MAX_MINTING_CLAIM_MEDIA_BYTES,
     headers: FETCH_HEADERS
   });
   return { buffer, contentType };

--- a/src/minting-claims/media-limits.ts
+++ b/src/minting-claims/media-limits.ts
@@ -1,0 +1,1 @@
+export const MAX_MINTING_CLAIM_MEDIA_BYTES = 200 * 1024 * 1024;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Increased maximum media upload size from 100MB to 200MB, allowing larger files to be attached during the minting/upload flow.
  * Improved upload failure alerts by including contract and claim context in error messages, making troubleshooting clearer and faster for users and support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/6529-Collections/6529seize-backend/pull/1574?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->