### PR TITLE
Return ApiDropV2 from /waves/:id/polls

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -212,7 +212,7 @@ Wave creators and wave admins can manage arbitrary wave metadata pairs through `
 
 Wave creators and wave admins can attach one inline poll to a chat drop through the drop creation API. Poll definitions, options, and votes are stored in `drop_polls`, `drop_poll_options`, and `drop_poll_votes`; poll reads follow existing drop and wave visibility rules, include the authenticated profile's selected option numbers, and poll votes replace the acting profile's previous answers for that poll. A poll vote also creates the normal notification and Firebase push notification path for the drop author with the voter identity and selected option labels.
 
-Wave poll listing is exposed through `/v2/waves/{id}/polls`, returning paginated poll summaries ordered by drop `created_at` descending by default, with optional `sort=closing_time` and `state=OPEN|CLOSED` filtering.
+Wave poll listing is exposed through `/v2/waves/{id}/polls`, returning paginated `ApiDropV2` data for drops that have inline polls, ordered by drop `created_at` descending by default, with optional `sort=closing_time` and `state=OPEN|CLOSED` filtering.
 
 ## Database Boundary
 

--- a/src/api-serverless/openapi.yaml
+++ b/src/api-serverless/openapi.yaml
@@ -10746,7 +10746,7 @@ components:
         data:
           type: array
           items:
-            $ref: "#/components/schemas/ApiWavePoll"
+            $ref: "#/components/schemas/ApiDropV2"
     ApiDropPollVoteRequest:
       type: object
       required:

--- a/src/api-serverless/src/drops/drop-polls-api-service.test.ts
+++ b/src/api-serverless/src/drops/drop-polls-api-service.test.ts
@@ -5,6 +5,8 @@ jest.mock('@/api/api-helpers', () => ({
 import { AuthenticationContext } from '@/auth-context';
 import { giveReadReplicaTimeToCatchUp } from '@/api/api-helpers';
 import { DropPollsApiService } from '@/api/drops/drop-polls.api.service';
+import { DropPollsOrderBy, DropPollState } from '@/api/drops/drop-polls.db';
+import { PageSortDirection } from '@/api/page-request';
 import { DropType } from '@/entities/IDrop';
 import { Time } from '@/time';
 
@@ -16,11 +18,13 @@ afterEach(() => {
 function createService() {
   const dropPollsDb = {
     createPoll: jest.fn().mockResolvedValue(undefined),
+    countWavePolls: jest.fn(),
     executeNativeQueriesInTransaction: jest.fn(
       async (callback: (connection: unknown) => Promise<void>) => {
         await callback('tx-connection');
       }
     ),
+    findWavePolls: jest.fn(),
     findPollByDropIdForUpdate: jest.fn(),
     findOptionsByPollId: jest.fn(),
     replaceVoterVotes: jest.fn().mockResolvedValue(true)
@@ -38,6 +42,11 @@ function createService() {
       created_by: 'creator-1',
       admin_group_id: 'admin-group',
       visibility_group_id: 'visibility-group'
+    }),
+    findWaveById: jest.fn().mockResolvedValue({
+      id: 'wave-1',
+      parent_wave_id: null,
+      visibility_group_id: null
     })
   };
   const userGroupsService = {
@@ -340,5 +349,80 @@ describe('DropPollsApiService', () => {
       { authenticationContext: AuthenticationContext.fromProfileId('voter-1') }
     );
     expect(result).toEqual({ id: 'drop-1' });
+  });
+
+  it('returns wave poll drops in poll query order', async () => {
+    jest.spyOn(Time, 'currentMillis').mockReturnValue(5_000);
+    const { service, deps } = createService();
+    deps.dropPollsDb.countWavePolls.mockResolvedValue(3);
+    deps.dropPollsDb.findWavePolls.mockResolvedValue([
+      {
+        id: 'poll-2',
+        wave_id: 'wave-1',
+        drop_id: 'drop-2',
+        closing_time: 7_000,
+        multichoice: false,
+        created_at: 2_000,
+        options: [],
+        voted: []
+      },
+      {
+        id: 'poll-1',
+        wave_id: 'wave-1',
+        drop_id: 'drop-1',
+        closing_time: 6_000,
+        multichoice: true,
+        created_at: 1_000,
+        options: [],
+        voted: []
+      }
+    ]);
+    deps.dropsService.findDropsV2ByIds.mockResolvedValue({
+      'drop-1': { id: 'drop-1' },
+      'drop-2': { id: 'drop-2' }
+    });
+
+    const result = await service.findWavePolls(
+      {
+        wave_id: 'wave-1',
+        page: 1,
+        page_size: 2,
+        sort_direction: PageSortDirection.DESC,
+        sort: DropPollsOrderBy.CREATED_AT,
+        state: DropPollState.OPEN
+      },
+      {}
+    );
+
+    expect(deps.dropPollsDb.countWavePolls).toHaveBeenCalledWith(
+      {
+        waveId: 'wave-1',
+        state: DropPollState.OPEN,
+        now: 5_000
+      },
+      {}
+    );
+    expect(deps.dropPollsDb.findWavePolls).toHaveBeenCalledWith(
+      {
+        waveId: 'wave-1',
+        limit: 2,
+        offset: 0,
+        order: PageSortDirection.DESC,
+        orderBy: DropPollsOrderBy.CREATED_AT,
+        state: DropPollState.OPEN,
+        now: 5_000
+      },
+      {}
+    );
+    expect(deps.dropsService.findDropsV2ByIds).toHaveBeenCalledWith(
+      ['drop-2', 'drop-1'],
+      {}
+    );
+    expect(result).toEqual({
+      count: 3,
+      page: 1,
+      next: true,
+      data: [{ id: 'drop-2' }, { id: 'drop-1' }]
+    });
   });
 });

--- a/src/api-serverless/src/drops/drop-polls.api.service.ts
+++ b/src/api-serverless/src/drops/drop-polls.api.service.ts
@@ -11,7 +11,6 @@ import {
   DropPollState,
   dropPollsDb
 } from '@/api/drops/drop-polls.db';
-import { mapDropPollToApiWavePoll } from '@/api/drops/drop-polls.mappers';
 import { ApiDropPollsPage } from '@/api/generated/models/ApiDropPollsPage';
 import { ApiDropPollVotersPage } from '@/api/generated/models/ApiDropPollVotersPage';
 import { ApiDropV2 } from '@/api/generated/models/ApiDropV2';
@@ -345,11 +344,17 @@ export class DropPollsApiService {
         ctx
       )
     ]);
+    const dropIds = polls.map((poll) => poll.drop_id);
+    const dropsById = dropIds.length
+      ? await this.dropsService.findDropsV2ByIds(dropIds, ctx)
+      : {};
     return {
       count,
       page: request.page,
       next: count > request.page * request.page_size,
-      data: polls.map((poll) => mapDropPollToApiWavePoll(poll, now))
+      data: dropIds
+        .map((dropId) => dropsById[dropId])
+        .filter((drop): drop is ApiDropV2 => drop !== undefined)
     };
   }
 

--- a/src/api-serverless/src/generated/models/ApiDropPollsPage.ts
+++ b/src/api-serverless/src/generated/models/ApiDropPollsPage.ts
@@ -10,11 +10,11 @@
  * Do not edit the class manually.
  */
 
-import { ApiWavePoll } from '../models/ApiWavePoll';
+import { ApiDropV2 } from '../models/ApiDropV2';
 import { HttpFile } from '../http/http';
 
 export class ApiDropPollsPage {
-    'data': Array<ApiWavePoll>;
+    'data': Array<ApiDropV2>;
     'count': number;
     'page': number;
     'next': boolean;
@@ -27,7 +27,7 @@ export class ApiDropPollsPage {
         {
             "name": "data",
             "baseName": "data",
-            "type": "Array<ApiWavePoll>",
+            "type": "Array<ApiDropV2>",
             "format": ""
         },
         {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed the `/v2/waves/{id}/polls` endpoint to return complete drop information alongside poll data, providing richer context for poll responses.

* **Documentation**
  * Updated API documentation to clarify the structure and ordering of poll responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->