### PR TITLE
Removed is_additional_action_promised from xtdh grants and added to wave decisions endpoint (bugfix)

### DIFF
--- a/src/api-serverless/openapi.yaml
+++ b/src/api-serverless/openapi.yaml
@@ -5973,6 +5973,14 @@ paths:
             minimum: 1
             maximum: 2000
             default: 100
+        - name: is_additional_action_promised
+          in: query
+          description: >-
+            Optional filter for winner drops by whether an additional action was
+            promised
+          required: false
+          schema:
+            type: boolean
       responses:
         "200":
           description: successful operation
@@ -7643,14 +7651,6 @@ paths:
             minimum: 1
             maximum: 2000
             default: 100
-        - name: is_additional_action_promised
-          in: query
-          description: >-
-            Optional filter for winner drops by whether an additional action was
-            promised
-          required: false
-          schema:
-            type: boolean
       responses:
         "200":
           description: successful operation


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `is_additional_action_promised` query parameter to the GET /waves/{id}/decisions endpoint for filtering results by additional action promise status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->