### PR TITLE
[codex] Update GitHub Actions runtimes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -97,21 +97,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check production preconditions
-        uses: actions/github-script@v3
+        shell: bash
         if: (github.event.inputs.service == 'cloudwatchAlarmsToDiscordLoop' || github.event.inputs.service == 'mediaResizerLoop' || github.event.inputs.service == 'nextgenMediaImageResolutions' || github.event.inputs.service == 'nextgenMediaProxyInterceptor' || github.event.inputs.service == 'nextgenMediaUploader') && github.event.inputs.environment != 'prod'
-        with:
-          script: core.setFailed('Given service can only be deployed to production environment')
+        run: |
+          echo "Given service can only be deployed to production environment" >&2
+          exit 1
       - name: Check staging preconditions
-        uses: actions/github-script@v3
+        shell: bash
         if: (github.event.inputs.service == 'dropMediaIngestStorage' || github.event.inputs.service == 'dropVideoConversionInvokerLoop') && github.event.inputs.environment != 'staging'
-        with:
-          script: core.setFailed('Given service can only be deployed to staging environment')
+        run: |
+          echo "Given service can only be deployed to staging environment" >&2
+          exit 1
       - name: Extract branch name
         shell: bash
-        run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+        run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> "$GITHUB_OUTPUT"
         id: extract_branch
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           ref: ${{ steps.extract_branch.outputs.branch }}
       - name: Install root dependencies
@@ -129,7 +131,7 @@ jobs:
         if: github.event.inputs.service == 'api'
         run: pushd src/api-serverless && npm run build && popd
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@13d241b293754004c80624b5567555c4a39ffbe3
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -190,7 +192,8 @@ jobs:
       - name: Deploy service
         if: github.event.inputs.service != 'api' && github.event.inputs.service != 'nextgenMediaProxyInterceptor' && github.event.inputs.service != 'mediaResizerLoop'
         run: |
-          export VERSION_DESCRIPTION="$(git rev-parse --short HEAD) - $(date) - $(git rev-parse --abbrev-ref HEAD) - $(git show -s --format=%s)"
+          VERSION_DESCRIPTION="$(git rev-parse --short HEAD) - $(date) - $(git rev-parse --abbrev-ref HEAD) - $(git show -s --format=%s)"
+          export VERSION_DESCRIPTION
           pushd src/${{ github.event.inputs.service }} && npm run sls-deploy:${{ github.event.inputs.environment }} && popd
       - name: Deploy API
         if: github.event.inputs.service == 'api'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -182,13 +182,15 @@ jobs:
             fi
           fi
 
-          echo "ATTACHMENTS_INGEST_S3_BUCKET=$ATTACHMENTS_BUCKET" >> "$GITHUB_ENV"
-          echo "DROP_MEDIA_SANITIZE_IMAGES=$DROP_MEDIA_SANITIZE_IMAGES_VALUE" >> "$GITHUB_ENV"
-          echo "DROP_MEDIA_INGEST_S3_BUCKET=$DROP_MEDIA_INGEST_BUCKET" >> "$GITHUB_ENV"
-          echo "DROP_MEDIA_INGEST_S3_REGION=$DROP_MEDIA_INGEST_REGION" >> "$GITHUB_ENV"
-          echo "DROP_MEDIA_INGEST_STAGE=${{ github.event.inputs.environment }}" >> "$GITHUB_ENV"
-          echo "DROP_MEDIA_SANITIZER_SQS_QUEUE_NAME=$DROP_MEDIA_SANITIZER_QUEUE" >> "$GITHUB_ENV"
-          echo "API_GATEWAY_WS_ENDPOINT=$API_GATEWAY_WS_ENDPOINT" >> "$GITHUB_ENV"
+          {
+            echo "ATTACHMENTS_INGEST_S3_BUCKET=$ATTACHMENTS_BUCKET"
+            echo "DROP_MEDIA_SANITIZE_IMAGES=$DROP_MEDIA_SANITIZE_IMAGES_VALUE"
+            echo "DROP_MEDIA_INGEST_S3_BUCKET=$DROP_MEDIA_INGEST_BUCKET"
+            echo "DROP_MEDIA_INGEST_S3_REGION=$DROP_MEDIA_INGEST_REGION"
+            echo "DROP_MEDIA_INGEST_STAGE=${{ github.event.inputs.environment }}"
+            echo "DROP_MEDIA_SANITIZER_SQS_QUEUE_NAME=$DROP_MEDIA_SANITIZER_QUEUE"
+            echo "API_GATEWAY_WS_ENDPOINT=$API_GATEWAY_WS_ENDPOINT"
+          } >> "$GITHUB_ENV"
       - name: Deploy service
         if: github.event.inputs.service != 'api' && github.event.inputs.service != 'nextgenMediaProxyInterceptor' && github.event.inputs.service != 'mediaResizerLoop'
         run: |

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -12,9 +12,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'

