### PR TITLE
Fix social bot routing for OG previews

### DIFF
--- a/src/api-serverless/src/og-metadata/og-metadata-service.test.ts
+++ b/src/api-serverless/src/og-metadata/og-metadata-service.test.ts
@@ -98,7 +98,7 @@ function makeDropWithWave(id: string, serialNo: number): ApiDropWithWave {
       is_signed: false,
       hide_link_preview: false,
       content:
-        'Drop content\n\nSecond paragraph\n\n![Inline image](https://example.com/inline.webp)',
+        'Drop content\n\n\nSecond paragraph\n\n![Inline image](https://example.com/inline.webp)',
       media: [{ url: `ipfs://${IPFS_CID}/drop.mp4`, mime_type: 'video/mp4' }],
       attachments: [
         {
@@ -485,7 +485,7 @@ describe('OgMetadataService', () => {
         is_additional_action_promised: true,
         title: 'Drop title',
         description: 'Drop description',
-        content: 'Drop content\n\nSecond paragraph',
+        content: 'Drop content\n\n\nSecond paragraph',
         votes: {
           is_open: true,
           total_votes_given: 11,

--- a/src/api-serverless/src/og-metadata/og-metadata-service.test.ts
+++ b/src/api-serverless/src/og-metadata/og-metadata-service.test.ts
@@ -98,7 +98,7 @@ function makeDropWithWave(id: string, serialNo: number): ApiDropWithWave {
       is_signed: false,
       hide_link_preview: false,
       content:
-        'Drop content\n\n![Inline image](https://example.com/inline.webp)',
+        'Drop content\n\nSecond paragraph\n\n![Inline image](https://example.com/inline.webp)',
       media: [{ url: `ipfs://${IPFS_CID}/drop.mp4`, mime_type: 'video/mp4' }],
       attachments: [
         {
@@ -485,7 +485,7 @@ describe('OgMetadataService', () => {
         is_additional_action_promised: true,
         title: 'Drop title',
         description: 'Drop description',
-        content: 'Drop content',
+        content: 'Drop content\n\nSecond paragraph',
         votes: {
           is_open: true,
           total_votes_given: 11,

--- a/src/api-serverless/src/og-metadata/og-metadata-service.test.ts
+++ b/src/api-serverless/src/og-metadata/og-metadata-service.test.ts
@@ -98,7 +98,7 @@ function makeDropWithWave(id: string, serialNo: number): ApiDropWithWave {
       is_signed: false,
       hide_link_preview: false,
       content:
-        'Drop content\n\n\nSecond paragraph\n\n![Inline image](https://example.com/inline.webp)',
+        'Drop content\n\nSecond paragraph\n\n\nThird paragraph\n\n![Inline image](https://example.com/inline.webp)',
       media: [{ url: `ipfs://${IPFS_CID}/drop.mp4`, mime_type: 'video/mp4' }],
       attachments: [
         {
@@ -485,7 +485,7 @@ describe('OgMetadataService', () => {
         is_additional_action_promised: true,
         title: 'Drop title',
         description: 'Drop description',
-        content: 'Drop content\n\n\nSecond paragraph',
+        content: 'Drop content\nSecond paragraph\n\nThird paragraph',
         votes: {
           is_open: true,
           total_votes_given: 11,

--- a/src/api-serverless/src/og-metadata/og-metadata.service.ts
+++ b/src/api-serverless/src/og-metadata/og-metadata.service.ts
@@ -758,7 +758,13 @@ export class OgMetadataService {
     const lines = normalized
       .split('\n')
       .map((line) => this.collapseWhitespace(line));
-    return lines.join('\n').trim();
+    return this.normalizeRenderedLineBreaks(lines.join('\n')).trim();
+  }
+
+  private normalizeRenderedLineBreaks(value: string): string {
+    return value.replace(/\n{2,}/g, (lineBreaks) =>
+      '\n'.repeat(lineBreaks.length - 1)
+    );
   }
 
   private gatewayMediaUrl(url: string | null | undefined): string | null {

--- a/src/api-serverless/src/og-metadata/og-metadata.service.ts
+++ b/src/api-serverless/src/og-metadata/og-metadata.service.ts
@@ -758,7 +758,10 @@ export class OgMetadataService {
     const lines = normalized
       .split('\n')
       .map((line) => this.collapseWhitespace(line));
-    return lines.join('\n').replace(/\n{3,}/g, '\n\n').trim();
+    return lines
+      .join('\n')
+      .replace(/\n{3,}/g, '\n\n')
+      .trim();
   }
 
   private gatewayMediaUrl(url: string | null | undefined): string | null {

--- a/src/api-serverless/src/og-metadata/og-metadata.service.ts
+++ b/src/api-serverless/src/og-metadata/og-metadata.service.ts
@@ -76,6 +76,10 @@ type MarkdownLinkReplacement = {
   readonly endIndex: number;
 };
 
+type CleanTextOptions = {
+  readonly preserveLineBreaks?: boolean;
+};
+
 export class OgMetadataService {
   private readonly logger = Logger.get(this.constructor.name);
 
@@ -409,7 +413,7 @@ export class OgMetadataService {
       description: this.cleanText(
         this.findPriorityMetadataValue(drop.priority_metadata, 'description')
       ),
-      content: this.cleanText(drop.content),
+      content: this.cleanText(drop.content, { preserveLineBreaks: true }),
       votes: drop.submission_context?.voting,
       media: this.mapDropMedia(drop),
       files: this.mapFiles(drop.attachments ?? [])
@@ -516,13 +520,18 @@ export class OgMetadataService {
     );
   }
 
-  private cleanText(value: string | null | undefined): string | null {
+  private cleanText(
+    value: string | null | undefined,
+    options: CleanTextOptions = {}
+  ): string | null {
     if (!value) {
       return null;
     }
     const withoutTags = this.stripHtmlTags(value);
-    const cleaned =
-      this.removeMarkdownMarkersAndCollapseWhitespace(withoutTags);
+    const cleaned = this.removeMarkdownMarkersAndCollapseWhitespace(
+      withoutTags,
+      options
+    );
     return cleaned.length ? cleaned : null;
   }
 
@@ -564,7 +573,10 @@ export class OgMetadataService {
     );
   }
 
-  private removeMarkdownMarkersAndCollapseWhitespace(value: string): string {
+  private removeMarkdownMarkersAndCollapseWhitespace(
+    value: string,
+    options: CleanTextOptions
+  ): string {
     const withoutMarkdown = this.replaceMarkdownLinks(value)
       .replace(/(^|\n)[ \t]{0,3}#{1,6}[ \t]+/g, '$1')
       .replace(/(^|\n)[ \t]{0,3}>[ \t]?/g, '$1')
@@ -573,6 +585,9 @@ export class OgMetadataService {
       .replace(/(\*{1,3})(\w(?:[^*\n]*?\w)?)\1/g, '$2')
       .replace(/(^|[^\w])(_{1,3})(\w(?:[^_\n]*?\w)?)\2($|[^\w])/g, '$1$3$4')
       .replace(/```/g, '');
+    if (options.preserveLineBreaks) {
+      return this.collapseWhitespacePreservingLineBreaks(withoutMarkdown);
+    }
     return this.collapseWhitespace(withoutMarkdown);
   }
 
@@ -736,6 +751,14 @@ export class OgMetadataService {
       result += char;
     }
     return result.trim();
+  }
+
+  private collapseWhitespacePreservingLineBreaks(value: string): string {
+    const normalized = value.replace(/\r\n?/g, '\n');
+    const lines = normalized
+      .split('\n')
+      .map((line) => this.collapseWhitespace(line));
+    return lines.join('\n').replace(/\n{3,}/g, '\n\n').trim();
   }
 
   private gatewayMediaUrl(url: string | null | undefined): string | null {

--- a/src/api-serverless/src/og-metadata/og-metadata.service.ts
+++ b/src/api-serverless/src/og-metadata/og-metadata.service.ts
@@ -758,10 +758,7 @@ export class OgMetadataService {
     const lines = normalized
       .split('\n')
       .map((line) => this.collapseWhitespace(line));
-    return lines
-      .join('\n')
-      .replace(/\n{3,}/g, '\n\n')
-      .trim();
+    return lines.join('\n').trim();
   }
 
   private gatewayMediaUrl(url: string | null | undefined): string | null {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * OG metadata cleaning now preserves line breaks in drop content so multi-paragraph text displays correctly in previews and shares.

* **Tests**
  * Updated tests to cover multi-paragraph drop content and verify the cleaned output preserves expected line breaks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->