### PR TITLE
Only allow media from tenor

### DIFF
--- a/src/drops/create-or-update-drop-use-case.test.ts
+++ b/src/drops/create-or-update-drop-use-case.test.ts
@@ -456,6 +456,28 @@ describe('CreateOrUpdateDropUseCase', () => {
     ).not.toThrow();
   });
 
+  it('allows only configured Tenor file extensions in chat link allowlist', () => {
+    const useCase = createUseCaseWithMocks();
+
+    for (const extension of ['gif', 'mp4', 'jpg', 'webp']) {
+      expect(
+        (useCase as any).isAllowedChatLink(
+          `https://media.tenor.com/abc123/tenor.${extension}?item=1`
+        )
+      ).toBe(true);
+    }
+    for (const extension of ['jpeg', 'png', 'html']) {
+      expect(
+        (useCase as any).isAllowedChatLink(
+          `https://media.tenor.com/abc123/tenor.${extension}`
+        )
+      ).toBe(false);
+    }
+    expect(
+      (useCase as any).isAllowedChatLink('https://media.tenor.com/abc123/tenor')
+    ).toBe(false);
+  });
+
   it('allows CloudFront media links when chat links are disabled', () => {
     const useCase = createUseCaseWithMocks();
 
@@ -476,6 +498,11 @@ describe('CreateOrUpdateDropUseCase', () => {
         groupIdsUserIsEligibleFor: []
       })
     ).not.toThrow();
+    expect(
+      (useCase as any).isAllowedChatLink(
+        'https://d3lqz0a4bldqgf.cloudfront.net/drops/asset.html'
+      )
+    ).toBe(true);
   });
 
   it('allows scheme-less Tenor candidates in chat link allowlist', () => {

--- a/src/drops/create-or-update-drop.use-case.ts
+++ b/src/drops/create-or-update-drop.use-case.ts
@@ -88,10 +88,8 @@ import {
 import { isWaveCreatorOrAdmin } from '@/waves/wave-admin.helpers';
 
 const ARWEAVE_ORIGIN = 'https://arweave.net';
-const ALLOWED_CHAT_LINK_ORIGINS = new Set([
-  'https://media.tenor.com',
-  CLOUDFRONT_LINK
-]);
+const TENOR_CHAT_LINK_ORIGIN = 'https://media.tenor.com';
+const ALLOWED_TENOR_CHAT_LINK_EXTENSION_REGEX = /\.(?:gif|mp4|jpg|webp)$/i;
 
 function isActiveIdentityNomination(nomination: { has_won: boolean }): boolean {
   return !nomination.has_won;
@@ -703,8 +701,13 @@ export class CreateOrUpdateDropUseCase {
 
   private isAllowedChatLink(candidate: string): boolean {
     try {
-      return ALLOWED_CHAT_LINK_ORIGINS.has(
-        new URL(this.normalizeChatLinkCandidate(candidate)).origin
+      const url = new URL(this.normalizeChatLinkCandidate(candidate));
+      if (url.origin === CLOUDFRONT_LINK) {
+        return true;
+      }
+      return (
+        url.origin === TENOR_CHAT_LINK_ORIGIN &&
+        ALLOWED_TENOR_CHAT_LINK_EXTENSION_REGEX.test(url.pathname)
       );
     } catch {
       return false;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat now supports Tenor-hosted media links with GIF, MP4, JPG, and WebP file formats.

* **Tests**
  * Added test coverage for chat link validation logic, ensuring only authorized media file extensions are accepted and invalid formats are rejected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/6529-Collections/6529seize-backend/pull/1587?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->