### PR TITLE
Clean OG preview mention tokens

### DIFF
--- a/src/api-serverless/src/og-metadata/og-metadata-service.test.ts
+++ b/src/api-serverless/src/og-metadata/og-metadata-service.test.ts
@@ -316,7 +316,7 @@ describe('OgMetadataService', () => {
       })
     );
     identityFetcher.getDropResolvedIdentityProfilesV2ByIds.mockResolvedValue({
-      'profile-1': makeResolvedProfile('Alice bio')
+      'profile-1': makeResolvedProfile('Alice bio with @[bob] and #[QUORUM]')
     });
 
     await expect(service.getProfileMetadata('alice', {})).resolves.toEqual({
@@ -336,7 +336,7 @@ describe('OgMetadataService', () => {
         rep: 100,
         level: 7,
         tdh: 1234.5,
-        description: 'Alice bio',
+        description: 'Alice bio with @bob and #QUORUM',
         twitter_handle: null,
         media: [
           {
@@ -423,6 +423,46 @@ describe('OgMetadataService', () => {
       [],
       undefined
     );
+  });
+
+  it('removes square brackets from wave description tokens', async () => {
+    const {
+      service,
+      identityFetcher,
+      wavesApiDb,
+      apiWaveOverviewMapper,
+      profilesDb,
+      identitySubscriptionsDb
+    } = makeService();
+    wavesApiDb.findWavesByIdsEligibleForRead.mockResolvedValue([
+      { id: 'wave-1', created_by: 'author-1' } as any
+    ]);
+    apiWaveOverviewMapper.mapWaves.mockResolvedValue({
+      'wave-1': {
+        id: 'wave-1',
+        name: 'Wave',
+        pfp: null,
+        subscribers_count: 12,
+        total_drops_count: 34,
+        description_drop: {
+          contents: 'Wave description with @[alice] and #[QUORUM]',
+          media: []
+        }
+      } as any
+    });
+    profilesDb.getProfileById.mockResolvedValue(
+      makeProfileRecord(new Date('2026-01-02T03:04:05.000Z'))
+    );
+    identitySubscriptionsDb.countDistinctSubscriberIdsForTarget.mockResolvedValue(
+      7
+    );
+    mockAuthorProfile(identityFetcher);
+
+    await expect(service.getWaveMetadata('wave-1', {})).resolves.toMatchObject({
+      wave: {
+        description: 'Wave description with @alice and #QUORUM'
+      }
+    });
   });
 
   it('resolves numeric drops by serial number and returns lightweight author info', async () => {
@@ -586,6 +626,36 @@ describe('OgMetadataService', () => {
         submitted_at: 1,
         won_at: 1234567890,
         is_additional_action_promised: true
+      }
+    });
+  });
+
+  it('removes square brackets from drop content tokens', async () => {
+    const {
+      service,
+      identityFetcher,
+      dropV2Service,
+      profilesDb,
+      identitySubscriptionsDb
+    } = makeService();
+    profilesDb.getProfileById.mockResolvedValue(
+      makeProfileRecord(new Date('2026-01-02T03:04:05.000Z'))
+    );
+    identitySubscriptionsDb.countDistinctSubscriberIdsForTarget.mockResolvedValue(
+      7
+    );
+    const dropWithWave = makeDropWithWave(UUID_DROP_ID, 45);
+    dropWithWave.drop.content =
+      '@[sepicaso] just bumped your rep up to 50k so you can submit now #[QUORUM]';
+    dropV2Service.findWithWaveByIdOrThrow.mockResolvedValue(dropWithWave);
+    mockAuthorProfile(identityFetcher);
+
+    await expect(
+      service.getDropMetadata(UUID_DROP_ID, {})
+    ).resolves.toMatchObject({
+      drop: {
+        content:
+          '@sepicaso just bumped your rep up to 50k so you can submit now #QUORUM'
       }
     });
   });

--- a/src/api-serverless/src/og-metadata/og-metadata.service.ts
+++ b/src/api-serverless/src/og-metadata/og-metadata.service.ts
@@ -578,6 +578,7 @@ export class OgMetadataService {
     options: CleanTextOptions
   ): string {
     const withoutMarkdown = this.replaceMarkdownLinks(value)
+      .replace(/([@#])\[([^\]\r\n]+)\]/g, '$1$2')
       .replace(/(^|\n)[ \t]{0,3}#{1,6}[ \t]+/g, '$1')
       .replace(/(^|\n)[ \t]{0,3}>[ \t]?/g, '$1')
       .replace(/\\([\\`*_[\]()#+\-.!>])/g, '$1')


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed generated OG metadata text to properly normalize markdown-style mention/hashtag tokens by removing unnecessary square brackets (e.g., `[`@name`]` → `@name`, `[`#tag`]` → `#tag`) in both profile descriptions and drop/wave contents.

* **Tests**
  * Added/expanded coverage to confirm bracket-stripping behavior for rich profile metadata as well as wave description and drop content token transformations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->