### PR TITLE
[codex] Harden v2 wave feed contracts

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -214,6 +214,8 @@ Important API responsibilities:
 
 Wave rows can be top-level waves or subwaves through the nullable `parent_wave_id` column. Top-level wave discovery endpoints exclude subwaves, while `/waves/{id}/subwaves` lists child wave overviews. Subwave read access also requires the parent wave to be visible, and deleting a parent wave cascades through the API service to delete its subwaves.
 
+The waves v2 read boundary keeps timeline, reply-thread, and curation feeds as separate contracts. `/v2/waves/{id}/drops` returns the wave timeline feed, `/v2/drops/{id}/replies` returns the reply thread for a root drop after resolving its owning visible wave, and `/v2/waves/{id}/curations/{curation_id}/drops` returns drops for one wave curation.
+
 The waves v2 boundary also exposes `/v2/official-waves`, backed by the `official_waves` selector table. It returns readable `ApiWaveOverview` rows for listed wave ids and skips stale entries whose wave row no longer exists.
 
 Wave creators and wave admins can manage arbitrary wave metadata pairs through `/v2/waves/{id}/metadata`. Read access follows the same wave visibility rules as other wave v2 reads, while writes are restricted to the creator or members of the wave admin group. Metadata is stored in `waves_metadatas`, keyed by wave id and metadata key.

--- a/src/api-serverless/openapi.yaml
+++ b/src/api-serverless/openapi.yaml
@@ -2236,6 +2236,65 @@ paths:
                 $ref: "#/components/schemas/ApiDropAndWave"
         "404":
           description: Drop not found
+  /v2/drops/{id}/replies:
+    get:
+      tags:
+        - DropsV2
+      summary: Get V2 replies to a drop.
+      description: Returns the reply thread for a drop using V2 drop and wave shapes.
+      operationId: getDropRepliesV2
+      x-6529-router:
+        enabled: true
+        auth: optional
+        handler:
+          import: "@/api/waves/waves-v2.handlers"
+          name: handleGetDropRepliesV2
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            format: int64
+            minimum: 1
+            maximum: 200
+            default: 50
+        - name: serial_no_limit
+          in: query
+          required: false
+          description: Serial number anchor for paginating replies.
+          schema:
+            type: integer
+            format: int64
+            minimum: 1
+        - name: search_strategy
+          in: query
+          required: false
+          description: >-
+            Use in combination with serial_no_limit. If this is not set then
+            FIND_OLDER is used.
+          schema:
+            $ref: "#/components/schemas/ApiDropSearchStrategy"
+        - name: drop_type
+          in: query
+          description: Filter by drop type
+          required: false
+          schema:
+            $ref: "#/components/schemas/ApiDropType"
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiWaveDropsFeedV2"
+        "404":
+          description: Drop not found
   /v2/drops/{id}/metadata:
     get:
       tags:
@@ -6086,7 +6145,9 @@ paths:
             type: string
         - name: from_identity
           in: query
-          description: If omitted, the authenticated profile is used. Anonymous requests without from_identity return 0.
+          description: >-
+            If omitted, the authenticated profile is used. Anonymous requests
+            without from_identity return 0.
           required: false
           schema:
             type: string
@@ -6934,7 +6995,10 @@ paths:
         - Waves
       summary: Get drops related to wave or parent drop
       deprecated: true
-      description: Deprecated. Use GET /v2/waves/{id}/drops instead.
+      description: >-
+        Deprecated. Use GET /v2/waves/{id}/drops for the wave timeline feed, GET
+        /v2/drops/{id}/replies for reply threads, and GET
+        /v2/waves/{id}/curations/{curation_id}/drops for curation drops.
       operationId: getDropsOfWave
       parameters:
         - name: id
@@ -7870,7 +7934,12 @@ paths:
     get:
       tags:
         - WavesV2
-      summary: Get V2 drops related to wave
+      summary: Get V2 timeline drops for a wave
+      description: >-
+        Returns the timeline feed for a wave. This endpoint does not accept
+        reply-thread or curation filters. Use GET /v2/drops/{id}/replies for
+        reply threads and GET /v2/waves/{id}/curations/{curation_id}/drops for
+        curation drops.
       operationId: getWaveDropsV2
       x-6529-router:
         enabled: true
@@ -7892,7 +7961,7 @@ paths:
             format: int64
             minimum: 1
             maximum: 200
-            default: 20
+            default: 50
         - name: serial_no_limit
           in: query
           required: false
@@ -7900,6 +7969,7 @@ paths:
           schema:
             type: integer
             format: int64
