### PR TITLE
Add number of open unanswered polls count to wave polls API

### DIFF
--- a/src/api-serverless/openapi.yaml
+++ b/src/api-serverless/openapi.yaml
@@ -10740,9 +10740,13 @@ components:
       type: object
       required:
         - data
+        - open_unanswered
       allOf:
         - $ref: "#/components/schemas/ApiPageBase"
       properties:
+        open_unanswered:
+          type: number
+          format: int64
         data:
           type: array
           items:

--- a/src/api-serverless/src/drops/drop-polls-api-service.test.ts
+++ b/src/api-serverless/src/drops/drop-polls-api-service.test.ts
@@ -19,6 +19,7 @@ function createService() {
   const dropPollsDb = {
     createPoll: jest.fn().mockResolvedValue(undefined),
     countWavePolls: jest.fn(),
+    countOpenUnansweredWavePolls: jest.fn().mockResolvedValue(0),
     executeNativeQueriesInTransaction: jest.fn(
       async (callback: (connection: unknown) => Promise<void>) => {
         await callback('tx-connection');
@@ -356,6 +357,7 @@ describe('DropPollsApiService', () => {
     jest.spyOn(Time, 'currentMillis').mockReturnValue(5_000);
     const { service, deps } = createService();
     deps.dropPollsDb.countWavePolls.mockResolvedValue(3);
+    deps.dropPollsDb.countOpenUnansweredWavePolls.mockResolvedValue(1);
     deps.dropPollsDb.findWavePolls.mockResolvedValue([
       {
         id: 'poll-2',
@@ -403,6 +405,13 @@ describe('DropPollsApiService', () => {
       },
       {}
     );
+    expect(deps.dropPollsDb.countOpenUnansweredWavePolls).toHaveBeenCalledWith(
+      {
+        waveId: 'wave-1',
+        now: 5_000
+      },
+      {}
+    );
     expect(deps.dropPollsDb.findWavePolls).toHaveBeenCalledWith(
       {
         waveId: 'wave-1',
@@ -421,6 +430,7 @@ describe('DropPollsApiService', () => {
     );
     expect(result).toEqual({
       count: 3,
+      open_unanswered: 1,
       page: 1,
       next: true,
       data: [{ id: 'drop-2' }, { id: 'drop-1' }]

--- a/src/api-serverless/src/drops/drop-polls-db.test.ts
+++ b/src/api-serverless/src/drops/drop-polls-db.test.ts
@@ -294,6 +294,56 @@ describe('DropPollsDb', () => {
     });
   });
 
+  it('counts all open wave polls as unanswered without a read context profile', async () => {
+    const { service, oneOrNull } = createDb();
+    oneOrNull.mockResolvedValueOnce({ cnt: '4' });
+
+    const count = await service.countOpenUnansweredWavePolls(
+      {
+        waveId: 'wave-1',
+        now: 2_000
+      },
+      {}
+    );
+
+    expect(count).toBe(4);
+    const [sql, params] = oneOrNull.mock.calls[0];
+    expect(sql).toContain('and p.closing_time > :now');
+    expect(sql).toContain(':contextProfileId is null');
+    expect(sql).toContain(`from ${DROP_POLL_VOTES_TABLE} v`);
+    expect(params).toEqual({
+      waveId: 'wave-1',
+      now: 2_000,
+      contextProfileId: null
+    });
+  });
+
+  it('excludes open wave polls already answered by the read context profile', async () => {
+    const { service, oneOrNull } = createDb();
+    oneOrNull.mockResolvedValueOnce({ cnt: 2 });
+
+    const count = await service.countOpenUnansweredWavePolls(
+      {
+        waveId: 'wave-1',
+        now: 2_000
+      },
+      {
+        authenticationContext: AuthenticationContext.fromProfileId('viewer-1')
+      }
+    );
+
+    expect(count).toBe(2);
+    const [sql, params] = oneOrNull.mock.calls[0];
+    expect(sql).toContain('not exists');
+    expect(sql).toContain('v.poll_id = p.id');
+    expect(sql).toContain('and v.voter_id = :contextProfileId');
+    expect(params).toEqual({
+      waveId: 'wave-1',
+      now: 2_000,
+      contextProfileId: 'viewer-1'
+    });
+  });
+
   it('skips replacing voter votes when selected options are unchanged', async () => {
     const { service, execute, bulkInsert } = createDb();
     execute.mockResolvedValueOnce([{ option_no: '2' }, { option_no: 3 }]);

--- a/src/api-serverless/src/drops/drop-polls-handlers.test.ts
+++ b/src/api-serverless/src/drops/drop-polls-handlers.test.ts
@@ -25,7 +25,13 @@ import { handleGetWavePollsV2 } from '@/api/drops/drop-polls.handlers';
 describe('drop polls handlers', () => {
   const timer = { marker: 'timer' } as any;
   const authenticationContext = { marker: 'auth' } as any;
-  const result = { count: 0, page: 1, next: false, data: [] };
+  const result = {
+    count: 0,
+    open_unanswered: 0,
+    page: 1,
+    next: false,
+    data: []
+  };
 
   beforeEach(() => {
     jest.clearAllMocks();

--- a/src/api-serverless/src/drops/drop-polls.api.service.ts
+++ b/src/api-serverless/src/drops/drop-polls.api.service.ts
@@ -325,11 +325,18 @@ export class DropPollsApiService {
     });
     const now = Time.currentMillis();
     const offset = (request.page - 1) * request.page_size;
-    const [count, polls] = await Promise.all([
+    const [count, openUnanswered, polls] = await Promise.all([
       this.dropPollsDb.countWavePolls(
         {
           waveId: request.wave_id,
           state: request.state,
+          now
+        },
+        ctx
+      ),
+      this.dropPollsDb.countOpenUnansweredWavePolls(
+        {
+          waveId: request.wave_id,
           now
         },
         ctx
@@ -353,6 +360,7 @@ export class DropPollsApiService {
       : {};
     return {
       count,
+      open_unanswered: openUnanswered,
       page: request.page,
       next: count > request.page * request.page_size,
       data: dropIds

--- a/src/api-serverless/src/drops/drop-polls.db.ts
+++ b/src/api-serverless/src/drops/drop-polls.db.ts
@@ -388,6 +388,47 @@ export class DropPollsDb extends LazyDbAccessCompatibleService {
     }
   }
 
+  public async countOpenUnansweredWavePolls(
+    {
+      waveId,
+      now
+    }: {
+      readonly waveId: string;
+      readonly now: number;
+    },
+    ctx: RequestContext
+  ): Promise<number> {
+    const timerKey = `${this.constructor.name}->countOpenUnansweredWavePolls`;
+    ctx.timer?.start(timerKey);
+    try {
+      const contextProfileId = getWaveReadContextProfileId(
+        ctx.authenticationContext
+      );
+      const row = await this.db.oneOrNull<{ cnt: number | string }>(
+        `
+        select count(*) as cnt
+        from ${DROP_POLLS_TABLE} p
+        where p.wave_id = :waveId
+          and p.closing_time > :now
+          and (
+            :contextProfileId is null
+            or not exists (
+              select 1
+              from ${DROP_POLL_VOTES_TABLE} v
+              where v.poll_id = p.id
+                and v.voter_id = :contextProfileId
+            )
+          )
+      `,
+        { waveId, now, contextProfileId },
+        { wrappedConnection: ctx.connection }
+      );
+      return Number(row?.cnt ?? 0);
+    } finally {
+      ctx.timer?.stop(timerKey);
+    }
+  }
+
   public async deleteByDropId(
     dropId: string,
     ctx: RequestContext

--- a/src/api-serverless/src/generated/models/ApiDropPollsPage.ts
+++ b/src/api-serverless/src/generated/models/ApiDropPollsPage.ts
@@ -14,6 +14,7 @@ import { ApiDropV2 } from '../models/ApiDropV2';
 import { HttpFile } from '../http/http';
 
 export class ApiDropPollsPage {
+    'open_unanswered': number;
     'data': Array<ApiDropV2>;
     'count': number;
     'page': number;
@@ -24,6 +25,12 @@ export class ApiDropPollsPage {
     static readonly mapping: {[index: string]: string} | undefined = undefined;
 
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
+        {
+            "name": "open_unanswered",
+            "baseName": "open_unanswered",
+            "type": "number",
+            "format": "int64"
+        },
         {
             "name": "data",
             "baseName": "data",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Wave poll API responses now include a new `open_unanswered` metric displaying the count of currently open polls within a wave that remain unanswered by the user.

* **Tests**
  * Comprehensive test coverage added for open unanswered polls counting, with validation for both authenticated and unauthenticated user contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->