### PR TITLE
Poll option where only chatters can respond

### DIFF
--- a/src/api-serverless/openapi.yaml
+++ b/src/api-serverless/openapi.yaml
@@ -9609,6 +9609,9 @@ components:
         anonymous:
           type: boolean
           default: false
+        only_droppers_can_respond:
+          type: boolean
+          default: false
         closing_time:
           type: integer
           format: int64
@@ -10702,6 +10705,7 @@ components:
         - voted
         - multichoice
         - anonymous
+        - only_droppers_can_respond
         - closing_time
         - is_open
       properties:
@@ -10721,6 +10725,8 @@ components:
         multichoice:
           type: boolean
         anonymous:
+          type: boolean
+        only_droppers_can_respond:
           type: boolean
         closing_time:
           type: integer
@@ -15231,6 +15237,7 @@ components:
         - voted
         - multichoice
         - anonymous
+        - only_droppers_can_respond
         - closing_time
         - is_open
       properties:
@@ -15257,6 +15264,8 @@ components:
         multichoice:
           type: boolean
         anonymous:
+          type: boolean
+        only_droppers_can_respond:
           type: boolean
         closing_time:
           type: integer

--- a/src/api-serverless/src/drops/drop-polls-api-service.test.ts
+++ b/src/api-serverless/src/drops/drop-polls-api-service.test.ts
@@ -192,6 +192,40 @@ describe('DropPollsApiService', () => {
     );
   });
 
