### PR TITLE
Fix wave score refresh log group deployment

### DIFF
--- a/src/waveScoreRefreshLoop/serverless.yaml
+++ b/src/waveScoreRefreshLoop/serverless.yaml
@@ -37,6 +37,12 @@ functions:
 
 resources:
   Resources:
+    WaveScoreRefreshLoopLogGroup:
+      Type: AWS::Logs::LogGroup
+      Properties:
+        LogGroupName: /aws/lambda/waveScoreRefreshLoop
+        RetentionInDays: 60
+
     WaveScoreRefreshStartQueue:
       Type: 'AWS::SQS::Queue'
       Properties:
@@ -75,8 +81,11 @@ resources:
                 - !GetAtt WaveScoreRefreshStartQueue.Arn
     WaveScoreRefreshLoopOOMFilter:
       Type: AWS::Logs::MetricFilter
+      DependsOn:
+        - WaveScoreRefreshLoopLogGroup
       Properties:
-        LogGroupName: /aws/lambda/waveScoreRefreshLoop
+        LogGroupName:
+          Ref: WaveScoreRefreshLoopLogGroup
         FilterPattern: 'Runtime.OutOfMemory'
         MetricTransformations:
           - MetricNamespace: 'Lambda/OOM'


### PR DESCRIPTION
## Summary
- add an explicit CloudWatch log group for waveScoreRefreshLoop
- make the OOM metric filter depend on and reference that log group

## Verification
- serverless print --stage=staging --region=eu-west-1 from src/waveScoreRefreshLoop with local env placeholders

## Deploy note
- fixes staging deploy failure in waveScoreRefreshLoop where CloudFormation created the metric filter before the Lambda log group existed