### PR TITLE
Support for anonymous polls

### DIFF
--- a/src/api-serverless/openapi.yaml
+++ b/src/api-serverless/openapi.yaml
@@ -2544,6 +2544,8 @@ paths:
                 $ref: "#/components/schemas/ApiDropPollVotersPage"
         "400":
           description: Invalid request
+        "403":
+          description: Poll is anonymous
         "404":
           description: Drop, poll, or option not found
   /v2/drops/{id}/poll/vote:
@@ -9604,6 +9606,9 @@ components:
             maxLength: 500
         multichoice:
           type: boolean
+        anonymous:
+          type: boolean
+          default: false
         closing_time:
           type: integer
           format: int64
@@ -10696,6 +10701,7 @@ components:
         - options
         - voted
         - multichoice
+        - anonymous
         - closing_time
         - is_open
       properties:
@@ -10713,6 +10719,8 @@ components:
             format: int64
             minimum: 1
         multichoice:
+          type: boolean
+        anonymous:
           type: boolean
         closing_time:
           type: integer
@@ -15222,6 +15230,7 @@ components:
         - options
         - voted
         - multichoice
+        - anonymous
         - closing_time
         - is_open
       properties:
@@ -15246,6 +15255,8 @@ components:
             format: int64
             minimum: 1
         multichoice:
+          type: boolean
+        anonymous:
           type: boolean
         closing_time:
           type: integer