+  it('rejects restricted poll creation when chat is disabled', async () => {
+    jest.spyOn(Time, 'currentMillis').mockReturnValue(1_000);
+    const { service, deps } = createService();
+    deps.wavesApiDb.findById.mockResolvedValueOnce({
+      id: 'wave-1',
+      created_by: 'creator-1',
+      admin_group_id: 'admin-group',
+      visibility_group_id: 'visibility-group',
+      chat_enabled: false,
+      chat_group_id: null
+    });
+
+    await expect(
+      service.createPollForDrop(
+        {
+          poll: {
+            options: ['First', 'Second'],
+            multichoice: false,
+            only_droppers_can_respond: true,
+            closing_time: 2_000
+          },
+          dropId: 'drop-1',
+          waveId: 'wave-1',
+          authorId: 'creator-1',
+          dropType: DropType.CHAT
+        },
+        {}
+      )
+    ).rejects.toThrow(
+      'Poll responses can only be restricted to droppers when chat is enabled'
+    );
+    expect(deps.dropPollsDb.createPoll).not.toHaveBeenCalled();
+  });
+
   it('rejects voter identity lookup for anonymous polls', async () => {
     const { service, deps } = createService();
     deps.dropPollsDb.findPollsByDropIds.mockResolvedValue({
@@ -433,6 +467,151 @@ describe('DropPollsApiService', () => {
       }),
       expect.objectContaining({ connection: 'tx-connection' })
     );
+  });
+
+  it('allows restricted poll votes in public chat without extra group lookup', async () => {
+    jest.spyOn(Time, 'currentMillis').mockReturnValue(1_000);
+    const { service, deps } = createService();
+    deps.wavesApiDb.findById.mockResolvedValueOnce({
+      id: 'wave-1',
+      created_by: 'creator-1',
+      admin_group_id: 'admin-group',
+      visibility_group_id: 'visibility-group',
+      chat_enabled: true,
+      chat_group_id: null
+    });
+    deps.dropPollsDb.replaceVoterVotes.mockResolvedValue(false);
+    deps.dropPollsDb.findPollByDropIdForUpdate.mockResolvedValue({
+      id: 'poll-1',
+      wave_id: 'wave-1',
+      drop_id: 'drop-1',
+      closing_time: 2_000,
+      multichoice: false,
+      anonymous: false,
+      only_droppers_can_respond: true
+    });
+    deps.dropPollsDb.findOptionsByPollId.mockResolvedValue([
+      {
+        poll_id: 'poll-1',
+        wave_id: 'wave-1',
+        drop_id: 'drop-1',
+        option_no: 1,
+        option_string: 'First'
+      }
+    ]);
+
+    await expect(
+      service.vote(
+        {
+          dropId: 'drop-1',
+          voterId: 'voter-1',
+          options: [1]
+        },
+        {
+          authenticationContext: AuthenticationContext.fromProfileId('voter-1')
+        }
+      )
+    ).resolves.toEqual({ id: 'drop-1' });
+    expect(
+      deps.userGroupsService.getGroupsUserIsEligibleFor
+    ).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows restricted poll votes from wave creators outside the chat group', async () => {
+    jest.spyOn(Time, 'currentMillis').mockReturnValue(1_000);
+    const { service, deps } = createService();
+    deps.wavesApiDb.findById.mockResolvedValueOnce({
+      id: 'wave-1',
+      created_by: 'voter-1',
+      admin_group_id: 'admin-group',
+      visibility_group_id: 'visibility-group',
+      chat_enabled: true,
+      chat_group_id: 'chat-group'
+    });
+    deps.dropPollsDb.replaceVoterVotes.mockResolvedValue(false);
+    deps.dropPollsDb.findPollByDropIdForUpdate.mockResolvedValue({
+      id: 'poll-1',
+      wave_id: 'wave-1',
+      drop_id: 'drop-1',
+      closing_time: 2_000,
+      multichoice: false,
+      anonymous: false,
+      only_droppers_can_respond: true
+    });
+    deps.dropPollsDb.findOptionsByPollId.mockResolvedValue([
+      {
+        poll_id: 'poll-1',
+        wave_id: 'wave-1',
+        drop_id: 'drop-1',
+        option_no: 1,
+        option_string: 'First'
+      }
+    ]);
+
+    await expect(
+      service.vote(
+        {
+          dropId: 'drop-1',
+          voterId: 'voter-1',
+          options: [1]
+        },
+        {
+          authenticationContext: AuthenticationContext.fromProfileId('voter-1')
+        }
+      )
+    ).resolves.toEqual({ id: 'drop-1' });
+    expect(
+      deps.userGroupsService.getGroupsUserIsEligibleFor
+    ).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows restricted poll votes from wave admins outside the chat group', async () => {
+    jest.spyOn(Time, 'currentMillis').mockReturnValue(1_000);
+    const { service, deps } = createService();
+    deps.wavesApiDb.findById.mockResolvedValueOnce({
+      id: 'wave-1',
+      created_by: 'creator-1',
+      admin_group_id: 'admin-group',
+      visibility_group_id: 'visibility-group',
+      chat_enabled: true,
+      chat_group_id: 'chat-group'
+    });
+    deps.userGroupsService.getGroupsUserIsEligibleFor.mockResolvedValue([
+      'admin-group'
+    ]);
+    deps.dropPollsDb.replaceVoterVotes.mockResolvedValue(false);
+    deps.dropPollsDb.findPollByDropIdForUpdate.mockResolvedValue({
+      id: 'poll-1',
+      wave_id: 'wave-1',
+      drop_id: 'drop-1',
+      closing_time: 2_000,
+      multichoice: false,
+      anonymous: false,
+      only_droppers_can_respond: true
+    });
+    deps.dropPollsDb.findOptionsByPollId.mockResolvedValue([
+      {
+        poll_id: 'poll-1',
+        wave_id: 'wave-1',
+        drop_id: 'drop-1',
+        option_no: 1,
+        option_string: 'First'
+      }
+    ]);
+
+    await expect(
+      service.vote(
+        {
+          dropId: 'drop-1',
+          voterId: 'voter-1',
+          options: [1]
+        },
+        {
+          authenticationContext: AuthenticationContext.fromProfileId('voter-1')
+        }
+      )
+    ).resolves.toEqual({ id: 'drop-1' });
+    expect(deps.dropPollsDb.replaceVoterVotes).toHaveBeenCalled();
   });
 
   it('replaces previous poll votes with selected choices', async () => {

--- a/src/api-serverless/src/drops/drop-polls-api-service.test.ts
+++ b/src/api-serverless/src/drops/drop-polls-api-service.test.ts
@@ -45,7 +45,9 @@ function createService() {
       id: 'wave-1',
       created_by: 'creator-1',
       admin_group_id: 'admin-group',
-      visibility_group_id: 'visibility-group'
+      visibility_group_id: 'visibility-group',
+      chat_enabled: true,
+      chat_group_id: null
     }),
     findWaveById: jest.fn().mockResolvedValue({
       id: 'wave-1',
@@ -124,6 +126,7 @@ describe('DropPollsApiService', () => {
         closing_time: 2_000,
         multichoice: false,
         anonymous: false,
+        only_droppers_can_respond: false,
         options: [
           { option_no: 1, option_string: 'First' },
           { option_no: 2, option_string: 'Second' }
@@ -161,6 +164,34 @@ describe('DropPollsApiService', () => {
     );
   });
 
+  it('creates polls restricted to wave chat participants when requested', async () => {
+    jest.spyOn(Time, 'currentMillis').mockReturnValue(1_000);
+    const { service, deps } = createService();
+
+    await service.createPollForDrop(
+      {
+        poll: {
+          options: ['First', 'Second'],
+          multichoice: false,
+          only_droppers_can_respond: true,
+          closing_time: 2_000
+        },
+        dropId: 'drop-1',
+        waveId: 'wave-1',
+        authorId: 'creator-1',
+        dropType: DropType.CHAT
+      },
+      {}
+    );
+
+    expect(deps.dropPollsDb.createPoll).toHaveBeenCalledWith(
+      expect.objectContaining({
+        only_droppers_can_respond: true
+      }),
+      {}
+    );
+  });
+
   it('rejects voter identity lookup for anonymous polls', async () => {
     const { service, deps } = createService();
     deps.dropPollsDb.findPollsByDropIds.mockResolvedValue({
@@ -171,6 +202,7 @@ describe('DropPollsApiService', () => {
         closing_time: 2_000,
         multichoice: false,
         anonymous: true,
+        only_droppers_can_respond: false,
         voted: [],
         options: [
           {
@@ -285,6 +317,14 @@ describe('DropPollsApiService', () => {
       multichoice: true,
       anonymous: false
     });
+    deps.wavesApiDb.findById.mockResolvedValueOnce({
+      id: 'wave-1',
+      created_by: 'creator-1',
+      admin_group_id: 'admin-group',
+      visibility_group_id: 'visibility-group',
+      chat_enabled: true,
+      chat_group_id: null
+    });
 
     await expect(
       service.vote(
@@ -299,6 +339,100 @@ describe('DropPollsApiService', () => {
       )
     ).rejects.toThrow('Poll is closed');
     expect(deps.dropPollsDb.replaceVoterVotes).not.toHaveBeenCalled();
+  });
+
+  it('rejects restricted poll votes from users who cannot chat in the wave', async () => {
+    jest.spyOn(Time, 'currentMillis').mockReturnValue(1_000);
+    const { service, deps } = createService();
+    deps.wavesApiDb.findById.mockResolvedValueOnce({
+      id: 'wave-1',
+      created_by: 'creator-1',
+      admin_group_id: 'admin-group',
+      visibility_group_id: 'visibility-group',
+      chat_enabled: true,
+      chat_group_id: 'chat-group'
+    });
+    deps.userGroupsService.getGroupsUserIsEligibleFor.mockResolvedValue([]);
+    deps.dropPollsDb.findPollByDropIdForUpdate.mockResolvedValue({
+      id: 'poll-1',
+      wave_id: 'wave-1',
+      drop_id: 'drop-1',
+      closing_time: 2_000,
+      multichoice: false,
+      anonymous: false,
+      only_droppers_can_respond: true
+    });
+
+    await expect(
+      service.vote(
+        {
+          dropId: 'drop-1',
+          voterId: 'voter-1',
+          options: [1]
+        },
+        {
+          authenticationContext: AuthenticationContext.fromProfileId('voter-1')
+        }
+      )
+    ).rejects.toThrow('Only wave chat participants can vote');
+    expect(deps.dropPollsDb.findOptionsByPollId).not.toHaveBeenCalled();
+    expect(deps.dropPollsDb.replaceVoterVotes).not.toHaveBeenCalled();
+  });
+
+  it('allows restricted poll votes from users who can chat in the wave', async () => {
+    jest.spyOn(Time, 'currentMillis').mockReturnValue(1_000);
+    const { service, deps } = createService();
+    deps.wavesApiDb.findById.mockResolvedValueOnce({
+      id: 'wave-1',
+      created_by: 'creator-1',
+      admin_group_id: 'admin-group',
+      visibility_group_id: 'visibility-group',
+      chat_enabled: true,
+      chat_group_id: 'chat-group'
+    });
+    deps.userGroupsService.getGroupsUserIsEligibleFor.mockResolvedValue([
+      'chat-group'
+    ]);
+    deps.dropPollsDb.replaceVoterVotes.mockResolvedValue(false);
+    deps.dropPollsDb.findPollByDropIdForUpdate.mockResolvedValue({
+      id: 'poll-1',
+      wave_id: 'wave-1',
+      drop_id: 'drop-1',
+      closing_time: 2_000,
+      multichoice: false,
+      anonymous: false,
+      only_droppers_can_respond: true
+    });
+    deps.dropPollsDb.findOptionsByPollId.mockResolvedValue([
+      {
+        poll_id: 'poll-1',
+        wave_id: 'wave-1',
+        drop_id: 'drop-1',
+        option_no: 1,
+        option_string: 'First'
+      }
+    ]);
+
+    await expect(
+      service.vote(
+        {
+          dropId: 'drop-1',
+          voterId: 'voter-1',
+          options: [1]
+        },
+        {
+          authenticationContext: AuthenticationContext.fromProfileId('voter-1')
+        }
+      )
+    ).resolves.toEqual({ id: 'drop-1' });
+    expect(deps.dropPollsDb.replaceVoterVotes).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pollId: 'poll-1',
+        voterId: 'voter-1',
+        optionNos: [1]
+      }),
+      expect.objectContaining({ connection: 'tx-connection' })
+    );
   });
 
   it('replaces previous poll votes with selected choices', async () => {

--- a/src/api-serverless/src/drops/drop-polls-db.test.ts
+++ b/src/api-serverless/src/drops/drop-polls-db.test.ts
@@ -20,6 +20,7 @@ function createPollCommand(): CreateDropPollCommand {
     closing_time: 2_000,
     multichoice: false,
     anonymous: false,
+    only_droppers_can_respond: false,
     options: [
       { option_no: 1, option_string: 'First' },
       { option_no: 2, option_string: 'Second' }
@@ -127,6 +128,7 @@ describe('DropPollsDb', () => {
         closing_time: '2000',
         multichoice: 1,
         anonymous: 0,
+        only_droppers_can_respond: 1,
         option_no: 1,
         option_string: 'First',
         votes: '5',
@@ -139,6 +141,7 @@ describe('DropPollsDb', () => {
         closing_time: '2000',
         multichoice: 1,
         anonymous: 0,
+        only_droppers_can_respond: 1,
         option_no: 2,
         option_string: 'Second',
         votes: '3',
@@ -153,6 +156,7 @@ describe('DropPollsDb', () => {
     expect(result['drop-1']).toMatchObject({
       id: 'poll-1',
       anonymous: false,
+      only_droppers_can_respond: true,
       voted: [2],
       options: [
         {
@@ -188,6 +192,7 @@ describe('DropPollsDb', () => {
           closing_time: '2000',
           multichoice: 1,
           anonymous: '1',
+          only_droppers_can_respond: '0',
           created_at: '1000'
         }
       ])
@@ -231,6 +236,7 @@ describe('DropPollsDb', () => {
     expect(result[0]).toMatchObject({
       id: 'poll-1',
       anonymous: true,
+      only_droppers_can_respond: false,
       voted: [2],
       options: [
         {

--- a/src/api-serverless/src/drops/drop-polls-mappers.test.ts
+++ b/src/api-serverless/src/drops/drop-polls-mappers.test.ts
@@ -11,6 +11,7 @@ describe('drop poll mappers', () => {
     closing_time: 2_000,
     multichoice: true,
     anonymous: true,
+    only_droppers_can_respond: true,
     created_at: 1_000,
     voted: [2, 1],
     options: [
@@ -45,6 +46,7 @@ describe('drop poll mappers', () => {
       voted: [1, 2],
       multichoice: true,
       anonymous: true,
+      only_droppers_can_respond: true,
       closing_time: 2_000,
       is_open: true
     });
@@ -57,6 +59,7 @@ describe('drop poll mappers', () => {
       drop_id: 'drop-1',
       created_at: 1_000,
       anonymous: true,
+      only_droppers_can_respond: true,
       is_open: false
     });
   });

--- a/src/api-serverless/src/drops/drop-polls.api.service.ts
+++ b/src/api-serverless/src/drops/drop-polls.api.service.ts
@@ -51,10 +51,6 @@ type SelectedPollOption = {
   readonly option_string: string;
 };
 
-function isTruthyDatabaseBoolean(value: unknown): boolean {
-  return value === true || value === 1 || value === '1';
-}
-
 export type CreateDropPollRequest = {
   readonly options: string[];
   readonly multichoice: boolean;
@@ -125,6 +121,11 @@ export class DropPollsApiService {
     ) {
       throw new ForbiddenException(
         `Only wave creators and admins can create polls`
+      );
+    }
+    if ((poll.only_droppers_can_respond ?? false) && !wave.chat_enabled) {
+      throw new BadRequestException(
+        `Poll responses can only be restricted to droppers when chat is enabled`
       );
     }
     await this.dropPollsDb.createPoll(
@@ -324,7 +325,13 @@ export class DropPollsApiService {
     readonly voterId: string;
     readonly ctx: RequestContext;
   }): Promise<void> {
-    if (!isTruthyDatabaseBoolean(poll.only_droppers_can_respond)) {
+    if (!poll.only_droppers_can_respond) {
+      return;
+    }
+    if (wave.chat_enabled && wave.chat_group_id === null) {
+      return;
+    }
+    if (wave.created_by === voterId) {
       return;
     }
     const groupIdsUserIsEligibleFor =
@@ -332,11 +339,16 @@ export class DropPollsApiService {
         voterId,
         ctx.timer
       );
-    const userCanChat =
+    const userCanChatInGroup =
       wave.chat_enabled &&
-      (wave.chat_group_id === null ||
-        groupIdsUserIsEligibleFor.includes(wave.chat_group_id));
-    if (!userCanChat) {
+      wave.chat_group_id !== null &&
+      groupIdsUserIsEligibleFor.includes(wave.chat_group_id);
+    const userCanManageWave = isWaveCreatorOrAdmin({
+      authenticatedProfileId: voterId,
+      wave,
+      groupIdsUserIsEligibleFor
+    });
+    if (!userCanChatInGroup && !userCanManageWave) {
       throw new ForbiddenException(`Only wave chat participants can vote`);
     }
   }

--- a/src/api-serverless/src/drops/drop-polls.api.service.ts
+++ b/src/api-serverless/src/drops/drop-polls.api.service.ts
@@ -26,7 +26,8 @@ import {
 } from '@/api/waves/wave-access.helpers';
 import { wavesApiDb, WavesApiDb } from '@/api/waves/waves.api.db';
 import { DropType } from '@/entities/IDrop';
-import { DropPollOptionEntity } from '@/entities/IDropPoll';
+import { DropPollEntity, DropPollOptionEntity } from '@/entities/IDropPoll';
+import { WaveEntity } from '@/entities/IWave';
 import {
   BadRequestException,
   ForbiddenException,
@@ -50,10 +51,15 @@ type SelectedPollOption = {
   readonly option_string: string;
 };
 
+function isTruthyDatabaseBoolean(value: unknown): boolean {
+  return value === true || value === 1 || value === '1';
+}
+
 export type CreateDropPollRequest = {
   readonly options: string[];
   readonly multichoice: boolean;
   readonly anonymous?: boolean;
+  readonly only_droppers_can_respond?: boolean;
   readonly closing_time: number;
 };
 
@@ -129,6 +135,7 @@ export class DropPollsApiService {
         closing_time: poll.closing_time,
         multichoice: poll.multichoice,
         anonymous: poll.anonymous ?? false,
+        only_droppers_can_respond: poll.only_droppers_can_respond ?? false,
         options: poll.options.map((option, index) => ({
           option_no: index + 1,
           option_string: option.trim()
@@ -237,6 +244,12 @@ export class DropPollsApiService {
         if (!poll.multichoice && uniqueOptions.length > 1) {
           throw new BadRequestException(`Poll does not allow multiple options`);
         }
+        await this.assertPollRespondentCanVote({
+          poll,
+          wave,
+          voterId,
+          ctx
+        });
         pollAnonymous = poll.anonymous;
         const pollOptions = await this.dropPollsDb.findOptionsByPollId(
           poll.id,
@@ -298,6 +311,34 @@ export class DropPollsApiService {
       throw new NotFoundException(`Drop ${dropId} not found`);
     }
     return apiDrop;
+  }
+
+  private async assertPollRespondentCanVote({
+    poll,
+    wave,
+    voterId,
+    ctx
+  }: {
+    readonly poll: DropPollEntity;
+    readonly wave: WaveEntity;
+    readonly voterId: string;
+    readonly ctx: RequestContext;
+  }): Promise<void> {
+    if (!isTruthyDatabaseBoolean(poll.only_droppers_can_respond)) {
+      return;
+    }
+    const groupIdsUserIsEligibleFor =
+      await this.userGroupsService.getGroupsUserIsEligibleFor(
+        voterId,
+        ctx.timer
+      );
+    const userCanChat =
+      wave.chat_enabled &&
+      (wave.chat_group_id === null ||
+        groupIdsUserIsEligibleFor.includes(wave.chat_group_id));
+    if (!userCanChat) {
+      throw new ForbiddenException(`Only wave chat participants can vote`);
+    }
   }
 
   private getSelectedPollOptions(

--- a/src/api-serverless/src/drops/drop-polls.db.ts
+++ b/src/api-serverless/src/drops/drop-polls.db.ts
@@ -38,6 +38,7 @@ export type CreateDropPollCommand = {
   readonly closing_time: number;
   readonly multichoice: boolean;
   readonly anonymous: boolean;
+  readonly only_droppers_can_respond: boolean;
   readonly options: readonly {
     readonly option_no: number;
     readonly option_string: string;
@@ -100,6 +101,7 @@ export class DropPollsDb extends LazyDbAccessCompatibleService {
           p.closing_time,
           p.multichoice,
           p.anonymous,
+          p.only_droppers_can_respond,
           o.option_no,
           o.option_string,
           count(v.voter_id) as votes,
@@ -121,6 +123,7 @@ export class DropPollsDb extends LazyDbAccessCompatibleService {
           p.closing_time,
           p.multichoice,
           p.anonymous,
+          p.only_droppers_can_respond,
           o.option_no,
           o.option_string
         order by p.drop_id asc, o.option_no asc
@@ -332,6 +335,7 @@ export class DropPollsDb extends LazyDbAccessCompatibleService {
           p.closing_time,
           p.multichoice,
           p.anonymous,
+          p.only_droppers_can_respond,
           d.created_at
         from ${DROP_POLLS_TABLE} p
         join ${DROPS_TABLE} d on d.id = p.drop_id
@@ -543,14 +547,16 @@ export class DropPollsDb extends LazyDbAccessCompatibleService {
           drop_id,
           closing_time,
           multichoice,
-          anonymous
+          anonymous,
+          only_droppers_can_respond
         ) values (
           :id,
           :wave_id,
           :drop_id,
           :closing_time,
           :multichoice,
-          :anonymous
+          :anonymous,
+          :only_droppers_can_respond
         )
       `,
       command,
@@ -711,7 +717,8 @@ export class DropPollsDb extends LazyDbAccessCompatibleService {
       drop_id: row.drop_id,
       closing_time: Number(row.closing_time),
       multichoice: toBoolean(row.multichoice),
-      anonymous: toBoolean(row.anonymous)
+      anonymous: toBoolean(row.anonymous),
+      only_droppers_can_respond: toBoolean(row.only_droppers_can_respond)
     };
   }
 

--- a/src/api-serverless/src/drops/drop-polls.mappers.ts
+++ b/src/api-serverless/src/drops/drop-polls.mappers.ts
@@ -24,6 +24,7 @@ export function mapDropPollToApi(
     voted: [...(poll.voted ?? [])].sort((a, b) => a - b),
     multichoice: poll.multichoice,
     anonymous: poll.anonymous,
+    only_droppers_can_respond: poll.only_droppers_can_respond ?? false,
     closing_time: poll.closing_time,
     is_open: now < poll.closing_time
   };

--- a/src/api-serverless/src/drops/drop-validator.test.ts
+++ b/src/api-serverless/src/drops/drop-validator.test.ts
@@ -166,6 +166,7 @@ describe('NewDropSchema', () => {
       options: ['First', 'Second'],
       multichoice: false,
       anonymous: false,
+      only_droppers_can_respond: false,
       closing_time: futureTimestamp
     });
   });
@@ -186,6 +187,41 @@ describe('NewDropSchema', () => {
     expect(result.value.poll).toMatchObject({
       anonymous: true
     });
+  });
+
+  it('accepts polls restricted to wave chat participants for chat drops', () => {
+    const result = NewDropSchema.validate({
+      ...createDropWithMetadata('artist', 'Artist'),
+      drop_type: ApiDropType.Chat,
+      poll: {
+        options: ['First', 'Second'],
+        multichoice: false,
+        only_droppers_can_respond: true,
+        closing_time: futureTimestamp
+      }
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.value.poll).toMatchObject({
+      only_droppers_can_respond: true
+    });
+  });
+
+  it('rejects polls with invalid only_droppers_can_respond values', () => {
+    const result = NewDropSchema.validate({
+      ...createDropWithMetadata('artist', 'Artist'),
+      drop_type: ApiDropType.Chat,
+      poll: {
+        options: ['First', 'Second'],
+        multichoice: false,
+        only_droppers_can_respond: 'invalid',
+        closing_time: futureTimestamp
+      }
+    });
+
+    expect(result.error?.message).toContain(
+      '"poll.only_droppers_can_respond" must be a boolean'
+    );
   });
 
   it('rejects polls with invalid anonymous values', () => {

--- a/src/api-serverless/src/drops/drop.validator.ts
+++ b/src/api-serverless/src/drops/drop.validator.ts
@@ -167,6 +167,7 @@ const NewDropPollSchema: Joi.ObjectSchema<ApiCreateDropPollRequest> =
       .required(),
     multichoice: Joi.boolean().required(),
     anonymous: Joi.boolean().optional().default(false),
+    only_droppers_can_respond: Joi.boolean().optional().default(false),
     closing_time: Joi.number()
       .integer()
       .required()

--- a/src/api-serverless/src/generated/models/ApiCreateDropPollRequest.ts
+++ b/src/api-serverless/src/generated/models/ApiCreateDropPollRequest.ts
@@ -16,6 +16,7 @@ export class ApiCreateDropPollRequest {
     'options': Set<string>;
     'multichoice': boolean;
     'anonymous'?: boolean;
+    'only_droppers_can_respond'?: boolean;
     /**
     * Future Unix timestamp in milliseconds.
     */
@@ -41,6 +42,12 @@ export class ApiCreateDropPollRequest {
         {
             "name": "anonymous",
             "baseName": "anonymous",
+            "type": "boolean",
+            "format": ""
+        },
+        {
+            "name": "only_droppers_can_respond",
+            "baseName": "only_droppers_can_respond",
             "type": "boolean",
             "format": ""
         },

--- a/src/api-serverless/src/generated/models/ApiDropPoll.ts
+++ b/src/api-serverless/src/generated/models/ApiDropPoll.ts
@@ -22,6 +22,7 @@ export class ApiDropPoll {
     'voted': Array<number>;
     'multichoice': boolean;
     'anonymous': boolean;
+    'only_droppers_can_respond': boolean;
     'closing_time': number;
     'is_open': boolean;
 
@@ -57,6 +58,12 @@ export class ApiDropPoll {
         {
             "name": "anonymous",
             "baseName": "anonymous",
+            "type": "boolean",
+            "format": ""
+        },
+        {
+            "name": "only_droppers_can_respond",
+            "baseName": "only_droppers_can_respond",
             "type": "boolean",
             "format": ""
         },

--- a/src/api-serverless/src/generated/models/ApiWavePoll.ts
+++ b/src/api-serverless/src/generated/models/ApiWavePoll.ts
@@ -25,6 +25,7 @@ export class ApiWavePoll {
     'voted': Array<number>;
     'multichoice': boolean;
     'anonymous': boolean;
+    'only_droppers_can_respond': boolean;
     'closing_time': number;
     'is_open': boolean;
 
@@ -78,6 +79,12 @@ export class ApiWavePoll {
         {
             "name": "anonymous",
             "baseName": "anonymous",
+            "type": "boolean",
+            "format": ""
+        },
+        {
+            "name": "only_droppers_can_respond",
+            "baseName": "only_droppers_can_respond",
             "type": "boolean",
             "format": ""
         },

--- a/src/entities/IDropPoll.ts
+++ b/src/entities/IDropPoll.ts
@@ -28,6 +28,9 @@ export class DropPollEntity {
 
   @Column({ type: 'boolean', nullable: false, default: false })
   readonly anonymous!: boolean;
+
+  @Column({ type: 'boolean', nullable: false, default: false })
+  readonly only_droppers_can_respond!: boolean;
 }
 
 @Entity(DROP_POLL_OPTIONS_TABLE)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added poll response restriction capability. Polls can now be restricted to allow responses only from users eligible for wave chat participation. When enabled, the system validates chat eligibility before recording each vote and rejects responses from ineligible voters. This restriction option is available when creating new polls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->