### PR TITLE
Added a reason: POLL_RESPONSE to websocket message when the update reason is response

### DIFF
--- a/src/api-serverless/src/drops/drop-polls-api-service.test.ts
+++ b/src/api-serverless/src/drops/drop-polls-api-service.test.ts
@@ -296,7 +296,8 @@ describe('DropPollsApiService', () => {
     );
     expect(deps.wsListenersNotifier.notifyAboutDropUpdate).toHaveBeenCalledWith(
       { id: 'drop-1' },
-      { authenticationContext: AuthenticationContext.fromProfileId('voter-1') }
+      { authenticationContext: AuthenticationContext.fromProfileId('voter-1') },
+      { reason: 'POLL_RESPONSE' }
     );
     expect(result).toEqual({ id: 'drop-1' });
   });

--- a/src/api-serverless/src/drops/drop-polls.api.service.ts
+++ b/src/api-serverless/src/drops/drop-polls.api.service.ts
@@ -41,6 +41,7 @@ import {
   wsListenersNotifier,
   WsListenersNotifier
 } from '@/api/ws/ws-listeners-notifier';
+import { DROP_UPDATE_REASON_POLL_RESPONSE } from '@/api/ws/ws-message';
 import { giveReadReplicaTimeToCatchUp } from '@/api/api-helpers';
 import { userNotifier, UserNotifier } from '@/notifications/user.notifier';
 
@@ -278,7 +279,9 @@ export class DropPollsApiService {
         { dropId, skipEligibilityCheck: true },
         ctx
       );
-      await this.wsListenersNotifier.notifyAboutDropUpdate(legacyDrop, ctx);
+      await this.wsListenersNotifier.notifyAboutDropUpdate(legacyDrop, ctx, {
+        reason: DROP_UPDATE_REASON_POLL_RESPONSE
+      });
     }
     const dropsById = await this.dropsService.findDropsV2ByIds([dropId], ctx);
     const apiDrop = dropsById[dropId];

--- a/src/api-serverless/src/ws/ws-listeners-notifier.ts
+++ b/src/api-serverless/src/ws/ws-listeners-notifier.ts
@@ -40,8 +40,9 @@ export class WsListenersNotifier {
     inputDrop: ApiDrop,
     ctx: RequestContext,
     {
+      reason,
       useSystemBroadcastAudience = false
-    }: { useSystemBroadcastAudience?: boolean } = {}
+    }: { reason?: string; useSystemBroadcastAudience?: boolean } = {}
   ): Promise<void> {
     ctx.timer?.start(`${this.constructor.name}->notifyAboutDrop`);
     try {
@@ -74,7 +75,8 @@ export class WsListenersNotifier {
                 this.removeDropsAuthRequestContext(
                   inputDrop,
                   profileId === null ? 0 : (creditLefts[profileId] ?? 0)
-                )
+                ),
+                reason
               )
             )
           })

--- a/src/api-serverless/src/ws/ws-message.test.ts
+++ b/src/api-serverless/src/ws/ws-message.test.ts
@@ -1,0 +1,32 @@
+import { ApiDrop } from '@/api/generated/models/ApiDrop';
+import {
+  DROP_UPDATE_REASON_POLL_RESPONSE,
+  dropUpdateMessage,
+  WsMessageType
+} from './ws-message';
+
+describe('ws-message', () => {
+  it('omits reason from drop update messages by default', () => {
+    const drop = { id: 'drop-1' } as ApiDrop;
+
+    const message = dropUpdateMessage(drop);
+
+    expect(message).toEqual({
+      type: WsMessageType.DROP_UPDATE,
+      data: { id: 'drop-1' }
+    });
+    expect(message).not.toHaveProperty('reason');
+  });
+
+  it('includes reason in drop update messages when provided', () => {
+    const drop = { id: 'drop-1' } as ApiDrop;
+
+    const message = dropUpdateMessage(drop, DROP_UPDATE_REASON_POLL_RESPONSE);
+
+    expect(message).toEqual({
+      type: WsMessageType.DROP_UPDATE,
+      data: { id: 'drop-1' },
+      reason: 'POLL_RESPONSE'
+    });
+  });
+});

--- a/src/api-serverless/src/ws/ws-message.ts
+++ b/src/api-serverless/src/ws/ws-message.ts
@@ -17,13 +17,23 @@ export enum WsMessageType {
 export interface WsMessage<MESSAGE_DATA> {
   type: WsMessageType;
   data: MESSAGE_DATA;
+  reason?: string;
 }
 
-export function dropUpdateMessage(data: ApiDrop): WsMessage<ApiDrop> {
-  return {
+export const DROP_UPDATE_REASON_POLL_RESPONSE = 'POLL_RESPONSE';
+
+export function dropUpdateMessage(
+  data: ApiDrop,
+  reason?: string
+): WsMessage<ApiDrop> {
+  const message: WsMessage<ApiDrop> = {
     type: WsMessageType.DROP_UPDATE,
     data
   };
+  if (reason !== undefined) {
+    message.reason = reason;
+  }
+  return message;
 }
 
 export function dropRatingUpdateMessage(data: ApiDrop): WsMessage<ApiDrop> {


### PR DESCRIPTION
Helps to get rid of "new message" bubbles when polls have responses

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced websocket update notifications to include contextual information about the reason for drop updates. When poll responses trigger changes, the system now explicitly identifies these events for improved tracking and system transparency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->