### PR TITLE
Add creator to v2 wave overviews

### DIFF
--- a/src/api-serverless/openapi.yaml
+++ b/src/api-serverless/openapi.yaml
@@ -15023,6 +15023,7 @@ components:
       required:
         - id
         - name
+        - creator
         - last_drop_time
         - created_at
         - subscribers_count
@@ -15039,6 +15040,8 @@ components:
           type: string
         pfp:
           type: string
+        creator:
+          $ref: "#/components/schemas/ApiProfileMin"
         last_drop_time:
           type: integer
           format: int64

--- a/src/api-serverless/src/generated/models/ApiWaveOverview.ts
+++ b/src/api-serverless/src/generated/models/ApiWaveOverview.ts
@@ -10,6 +10,7 @@
  * Do not edit the class manually.
  */
 
+import { ApiProfileMin } from '../models/ApiProfileMin';
 import { ApiWaveOverviewContextProfileContext } from '../models/ApiWaveOverviewContextProfileContext';
 import { ApiWaveOverviewContributor } from '../models/ApiWaveOverviewContributor';
 import { ApiWaveOverviewDescriptionDrop } from '../models/ApiWaveOverviewDescriptionDrop';
@@ -19,6 +20,7 @@ export class ApiWaveOverview {
     'id': string;
     'name': string;
     'pfp'?: string;
+    'creator': ApiProfileMin;
     'last_drop_time': number;
     'created_at': number;
     'subscribers_count': number;
@@ -54,6 +56,12 @@ export class ApiWaveOverview {
             "name": "pfp",
             "baseName": "pfp",
             "type": "string",
+            "format": ""
+        },
+        {
+            "name": "creator",
+            "baseName": "creator",
+            "type": "ApiProfileMin",
             "format": ""
         },
         {

--- a/src/api-serverless/src/og-metadata/og-metadata-service.test.ts
+++ b/src/api-serverless/src/og-metadata/og-metadata-service.test.ts
@@ -165,6 +165,11 @@ function makeDropWithWave(id: string, serialNo: number): ApiDropWithWave {
     wave: {
       id: 'wave-1',
       name: 'Wave',
+      creator: makeApiProfileMin({
+        id: 'creator-1',
+        handle: 'creator',
+        level: 7
+      }),
       last_drop_time: 1,
       created_at: 1,
       subscribers_count: 12,

--- a/src/api-serverless/src/waves/api-wave-overview-mapper.test.ts
+++ b/src/api-serverless/src/waves/api-wave-overview-mapper.test.ts
@@ -6,7 +6,10 @@ import {
   WaveEntity,
   WaveType
 } from '@/entities/IWave';
-import { ApiWaveOverviewMapper } from './api-wave-overview.mapper';
+import {
+  ApiWaveOverviewMapper,
+  createUnknownWaveCreatorProfile
+} from './api-wave-overview.mapper';
 
 function makeWave(overrides: Partial<WaveEntity> = {}): WaveEntity {
   return {
@@ -96,33 +99,6 @@ function makeProfile(overrides: Record<string, unknown> = {}) {
     profile_wave_id: null,
     is_wave_creator: true,
     ...overrides
-  };
-}
-
-function makeUnknownProfile(profileId: string) {
-  return {
-    id: profileId,
-    handle: 'Unknown profile',
-    banner1_color: null,
-    banner2_color: null,
-    pfp: null,
-    cic: 0,
-    rep: 0,
-    tdh: 0,
-    xtdh: 0,
-    xtdh_rate: 0,
-    tdh_rate: 0,
-    level: 0,
-    classification: 'PSEUDONYM',
-    sub_classification: null,
-    archived: true,
-    profile_wave_id: null,
-    subscribed_actions: [],
-    primary_address: '',
-    active_main_stage_submission_ids: [],
-    winner_main_stage_drop_ids: [],
-    artist_of_prevote_cards: [],
-    is_wave_creator: false
   };
 }
 
@@ -255,7 +231,28 @@ describe('ApiWaveOverviewMapper', () => {
       authenticationContext: AuthenticationContext.notAuthenticated()
     });
 
-    expect(result['wave-1'].creator).toEqual(makeUnknownProfile('creator-1'));
+    expect(result['wave-1'].creator).toEqual(
+      createUnknownWaveCreatorProfile({
+        profileId: 'creator-1',
+        waveId: 'wave-1'
+      })
+    );
+  });
+
+  it('does not fetch a malformed creator id when created_by is missing', async () => {
+    const { mapper, deps } = createMapper();
+    const waveWithoutCreator = makeWave({
+      created_by: undefined as unknown as string
+    });
+
+    const result = await mapper.mapWaves([waveWithoutCreator], {
+      authenticationContext: AuthenticationContext.notAuthenticated()
+    });
+
+    expect(deps.identityFetcher.getOverviewsByIds).not.toHaveBeenCalled();
+    expect(result['wave-1'].creator).toEqual(
+      createUnknownWaveCreatorProfile({ waveId: 'wave-1' })
+    );
   });
 
   it('maps visible parent wave and visible child presence', async () => {
@@ -298,6 +295,10 @@ describe('ApiWaveOverviewMapper', () => {
         parent_wave: expect.objectContaining({
           id: parentWave.id,
           name: parentWave.name,
+          creator: makeProfile({
+            id: 'parent-creator',
+            handle: 'parentCreator'
+          }),
           has_subwaves: true
         })
       })

--- a/src/api-serverless/src/waves/api-wave-overview-mapper.test.ts
+++ b/src/api-serverless/src/waves/api-wave-overview-mapper.test.ts
@@ -71,6 +71,61 @@ function makeMetric(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function makeProfile(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'creator-1',
+    handle: 'creator',
+    pfp: 'creator.png',
+    banner1_color: null,
+    banner2_color: null,
+    cic: 0,
+    rep: 0,
+    tdh: 0,
+    tdh_rate: 0,
+    xtdh: 0,
+    xtdh_rate: 0,
+    level: 42,
+    classification: 'PSEUDONYM',
+    sub_classification: null,
+    primary_address: '0x0000000000000000000000000000000000000000',
+    subscribed_actions: [],
+    archived: false,
+    active_main_stage_submission_ids: [],
+    winner_main_stage_drop_ids: [],
+    artist_of_prevote_cards: [],
+    profile_wave_id: null,
+    is_wave_creator: true,
+    ...overrides
+  };
+}
+
+function makeUnknownProfile(profileId: string) {
+  return {
+    id: profileId,
+    handle: 'Unknown profile',
+    banner1_color: null,
+    banner2_color: null,
+    pfp: null,
+    cic: 0,
+    rep: 0,
+    tdh: 0,
+    xtdh: 0,
+    xtdh_rate: 0,
+    tdh_rate: 0,
+    level: 0,
+    classification: 'PSEUDONYM',
+    sub_classification: null,
+    archived: true,
+    profile_wave_id: null,
+    subscribed_actions: [],
+    primary_address: '',
+    active_main_stage_submission_ids: [],
+    winner_main_stage_drop_ids: [],
+    artist_of_prevote_cards: [],
+    is_wave_creator: false
+  };
+}
+
 function createMapper() {
   const wavesApiDb = {
     findWavesMetricsByWaveIds: jest.fn().mockResolvedValue({
@@ -101,6 +156,15 @@ function createMapper() {
   const directMessageWaveDisplayService = {
     resolveWaveDisplayByWaveIdForContext: jest.fn().mockResolvedValue({})
   };
+  const identityFetcher = {
+    getOverviewsByIds: jest.fn().mockResolvedValue({
+      'creator-1': makeProfile(),
+      'parent-creator': makeProfile({
+        id: 'parent-creator',
+        handle: 'parentCreator'
+      })
+    })
+  };
 
   return {
     mapper: new ApiWaveOverviewMapper(
@@ -108,14 +172,16 @@ function createMapper() {
       dropsDb as any,
       identitySubscriptionsDb as any,
       userGroupsService as any,
-      directMessageWaveDisplayService as any
+      directMessageWaveDisplayService as any,
+      identityFetcher as any
     ),
     deps: {
       wavesApiDb,
       dropsDb,
       identitySubscriptionsDb,
       userGroupsService,
-      directMessageWaveDisplayService
+      directMessageWaveDisplayService,
+      identityFetcher
     }
   };
 }
@@ -132,6 +198,7 @@ describe('ApiWaveOverviewMapper', () => {
     expect(result['wave-1']).toEqual({
       id: 'wave-1',
       name: 'Wave 1',
+      creator: makeProfile(),
       last_drop_time: 456,
       created_at: 100,
       subscribers_count: 11,
@@ -161,6 +228,10 @@ describe('ApiWaveOverviewMapper', () => {
       ['description-drop-1'],
       ctx
     );
+    expect(deps.identityFetcher.getOverviewsByIds).toHaveBeenCalledWith(
+      ['creator-1'],
+      ctx
+    );
   });
 
   it('maps disabled links flag from wave settings', async () => {
@@ -176,11 +247,23 @@ describe('ApiWaveOverviewMapper', () => {
     expect(result['wave-1']?.links_disabled).toBe(true);
   });
 
+  it('maps a level zero creator fallback when the profile is missing', async () => {
+    const { mapper, deps } = createMapper();
+    deps.identityFetcher.getOverviewsByIds.mockResolvedValue({});
+
+    const result = await mapper.mapWaves([makeWave()], {
+      authenticationContext: AuthenticationContext.notAuthenticated()
+    });
+
+    expect(result['wave-1'].creator).toEqual(makeUnknownProfile('creator-1'));
+  });
+
   it('maps visible parent wave and visible child presence', async () => {
     const { mapper, deps } = createMapper();
     const parentWave = makeWave({
       id: 'parent-wave',
       name: 'Parent Wave',
+      created_by: 'parent-creator',
       description_drop_id: 'parent-description-drop'
     });
     const subwave = makeWave({
@@ -329,6 +412,7 @@ describe('ApiWaveOverviewMapper', () => {
     expect(result['wave-1']).toEqual({
       id: 'wave-1',
       name: 'Direct Chat',
+      creator: makeProfile(),
       pfp: 'display.png',
       last_drop_time: 456,
       created_at: 100,

--- a/src/api-serverless/src/waves/api-wave-overview.mapper.ts
+++ b/src/api-serverless/src/waves/api-wave-overview.mapper.ts
@@ -14,10 +14,16 @@ import { ApiWaveOverview } from '@/api/generated/models/ApiWaveOverview';
 import { ApiWaveOverviewContributor } from '@/api/generated/models/ApiWaveOverviewContributor';
 import { ApiWaveOverviewContextProfileContext } from '@/api/generated/models/ApiWaveOverviewContextProfileContext';
 import { ApiWaveOverviewDescriptionDrop } from '@/api/generated/models/ApiWaveOverviewDescriptionDrop';
+import { ApiProfileMin } from '@/api/generated/models/ApiProfileMin';
+import { ApiProfileClassification } from '@/api/generated/models/ApiProfileClassification';
 import {
   identitySubscriptionsDb,
   IdentitySubscriptionsDb
 } from '@/api/identity-subscriptions/identity-subscriptions.db';
+import {
+  identityFetcher,
+  IdentityFetcher
+} from '@/api/identities/identity.fetcher';
 import {
   userGroupsService,
   UserGroupsService
@@ -38,7 +44,8 @@ export class ApiWaveOverviewMapper {
     private readonly dropsDb: DropsDb,
     private readonly identitySubscriptionsDb: IdentitySubscriptionsDb,
     private readonly userGroupsService: UserGroupsService,
-    private readonly directMessageWaveDisplayService: DirectMessageWaveDisplayService
+    private readonly directMessageWaveDisplayService: DirectMessageWaveDisplayService,
+    private readonly identityFetcher: IdentityFetcher
   ) {}
 
   public async mapWaves(
@@ -89,7 +96,8 @@ export class ApiWaveOverviewMapper {
         unreadDropsCountByWaveId,
         firstUnreadDropSerialNoByWaveId,
         chatDropCooldownsByWaveId,
-        waveIdsWithVisibleSubwaves
+        waveIdsWithVisibleSubwaves,
+        profilesById
       ] = await Promise.all([
         this.wavesApiDb.findWavesMetricsByWaveIds(waveIds, ctx),
         this.dropsDb.getDropPartOnes(descriptionDropIds, ctx),
@@ -162,6 +170,10 @@ export class ApiWaveOverviewMapper {
           waveIds,
           groupIdsUserIsEligibleFor,
           ctx
+        ),
+        this.identityFetcher.getOverviewsByIds(
+          collections.distinct(relatedEntities.map((wave) => wave.created_by)),
+          ctx
         )
       ]);
 
@@ -183,7 +195,8 @@ export class ApiWaveOverviewMapper {
               firstUnreadDropSerialNoByWaveId[wave.id] ?? undefined,
             nextDropTimestamp:
               chatDropCooldownsByWaveId[wave.id]?.next_drop_timestamp,
-            hasSubwaves: waveIdsWithVisibleSubwaves.has(wave.id)
+            hasSubwaves: waveIdsWithVisibleSubwaves.has(wave.id),
+            profilesById
           });
           return acc;
         },
@@ -221,7 +234,8 @@ export class ApiWaveOverviewMapper {
     unreadDropsCount,
     firstUnreadDropSerialNo,
     nextDropTimestamp,
-    hasSubwaves
+    hasSubwaves,
+    profilesById
   }: {
     wave: WaveEntity;
     metrics?: {
@@ -241,11 +255,13 @@ export class ApiWaveOverviewMapper {
     firstUnreadDropSerialNo?: number;
     nextDropTimestamp?: number;
     hasSubwaves: boolean;
+    profilesById: Record<string, ApiProfileMin>;
   }): ApiWaveOverview {
     const pfp = resolveWavePictureOverride(wave.picture, display);
     const overview: ApiWaveOverview = {
       id: wave.id,
       name: display?.name ?? wave.name,
+      creator: this.getProfileMinOrUnknown(wave.created_by, profilesById),
       last_drop_time: metrics?.latest_drop_timestamp ?? 0,
       created_at: wave.created_at,
       subscribers_count: metrics?.subscribers_count ?? 0,
@@ -373,6 +389,38 @@ export class ApiWaveOverviewMapper {
 
     return result;
   }
+
+  private getProfileMinOrUnknown(
+    profileId: string,
+    profilesById: Record<string, ApiProfileMin>
+  ): ApiProfileMin {
+    return (
+      profilesById[profileId] ?? {
+        id: profileId,
+        handle: 'Unknown profile',
+        banner1_color: null,
+        banner2_color: null,
+        pfp: null,
+        cic: 0,
+        rep: 0,
+        tdh: 0,
+        xtdh: 0,
+        xtdh_rate: 0,
+        tdh_rate: 0,
+        level: 0,
+        classification: ApiProfileClassification.Pseudonym,
+        sub_classification: null,
+        archived: true,
+        profile_wave_id: null,
+        subscribed_actions: [],
+        primary_address: '',
+        active_main_stage_submission_ids: [],
+        winner_main_stage_drop_ids: [],
+        artist_of_prevote_cards: [],
+        is_wave_creator: false
+      }
+    );
+  }
 }
 
 export const apiWaveOverviewMapper = new ApiWaveOverviewMapper(
@@ -380,5 +428,6 @@ export const apiWaveOverviewMapper = new ApiWaveOverviewMapper(
   dropsDb,
   identitySubscriptionsDb,
   userGroupsService,
-  directMessageWaveDisplayService
+  directMessageWaveDisplayService,
+  identityFetcher
 );

--- a/src/api-serverless/src/waves/api-wave-overview.mapper.ts
+++ b/src/api-serverless/src/waves/api-wave-overview.mapper.ts
@@ -38,6 +38,39 @@ import { getWaveReadContextProfileId } from '@/api/waves/wave-access.helpers';
 import { wavesApiDb, WavesApiDb } from '@/api/waves/waves.api.db';
 import { resolveNextDropAllowed } from '@/waves/wave-chat-slow-mode.helpers';
 
+export function createUnknownWaveCreatorProfile({
+  profileId,
+  waveId
+}: {
+  profileId?: string | null;
+  waveId: string;
+}): ApiProfileMin {
+  return {
+    id: profileId ?? `unknown-wave-creator-${waveId}`,
+    handle: 'Unknown profile',
+    banner1_color: null,
+    banner2_color: null,
+    pfp: null,
+    cic: 0,
+    rep: 0,
+    tdh: 0,
+    xtdh: 0,
+    xtdh_rate: 0,
+    tdh_rate: 0,
+    level: 0,
+    classification: ApiProfileClassification.Pseudonym,
+    sub_classification: null,
+    archived: true,
+    profile_wave_id: null,
+    subscribed_actions: [],
+    primary_address: '',
+    active_main_stage_submission_ids: [],
+    winner_main_stage_drop_ids: [],
+    artist_of_prevote_cards: [],
+    is_wave_creator: false
+  };
+}
+
 export class ApiWaveOverviewMapper {
   constructor(
     private readonly wavesApiDb: WavesApiDb,
@@ -83,6 +116,11 @@ export class ApiWaveOverviewMapper {
       const waveIds = relatedEntities.map((wave) => wave.id);
       const descriptionDropIds = collections.distinct(
         relatedEntities.map((wave) => wave.description_drop_id)
+      );
+      const creatorIds = collections.distinct(
+        relatedEntities
+          .map((wave) => wave.created_by)
+          .filter((profileId): profileId is string => !!profileId)
       );
 
       const [
@@ -171,10 +209,9 @@ export class ApiWaveOverviewMapper {
           groupIdsUserIsEligibleFor,
           ctx
         ),
-        this.identityFetcher.getOverviewsByIds(
-          collections.distinct(relatedEntities.map((wave) => wave.created_by)),
-          ctx
-        )
+        creatorIds.length
+          ? this.identityFetcher.getOverviewsByIds(creatorIds, ctx)
+          : Promise.resolve({} as Record<string, ApiProfileMin>)
       ]);
 
       const overviewsByWaveId = relatedEntities.reduce(
@@ -261,7 +298,7 @@ export class ApiWaveOverviewMapper {
     const overview: ApiWaveOverview = {
       id: wave.id,
       name: display?.name ?? wave.name,
-      creator: this.getProfileMinOrUnknown(wave.created_by, profilesById),
+      creator: this.getProfileMinOrUnknown(wave, profilesById),
       last_drop_time: metrics?.latest_drop_timestamp ?? 0,
       created_at: wave.created_at,
       subscribers_count: metrics?.subscribers_count ?? 0,
@@ -391,34 +428,16 @@ export class ApiWaveOverviewMapper {
   }
 
   private getProfileMinOrUnknown(
-    profileId: string,
+    wave: WaveEntity,
     profilesById: Record<string, ApiProfileMin>
   ): ApiProfileMin {
+    const profileId = wave.created_by;
+    if (!profileId) {
+      return createUnknownWaveCreatorProfile({ waveId: wave.id });
+    }
     return (
-      profilesById[profileId] ?? {
-        id: profileId,
-        handle: 'Unknown profile',
-        banner1_color: null,
-        banner2_color: null,
-        pfp: null,
-        cic: 0,
-        rep: 0,
-        tdh: 0,
-        xtdh: 0,
-        xtdh_rate: 0,
-        tdh_rate: 0,
-        level: 0,
-        classification: ApiProfileClassification.Pseudonym,
-        sub_classification: null,
-        archived: true,
-        profile_wave_id: null,
-        subscribed_actions: [],
-        primary_address: '',
-        active_main_stage_submission_ids: [],
-        winner_main_stage_drop_ids: [],
-        artist_of_prevote_cards: [],
-        is_wave_creator: false
-      }
+      profilesById[profileId] ??
+      createUnknownWaveCreatorProfile({ profileId, waveId: wave.id })
     );
   }
 }


### PR DESCRIPTION
## Summary
- Add required `creator: ApiProfileMin` to `ApiWaveOverview` in OpenAPI and generated API model.
- Populate v2 wave overviews with creator profile data from `identityFetcher.getOverviewsByIds`, including visible parent waves.
- Fall back to an archived level-0 unknown profile if a creator id cannot be resolved, so the required response field never disappears.
- Update mapper and OG metadata tests for the new contract.

## Why
Wave scoring needs creator level/TDH-derived profile data directly from v2 wave overview responses, without legacy wave detail fetches.

## Checks
- `npx jest src/api-serverless/src/waves/api-wave-overview-mapper.test.ts src/api-serverless/src/og-metadata/og-metadata-service.test.ts --runInBand --detectOpenHandles`
- `bash -lc "npm run tsc -- -p tsconfig.json --noEmit"`
- `bash -lc "npm run lint"`

## Deployment Notes
- No DB migrations.
- Redeploy API/serverless backend only; no loop/queue worker ordering required.
- Deployment order: API Lambda/API Gateway after merge, then frontend can consume `wave.creator.level` from v2 overviews.