--- a/scripts/generate-deploy-config.mjs
+++ b/scripts/generate-deploy-config.mjs
@@ -92,21 +92,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check production preconditions
-        uses: actions/github-script@v3
+        shell: bash
         if: ${prodCondition}
-        with:
-          script: core.setFailed('Given service can only be deployed to production environment')
+        run: |
+          echo "Given service can only be deployed to production environment" >&2
+          exit 1
       - name: Check staging preconditions
-        uses: actions/github-script@v3
+        shell: bash
         if: ${stagingCondition}
-        with:
-          script: core.setFailed('Given service can only be deployed to staging environment')
+        run: |
+          echo "Given service can only be deployed to staging environment" >&2
+          exit 1
       - name: Extract branch name
         shell: bash
-        run: echo "branch=\${GITHUB_HEAD_REF:-\${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+        run: echo "branch=\${GITHUB_HEAD_REF:-\${GITHUB_REF#refs/heads/}}" >> "$GITHUB_OUTPUT"
         id: extract_branch
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           ref: \${{ steps.extract_branch.outputs.branch }}
       - name: Install root dependencies
@@ -124,7 +126,7 @@ jobs:
         if: github.event.inputs.service == 'api'
         run: pushd src/api-serverless && npm run build && popd
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@13d241b293754004c80624b5567555c4a39ffbe3
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
         with:
           aws-access-key-id: \${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: \${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -185,7 +187,8 @@ jobs:
       - name: Deploy service
         if: github.event.inputs.service != 'api' && github.event.inputs.service != 'nextgenMediaProxyInterceptor' && github.event.inputs.service != 'mediaResizerLoop'
         run: |
-          export VERSION_DESCRIPTION="$(git rev-parse --short HEAD) - $(date) - $(git rev-parse --abbrev-ref HEAD) - $(git show -s --format=%s)"
+          VERSION_DESCRIPTION="$(git rev-parse --short HEAD) - $(date) - $(git rev-parse --abbrev-ref HEAD) - $(git show -s --format=%s)"
+          export VERSION_DESCRIPTION
           pushd src/\${{ github.event.inputs.service }} && npm run sls-deploy:\${{ github.event.inputs.environment }} && popd
       - name: Deploy API
         if: github.event.inputs.service == 'api'

--- a/scripts/generate-deploy-config.mjs
+++ b/scripts/generate-deploy-config.mjs
@@ -177,13 +177,15 @@ jobs:
             fi
           fi
 
-          echo "ATTACHMENTS_INGEST_S3_BUCKET=$ATTACHMENTS_BUCKET" >> "$GITHUB_ENV"
-          echo "DROP_MEDIA_SANITIZE_IMAGES=$DROP_MEDIA_SANITIZE_IMAGES_VALUE" >> "$GITHUB_ENV"
-          echo "DROP_MEDIA_INGEST_S3_BUCKET=$DROP_MEDIA_INGEST_BUCKET" >> "$GITHUB_ENV"
-          echo "DROP_MEDIA_INGEST_S3_REGION=$DROP_MEDIA_INGEST_REGION" >> "$GITHUB_ENV"
-          echo "DROP_MEDIA_INGEST_STAGE=\${{ github.event.inputs.environment }}" >> "$GITHUB_ENV"
-          echo "DROP_MEDIA_SANITIZER_SQS_QUEUE_NAME=$DROP_MEDIA_SANITIZER_QUEUE" >> "$GITHUB_ENV"
-          echo "API_GATEWAY_WS_ENDPOINT=$API_GATEWAY_WS_ENDPOINT" >> "$GITHUB_ENV"
+          {
+            echo "ATTACHMENTS_INGEST_S3_BUCKET=$ATTACHMENTS_BUCKET"
+            echo "DROP_MEDIA_SANITIZE_IMAGES=$DROP_MEDIA_SANITIZE_IMAGES_VALUE"
+            echo "DROP_MEDIA_INGEST_S3_BUCKET=$DROP_MEDIA_INGEST_BUCKET"
+            echo "DROP_MEDIA_INGEST_S3_REGION=$DROP_MEDIA_INGEST_REGION"
+            echo "DROP_MEDIA_INGEST_STAGE=\${{ github.event.inputs.environment }}"
+            echo "DROP_MEDIA_SANITIZER_SQS_QUEUE_NAME=$DROP_MEDIA_SANITIZER_QUEUE"
+            echo "API_GATEWAY_WS_ENDPOINT=$API_GATEWAY_WS_ENDPOINT"
+          } >> "$GITHUB_ENV"
       - name: Deploy service
         if: github.event.inputs.service != 'api' && github.event.inputs.service != 'nextgenMediaProxyInterceptor' && github.event.inputs.service != 'mediaResizerLoop'
         run: |


### PR DESCRIPTION
## Summary

- Replace old deploy workflow `actions/github-script@v3` precondition checks with equivalent Bash failure steps.
- Update backend GitHub Actions to Node 24-ready action majors: `actions/checkout@v6`, `actions/setup-node@v6`, and `aws-actions/configure-aws-credentials` pinned to the v6.2.0 release commit SHA.
- Regenerate `.github/workflows/deploy.yml` from `scripts/generate-deploy-config.mjs` so generated workflow checks stay stable.

## Why

GitHub Actions is moving default JavaScript action execution to Node 24. The backend API deploy had workflow-maintenance warnings for old action runtimes, even though the API deploy itself succeeded.

## Impact

This is workflow maintenance only. No application code, Lambda code, runtime configuration, or deployment target behavior changes.

## Validation

- `npm run generate:deploy-config`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/deploy.yml .github/workflows/on-pull-request.yml`
- YAML parse for `.github/workflows/deploy.yml` and `.github/workflows/on-pull-request.yml`
- deploy workflow regeneration idempotency check
- deprecated-pattern scan for old checkout/github-script/set-output/save-state usage
- `node --check scripts/generate-deploy-config.mjs`
- `npx eslint scripts/generate-deploy-config.mjs --max-warnings=0`
- `git diff --check`
- `npm run lint` attempted; on this Windows host it fails before ESLint because the `main` branch script starts with POSIX-style `NODE_OPTIONS=...`. Equivalent PowerShell command passed: `$env:NODE_OPTIONS='--max-old-space-size=8192'; npx eslint "src/**/*.ts" --fix --max-warnings=0`.

## Bot / CI Follow-up

- 6529bot general review initially requested re-pinning `aws-actions/configure-aws-credentials`; fixed by pinning the v6.2.0 commit SHA.
- 6529bot follow-up review: no new findings.
- SonarCloud, DCO, Snyk, and Build backend and API checks are passing.
- CodeRabbit skipped automatic review because this PR is draft; a manual trigger was attempted, but CodeRabbit reported review rate limits before later marking the command completed.

## Deploy Notes

No Lambdas need redeploying; this only changes GitHub Actions workflow maintenance.