--- a/src/api-serverless/src/drops/drop-polls-api-service.test.ts
+++ b/src/api-serverless/src/drops/drop-polls-api-service.test.ts
@@ -20,12 +20,15 @@ function createService() {
     createPoll: jest.fn().mockResolvedValue(undefined),
     countWavePolls: jest.fn(),
     countOpenUnansweredWavePolls: jest.fn().mockResolvedValue(0),
+    countOptionVoters: jest.fn().mockResolvedValue(0),
     executeNativeQueriesInTransaction: jest.fn(
       async (callback: (connection: unknown) => Promise<void>) => {
         await callback('tx-connection');
       }
     ),
     findWavePolls: jest.fn(),
+    findPollsByDropIds: jest.fn(),
+    findOptionVoterIds: jest.fn().mockResolvedValue([]),
     findPollByDropIdForUpdate: jest.fn(),
     findOptionsByPollId: jest.fn(),
     replaceVoterVotes: jest.fn().mockResolvedValue(true)
@@ -85,6 +88,7 @@ function createService() {
       dropsDb,
       wavesApiDb,
       userGroupsService,
+      identityFetcher,
       dropsService,
       wsListenersNotifier,
       userNotifier
@@ -119,6 +123,7 @@ describe('DropPollsApiService', () => {
         drop_id: 'drop-1',
         closing_time: 2_000,
         multichoice: false,
+        anonymous: false,
         options: [
           { option_no: 1, option_string: 'First' },
           { option_no: 2, option_string: 'Second' }
@@ -126,6 +131,78 @@ describe('DropPollsApiService', () => {
       }),
       {}
     );
+  });
+
+  it('creates anonymous polls when requested', async () => {
+    jest.spyOn(Time, 'currentMillis').mockReturnValue(1_000);
+    const { service, deps } = createService();
+
+    await service.createPollForDrop(
+      {
+        poll: {
+          options: ['First', 'Second'],
+          multichoice: false,
+          anonymous: true,
+          closing_time: 2_000
+        },
+        dropId: 'drop-1',
+        waveId: 'wave-1',
+        authorId: 'creator-1',
+        dropType: DropType.CHAT
+      },
+      {}
+    );
+
+    expect(deps.dropPollsDb.createPoll).toHaveBeenCalledWith(
+      expect.objectContaining({
+        anonymous: true
+      }),
+      {}
+    );
+  });
+
+  it('rejects voter identity lookup for anonymous polls', async () => {
+    const { service, deps } = createService();
+    deps.dropPollsDb.findPollsByDropIds.mockResolvedValue({
+      'drop-1': {
+        id: 'poll-1',
+        wave_id: 'wave-1',
+        drop_id: 'drop-1',
+        closing_time: 2_000,
+        multichoice: false,
+        anonymous: true,
+        voted: [],
+        options: [
+          {
+            poll_id: 'poll-1',
+            wave_id: 'wave-1',
+            drop_id: 'drop-1',
+            option_no: 1,
+            option_string: 'First',
+            votes: 3,
+            voted_by_context_profile: false
+          }
+        ]
+      }
+    });
+
+    await expect(
+      service.findOptionVoters(
+        {
+          dropId: 'drop-1',
+          optionNo: 1,
+          page: 1,
+          pageSize: 20
+        },
+        {}
+      )
+    ).rejects.toThrow('Poll is anonymous');
+
+    expect(deps.dropPollsDb.countOptionVoters).not.toHaveBeenCalled();
+    expect(deps.dropPollsDb.findOptionVoterIds).not.toHaveBeenCalled();
+    expect(
+      deps.identityFetcher.getApiIdentityOverviewsByIds
+    ).not.toHaveBeenCalled();
   });
 
   it('rejects poll creation by users who are not wave creators or admins', async () => {
@@ -205,7 +282,8 @@ describe('DropPollsApiService', () => {
       wave_id: 'wave-1',
       drop_id: 'drop-1',
       closing_time: 2_000,
-      multichoice: true
+      multichoice: true,
+      anonymous: false
     });
 
     await expect(
@@ -301,6 +379,46 @@ describe('DropPollsApiService', () => {
       { reason: 'POLL_RESPONSE' }
     );
     expect(result).toEqual({ id: 'drop-1' });
+  });
+
+  it('does not notify the drop author when an anonymous poll vote changes', async () => {
+    jest.spyOn(Time, 'currentMillis').mockReturnValue(1_000);
+    const { service, deps } = createService();
+    deps.dropPollsDb.findPollByDropIdForUpdate.mockResolvedValue({
+      id: 'poll-1',
+      wave_id: 'wave-1',
+      drop_id: 'drop-1',
+      closing_time: 2_000,
+      multichoice: true,
+      anonymous: true
+    });
+    deps.dropPollsDb.findOptionsByPollId.mockResolvedValue([
+      {
+        poll_id: 'poll-1',
+        wave_id: 'wave-1',
+        drop_id: 'drop-1',
+        option_no: 2,
+        option_string: 'Second'
+      }
+    ]);
+
+    await service.vote(
+      {
+        dropId: 'drop-1',
+        voterId: 'voter-1',
+        options: [2]
+      },
+      { authenticationContext: AuthenticationContext.fromProfileId('voter-1') }
+    );
+
+    expect(deps.dropPollsDb.replaceVoterVotes).toHaveBeenCalled();
+    expect(deps.userNotifier.notifyOfDropPollVote).not.toHaveBeenCalled();
+    expect(giveReadReplicaTimeToCatchUp).toHaveBeenCalled();
+    expect(deps.wsListenersNotifier.notifyAboutDropUpdate).toHaveBeenCalledWith(
+      { id: 'drop-1' },
+      { authenticationContext: AuthenticationContext.fromProfileId('voter-1') },
+      { reason: 'POLL_RESPONSE' }
+    );
   });
 
   it('does not notify or broadcast when poll vote selections are unchanged', async () => {

--- a/src/api-serverless/src/drops/drop-polls-db.test.ts
+++ b/src/api-serverless/src/drops/drop-polls-db.test.ts
@@ -19,6 +19,7 @@ function createPollCommand(): CreateDropPollCommand {
     drop_id: 'drop-1',
     closing_time: 2_000,
     multichoice: false,
+    anonymous: false,
     options: [
       { option_no: 1, option_string: 'First' },
       { option_no: 2, option_string: 'Second' }
@@ -125,6 +126,7 @@ describe('DropPollsDb', () => {
         drop_id: 'drop-1',
         closing_time: '2000',
         multichoice: 1,
+        anonymous: 0,
         option_no: 1,
         option_string: 'First',
         votes: '5',
@@ -136,6 +138,7 @@ describe('DropPollsDb', () => {
         drop_id: 'drop-1',
         closing_time: '2000',
         multichoice: 1,
+        anonymous: 0,
         option_no: 2,
         option_string: 'Second',
         votes: '3',
@@ -149,6 +152,7 @@ describe('DropPollsDb', () => {
 
     expect(result['drop-1']).toMatchObject({
       id: 'poll-1',
+      anonymous: false,
       voted: [2],
       options: [
         {
@@ -183,6 +187,7 @@ describe('DropPollsDb', () => {
           drop_id: 'drop-1',
           closing_time: '2000',
           multichoice: 1,
+          anonymous: '1',
           created_at: '1000'
         }
       ])
@@ -225,6 +230,7 @@ describe('DropPollsDb', () => {
     expect(result).toHaveLength(1);
     expect(result[0]).toMatchObject({
       id: 'poll-1',
+      anonymous: true,
       voted: [2],
       options: [
         {

--- a/src/api-serverless/src/drops/drop-polls-mappers.test.ts
+++ b/src/api-serverless/src/drops/drop-polls-mappers.test.ts
@@ -1,0 +1,63 @@
+import {
+  mapDropPollToApi,
+  mapDropPollToApiWavePoll
+} from '@/api/drops/drop-polls.mappers';
+
+describe('drop poll mappers', () => {
+  const poll = {
+    id: 'poll-1',
+    wave_id: 'wave-1',
+    drop_id: 'drop-1',
+    closing_time: 2_000,
+    multichoice: true,
+    anonymous: true,
+    created_at: 1_000,
+    voted: [2, 1],
+    options: [
+      {
+        poll_id: 'poll-1',
+        wave_id: 'wave-1',
+        drop_id: 'drop-1',
+        option_no: 2,
+        option_string: 'Second',
+        votes: 3,
+        voted_by_context_profile: true
+      },
+      {
+        poll_id: 'poll-1',
+        wave_id: 'wave-1',
+        drop_id: 'drop-1',
+        option_no: 1,
+        option_string: 'First',
+        votes: 5,
+        voted_by_context_profile: true
+      }
+    ]
+  };
+
+  it('maps anonymous poll metadata and viewer vote selections', () => {
+    expect(mapDropPollToApi(poll, 1_500)).toEqual({
+      id: 'poll-1',
+      options: [
+        { option_no: 1, option_string: 'First', votes: 5 },
+        { option_no: 2, option_string: 'Second', votes: 3 }
+      ],
+      voted: [1, 2],
+      multichoice: true,
+      anonymous: true,
+      closing_time: 2_000,
+      is_open: true
+    });
+  });
+
+  it('maps anonymous metadata for wave poll responses', () => {
+    expect(mapDropPollToApiWavePoll(poll, 2_500)).toMatchObject({
+      id: 'poll-1',
+      wave_id: 'wave-1',
+      drop_id: 'drop-1',
+      created_at: 1_000,
+      anonymous: true,
+      is_open: false
+    });
+  });
+});

--- a/src/api-serverless/src/drops/drop-polls.api.service.ts
+++ b/src/api-serverless/src/drops/drop-polls.api.service.ts
@@ -53,6 +53,7 @@ type SelectedPollOption = {
 export type CreateDropPollRequest = {
   readonly options: string[];
   readonly multichoice: boolean;
+  readonly anonymous?: boolean;
   readonly closing_time: number;
 };
 
@@ -127,6 +128,7 @@ export class DropPollsApiService {
         drop_id: dropId,
         closing_time: poll.closing_time,
         multichoice: poll.multichoice,
+        anonymous: poll.anonymous ?? false,
         options: poll.options.map((option, index) => ({
           option_no: index + 1,
           option_string: option.trim()
@@ -161,6 +163,9 @@ export class DropPollsApiService {
       throw new NotFoundException(
         `Poll option ${optionNo} not found for drop ${dropId}`
       );
+    }
+    if (poll.anonymous) {
+      throw new ForbiddenException(`Poll is anonymous`);
     }
     const offset = (page - 1) * pageSize;
     const [count, voterIds] = await Promise.all([
@@ -215,6 +220,7 @@ export class DropPollsApiService {
     }
     let selectedPollOptions: SelectedPollOption[] = [];
     let pollVoteChanged = false;
+    let pollAnonymous = false;
     await this.dropPollsDb.executeNativeQueriesInTransaction(
       async (connection) => {
         const txCtx = { ...ctx, connection };
@@ -231,6 +237,7 @@ export class DropPollsApiService {
         if (!poll.multichoice && uniqueOptions.length > 1) {
           throw new BadRequestException(`Poll does not allow multiple options`);
         }
+        pollAnonymous = poll.anonymous;
         const pollOptions = await this.dropPollsDb.findOptionsByPollId(
           poll.id,
           txCtx
@@ -264,16 +271,18 @@ export class DropPollsApiService {
       }
     );
     if (pollVoteChanged) {
-      await this.userNotifier.notifyOfDropPollVote(
-        {
-          voter_id: voterId,
-          drop_id: dropId,
-          drop_author_id: drop.author_id,
-          poll_options: selectedPollOptions,
-          wave_id: drop.wave_id
-        },
-        wave.visibility_group_id
-      );
+      if (!pollAnonymous) {
+        await this.userNotifier.notifyOfDropPollVote(
+          {
+            voter_id: voterId,
+            drop_id: dropId,
+            drop_author_id: drop.author_id,
+            poll_options: selectedPollOptions,
+            wave_id: drop.wave_id
+          },
+          wave.visibility_group_id
+        );
+      }
       await giveReadReplicaTimeToCatchUp();
       const legacyDrop = await this.dropsService.findDropByIdOrThrow(
         { dropId, skipEligibilityCheck: true },

--- a/src/api-serverless/src/drops/drop-polls.db.ts
+++ b/src/api-serverless/src/drops/drop-polls.db.ts
@@ -37,6 +37,7 @@ export type CreateDropPollCommand = {
   readonly drop_id: string;
   readonly closing_time: number;
   readonly multichoice: boolean;
+  readonly anonymous: boolean;
   readonly options: readonly {
     readonly option_no: number;
     readonly option_string: string;
@@ -98,6 +99,7 @@ export class DropPollsDb extends LazyDbAccessCompatibleService {
           p.drop_id,
           p.closing_time,
           p.multichoice,
+          p.anonymous,
           o.option_no,
           o.option_string,
           count(v.voter_id) as votes,
@@ -118,6 +120,7 @@ export class DropPollsDb extends LazyDbAccessCompatibleService {
           p.drop_id,
           p.closing_time,
           p.multichoice,
+          p.anonymous,
           o.option_no,
           o.option_string
         order by p.drop_id asc, o.option_no asc
@@ -328,6 +331,7 @@ export class DropPollsDb extends LazyDbAccessCompatibleService {
           p.drop_id,
           p.closing_time,
           p.multichoice,
+          p.anonymous,
           d.created_at
         from ${DROP_POLLS_TABLE} p
         join ${DROPS_TABLE} d on d.id = p.drop_id
@@ -538,13 +542,15 @@ export class DropPollsDb extends LazyDbAccessCompatibleService {
           wave_id,
           drop_id,
           closing_time,
-          multichoice
+          multichoice,
+          anonymous
         ) values (
           :id,
           :wave_id,
           :drop_id,
           :closing_time,
-          :multichoice
+          :multichoice,
+          :anonymous
         )
       `,
       command,
@@ -704,7 +710,8 @@ export class DropPollsDb extends LazyDbAccessCompatibleService {
       wave_id: row.wave_id,
       drop_id: row.drop_id,
       closing_time: Number(row.closing_time),
-      multichoice: toBoolean(row.multichoice)
+      multichoice: toBoolean(row.multichoice),
+      anonymous: toBoolean(row.anonymous)
     };
   }
 

--- a/src/api-serverless/src/drops/drop-polls.mappers.ts
+++ b/src/api-serverless/src/drops/drop-polls.mappers.ts
@@ -23,6 +23,7 @@ export function mapDropPollToApi(
     options: mapOptions(poll),
     voted: [...(poll.voted ?? [])].sort((a, b) => a - b),
     multichoice: poll.multichoice,
+    anonymous: poll.anonymous,
     closing_time: poll.closing_time,
     is_open: now < poll.closing_time
   };

--- a/src/api-serverless/src/drops/drop-validator.test.ts
+++ b/src/api-serverless/src/drops/drop-validator.test.ts
@@ -165,8 +165,44 @@ describe('NewDropSchema', () => {
     expect(result.value.poll).toMatchObject({
       options: ['First', 'Second'],
       multichoice: false,
+      anonymous: false,
       closing_time: futureTimestamp
     });
+  });
+
+  it('accepts anonymous polls for chat drops', () => {
+    const result = NewDropSchema.validate({
+      ...createDropWithMetadata('artist', 'Artist'),
+      drop_type: ApiDropType.Chat,
+      poll: {
+        options: ['First', 'Second'],
+        multichoice: false,
+        anonymous: true,
+        closing_time: futureTimestamp
+      }
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.value.poll).toMatchObject({
+      anonymous: true
+    });
+  });
+
+  it('rejects polls with invalid anonymous values', () => {
+    const result = NewDropSchema.validate({
+      ...createDropWithMetadata('artist', 'Artist'),
+      drop_type: ApiDropType.Chat,
+      poll: {
+        options: ['First', 'Second'],
+        multichoice: false,
+        anonymous: 'invalid',
+        closing_time: futureTimestamp
+      }
+    });
+
+    expect(result.error?.message).toContain(
+      '"poll.anonymous" must be a boolean'
+    );
   });
 
   it('rejects polls for participatory drops', () => {

--- a/src/api-serverless/src/drops/drop.validator.ts
+++ b/src/api-serverless/src/drops/drop.validator.ts
@@ -166,6 +166,7 @@ const NewDropPollSchema: Joi.ObjectSchema<ApiCreateDropPollRequest> =
       .unique()
       .required(),
     multichoice: Joi.boolean().required(),
+    anonymous: Joi.boolean().optional().default(false),
     closing_time: Joi.number()
       .integer()
       .required()

--- a/src/api-serverless/src/generated/models/ApiCreateDropPollRequest.ts
+++ b/src/api-serverless/src/generated/models/ApiCreateDropPollRequest.ts
@@ -15,6 +15,7 @@ import { HttpFile } from '../http/http';
 export class ApiCreateDropPollRequest {
     'options': Set<string>;
     'multichoice': boolean;
+    'anonymous'?: boolean;
     /**
     * Future Unix timestamp in milliseconds.
     */
@@ -34,6 +35,12 @@ export class ApiCreateDropPollRequest {
         {
             "name": "multichoice",
             "baseName": "multichoice",
+            "type": "boolean",
+            "format": ""
+        },
+        {
+            "name": "anonymous",
+            "baseName": "anonymous",
             "type": "boolean",
             "format": ""
         },

--- a/src/api-serverless/src/generated/models/ApiDropPoll.ts
+++ b/src/api-serverless/src/generated/models/ApiDropPoll.ts
@@ -21,6 +21,7 @@ export class ApiDropPoll {
     */
     'voted': Array<number>;
     'multichoice': boolean;
+    'anonymous': boolean;
     'closing_time': number;
     'is_open': boolean;
 
@@ -50,6 +51,12 @@ export class ApiDropPoll {
         {
             "name": "multichoice",
             "baseName": "multichoice",
+            "type": "boolean",
+            "format": ""
+        },
+        {
+            "name": "anonymous",
+            "baseName": "anonymous",
             "type": "boolean",
             "format": ""
         },

--- a/src/api-serverless/src/generated/models/ApiWavePoll.ts
+++ b/src/api-serverless/src/generated/models/ApiWavePoll.ts
@@ -24,6 +24,7 @@ export class ApiWavePoll {
     */
     'voted': Array<number>;
     'multichoice': boolean;
+    'anonymous': boolean;
     'closing_time': number;
     'is_open': boolean;
 
@@ -71,6 +72,12 @@ export class ApiWavePoll {
         {
             "name": "multichoice",
             "baseName": "multichoice",
+            "type": "boolean",
+            "format": ""
+        },
+        {
+            "name": "anonymous",
+            "baseName": "anonymous",
             "type": "boolean",
             "format": ""
         },

--- a/src/api-serverless/src/ws/ws-listeners-notifier.test.ts
+++ b/src/api-serverless/src/ws/ws-listeners-notifier.test.ts
@@ -1,0 +1,51 @@
+import { ApiDropType } from '@/api/generated/models/ApiDropType';
+import { WsListenersNotifier } from '@/api/ws/ws-listeners-notifier';
+
+describe('WsListenersNotifier', () => {
+  it('removes viewer poll selections from anonymous poll drop updates', async () => {
+    const appWebSockets = {
+      send: jest.fn().mockResolvedValue(undefined)
+    };
+    const wsConnectionRepository = {
+      getCurrentlyOnlineCommunityMemberConnectionIds: jest
+        .fn()
+        .mockResolvedValue([
+          { connectionId: 'connection-1', profileId: 'viewer-1' }
+        ])
+    };
+    const notifier = new WsListenersNotifier(
+      appWebSockets as any,
+      wsConnectionRepository as any
+    );
+
+    await notifier.notifyAboutDropUpdate(
+      {
+        id: 'drop-1',
+        drop_type: ApiDropType.Chat,
+        author: { id: 'author-1', subscribed_actions: [] },
+        wave: {
+          id: 'wave-1',
+          visibility_group_id: null
+        },
+        parts: [],
+        poll: {
+          id: 'poll-1',
+          options: [{ option_no: 1, option_string: 'First', votes: 4 }],
+          voted: [1],
+          multichoice: false,
+          anonymous: true,
+          closing_time: 2_000,
+          is_open: true
+        }
+      } as any,
+      {}
+    );
+
+    const message = JSON.parse(appWebSockets.send.mock.calls[0][0].message);
+    expect(message.data.poll).toMatchObject({
+      anonymous: true,
+      voted: [],
+      options: [{ option_no: 1, option_string: 'First', votes: 4 }]
+    });
+  });
+});

--- a/src/api-serverless/src/ws/ws-listeners-notifier.ts
+++ b/src/api-serverless/src/ws/ws-listeners-notifier.ts
@@ -326,6 +326,9 @@ export class WsListenersNotifier {
       (modifiedDrop.author as any).subscribed_actions = undefined;
       (modifiedDrop as any).context_profile_context = undefined;
     }
+    if (modifiedDrop.poll?.anonymous) {
+      modifiedDrop.poll.voted = [];
+    }
     for (const part of modifiedDrop.parts) {
       if (part.quoted_drop?.drop) {
         part.quoted_drop.drop = this.removeDropsAuthRequestContext(

--- a/src/entities/IDropPoll.ts
+++ b/src/entities/IDropPoll.ts
@@ -25,6 +25,9 @@ export class DropPollEntity {
 
   @Column({ type: 'boolean', nullable: false })
   readonly multichoice!: boolean;
+
+  @Column({ type: 'boolean', nullable: false, default: false })
+  readonly anonymous!: boolean;
 }
 
 @Entity(DROP_POLL_OPTIONS_TABLE)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Anonymous Polls: Poll creators can now designate polls as anonymous. Anonymous polls hide voter identities from participants, prevent access to voter lists via API (returning a 403 error), and suppress personal vote notifications to protect privacy while maintaining full poll functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->