+            minimum: 1
         - name: search_strategy
           in: query
           required: false

--- a/src/api-serverless/openapi.yaml
+++ b/src/api-serverless/openapi.yaml
@@ -2293,6 +2293,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiWaveDropsFeedV2"
+        "400":
+          description: Invalid reply feed query params
         "404":
           description: Drop not found
   /v2/drops/{id}/metadata:
@@ -7991,6 +7993,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiWaveDropsFeedV2"
+        "400":
+          description: Invalid wave timeline feed query params
   /v2/waves/{id}/polls:
     get:
       tags:

--- a/src/api-serverless/src/generated/routes/openapi-generated.routes.ts
+++ b/src/api-serverless/src/generated/routes/openapi-generated.routes.ts
@@ -10,8 +10,8 @@ import { handleDownloadDropV2VotersById, handleGetBoostedDropsV2, handleGetCurat
 import { handleResolveDecentralizedMedia } from '@/api/media/decentralized-media.handlers';
 import { handleGetNotificationsV2 } from '@/api/notifications/notifications-v2.handlers';
 import { handleGetOgMetadataDrop, handleGetOgMetadataProfile, handleGetOgMetadataWave } from '@/api/og-metadata/og-metadata.handlers';
-import { handleCreateWaveMetadata, handleDeleteWaveMetadata, handleGetOfficialWaves, handleGetWaveDecisionsV2, handleGetWaveDropsV2, handleGetWaveLeaderboardV2, handleGetWaveMetadata, handleGetWavesV2, handleListWaveCurationDropsV2, handleListWaveSubwaves, handleSearchDropsInWaveV2 } from '@/api/waves/waves-v2.handlers';
-import { CreateWaveMetadataRequest, CreateWaveMetadataResponse, DeleteWaveMetadataRequest, DeleteWaveMetadataResponse, DownloadDropV2VotersByIdRequest, DownloadDropV2VotersByIdResponse, GetBoostedDropsV2Request, GetBoostedDropsV2Response, GetCuratedProfileWaveDropsV2Request, GetCuratedProfileWaveDropsV2Response, GetDropPollOptionVotersV2Request, GetDropPollOptionVotersV2Response, GetDropsV2Request, GetDropsV2Response, GetDropV2BoostsByIdRequest, GetDropV2BoostsByIdResponse, GetDropV2ByIdRequest, GetDropV2ByIdResponse, GetDropV2MetadataByIdRequest, GetDropV2MetadataByIdResponse, GetDropV2PartByIdRequest, GetDropV2PartByIdResponse, GetDropV2ReactionsByIdRequest, GetDropV2ReactionsByIdResponse, GetDropV2VoteEditLogsByIdRequest, GetDropV2VoteEditLogsByIdResponse, GetDropV2VotersByIdRequest, GetDropV2VotersByIdResponse, GetNotificationsV2Request, GetNotificationsV2Response, GetOfficialWavesRequest, GetOfficialWavesResponse, GetOgMetadataDropRequest, GetOgMetadataDropResponse, GetOgMetadataProfileRequest, GetOgMetadataProfileResponse, GetOgMetadataWaveRequest, GetOgMetadataWaveResponse, GetWaveDecisionsV2Request, GetWaveDecisionsV2Response, GetWaveDropsV2Request, GetWaveDropsV2Response, GetWaveLeaderboardV2Request, GetWaveLeaderboardV2Response, GetWaveMetadataRequest, GetWaveMetadataResponse, GetWavePollsV2Request, GetWavePollsV2Response, GetWavesV2Request, GetWavesV2Response, ListWaveCurationDropsV2Request, ListWaveCurationDropsV2Response, ListWaveSubwavesRequest, ListWaveSubwavesResponse, ResolveDecentralizedMediaRequest, ResolveDecentralizedMediaResponse, SearchDropsInWaveV2Request, SearchDropsInWaveV2Response, VoteDropPollV2Request, VoteDropPollV2Response } from './operations';
+import { handleCreateWaveMetadata, handleDeleteWaveMetadata, handleGetDropRepliesV2, handleGetOfficialWaves, handleGetWaveDecisionsV2, handleGetWaveDropsV2, handleGetWaveLeaderboardV2, handleGetWaveMetadata, handleGetWavesV2, handleListWaveCurationDropsV2, handleListWaveSubwaves, handleSearchDropsInWaveV2 } from '@/api/waves/waves-v2.handlers';
+import { CreateWaveMetadataRequest, CreateWaveMetadataResponse, DeleteWaveMetadataRequest, DeleteWaveMetadataResponse, DownloadDropV2VotersByIdRequest, DownloadDropV2VotersByIdResponse, GetBoostedDropsV2Request, GetBoostedDropsV2Response, GetCuratedProfileWaveDropsV2Request, GetCuratedProfileWaveDropsV2Response, GetDropPollOptionVotersV2Request, GetDropPollOptionVotersV2Response, GetDropRepliesV2Request, GetDropRepliesV2Response, GetDropsV2Request, GetDropsV2Response, GetDropV2BoostsByIdRequest, GetDropV2BoostsByIdResponse, GetDropV2ByIdRequest, GetDropV2ByIdResponse, GetDropV2MetadataByIdRequest, GetDropV2MetadataByIdResponse, GetDropV2PartByIdRequest, GetDropV2PartByIdResponse, GetDropV2ReactionsByIdRequest, GetDropV2ReactionsByIdResponse, GetDropV2VoteEditLogsByIdRequest, GetDropV2VoteEditLogsByIdResponse, GetDropV2VotersByIdRequest, GetDropV2VotersByIdResponse, GetNotificationsV2Request, GetNotificationsV2Response, GetOfficialWavesRequest, GetOfficialWavesResponse, GetOgMetadataDropRequest, GetOgMetadataDropResponse, GetOgMetadataProfileRequest, GetOgMetadataProfileResponse, GetOgMetadataWaveRequest, GetOgMetadataWaveResponse, GetWaveDecisionsV2Request, GetWaveDecisionsV2Response, GetWaveDropsV2Request, GetWaveDropsV2Response, GetWaveLeaderboardV2Request, GetWaveLeaderboardV2Response, GetWaveMetadataRequest, GetWaveMetadataResponse, GetWavePollsV2Request, GetWavePollsV2Response, GetWavesV2Request, GetWavesV2Response, ListWaveCurationDropsV2Request, ListWaveCurationDropsV2Response, ListWaveSubwavesRequest, ListWaveSubwavesResponse, ResolveDecentralizedMediaRequest, ResolveDecentralizedMediaResponse, SearchDropsInWaveV2Request, SearchDropsInWaveV2Response, VoteDropPollV2Request, VoteDropPollV2Response } from './operations';
 const router = asyncRouter();
 router.post(
   '/media/resolve',
@@ -163,6 +163,17 @@ router.get(
     res: Response<ApiResponse<GetDropV2ReactionsByIdResponse>>
   ) => {
     res.send(await handleGetDropV2ReactionsById(req));
+  }
+);
+
+router.get(
+  '/v2/drops/:id/replies',
+  maybeAuthenticatedUser(),
+  async (
+    req: GetDropRepliesV2Request,
+    res: Response<ApiResponse<GetDropRepliesV2Response>>
+  ) => {
+    res.send(await handleGetDropRepliesV2(req));
   }
 );
 

--- a/src/api-serverless/src/generated/routes/operations.ts
+++ b/src/api-serverless/src/generated/routes/operations.ts
@@ -266,6 +266,27 @@ export type GetDropV2ReactionsByIdRequest = Request<
   Record<string, never>
 >;
 
+export interface GetDropRepliesV2PathParams {
+  "id": string;
+}
+
+export interface GetDropRepliesV2Query {
+  "limit"?: number;
+  "serial_no_limit"?: number;
+  "search_strategy"?: string;
+  "drop_type"?: string;
+}
+
+export type GetDropRepliesV2Response = ApiWaveDropsFeedV2;
+
+export type GetDropRepliesV2Request = Request<
+  GetDropRepliesV2PathParams,
+  ApiResponse<GetDropRepliesV2Response>,
+  never,
+  GetDropRepliesV2Query,
+  Record<string, never>
+>;
+
 export interface GetDropV2VotersByIdPathParams {
   "id": string;
 }

--- a/src/api-serverless/src/waves/api-wave-v2-service.test.ts
+++ b/src/api-serverless/src/waves/api-wave-v2-service.test.ts
@@ -566,6 +566,57 @@ describe('ApiWaveV2Service', () => {
     );
   });
 
