### PR TITLE
Revert minting claim media URLs

### DIFF
--- a/src/minting-claims/claims-media-arweave-upload.test.ts
+++ b/src/minting-claims/claims-media-arweave-upload.test.ts
@@ -398,6 +398,43 @@ describe('uploadMintingClaimToArweave', () => {
     );
   });
 
+  it('does not re-emit stored media resolver URLs on image reuse', async () => {
+    uploadFileMock.mockReset();
+    uploadFileMock.mockResolvedValueOnce({
+      url: 'https://arweave.net/_MSzxiISR3AgFJqhzBoAbCtFGMglSqRmZi5NTgZLfL4'
+    });
+
+    const result = await uploadMintingClaimToArweave(
+      MEMES_CONTRACT,
+      baseClaim({
+        image_location:
+          'https://media.6529.io/ipfs/bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi',
+        image_details: JSON.stringify({
+          bytes: 123,
+          format: 'PNG',
+          sha256:
+            '2c8648d103e3dd7ad87660da0f126a1443b6d21ac1bd3ec000c5e24e2373a90c',
+          width: 800,
+          height: 800
+        })
+      })
+    );
+
+    expect(result.imageLocationUrl).toBe(
+      'ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi'
+    );
+    expect(uploadFileMock).toHaveBeenCalledTimes(1);
+    const metadataUploadBuffer = uploadFileMock.mock.calls[0]?.[0] as Buffer;
+    const uploadedMetadata = JSON.parse(metadataUploadBuffer.toString('utf8'));
+
+    expect(uploadedMetadata.image).toBe(
+      'ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi'
+    );
+    expect(uploadedMetadata.image_url).toBe(
+      'ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi'
+    );
+  });
+
   it('uploads HTML MEMES metadata in object shape', async () => {
     uploadFileMock.mockReset();
     uploadFileMock
@@ -470,6 +507,43 @@ describe('uploadMintingClaimToArweave', () => {
           'ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi'
       )
     ).toBe(false);
+
+    const metadataUploadBuffer = uploadFileMock.mock.calls[1]?.[0] as Buffer;
+    const uploadedMetadata = JSON.parse(metadataUploadBuffer.toString('utf8'));
+
+    expect(uploadedMetadata.animation).toBeUndefined();
+    expect(uploadedMetadata.animation_url).toBe(
+      'ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi'
+    );
+    expect(uploadedMetadata.animation_details).toEqual({ format: 'HTML' });
+  });
+
+  it('copies html media resolver animation_url to animation_location as native ipfs', async () => {
+    uploadFileMock.mockReset();
+    uploadFileMock
+      .mockResolvedValueOnce({
+        url: 'https://arweave.net/OI6-rpJ2C3Ab4HiZRWt5A1SumhjnYigmSPBPX0ICBj8'
+      })
+      .mockResolvedValueOnce({
+        url: 'https://arweave.net/_MSzxiISR3AgFJqhzBoAbCtFGMglSqRmZi5NTgZLfL4'
+      });
+
+    const result = await uploadMintingClaimToArweave(
+      MEMES_CONTRACT,
+      baseClaim({
+        animation_url:
+          'https://media.6529.io/ipfs/bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi',
+        animation_details: JSON.stringify({
+          format: 'HTML'
+        })
+      })
+    );
+
+    expect(result.animationLocationUrl).toBe(
+      'ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi'
+    );
+    expect(uploadFileMock).toHaveBeenCalledTimes(2);
+    expect(fetchPublicUrlToBufferMock).toHaveBeenCalledTimes(1);
 
     const metadataUploadBuffer = uploadFileMock.mock.calls[1]?.[0] as Buffer;
     const uploadedMetadata = JSON.parse(metadataUploadBuffer.toString('utf8'));
@@ -642,6 +716,52 @@ describe('uploadMintingClaimToArweave', () => {
       2,
       Buffer.from('video-bytes'),
       'video/mp4'
+    );
+  });
+
+  it('fetches non-html bare arweave animation_url as an Arweave gateway URL', async () => {
+    const arweaveTxId = 'OdpVtqurZU9P-uEAJ4BsDIjAduAufQ6_sJxTu6MNYHc';
+    uploadFileMock.mockReset();
+    fetchPublicUrlToBufferMock
+      .mockResolvedValueOnce({
+        buffer: Buffer.from('image-bytes'),
+        contentType: 'image/png',
+        finalUrl: 'https://cdn.example.com/image.png'
+      })
+      .mockResolvedValueOnce({
+        buffer: Buffer.from('video-bytes'),
+        contentType: 'video/mp4',
+        finalUrl: `https://arweave.net/${arweaveTxId}`
+      });
+    uploadFileMock
+      .mockResolvedValueOnce({
+        url: 'https://arweave.net/OI6-rpJ2C3Ab4HiZRWt5A1SumhjnYigmSPBPX0ICBj8'
+      })
+      .mockResolvedValueOnce({
+        url: `https://arweave.net/${arweaveTxId}`
+      })
+      .mockResolvedValueOnce({
+        url: 'https://arweave.net/_MSzxiISR3AgFJqhzBoAbCtFGMglSqRmZi5NTgZLfL4'
+      });
+
+    await uploadMintingClaimToArweave(
+      MEMES_CONTRACT,
+      baseClaim({
+        animation_url: arweaveTxId,
+        animation_details: JSON.stringify({
+          bytes: 456,
+          format: 'MP4',
+          duration: 4,
+          sha256: 'b'.repeat(64),
+          width: 1000,
+          height: 1000,
+          codecs: ['avc1']
+        })
+      })
+    );
+
+    expect(fetchPublicUrlToBufferMock.mock.calls[1]?.[0]).toBe(
+      `https://arweave.net/${arweaveTxId}`
     );
   });
 

--- a/src/minting-claims/claims-media-arweave-upload.test.ts
+++ b/src/minting-claims/claims-media-arweave-upload.test.ts
@@ -437,7 +437,7 @@ describe('uploadMintingClaimToArweave', () => {
     expect(uploadedMetadata.animation_details).toEqual({ format: 'HTML' });
   });
 
-  it('copies html ipfs animation_url to animation_location as resolver URL', async () => {
+  it('copies html ipfs animation_url to animation_location as the original URL', async () => {
     uploadFileMock.mockReset();
     uploadFileMock
       .mockResolvedValueOnce({
@@ -459,7 +459,7 @@ describe('uploadMintingClaimToArweave', () => {
     );
 
     expect(result.animationLocationUrl).toBe(
-      'https://media.6529.io/ipfs/bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi'
+      'ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi'
     );
     expect(uploadFileMock).toHaveBeenCalledTimes(2);
     expect(fetchPublicUrlToBufferMock).toHaveBeenCalledTimes(1);
@@ -476,12 +476,12 @@ describe('uploadMintingClaimToArweave', () => {
 
     expect(uploadedMetadata.animation).toBeUndefined();
     expect(uploadedMetadata.animation_url).toBe(
-      'https://media.6529.io/ipfs/bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi'
+      'ipfs://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi'
     );
     expect(uploadedMetadata.animation_details).toEqual({ format: 'HTML' });
   });
 
-  it('copies html arweave animation_url to animation_location as resolver URL', async () => {
+  it('copies html arweave animation_url to animation_location as an Arweave URL', async () => {
     uploadFileMock.mockReset();
     uploadFileMock
       .mockResolvedValueOnce({
@@ -503,7 +503,7 @@ describe('uploadMintingClaimToArweave', () => {
     );
 
     expect(result.animationLocationUrl).toBe(
-      'https://media.6529.io/arweave/oi6-rpj2c3ab4hizrwt5a1sumhjnyigmspbpx0icbj8'
+      'https://arweave.net/oi6-rpj2c3ab4hizrwt5a1sumhjnyigmspbpx0icbj8'
     );
     expect(uploadFileMock).toHaveBeenCalledTimes(2);
     expect(fetchPublicUrlToBufferMock).toHaveBeenCalledTimes(1);
@@ -520,7 +520,7 @@ describe('uploadMintingClaimToArweave', () => {
 
     expect(uploadedMetadata.animation).toBeUndefined();
     expect(uploadedMetadata.animation_url).toBe(
-      'https://media.6529.io/arweave/oi6-rpj2c3ab4hizrwt5a1sumhjnyigmspbpx0icbj8'
+      'https://arweave.net/oi6-rpj2c3ab4hizrwt5a1sumhjnyigmspbpx0icbj8'
     );
     expect(uploadedMetadata.animation_details).toEqual({ format: 'HTML' });
   });
@@ -537,7 +537,7 @@ describe('uploadMintingClaimToArweave', () => {
         buffer: Buffer.from('video-bytes'),
         contentType: 'application/octet-stream',
         finalUrl:
-          'https://media.6529.io/ipfs/bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi'
+          'https://ipfs.io/ipfs/bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi'
       });
     uploadFileMock
       .mockResolvedValueOnce({
@@ -568,10 +568,10 @@ describe('uploadMintingClaimToArweave', () => {
     );
 
     expect(result.animationLocationUrl).toBe(
-      'https://media.6529.io/arweave/OdpVtqurZU9P-uEAJ4BsDIjAduAufQ6_sJxTu6MNYHc'
+      'https://arweave.net/OdpVtqurZU9P-uEAJ4BsDIjAduAufQ6_sJxTu6MNYHc'
     );
     expect(fetchPublicUrlToBufferMock.mock.calls[1]?.[0]).toBe(
-      'https://media.6529.io/ipfs/bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi'
+      'https://ipfs.io/ipfs/bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi'
     );
     expect(uploadFileMock).toHaveBeenNthCalledWith(
       2,
@@ -583,10 +583,10 @@ describe('uploadMintingClaimToArweave', () => {
     const uploadedMetadata = JSON.parse(metadataUploadBuffer.toString('utf8'));
 
     expect(uploadedMetadata.animation).toBe(
-      'https://media.6529.io/arweave/OdpVtqurZU9P-uEAJ4BsDIjAduAufQ6_sJxTu6MNYHc'
+      'https://arweave.net/OdpVtqurZU9P-uEAJ4BsDIjAduAufQ6_sJxTu6MNYHc'
     );
     expect(uploadedMetadata.animation_url).toBe(
-      'https://media.6529.io/arweave/OdpVtqurZU9P-uEAJ4BsDIjAduAufQ6_sJxTu6MNYHc'
+      'https://arweave.net/OdpVtqurZU9P-uEAJ4BsDIjAduAufQ6_sJxTu6MNYHc'
     );
   });
 
@@ -602,7 +602,7 @@ describe('uploadMintingClaimToArweave', () => {
         buffer: Buffer.from('video-bytes'),
         contentType: 'application/octet-stream',
         finalUrl:
-          'https://media.6529.io/ipfs/bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi'
+          'https://ipfs.io/ipfs/bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi'
       });
     uploadFileMock
       .mockResolvedValueOnce({
@@ -633,10 +633,10 @@ describe('uploadMintingClaimToArweave', () => {
     );
 
     expect(result.animationLocationUrl).toBe(
-      'https://media.6529.io/arweave/OdpVtqurZU9P-uEAJ4BsDIjAduAufQ6_sJxTu6MNYHc'
+      'https://arweave.net/OdpVtqurZU9P-uEAJ4BsDIjAduAufQ6_sJxTu6MNYHc'
     );
     expect(fetchPublicUrlToBufferMock.mock.calls[1]?.[0]).toBe(
-      'https://media.6529.io/ipfs/bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi'
+      'https://ipfs.io/ipfs/bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi'
     );
     expect(uploadFileMock).toHaveBeenNthCalledWith(
       2,
@@ -680,10 +680,10 @@ describe('uploadMintingClaimToArweave', () => {
     const uploadedMetadata = JSON.parse(metadataUploadBuffer.toString('utf8'));
 
     expect(uploadedMetadata.animation).toBe(
-      'https://media.6529.io/arweave/4nB40b2aSkEM2w69cZIK9YHyg4Zy80iTA6fcwJwZk6w'
+      'https://arweave.net/4nB40b2aSkEM2w69cZIK9YHyg4Zy80iTA6fcwJwZk6w'
     );
     expect(uploadedMetadata.animation_url).toBe(
-      'https://media.6529.io/arweave/4nB40b2aSkEM2w69cZIK9YHyg4Zy80iTA6fcwJwZk6w'
+      'https://arweave.net/4nB40b2aSkEM2w69cZIK9YHyg4Zy80iTA6fcwJwZk6w'
     );
     expect(uploadedMetadata.animation_details).toEqual({
       bytes: 8133420,

--- a/src/minting-claims/claims-media-arweave-upload.ts
+++ b/src/minting-claims/claims-media-arweave-upload.ts
@@ -10,9 +10,9 @@ import { Logger } from '@/logging';
 import { isMemesContract } from '@/minting-claims/external-url';
 import { MAX_MINTING_CLAIM_MEDIA_BYTES } from '@/minting-claims/media-limits';
 import {
-  normalizeDecentralizedMediaUri,
   parseDecentralizedMediaRef,
-  to6529ResolverUrl
+  toExternalFallbackUrls,
+  toNativeUri
 } from '@/decentralized-media/decentralized-media';
 import { createHash } from 'node:crypto';
 
@@ -188,7 +188,15 @@ function isArweaveUrl(value: string): boolean {
   return parseDecentralizedMediaRef(value)?.protocol === 'arweave';
 }
 
-function buildStoredLocationUrl(
+function is6529MediaResolverUrl(value: string): boolean {
+  try {
+    return new URL(value).hostname.toLowerCase() === 'media.6529.io';
+  } catch {
+    return false;
+  }
+}
+
+function buildMintingClaimLocationUrl(
   location: string | null | undefined,
   allowProtocolPassthrough = false
 ): string | null {
@@ -197,22 +205,26 @@ function buildStoredLocationUrl(
   if (trimmed === '') return null;
   const ref = parseDecentralizedMediaRef(trimmed);
   if (ref) {
-    if (ref.protocol === 'arweave' || allowProtocolPassthrough) {
-      return to6529ResolverUrl(ref);
+    if (ref.protocol === 'arweave') {
+      return toExternalFallbackUrls(ref)[0] ?? trimmed;
+    }
+    if (allowProtocolPassthrough) {
+      return is6529MediaResolverUrl(trimmed) ? toNativeUri(ref) : trimmed;
     }
   }
   if (isProtocolUrl(trimmed)) {
     if (allowProtocolPassthrough) {
       return trimmed;
     }
-    return to6529ResolverUrl({ protocol: 'arweave', id: trimmed, path: '' });
+    return trimmed;
   }
-  return to6529ResolverUrl({ protocol: 'arweave', id: trimmed, path: '' });
+  return `https://arweave.net/${trimmed}`;
 }
 
 function resolveAnimationFetchUrl(url: string): string {
   const trimmed = url.trim();
-  return normalizeDecentralizedMediaUri(trimmed) ?? trimmed;
+  const ref = parseDecentralizedMediaRef(trimmed);
+  return ref ? (toExternalFallbackUrls(ref)[0] ?? trimmed) : trimmed;
 }
 
 function contentTypeFromAnimationFormat(format: string | null | undefined) {
@@ -250,7 +262,7 @@ async function uploadImageToArweaveOrThrow(
   const existingDetails =
     parseJsonOrNull<{ sha256?: unknown }>(claim.image_details) ?? null;
   const existingSha256 = normalizeSha256(existingDetails?.sha256);
-  const existingArweaveUrl = buildStoredLocationUrl(
+  const existingArweaveUrl = buildMintingClaimLocationUrl(
     claim.image_location,
     false
   );
@@ -266,7 +278,7 @@ async function uploadImageToArweaveOrThrow(
     fetched.buffer,
     contentType
   );
-  return buildStoredLocationUrl(url, false) ?? url;
+  return buildMintingClaimLocationUrl(url, false) ?? url;
 }
 
 async function uploadAnimationToArweaveIfPresent(
@@ -279,7 +291,7 @@ async function uploadAnimationToArweaveIfPresent(
     parseJsonOrNull<{ format?: string }>(claim.animation_details) ?? null;
   if (details?.format === 'HTML') {
     if (isIpfsUrl(animationUrl) || isArweaveUrl(animationUrl)) {
-      return buildStoredLocationUrl(animationUrl, true);
+      return buildMintingClaimLocationUrl(animationUrl, true);
     }
     return null;
   }
@@ -309,7 +321,7 @@ async function uploadAnimationToArweaveIfPresent(
   const existingSha256 = normalizeSha256(
     (details as { sha256?: unknown }).sha256
   );
-  const existingArweaveUrl = buildStoredLocationUrl(
+  const existingArweaveUrl = buildMintingClaimLocationUrl(
     claim.animation_location,
     false
   );
@@ -325,7 +337,7 @@ async function uploadAnimationToArweaveIfPresent(
     buffer,
     contentTypeToUpload
   );
-  return buildStoredLocationUrl(url, false) ?? url;
+  return buildMintingClaimLocationUrl(url, false) ?? url;
 }
 
 function resolveAnimationContentTypeForUpload({
@@ -574,7 +586,7 @@ async function uploadClaimMetadataToArweave(
     buffer,
     'application/json'
   );
-  return buildStoredLocationUrl(url, false) ?? url;
+  return buildMintingClaimLocationUrl(url, false) ?? url;
 }
 
 function buildArweaveMetadataPayload(

--- a/src/minting-claims/claims-media-arweave-upload.ts
+++ b/src/minting-claims/claims-media-arweave-upload.ts
@@ -20,6 +20,7 @@ const logger = Logger.get('claims-media-arweave-upload');
 export const MIN_EDITION_SIZE = 300;
 
 const FETCH_MEDIA_TIMEOUT_MS = 60_000;
+const ARWEAVE_TX_ID_PATTERN = /^[A-Za-z0-9_-]{43}$/;
 const ARWEAVE_METADATA_CREATED_BY = '6529 Collections';
 const ARWEAVE_POINTS_TRAIT_PREFIX = 'Points - ';
 const TYPE_MEME_TRAIT = 'Type - Meme';
@@ -175,10 +176,6 @@ function normalizeSha256(value: unknown): string | null {
   return normalized;
 }
 
-function isProtocolUrl(value: string): boolean {
-  return /^[a-z][a-z0-9+.-]*:\/\//i.test(value);
-}
-
 function isIpfsUrl(value: string): boolean {
   const ref = parseDecentralizedMediaRef(value);
   return ref?.protocol === 'ipfs' || ref?.protocol === 'ipns';
@@ -186,6 +183,10 @@ function isIpfsUrl(value: string): boolean {
 
 function isArweaveUrl(value: string): boolean {
   return parseDecentralizedMediaRef(value)?.protocol === 'arweave';
+}
+
+function isProtocolUrl(value: string): boolean {
+  return /^[a-z][a-z0-9+.-]*:\/\//i.test(value);
 }
 
 function is6529MediaResolverUrl(value: string): boolean {
@@ -211,11 +212,9 @@ function buildMintingClaimLocationUrl(
     if (allowProtocolPassthrough) {
       return is6529MediaResolverUrl(trimmed) ? toNativeUri(ref) : trimmed;
     }
+    return toNativeUri(ref);
   }
   if (isProtocolUrl(trimmed)) {
-    if (allowProtocolPassthrough) {
-      return trimmed;
-    }
     return trimmed;
   }
   return `https://arweave.net/${trimmed}`;
@@ -224,7 +223,12 @@ function buildMintingClaimLocationUrl(
 function resolveAnimationFetchUrl(url: string): string {
   const trimmed = url.trim();
   const ref = parseDecentralizedMediaRef(trimmed);
-  return ref ? (toExternalFallbackUrls(ref)[0] ?? trimmed) : trimmed;
+  if (ref) {
+    return toExternalFallbackUrls(ref)[0] ?? trimmed;
+  }
+  return ARWEAVE_TX_ID_PATTERN.test(trimmed)
+    ? `https://arweave.net/${trimmed}`
+    : trimmed;
 }
 
 function contentTypeFromAnimationFormat(format: string | null | undefined) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Refined how minted claim media URLs are normalized during upload, ensuring images and animations preserve native IPFS/Arweave forms when appropriate.
  * Updated handling for animation passthrough and Arweave transaction inputs, so resulting metadata and returned locations resolve consistently.
  * GLB and HTML animation media now follow the same improved URL normalization rules.
* **Tests**
  * Updated and expanded media upload assertions across multiple URL formats (including IPFS casing and Arweave transaction IDs) to match the new behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->