### PR TITLE
Added exclude_followed to waves v2 for more sort options

### DIFF
--- a/src/api-serverless/openapi.yaml
+++ b/src/api-serverless/openapi.yaml
@@ -7744,8 +7744,9 @@ paths:
         - name: exclude_followed
           in: query
           description: >-
-            HOT view only. If true then result excludes waves the authenticated
-            user already follows.
+            HOT view and OVERVIEW view with
+            overview_type=SCORED_RECENTLY_DROPPED_TO only. If true then result
+            excludes waves the authenticated user already follows.
           required: false
           schema:
             type: boolean

--- a/src/api-serverless/src/waves/api-wave-v2-service.test.ts
+++ b/src/api-serverless/src/waves/api-wave-v2-service.test.ts
@@ -12,6 +12,7 @@ import { ApiDropType } from '@/api/generated/models/ApiDropType';
 import { ApiWavesOverviewType } from '@/api/generated/models/ApiWavesOverviewType';
 import { ApiWavesPinFilter } from '@/api/generated/models/ApiWavesPinFilter';
 import { ApiWavesV2ListType } from '@/api/generated/models/ApiWavesV2ListType';
+import { ApiWaveScoreSort } from '@/api/generated/models/ApiWaveScoreSort';
 import { ApiWaveV2Service } from '@/api/waves/api-wave-v2.service';
 
 function makeDrop(overrides: Partial<DropEntity> = {}): DropEntity {
@@ -124,6 +125,7 @@ function createService() {
     searchWaves: jest.fn().mockResolvedValue([]),
     findMostSubscribedWaves: jest.fn().mockResolvedValue([]),
     findRecentlyDroppedToWaves: jest.fn().mockResolvedValue([]),
+    findScoredRecentlyDroppedToWaves: jest.fn().mockResolvedValue([]),
     findHotWaves: jest.fn().mockResolvedValue([]),
     findFavouriteWavesOfIdentity: jest.fn().mockResolvedValue([]),
     findOfficialWaves: jest.fn().mockResolvedValue([])
@@ -341,6 +343,49 @@ describe('ApiWaveV2Service', () => {
         offset: 1,
         authenticated_user_id: 'viewer-1',
         exclude_followed: false
+      })
+    );
+    expect(result).toEqual({
+      data: [{ id: 'wave-1' }],
+      page: 2,
+      next: true
+    });
+  });
+
+  it('gets scored overview waves excluding followed waves', async () => {
+    const { service, deps } = createService();
+    const waveEntities = [
+      makeWave({ id: 'wave-1' }),
+      makeWave({ id: 'wave-2' })
+    ];
+    deps.wavesApiDb.findScoredRecentlyDroppedToWaves.mockResolvedValue(
+      waveEntities
+    );
+    const ctx = {
+      authenticationContext: AuthenticationContext.fromProfileId('viewer-1')
+    };
+
+    const result = await service.findWaves(
+      {
+        view: ApiWavesV2ListType.Overview,
+        overview_type: ApiWavesOverviewType.ScoredRecentlyDroppedTo,
+        page: 2,
+        page_size: 1,
+        score_sort: ApiWaveScoreSort.Rep,
+        exclude_followed: true
+      },
+      ctx
+    );
+
+    expect(
+      deps.wavesApiDb.findScoredRecentlyDroppedToWaves
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        limit: 2,
+        offset: 1,
+        authenticated_user_id: 'viewer-1',
+        score_sort: ApiWaveScoreSort.Rep,
+        exclude_followed: true
       })
     );
     expect(result).toEqual({

--- a/src/api-serverless/src/waves/api-wave-v2.service.ts
+++ b/src/api-serverless/src/waves/api-wave-v2.service.ts
@@ -405,6 +405,12 @@ export class ApiWaveV2Service {
         `You can't see waves organised by your behaviour unless you're authenticated`
       );
     }
+    const excludeFollowed = request.exclude_followed ?? false;
+    if (excludeFollowed && !authenticatedProfileId) {
+      throw new BadRequestException(
+        `You can't exclude followed waves unless you're authenticated`
+      );
+    }
     const findParams = {
       authenticated_user_id: authenticatedProfileId,
       only_waves_followed_by_authenticated_user: onlyFollowed,
@@ -423,6 +429,7 @@ export class ApiWaveV2Service {
             ? await this.wavesApiDb.findScoredRecentlyDroppedToWaves({
                 ...findParams,
                 score_sort: request.score_sort ?? ApiWaveScoreSort.Balanced,
+                exclude_followed: excludeFollowed,
                 min_visibility_score: request.min_visibility_score,
                 min_quality_score: request.min_quality_score,
                 min_hotness_score: request.min_hotness_score,

--- a/src/api-serverless/src/waves/wave.api.service.ts
+++ b/src/api-serverless/src/waves/wave.api.service.ts
@@ -1682,7 +1682,8 @@ export class WaveApiService {
           offset,
           direct_message,
           pinned,
-          score_sort: ApiWaveScoreSort.Balanced
+          score_sort: ApiWaveScoreSort.Balanced,
+          exclude_followed: false
         });
       default:
         assertUnreachable(type);

--- a/src/api-serverless/src/waves/waves-api-db.test.ts
+++ b/src/api-serverless/src/waves/waves-api-db.test.ts
@@ -1,11 +1,16 @@
 import 'reflect-metadata';
 import {
   DROPS_TABLE,
+  IDENTITY_SUBSCRIPTIONS_TABLE,
   WAVE_CHAT_DROP_COOLDOWNS_TABLE,
   WAVE_DROPPER_METRICS_TABLE,
   WAVE_METRICS_TABLE,
   WAVE_READER_METRICS_TABLE
 } from '@/constants';
+import {
+  ActivityEventAction,
+  ActivityEventTargetType
+} from '@/entities/IActivityEvent';
 import { DropType } from '@/entities/IDrop';
 import { RequestContext } from '@/request.context';
 import { sqlExecutor } from '@/sql-executor';
@@ -224,6 +229,19 @@ describeWithSeed(
       ]
     },
     {
+      table: IDENTITY_SUBSCRIPTIONS_TABLE,
+      rows: [
+        {
+          subscriber_id: author.profile_id!,
+          target_id: mutedHighScoreWave.id,
+          target_type: ActivityEventTargetType.WAVE,
+          target_action: ActivityEventAction.DROP_CREATED,
+          wave_id: mutedHighScoreWave.id,
+          subscribed_to_all_drops: false
+        }
+      ]
+    },
+    {
       table: WAVE_READER_METRICS_TABLE,
       rows: [
         {
@@ -246,11 +264,28 @@ describeWithSeed(
         direct_message: false,
         pinned: null,
         score_sort: ApiWaveScoreSort.Balanced,
+        exclude_followed: false,
         min_visibility_score: 50,
         min_quality_score: 50,
         min_hotness_score: 50,
         min_rep_sort_score: 50,
         visibility_tier: ApiWaveVisibilityTier.TrustedVisible
+      });
+
+      expect(waves.map((wave) => wave.id)).toEqual([visibleScoredWave.id]);
+    });
+
+    it('excludes followed waves from scored sort results', async () => {
+      const waves = await repo.findScoredRecentlyDroppedToWaves({
+        authenticated_user_id: author.profile_id!,
+        only_waves_followed_by_authenticated_user: false,
+        offset: 0,
+        limit: 10,
+        eligibleGroups: [],
+        direct_message: false,
+        pinned: null,
+        score_sort: ApiWaveScoreSort.Quality,
+        exclude_followed: true
       });
 
       expect(waves.map((wave) => wave.id)).toEqual([visibleScoredWave.id]);

--- a/src/api-serverless/src/waves/waves-v2-handlers.test.ts
+++ b/src/api-serverless/src/waves/waves-v2-handlers.test.ts
@@ -135,7 +135,8 @@ describe('waves v2 handlers', () => {
           overview_type: ApiWavesOverviewType.MostSubscribed,
           only_waves_followed_by_authenticated_user: true,
           direct_message: false,
-          pinned: ApiWavesPinFilter.Pinned
+          pinned: ApiWavesPinFilter.Pinned,
+          exclude_followed: false
         },
         {
           authenticationContext,

--- a/src/api-serverless/src/waves/waves-v2.handlers.ts
+++ b/src/api-serverless/src/waves/waves-v2.handlers.ts
@@ -482,6 +482,7 @@ function validateWavesV2Params(
             .uppercase()
             .valid(...Object.values(ApiWaveScoreSort))
             .optional(),
+          exclude_followed: booleanQuerySchema().optional().default(false),
           min_visibility_score: Joi.number().min(0).max(100).optional(),
           min_quality_score: Joi.number().min(0).max(100).optional(),
           min_hotness_score: Joi.number().min(0).max(100).optional(),

--- a/src/api-serverless/src/waves/waves.api.db.ts
+++ b/src/api-serverless/src/waves/waves.api.db.ts
@@ -2017,6 +2017,7 @@ export class WavesApiDb extends LazyDbAccessCompatibleService {
     direct_message?: boolean;
     pinned: ApiWavesPinFilter | null;
     score_sort: ApiWaveScoreSort;
+    exclude_followed: boolean;
     min_visibility_score?: number;
     min_quality_score?: number;
     min_hotness_score?: number;
@@ -2084,6 +2085,15 @@ export class WavesApiDb extends LazyDbAccessCompatibleService {
           ? `join ${IDENTITY_SUBSCRIPTIONS_TABLE} f on f.target_type = 'WAVE' and f.target_action = 'DROP_CREATED' and f.target_id = w.id`
           : ``
       }
+      ${
+        param.exclude_followed
+          ? `left join ${IDENTITY_SUBSCRIPTIONS_TABLE} xf
+              on xf.subscriber_id = :authenticated_user_id
+             and xf.target_id = w.id
+             and xf.target_type = :wave_target_type
+             and xf.target_action = :drop_created_action`
+          : ``
+      }
       join ${WAVE_METRICS_TABLE} wm on wm.wave_id = w.id
       ${
         param.authenticated_user_id
@@ -2097,6 +2107,7 @@ export class WavesApiDb extends LazyDbAccessCompatibleService {
             ? `f.subscriber_id = :authenticated_user_id and`
             : ``
         }
+        ${param.exclude_followed ? `xf.id is null and` : ``}
         ${
           param.direct_message !== undefined
             ? ` w.is_direct_message = :direct_message and `
@@ -2117,7 +2128,11 @@ export class WavesApiDb extends LazyDbAccessCompatibleService {
       join wids on w.id = wids.id
     order by wids.tier_rank asc, wids.sort_val desc, wids.latest_drop_timestamp desc, w.id desc`;
     return this.db
-      .execute<RawWaveEntity>(sql, param)
+      .execute<RawWaveEntity>(sql, {
+        ...param,
+        wave_target_type: ActivityEventTargetType.WAVE,
+        drop_created_action: ActivityEventAction.DROP_CREATED
+      })
       .then((res) => res.map((it) => this.parseWaveEntity(it)));
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an `exclude_followed` option for overview wave results, letting users filter out waves they already follow.
  * The option now works for both Hot and Scored Recently Dropped to Overview modes.

* **Bug Fixes**
  * Improved request handling so unauthenticated requests can’t use the followed-wave exclusion filter.
  * Updated pagination and result behavior to respect the new filter consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->