+  it('finds reply feeds by drop id and resolves the owning visible wave', async () => {
+    const { service, deps } = createService();
+    const rootDrop = makeDrop({ id: 'root-drop', wave_id: 'wave-1' });
+    const reply = makeDrop({ id: 'reply-1', reply_to_drop_id: 'root-drop' });
+    deps.dropsDb.findDropByIdWithEligibilityCheck.mockResolvedValue(rootDrop);
+    deps.dropsDb.findLatestDropRepliesSimple.mockResolvedValue([reply]);
+
+    const result = await service.findDropRepliesFeed(
+      {
+        drop_id: 'root-drop',
+        amount: 5,
+        serial_no_limit: null,
+        search_strategy: ApiDropSearchStrategy.Newer,
+        drop_type: null
+      },
+      {
+        authenticationContext: AuthenticationContext.fromProfileId('viewer-1')
+      }
+    );
+
+    expect(result).toEqual({
+      drops: [{ id: 'reply-1' }],
+      wave: { id: 'wave-1' },
+      trace: [{ drop_id: 'root-drop', is_deleted: false }],
+      root_drop: { id: 'root-drop' }
+    });
+    expect(deps.dropsDb.findDropByIdWithEligibilityCheck).toHaveBeenCalledTimes(
+      1
+    );
+    expect(deps.dropsDb.findDropByIdWithEligibilityCheck).toHaveBeenCalledWith(
+      'root-drop',
+      ['group-1'],
+      undefined
+    );
+    expect(deps.dropsDb.findWaveByIdOrNull).toHaveBeenCalledWith(
+      'wave-1',
+      undefined
+    );
+    expect(deps.dropsDb.findLatestDropRepliesSimple).toHaveBeenCalledWith(
+      {
+        drop_id: 'root-drop',
+        amount: 5,
+        serial_no_limit: null,
+        search_strategy: ApiDropSearchStrategy.Newer,
+        curation_id: null,
+        drop_type: null
+      },
+      expect.any(Object)
+    );
+  });
+
   it('hides curation feeds when the wave is not visible', async () => {
     const { service, deps } = createService();
     deps.userGroupsService.getGroupsUserIsEligibleFor.mockResolvedValue([]);

--- a/src/api-serverless/src/waves/api-wave-v2.service.ts
+++ b/src/api-serverless/src/waves/api-wave-v2.service.ts
@@ -1,6 +1,6 @@
 import { collections } from '@/collections';
 import { assertUnreachable } from '@/assertions';
-import { DropType } from '@/entities/IDrop';
+import { DropEntity, DropType } from '@/entities/IDrop';
 import { WaveEntity } from '@/entities/IWave';
 import { enums } from '@/enums';
 import { BadRequestException, NotFoundException } from '@/exceptions';
@@ -53,6 +53,14 @@ export interface FindWaveDropsFeedV2Request {
   readonly search_strategy: ApiDropSearchStrategy;
   readonly drop_type: ApiDropType | null;
   readonly curation_id: string | null;
+}
+
+export interface FindDropRepliesFeedV2Request {
+  readonly drop_id: string;
+  readonly serial_no_limit: number | null;
+  readonly amount: number;
+  readonly search_strategy: ApiDropSearchStrategy;
+  readonly drop_type: ApiDropType | null;
 }
 
 export interface FindWavesV2Request {
@@ -233,6 +241,59 @@ export class ApiWaveV2Service {
             },
             ctx
           );
+    } finally {
+      ctx.timer?.stop(timerKey);
+    }
+  }
+
+  public async findDropRepliesFeed(
+    request: FindDropRepliesFeedV2Request,
+    ctx: RequestContext
+  ): Promise<ApiWaveDropsFeedV2> {
+    const timerKey = `${this.constructor.name}->findDropRepliesFeed`;
+    ctx.timer?.start(timerKey);
+    try {
+      const contextProfileId = getWaveReadContextProfileId(
+        ctx.authenticationContext
+      );
+      const groupIdsUserIsEligibleFor =
+        await this.userGroupsService.getGroupsUserIsEligibleFor(
+          contextProfileId,
+          ctx.timer
+        );
+      const rootDrop = await this.findVisibleRootDropOrThrow(
+        request.drop_id,
+        groupIdsUserIsEligibleFor,
+        ctx
+      );
+      const { wave, curationFilter, notFoundMessage } =
+        await this.findWaveAndCurationFilter(
+          {
+            waveId: rootDrop.wave_id,
+            curationId: null
+          },
+          ctx
+        );
+      const visibleWave = await assertWaveAndParentVisibleOrThrow({
+        wave,
+        groupsUserIsEligibleFor: groupIdsUserIsEligibleFor,
+        message: notFoundMessage,
+        wavesApiDb: this.wavesApiDb,
+        ctx
+      });
+
+      return await this.findReplyFeed(
+        {
+          ...request,
+          wave_id: visibleWave.id,
+          wave: visibleWave,
+          curationFilter,
+          curation_id: null,
+          groupIdsUserIsEligibleFor,
+          rootDrop
+        },
+        ctx
+      );
     } finally {
       ctx.timer?.stop(timerKey);
     }
@@ -576,6 +637,22 @@ export class ApiWaveV2Service {
     };
   }
 
