### PR TITLE
Get wave poll drops endpoint

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -212,6 +212,8 @@ Wave creators and wave admins can manage arbitrary wave metadata pairs through `
 
 Wave creators and wave admins can attach one inline poll to a chat drop through the drop creation API. Poll definitions, options, and votes are stored in `drop_polls`, `drop_poll_options`, and `drop_poll_votes`; poll reads follow existing drop and wave visibility rules, include the authenticated profile's selected option numbers, and poll votes replace the acting profile's previous answers for that poll. A poll vote also creates the normal notification and Firebase push notification path for the drop author with the voter identity and selected option labels.
 
+Wave poll listing is exposed through `/v2/waves/{id}/polls`, returning paginated poll summaries ordered by drop `created_at` descending by default, with optional `sort=closing_time` and `state=OPEN|CLOSED` filtering.
+
 ## Database Boundary
 
 There are two DB access modes:

--- a/src/api-serverless/openapi.yaml
+++ b/src/api-serverless/openapi.yaml
@@ -7640,13 +7640,13 @@ paths:
             minimum: 1
             maximum: 100
             default: 20
-        - name: order
+        - name: sort_direction
           in: query
           required: false
           schema:
             $ref: "#/components/schemas/ApiPageSortDirection"
-            default: ASC
-        - name: order_by
+            default: DESC
+        - name: sort
           in: query
           required: false
           schema:
@@ -7661,8 +7661,8 @@ paths:
           schema:
             type: string
             enum:
-              - open
-              - closed
+              - OPEN
+              - CLOSED
       responses:
         "200":
           description: successful operation

--- a/src/api-serverless/src/drops/drop-polls-db.test.ts
+++ b/src/api-serverless/src/drops/drop-polls-db.test.ts
@@ -8,7 +8,8 @@ import { PageSortDirection } from '@/api/page-request';
 import {
   CreateDropPollCommand,
   DropPollsDb,
-  DropPollsOrderBy
+  DropPollsOrderBy,
+  DropPollState
 } from './drop-polls.db';
 
 function createPollCommand(): CreateDropPollCommand {
@@ -27,6 +28,7 @@ function createPollCommand(): CreateDropPollCommand {
 
 function createDb() {
   const execute = jest.fn().mockResolvedValue([]);
+  const oneOrNull = jest.fn().mockResolvedValue(null);
   const bulkInsert = jest.fn().mockResolvedValue(undefined);
   const transactionalConnection = { connection: { id: 'tx' } };
   const executeNativeQueriesInTransaction = jest.fn(async (fn) =>
@@ -36,6 +38,7 @@ function createDb() {
     () =>
       ({
         execute,
+        oneOrNull,
         bulkInsert,
         executeNativeQueriesInTransaction
       }) as any
@@ -44,6 +47,7 @@ function createDb() {
   return {
     service,
     execute,
+    oneOrNull,
     bulkInsert,
     executeNativeQueriesInTransaction,
     transactionalConnection
@@ -236,6 +240,57 @@ describe('DropPollsDb', () => {
     expect(execute.mock.calls[1][1]).toEqual({
       pollIds: ['poll-1'],
       contextProfileId: 'viewer-1'
+    });
+  });
+
+  it('sorts wave polls by closing time and filters closed polls', async () => {
+    const { service, execute } = createDb();
+
+    const result = await service.findWavePolls(
+      {
+        waveId: 'wave-1',
+        limit: 10,
+        offset: 5,
+        order: PageSortDirection.DESC,
+        orderBy: DropPollsOrderBy.CLOSING_TIME,
+        state: DropPollState.CLOSED,
+        now: 2_000
+      },
+      {}
+    );
+
+    expect(result).toEqual([]);
+    expect(execute).toHaveBeenCalledTimes(1);
+    const [sql, params] = execute.mock.calls[0];
+    expect(sql).toContain('and p.closing_time <= :now');
+    expect(sql).toContain('order by p.closing_time DESC, p.id DESC');
+    expect(params).toEqual({
+      waveId: 'wave-1',
+      now: 2_000,
+      limit: 10,
+      offset: 5
+    });
+  });
+
+  it('counts only open wave polls when open state is requested', async () => {
+    const { service, oneOrNull } = createDb();
+    oneOrNull.mockResolvedValueOnce({ cnt: '3' });
+
+    const count = await service.countWavePolls(
+      {
+        waveId: 'wave-1',
+        state: DropPollState.OPEN,
+        now: 2_000
+      },
+      {}
+    );
+
+    expect(count).toBe(3);
+    const [sql, params] = oneOrNull.mock.calls[0];
+    expect(sql).toContain('and p.closing_time > :now');
+    expect(params).toEqual({
+      waveId: 'wave-1',
+      now: 2_000
     });
   });
 

--- a/src/api-serverless/src/drops/drop-polls-handlers.test.ts
+++ b/src/api-serverless/src/drops/drop-polls-handlers.test.ts
@@ -19,8 +19,8 @@ jest.mock('@/time', () => ({
 }));
 
 import { PageSortDirection } from '@/api/page-request';
-import { DropPollsOrderBy, DropPollState } from './drop-polls.db';
-import { handleGetWavePollsV2 } from './drop-polls.handlers';
+import { DropPollsOrderBy, DropPollState } from '@/api/drops/drop-polls.db';
+import { handleGetWavePollsV2 } from '@/api/drops/drop-polls.handlers';
 
 describe('drop polls handlers', () => {
   const timer = { marker: 'timer' } as any;

--- a/src/api-serverless/src/drops/drop-polls-handlers.test.ts
+++ b/src/api-serverless/src/drops/drop-polls-handlers.test.ts
@@ -1,0 +1,88 @@
+const mockFindWavePolls = jest.fn();
+const mockGetAuthenticationContext = jest.fn();
+const mockGetFromRequest = jest.fn();
+
+jest.mock('@/api/auth/auth', () => ({
+  getAuthenticationContext: mockGetAuthenticationContext
+}));
+
+jest.mock('@/api/drops/drop-polls.api.service', () => ({
+  dropPollsApiService: {
+    findWavePolls: mockFindWavePolls
+  }
+}));
+
+jest.mock('@/time', () => ({
+  Timer: {
+    getFromRequest: mockGetFromRequest
+  }
+}));
+
+import { PageSortDirection } from '@/api/page-request';
+import { DropPollsOrderBy, DropPollState } from './drop-polls.db';
+import { handleGetWavePollsV2 } from './drop-polls.handlers';
+
+describe('drop polls handlers', () => {
+  const timer = { marker: 'timer' } as any;
+  const authenticationContext = { marker: 'auth' } as any;
+  const result = { count: 0, page: 1, next: false, data: [] };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFindWavePolls.mockResolvedValue(result);
+    mockGetAuthenticationContext.mockResolvedValue(authenticationContext);
+    mockGetFromRequest.mockReturnValue(timer);
+  });
+
+  describe('handleGetWavePollsV2', () => {
+    it('uses created_at descending sort without state filtering by default', async () => {
+      const req = {
+        params: { id: 'wave-1' },
+        query: {}
+      } as any;
+
+      await expect(handleGetWavePollsV2(req)).resolves.toBe(result);
+
+      expect(mockGetFromRequest).toHaveBeenCalledWith(req);
+      expect(mockGetAuthenticationContext).toHaveBeenCalledWith(req, timer);
+      expect(mockFindWavePolls).toHaveBeenCalledWith(
+        {
+          wave_id: 'wave-1',
+          page: 1,
+          page_size: 20,
+          sort_direction: PageSortDirection.DESC,
+          sort: DropPollsOrderBy.CREATED_AT,
+          state: null
+        },
+        { authenticationContext, timer }
+      );
+    });
+
+    it('passes explicit closing time sort and open state filters', async () => {
+      const req = {
+        params: { id: 'wave-1' },
+        query: {
+          page: '2',
+          page_size: '10',
+          sort_direction: 'ASC',
+          sort: 'closing_time',
+          state: 'OPEN'
+        }
+      } as any;
+
+      await handleGetWavePollsV2(req);
+
+      expect(mockFindWavePolls).toHaveBeenCalledWith(
+        {
+          wave_id: 'wave-1',
+          page: 2,
+          page_size: 10,
+          sort_direction: PageSortDirection.ASC,
+          sort: DropPollsOrderBy.CLOSING_TIME,
+          state: DropPollState.OPEN
+        },
+        { authenticationContext, timer }
+      );
+    });
+  });
+});

--- a/src/api-serverless/src/drops/drop-polls.api.service.ts
+++ b/src/api-serverless/src/drops/drop-polls.api.service.ts
@@ -60,8 +60,8 @@ export type FindWavePollsRequest = {
   readonly wave_id: string;
   readonly page: number;
   readonly page_size: number;
-  readonly order: PageSortDirection;
-  readonly order_by: DropPollsOrderBy;
+  readonly sort_direction: PageSortDirection;
+  readonly sort: DropPollsOrderBy;
   readonly state: DropPollState | null;
 };
 
@@ -337,8 +337,8 @@ export class DropPollsApiService {
           waveId: request.wave_id,
           limit: request.page_size,
           offset,
-          order: request.order,
-          orderBy: request.order_by,
+          order: request.sort_direction,
+          orderBy: request.sort,
           state: request.state,
           now
         },

--- a/src/api-serverless/src/drops/drop-polls.handlers.ts
+++ b/src/api-serverless/src/drops/drop-polls.handlers.ts
@@ -37,9 +37,7 @@ type WavePollsPathParams = {
   readonly id: string;
 };
 
-type WavePollsQuery = Omit<FindWavePollsRequest, 'wave_id' | 'state'> & {
-  readonly state: 'open' | 'closed' | null;
-};
+type WavePollsQuery = Omit<FindWavePollsRequest, 'wave_id'>;
 
 const DropPollOptionVotersPathParamsSchema: Joi.ObjectSchema<DropPollOptionVotersPathParams> =
   Joi.object({
@@ -77,18 +75,18 @@ const WavePollsQuerySchema: Joi.ObjectSchema<WavePollsQuery> =
   Joi.object<WavePollsQuery>({
     page: Joi.number().integer().min(1).optional().default(1),
     page_size: Joi.number().integer().min(1).max(100).optional().default(20),
-    order: Joi.string()
+    sort_direction: Joi.string()
       .uppercase()
       .valid(...Object.values(PageSortDirection))
       .optional()
-      .default(PageSortDirection.ASC),
-    order_by: Joi.string()
+      .default(PageSortDirection.DESC),
+    sort: Joi.string()
       .valid(...Object.values(DropPollsOrderBy))
       .optional()
       .default(DropPollsOrderBy.CREATED_AT),
     state: Joi.string()
-      .lowercase()
-      .valid('open', 'closed')
+      .uppercase()
+      .valid(...Object.values(DropPollState))
       .optional()
       .default(null)
   });
@@ -156,21 +154,10 @@ export async function handleGetWavePollsV2(
       wave_id: id,
       page: query.page,
       page_size: query.page_size,
-      order: query.order,
-      order_by: query.order_by,
-      state: mapPollState(query.state)
+      sort_direction: query.sort_direction,
+      sort: query.sort,
+      state: query.state
     },
     { authenticationContext, timer }
   );
-}
-
-function mapPollState(state: 'open' | 'closed' | null): DropPollState | null {
-  switch (state) {
-    case 'open':
-      return DropPollState.OPEN;
-    case 'closed':
-      return DropPollState.CLOSED;
-    case null:
-      return null;
-  }
 }

--- a/src/api-serverless/src/generated/routes/operations.ts
+++ b/src/api-serverless/src/generated/routes/operations.ts
@@ -514,9 +514,9 @@ export interface GetWavePollsV2PathParams {
 export interface GetWavePollsV2Query {
   "page"?: number;
   "page_size"?: number;
-  "order"?: string;
-  "order_by"?: "created_at" | "closing_time";
-  "state"?: "open" | "closed";
+  "sort_direction"?: string;
+  "sort"?: "created_at" | "closing_time";
+  "state"?: "OPEN" | "CLOSED";
 }
 
 export type GetWavePollsV2Response = ApiDropPollsPage;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added wave polls listing v2: pagination, state filtering (OPEN/CLOSED), and sorting by creation or closing time.

* **Behavior Changes**
  * Default listing order is newest-first (descending). State values are now uppercase (OPEN/CLOSED). Query parameter names for sort direction and field were standardized.

* **Documentation**
  * Updated API docs to reflect the new endpoint behavior and parameters.

* **Tests**
  * Added/updated tests to validate ordering, state filtering, pagination, and parameter parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->