### PR TITLE
Enable 6529bot reviewer config

### DIFF
--- a/.github/6529bot.yml
+++ b/.github/6529bot.yml
@@ -1,0 +1,41 @@
+version: 1
+enabled: true
+
+reviewKinds:
+  allowed: [general, followup, wcag, i18n, security]
+  initial: [general, security]
+  followup: [followup]
+
+commands:
+  enabled: true
+
+lanes:
+  - provider: anthropic
+    model: claude-opus-4-8
+
+limits:
+  maxJobsPerDelivery: 4
+
+admission:
+  publicRepoMode: trusted
+  privateRepoMode: open
+  draftPrMode: skip
+  trustedPermission: write
+  trustedUsers: []
+  trustedTeams: []
+  trustedOrganizations: []
+  denyUsers: []
+
+budget:
+  mode: enforce
+  defaultEstimatedCostUsd: 1
+  caps:
+    repo:
+      dailyUsd: 10
+      monthlyUsd: 200
+    requestor:
+      dailyUsd: 5
+    pr:
+      dailyUsd: 3
+    review_kind:
+      dailyUsd: 5


### PR DESCRIPTION
## Summary
- Add `.github/6529bot.yml` for the central 6529bot GitHub App path
- Enable Anthropic `claude-opus-4-8` as the review lane
- Enable initial `general` and `security` reviews, follow-up reviews, and maintainer commands
- Add enforced repo/requestor/PR/review-kind budget caps

## Notes
- This does not add provider keys, workflows, AWS credentials, or bot code to this repository.
- Live reviews still require the central 6529bot App installation/runtime and central worker credentials to be ready.

## Validation
- `npm run validate:repo-config -- templates/dogfood-repository-config.yml`
- `npm run dogfood:target -- -- --repository-config templates/dogfood-repository-config.yml --mode limited-initial --require-ready`