### PR TITLE
Add waveoverview when boosted drops are fetched globally

### DIFF
--- a/src/api-serverless/src/drops/api-drop-v2-service.test.ts
+++ b/src/api-serverless/src/drops/api-drop-v2-service.test.ts
@@ -1003,11 +1003,70 @@ describe('ApiDropV2Service', () => {
       ctx
     );
     expect(deps.apiDropMapper.mapDrops).toHaveBeenCalledWith(dropEntities, ctx);
+    expect(
+      deps.wavesApiDb.findWavesByIdsEligibleForRead
+    ).not.toHaveBeenCalled();
+    expect(deps.apiWaveOverviewMapper.mapWaves).not.toHaveBeenCalled();
     expect(result).toEqual({
       data: [{ id: 'drop-1' }, { id: 'drop-2' }],
       count: 3,
       page: 1,
       next: true
+    });
+  });
+
+  it('fills wave overviews for global boosted drops', async () => {
+    const { service, deps } = createService();
+    const dropEntities = [
+      makeDrop({ id: 'drop-1', wave_id: 'wave-1' }),
+      makeDrop({ id: 'drop-2', wave_id: 'wave-2' })
+    ];
+    const waveEntities = [makeWave(), makeWave({ id: 'wave-2' })];
+    const ctx = {
+      authenticationContext: AuthenticationContext.fromProfileId('viewer-1')
+    };
+    deps.dropsDb.findBoostedDrops.mockResolvedValue(dropEntities);
+    deps.dropsDb.countBoostedDrops.mockResolvedValue(2);
+    deps.wavesApiDb.findWavesByIdsEligibleForRead.mockResolvedValue(
+      waveEntities
+    );
+    deps.apiWaveOverviewMapper.mapWaves.mockResolvedValue({
+      'wave-1': { id: 'wave-1' },
+      'wave-2': { id: 'wave-2' }
+    });
+
+    const result = await service.findBoostedDrops(
+      {
+        author: null,
+        booster: null,
+        wave_id: null,
+        min_boosts: null,
+        count_only_boosts_after: 1,
+        page_size: 2,
+        page: 1,
+        sort_direction: ApiPageSortDirection.Desc,
+        sort: 'last_boosted_at'
+      },
+      ctx
+    );
+
+    expect(deps.wavesApiDb.findWavesByIdsEligibleForRead).toHaveBeenCalledWith(
+      ['wave-1', 'wave-2'],
+      ['group-1'],
+      undefined
+    );
+    expect(deps.apiWaveOverviewMapper.mapWaves).toHaveBeenCalledWith(
+      waveEntities,
+      ctx
+    );
+    expect(result).toEqual({
+      data: [
+        { id: 'drop-1', wave: { id: 'wave-1' } },
+        { id: 'drop-2', wave: { id: 'wave-2' } }
+      ],
+      count: 2,
+      page: 1,
+      next: false
     });
   });
 

--- a/src/api-serverless/src/drops/api-drop-v2.service.ts
+++ b/src/api-serverless/src/drops/api-drop-v2.service.ts
@@ -33,6 +33,7 @@ import { DropEntity, DropType } from '@/entities/IDrop';
 import { ApiDropReactionV2 } from '@/api/generated/models/ApiDropReactionV2';
 import { reactionsDb, ReactionsDb } from '@/api/drops/reactions.db';
 import { wavesApiDb, WavesApiDb } from '@/api/waves/waves.api.db';
+import { ApiWaveOverview } from '@/api/generated/models/ApiWaveOverview';
 
 export type ApiDropWithWave = ApiDropAndWave;
 export type DropVotersSearchParams = {
@@ -460,9 +461,28 @@ export class ApiDropV2Service {
           ctx
         )
       ]);
-      const dropsById = await this.apiDropMapper.mapDrops(dropEntities, ctx);
+      const dropsByIdPromise = this.apiDropMapper.mapDrops(dropEntities, ctx);
+      const wavesByIdPromise =
+        req.wave_id === null
+          ? this.mapBoostedDropWaves(
+              dropEntities,
+              groupIdsUserIsEligibleFor,
+              ctx
+            )
+          : Promise.resolve({} as Record<string, ApiWaveOverview>);
+      const [dropsById, wavesById] = await Promise.all([
+        dropsByIdPromise,
+        wavesByIdPromise
+      ]);
       return {
-        data: dropEntities.map((drop) => dropsById[drop.id]),
+        data: dropEntities.map((drop) => {
+          const apiDrop = dropsById[drop.id];
+          const wave = wavesById[drop.wave_id];
+          if (wave) {
+            apiDrop.wave = wave;
+          }
+          return apiDrop;
+        }),
         count,
         page: req.page,
         next: count > req.page_size * req.page
@@ -470,6 +490,25 @@ export class ApiDropV2Service {
     } finally {
       ctx.timer?.stop(timerKey);
     }
+  }
+
+  private async mapBoostedDropWaves(
+    dropEntities: DropEntity[],
+    groupIdsUserIsEligibleFor: string[],
+    ctx: RequestContext
+  ): Promise<Record<string, ApiWaveOverview>> {
+    if (!dropEntities.length) {
+      return {};
+    }
+    const waveIds = Array.from(
+      new Set(dropEntities.map((drop) => drop.wave_id))
+    );
+    const waveEntities = await this.wavesApiDb.findWavesByIdsEligibleForRead(
+      waveIds,
+      groupIdsUserIsEligibleFor,
+      ctx.connection
+    );
+    return this.apiWaveOverviewMapper.mapWaves(waveEntities, ctx);
   }
 
   public async findVoteEditLogsByDropIdOrThrow(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Wave overview data is now properly included when retrieving globally boosted drops

* **Tests**
  * Enhanced test coverage for wave overview enrichment in boosted drop queries

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/6529-Collections/6529seize-backend/pull/1596?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->