+  private async findVisibleRootDropOrThrow(
+    dropId: string,
+    groupIdsUserIsEligibleFor: string[],
+    ctx: RequestContext
+  ): Promise<DropEntity> {
+    const rootDrop = await this.dropsDb.findDropByIdWithEligibilityCheck(
+      dropId,
+      groupIdsUserIsEligibleFor,
+      ctx.connection
+    );
+    if (!rootDrop) {
+      throw new NotFoundException(`Drop ${dropId} not found`);
+    }
+    return rootDrop;
+  }
+
   private async findWaveFeed(
     {
       wave,
@@ -620,23 +697,27 @@ export class ApiWaveV2Service {
       search_strategy,
       curationFilter,
       drop_type,
-      groupIdsUserIsEligibleFor
+      groupIdsUserIsEligibleFor,
+      rootDrop: providedRootDrop
     }: Omit<FindWaveDropsFeedV2Request, 'drop_id'> & {
       readonly drop_id: string;
       readonly wave: WaveEntity;
       readonly curationFilter: string | null;
       readonly groupIdsUserIsEligibleFor: string[];
+      readonly rootDrop?: DropEntity;
     },
     ctx: RequestContext
   ): Promise<ApiWaveDropsFeedV2> {
     const dropId = drop_id;
     const resolvedDropType = this.resolveDropType(drop_type);
     const [rootDrop, trace, dropEntities, apiWaveById] = await Promise.all([
-      this.dropsDb.findDropByIdWithEligibilityCheck(
-        dropId,
-        groupIdsUserIsEligibleFor,
-        ctx.connection
-      ),
+      providedRootDrop
+        ? Promise.resolve(providedRootDrop)
+        : this.dropsDb.findDropByIdWithEligibilityCheck(
+            dropId,
+            groupIdsUserIsEligibleFor,
+            ctx.connection
+          ),
       this.dropsDb.getTraceForDrop(dropId, ctx),
       this.dropsDb.findLatestDropRepliesSimple(
         {

--- a/src/api-serverless/src/waves/api-wave-v2.service.ts
+++ b/src/api-serverless/src/waves/api-wave-v2.service.ts
@@ -732,6 +732,8 @@ export class ApiWaveV2Service {
       ),
       this.apiWaveOverviewMapper.mapWaves([wave], ctx)
     ]);
+    // This remains defensive for callers that provide a wave separately from
+    // the root drop lookup.
     if (rootDrop?.wave_id !== wave.id) {
       throw new NotFoundException(`Drop ${dropId} not found`);
     }

--- a/src/api-serverless/src/waves/waves-v2-handlers.test.ts
+++ b/src/api-serverless/src/waves/waves-v2-handlers.test.ts
@@ -362,6 +362,18 @@ describe('waves v2 handlers', () => {
       );
       expect(mockFindDropRepliesFeed).not.toHaveBeenCalled();
     });
+
+    it('rejects unsupported params on the reply feed', async () => {
+      const req = {
+        params: { id: 'drop-1' },
+        query: { curation_id: 'curation-1' }
+      } as any;
+
+      await expect(handleGetDropRepliesV2(req)).rejects.toThrow(
+        '"curation_id" is not allowed'
+      );
+      expect(mockFindDropRepliesFeed).not.toHaveBeenCalled();
+    });
   });
 
   describe('handleListWaveCurationDropsV2', () => {

--- a/src/api-serverless/src/waves/waves-v2-handlers.test.ts
+++ b/src/api-serverless/src/waves/waves-v2-handlers.test.ts
@@ -1,6 +1,7 @@
 const mockFindWaves = jest.fn();
 const mockFindOfficialWaves = jest.fn();
 const mockFindDropsFeed = jest.fn();
+const mockFindDropRepliesFeed = jest.fn();
 const mockFindWaveCurationDrops = jest.fn();
 const mockSearchDropsContainingPhraseInWave = jest.fn();
 const mockSearchConcludedWaveDecisionsV2 = jest.fn();
@@ -23,6 +24,7 @@ jest.mock('@/api/waves/api-wave-v2.service', () => ({
     findWaves: mockFindWaves,
     findOfficialWaves: mockFindOfficialWaves,
     findDropsFeed: mockFindDropsFeed,
+    findDropRepliesFeed: mockFindDropRepliesFeed,
     findWaveCurationDrops: mockFindWaveCurationDrops,
     searchDropsContainingPhraseInWave: mockSearchDropsContainingPhraseInWave
   }
@@ -69,6 +71,7 @@ import { PageSortDirection } from '@/api/page-request';
 import { LeaderboardSort } from '@/drops/drops.db';
 import {
   handleGetWaveDecisionsV2,
+  handleGetDropRepliesV2,
   handleGetWaveDropsV2,
   handleGetWaveLeaderboardV2,
   handleGetOfficialWaves,
@@ -211,7 +214,7 @@ describe('waves v2 handlers', () => {
       const req = {
         params: { id: 'wave-1' },
         query: {
-          limit: '25',
+          limit: '200',
           serial_no_limit: '100',
           search_strategy: ApiDropSearchStrategy.Newer,
           drop_type: ApiDropType.Chat
@@ -224,7 +227,7 @@ describe('waves v2 handlers', () => {
         {
           wave_id: 'wave-1',
           drop_id: null,
-          amount: 25,
+          amount: 200,
           serial_no_limit: 100,
           search_strategy: ApiDropSearchStrategy.Newer,
           drop_type: ApiDropType.Chat,
@@ -244,6 +247,120 @@ describe('waves v2 handlers', () => {
         '"id" is required'
       );
       expect(mockFindDropsFeed).not.toHaveBeenCalled();
+    });
+
+    it('rejects invalid feed query params', async () => {
+      const req = {
+        params: { id: 'wave-1' },
+        query: {
+          limit: '201',
+          serial_no_limit: '0',
+          search_strategy: 'SIDEWAYS'
+        }
+      } as any;
+
+      await expect(handleGetWaveDropsV2(req)).rejects.toThrow(
+        '"limit" must be less than or equal to 200'
+      );
+      expect(mockFindDropsFeed).not.toHaveBeenCalled();
+    });
+
+    it('rejects legacy reply feed params on the main wave feed', async () => {
+      const req = {
+        params: { id: 'wave-1' },
+        query: { drop_id: 'drop-1' }
+      } as any;
+
+      await expect(handleGetWaveDropsV2(req)).rejects.toThrow(
+        '"drop_id" is not allowed'
+      );
+      expect(mockFindDropsFeed).not.toHaveBeenCalled();
+    });
+
+    it('rejects curation params on the main wave feed', async () => {
+      const req = {
+        params: { id: 'wave-1' },
+        query: { curation_id: 'curation-1' }
+      } as any;
+
+      await expect(handleGetWaveDropsV2(req)).rejects.toThrow(
+        '"curation_id" is not allowed'
+      );
+      expect(mockFindDropsFeed).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handleGetDropRepliesV2', () => {
+    const result = {
+      drops: [],
+      wave: { id: 'wave-1' },
+      root_drop: { id: 'drop-1' }
+    } as any;
+
+    beforeEach(() => {
+      mockFindDropRepliesFeed.mockResolvedValue(result);
+    });
+
+    it('applies reply feed defaults before calling the service', async () => {
+      const req = { params: { id: 'drop-1' }, query: {} } as any;
+
+      await expect(handleGetDropRepliesV2(req)).resolves.toBe(result);
+
+      expect(mockGetFromRequest).toHaveBeenCalledWith(req);
+      expect(mockGetAuthenticationContext).toHaveBeenCalledWith(req, timer);
+      expect(mockFindDropRepliesFeed).toHaveBeenCalledWith(
+        {
+          drop_id: 'drop-1',
+          amount: 50,
+          serial_no_limit: null,
+          search_strategy: ApiDropSearchStrategy.Older,
+          drop_type: null
+        },
+        {
+          authenticationContext,
+          timer
+        }
+      );
+    });
+
+    it('normalizes reply feed query params before calling the service', async () => {
+      const req = {
+        params: { id: 'drop-1' },
+        query: {
+          limit: '200',
+          serial_no_limit: '100',
+          search_strategy: ApiDropSearchStrategy.Newer,
+          drop_type: ApiDropType.Chat
+        }
+      } as any;
+
+      await handleGetDropRepliesV2(req);
+
+      expect(mockFindDropRepliesFeed).toHaveBeenCalledWith(
+        {
+          drop_id: 'drop-1',
+          amount: 200,
+          serial_no_limit: 100,
+          search_strategy: ApiDropSearchStrategy.Newer,
+          drop_type: ApiDropType.Chat
+        },
+        {
+          authenticationContext,
+          timer
+        }
+      );
+    });
+
+    it('rejects invalid reply feed query params', async () => {
+      const req = {
+        params: { id: 'drop-1' },
+        query: { drop_type: 'UNKNOWN' }
+      } as any;
+
+      await expect(handleGetDropRepliesV2(req)).rejects.toThrow(
+        '"drop_type" must be one of'
+      );
+      expect(mockFindDropRepliesFeed).not.toHaveBeenCalled();
     });
   });
 

--- a/src/api-serverless/src/waves/waves-v2.handlers.ts
+++ b/src/api-serverless/src/waves/waves-v2.handlers.ts
@@ -1,5 +1,4 @@
 import { getAuthenticationContext } from '@/api/auth/auth';
-import { dropsService } from '@/api/drops/drops.api.service';
 import { ApiDropSearchStrategy } from '@/api/generated/models/ApiDropSearchStrategy';
 import { ApiDropType } from '@/api/generated/models/ApiDropType';
 import { ApiDropsLeaderboardPageV2 } from '@/api/generated/models/ApiDropsLeaderboardPageV2';
@@ -27,8 +26,10 @@ import {
   GetOfficialWavesRequest,
   ListWaveSubwavesRequest,
   ListWaveCurationDropsV2Request,
+  GetDropRepliesV2Request,
   SearchDropsInWaveV2Request
 } from '@/api/generated/routes/operations';
+import { dropsService } from '@/api/drops/drops.api.service';
 import { PageSortDirection } from '@/api/page-request';
 import { getValidatedByJoiOrThrow } from '@/api/validation';
 import {
@@ -42,13 +43,25 @@ import {
 } from '@/api/waves/wave-decisions-api.service';
 import { waveMetadataApiService } from '@/api/waves/wave-metadata.api.service';
 import { LeaderboardParams, LeaderboardSort } from '@/drops/drops.db';
-import { enums } from '@/enums';
-import { numbers } from '@/numbers';
 import { Timer } from '@/time';
 import * as Joi from 'joi';
 
+const DEFAULT_WAVE_DROPS_V2_LIMIT = 50;
+const MAX_WAVE_DROPS_V2_LIMIT = 200;
+
 type GetWaveDropsV2PathParams = {
   id: string;
+};
+
+type GetDropRepliesV2PathParams = {
+  id: string;
+};
+
+type DropsFeedV2Query = {
+  limit: number;
+  serial_no_limit: number | null;
+  search_strategy: ApiDropSearchStrategy;
+  drop_type: ApiDropType | null;
 };
 
 type WaveMetadataPathParams = {
@@ -63,6 +76,28 @@ type DeleteWaveMetadataPathParams = {
 const GetWaveDropsV2PathParamsSchema: Joi.ObjectSchema<GetWaveDropsV2PathParams> =
   Joi.object({
     id: Joi.string().required()
+  });
+
+const GetDropRepliesV2PathParamsSchema: Joi.ObjectSchema<GetDropRepliesV2PathParams> =
+  Joi.object({
+    id: Joi.string().required()
+  });
+
+const DropsFeedV2QuerySchema: Joi.ObjectSchema<DropsFeedV2Query> =
+  Joi.object<DropsFeedV2Query>({
+    limit: Joi.number()
+      .integer()
+      .min(1)
+      .max(MAX_WAVE_DROPS_V2_LIMIT)
+      .default(DEFAULT_WAVE_DROPS_V2_LIMIT),
+    serial_no_limit: Joi.number().integer().min(1).optional().default(null),
+    search_strategy: Joi.string()
+      .valid(...Object.values(ApiDropSearchStrategy))
+      .default(ApiDropSearchStrategy.Older),
+    drop_type: Joi.string()
+      .valid(...Object.values(ApiDropType))
+      .optional()
+      .default(null)
   });
 
 const WaveMetadataPathParamsSchema: Joi.ObjectSchema<WaveMetadataPathParams> =
@@ -295,26 +330,42 @@ export async function handleGetWaveDropsV2(
   );
   const timer = Timer.getFromRequest(req);
   const authenticationContext = await getAuthenticationContext(req, timer);
-  const amount = numbers.parseIntOrNull(String(req.query.limit)) ?? 200;
-  const serialNoLimit = req.query.serial_no_limit
-    ? numbers.parseIntOrNull(String(req.query.serial_no_limit))
-    : null;
-  const searchStrategy =
-    enums.resolve(ApiDropSearchStrategy, req.query.search_strategy) ??
-    ApiDropSearchStrategy.Older;
-  const dropType = req.query.drop_type
-    ? (enums.resolve(ApiDropType, req.query.drop_type) ?? null)
-    : null;
+  const { limit, serial_no_limit, search_strategy, drop_type } =
+    getValidatedByJoiOrThrow(req.query, DropsFeedV2QuerySchema);
 
   return apiWaveV2Service.findDropsFeed(
     {
       wave_id: id,
       drop_id: null,
-      amount: amount >= 200 || amount < 1 ? 50 : amount,
-      serial_no_limit: serialNoLimit,
-      search_strategy: searchStrategy,
-      drop_type: dropType,
+      amount: limit,
+      serial_no_limit,
+      search_strategy,
+      drop_type,
       curation_id: null
+    },
+    { authenticationContext, timer }
+  );
+}
+
+export async function handleGetDropRepliesV2(
+  req: GetDropRepliesV2Request
+): Promise<ApiWaveDropsFeedV2> {
+  const { id } = getValidatedByJoiOrThrow(
+    req.params,
+    GetDropRepliesV2PathParamsSchema
+  );
+  const timer = Timer.getFromRequest(req);
+  const authenticationContext = await getAuthenticationContext(req, timer);
+  const { limit, serial_no_limit, search_strategy, drop_type } =
+    getValidatedByJoiOrThrow(req.query, DropsFeedV2QuerySchema);
+
+  return apiWaveV2Service.findDropRepliesFeed(
+    {
+      drop_id: id,
+      amount: limit,
+      serial_no_limit,
+      search_strategy,
+      drop_type
     },
     { authenticationContext, timer }
   );


### PR DESCRIPTION
## Issue
- The V2 wave drops contract was too loose: docs implied one replacement path, while handler behavior silently normalized or ignored invalid query params.
- That made it unclear whether `/v2/waves/{id}/drops` was the wave timeline feed, a reply-thread feed, a curation feed, or all of the above.

## Fix
- Make `/v2/waves/{id}/drops` explicitly documented and enforced as the V2 wave timeline feed.
- Add `GET /v2/drops/{id}/replies` as the dedicated V2 reply-thread route.
- Update V1 deprecation guidance to point clients to the correct V2 route for timeline, replies, and curation drops.
- Preserve existing timeline semantics and the documented max `limit` of 200 for compatibility.

## Changes
- Added Joi validation for shared V2 feed query params with `limit` default 50, max 200, positive `serial_no_limit`, valid `search_strategy`, and valid `drop_type`.
- Reject unsupported `drop_id` and `curation_id` on `/v2/waves/{id}/drops` so docs and runtime behavior match.
- Added V2 reply-feed service flow that resolves the parent drop's owning visible wave before returning the reply feed.
- Regenerated OpenAPI route artifacts for the new route.
- Documented the V2 timeline/replies/curation route split in `docs/architecture.md`.
- Added handler and service tests for defaults, max limit, rejected invalid params, rejected legacy filters, and reply-feed resolution.

## Validation
- `npm run restructure-openapi`
- `npm test -- src/api-serverless/src/waves/waves-v2-handlers.test.ts src/api-serverless/src/waves/api-wave-v2-service.test.ts src/drops/drops.db.test.ts src/api-serverless/generate-openapi-routes.test.ts`
- `npm test -- src/api-serverless/src/waves/waves-v2-handlers.test.ts src/api-serverless/src/waves/api-wave-v2-service.test.ts`
- Manual Windows equivalent of `npm run lint`: `npx eslint "src/**/*.ts" --fix --max-warnings=0` with `NODE_OPTIONS=--max-old-space-size=8192`
- `npx tsc -p tsconfig.json --noEmit`
- Frontend compatibility search: current frontend does not send `drop_id` or `curation_id` to `/v2/waves/{id}/drops`; current limits are <= 50; reply UI still uses the older parent-drop query route.

## Risk
- Medium: this tightens API contract behavior for `/v2/waves/{id}/drops`. Clients sending undocumented `drop_id` or `curation_id` there now get a 400 instead of an ignored or misleading timeline response.
- Rollback: revert this PR; V1 routes are unchanged.

## Review Notes
- Please focus review on whether the new V2 route split is the right long-term contract before we port more V1 read behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new V2 API endpoint to fetch a drop’s reply thread, including pagination and optional filtering.
* **Bug Fixes**
  * Improved V2 wave feed query handling by consistently validating and normalizing pagination/filter parameters.
* **Documentation**
  * Updated architecture notes to clarify how v2 read boundaries split timeline, reply, and curation feeds.
  * Refreshed endpoint docs to distinguish timeline drops from reply-thread and curation drops, and to clarify pagination/response details.
* **Tests**
  * Added/extended coverage for reply-thread retrieval and feed query validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->