### PR TITLE
Add repository agent skill guidance

### DIFF
--- a/.agents/skills/api-skill/SKILL.md
+++ b/.agents/skills/api-skill/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: api-skill
+description: Build or modify API endpoints in this repository by driving API contracts from src/api-serverless/openapi.yaml, regenerating generated models/routes, implementing thin handlers or legacy manual routes, and wiring validation/auth/timing correctly. Use when creating new API endpoints, changing API request or response models, adding generated x-6529-router operations, or updating API route behavior.
+---
+
+# API Development
+
+Use this workflow for API contract, route, handler, and generated-model changes.
+
+## Workflow
+
+1. Update `src/api-serverless/openapi.yaml` first for every public request or response shape change.
+2. Name new API schemas with an `Api` prefix and use generated models from `@/api/generated/models/...`.
+3. Prefer generated route wiring for new endpoints. Add `x-6529-router` to the OpenAPI operation unless the generator cannot support the route shape or the user explicitly asks for manual routing:
+   ```yaml
+   x-6529-router:
+     enabled: true
+     auth: optional # optional | required | none
+     cache: true # optional; emits cacheRequest()
+     handler:
+       import: "@/api/some-feature/get-something.handler"
+       name: handleGetSomething
+   ```
+4. After editing OpenAPI, run both commands from `src/api-serverless`:
+   ```bash
+   npm run restructure-openapi && npm run generate
+   ```
+   `npm run generate:openapi` is equivalent when available.
+5. Treat `src/api-serverless/src/generated` as generated-only; never edit it manually.
+6. Implement handler/service logic after generated types exist, then verify the contract matches OpenAPI.
+
+## Generated Routes
+
+1. Add or update the OpenAPI operation with `operationId`, params, request/response schemas, and `x-6529-router`.
+2. It is OK if the handler file does not exist yet. `npm run generate` writes the configured handler import/name into generated code; TypeScript fails until the handler is implemented.
+3. Implement the handler at the exact `x-6529-router.handler.import` path and export the exact configured `name`.
+4. Import generated operation request/query/path/body/response types from `@/api/generated/routes/operations` and generated models from `@/api/generated/models/...`.
+5. Do not add duplicate manual `.routes.ts` wiring or app wiring for generated endpoints. The generated router is already mounted in `src/api-serverless/src/app.ts`.
+6. If the generator rejects a needed route shape, extend `src/api-serverless/generate-openapi-routes.ts` when that is in scope; otherwise use a manual route and call out why.
+
+Generated routes currently support:
+
+- parameters with `in: path` or `in: query`; all other parameter locations are rejected
+- no `requestBody`, which generates a request body type of `never`
+- `requestBody.content.application/json.schema.$ref` request bodies; other request body shapes are rejected
+- responses from the `200` response only: `application/json` with a direct schema `$ref`, `application/json` with an array whose `items` are a `$ref`, or `text/csv` with schema `type: string`
+
+## Middleware Options
+
+Use `x-6529-router.auth` for auth middleware and `x-6529-router.cache` for request caching:
+
+```yaml
+x-6529-router:
+  enabled: true
+  auth: required
+  cache:
+    ttlSeconds: 900
+    authDependent: true
+  handler:
+    import: "@/api/some-feature/get-something.handler"
+    name: handleGetSomething
+```
+
+- `cache: true` emits `cacheRequest()`.
+- `cache.ttlSeconds` emits `cacheRequest({ ttl: Time.seconds(value) })`.
+- `cache.authDependent: true` includes the authenticated/anonymous identity in the cache key.
+- Use `cache.methods` when a generated route should cache non-GET methods.
+
+## Handler Rules
+
+1. For new generated endpoints, implement a thin handler file such as `src/api-serverless/src/<feature>/<operation>.handler.ts`.
+2. Use generated operation types in the handler signature:
+   ```typescript
+   import { ApiSomething } from "@/api/generated/models/ApiSomething";
+   import { GetSomethingRequest } from "@/api/generated/routes/operations";
+
+   export async function handleGetSomething(
+     req: GetSomethingRequest
+   ): Promise<ApiSomething> {
+     // validate input, call service, return generated response shape
+   }
+   ```
+3. Validate route input with Joi using `getValidatedByJoiOrThrow` or `getValidatedByJoi`.
+4. Keep handlers thin: validate input, prepare request context, call services, and return generated response shapes.
+5. Never mark routes as cached unless explicitly instructed or an existing equivalent route is already cached for the same semantics.
+6. Manual `.routes.ts` files are legacy/escape-hatch only.
+
+## Auth And Context
+
+1. Set `x-6529-router.auth: required` when authentication is required; generated routing uses `needsAuthenticatedUser()`.
+2. Set `x-6529-router.auth: optional` when authentication is optional; generated routing uses `maybeAuthenticatedUser()`.
+3. Use `getAuthenticationContext(req)` after auth middleware when auth context is needed.
+4. Initialize `const timer = Timer.getFromRequest(req);` when downstream work should be timed.
+5. Pass `timer` or a `RequestContext` to downstream service/repository calls when those APIs expect it.
+
+## Validation
+
+- [ ] Updated `src/api-serverless/openapi.yaml` first.
+- [ ] All new schemas/models in OpenAPI start with `Api`.
+- [ ] Added `x-6529-router.enabled: true` for new generated endpoints.
+- [ ] Added `x-6529-router.cache` only when request caching is required.
+- [ ] Declared the final handler import/name in `x-6529-router.handler`.
+- [ ] Ran `cd src/api-serverless && npm run restructure-openapi && npm run generate`.
+- [ ] Did not manually edit `src/api-serverless/src/generated/*`.
+- [ ] Used generated operation types and generated models.
+- [ ] Added Joi validation.
+- [ ] Set auth correctly.
+- [ ] Used `getAuthenticationContext(req)` where needed.
+- [ ] Kept handler logic light and service-driven.
+- [ ] Avoided duplicate manual route/app wiring for generated endpoints.
+- [ ] Verified route behavior matches `openapi.yaml`.

--- a/.agents/skills/api-skill/SKILL.md
+++ b/.agents/skills/api-skill/SKILL.md
@@ -38,7 +38,7 @@ Use this workflow for API contract, route, handler, and generated-model changes.
 5. Do not add duplicate manual `.routes.ts` wiring or app wiring for generated endpoints. The generated router is already mounted in `src/api-serverless/src/app.ts`.
 6. If the generator rejects a needed route shape, extend `src/api-serverless/generate-openapi-routes.ts` when that is in scope; otherwise use a manual route and call out why.
 
-Generated routes currently support:
+`src/api-serverless/generate-openapi-routes.ts` is the source of truth for generated-route constraints. Before relying on a detailed constraint below, verify it against that generator if the route shape or middleware behavior is unusual. Generated routes currently support:
 
 - parameters with `in: path` or `in: query`; all other parameter locations are rejected
 - no `requestBody`, which generates a request body type of `never`
@@ -61,9 +61,9 @@ x-6529-router:
     name: handleGetSomething
 ```
 
-- `cache: true` emits `cacheRequest()`.
-- `cache.ttlSeconds` emits `cacheRequest({ ttl: Time.seconds(value) })`.
-- `cache.authDependent: true` includes the authenticated/anonymous identity in the cache key.
+- `cache: true` emits request caching.
+- `cache.ttlSeconds` configures the cache TTL.
+- `cache.authDependent: true` configures auth-aware cache behavior.
 - Use `cache.methods` when a generated route should cache non-GET methods.
 
 ## Handler Rules

--- a/.agents/skills/community-metrics/SKILL.md
+++ b/.agents/skills/community-metrics/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: community-metrics
+description: Add or change community metrics in the 6529 SEIZE backend by updating metric rollup enums, recorder methods, recording call sites, optional historical backfills, OpenAPI response models, and community-metrics API aggregation. Use when adding new community metrics, exposing metric summaries or series, tracking community activity, or changing MetricsRecorder/MetricsDb behavior.
+---
+
+# Community Metrics
+
+Use this workflow for metrics based on `metric_rollup_hour` and exposed through `/community-metrics`.
+
+## Workflow
+
+1. Define the metric contract before editing:
+   - enum name in `UPPER_SNAKE_CASE`
+   - event source and recording call sites
+   - aggregation semantics: event count, value sum, latest overwritten value, distinct scoped count, or custom query
+   - dimensions stored in `scope`, `key1`, or `key2`
+   - whether historical backfill is required
+2. Locate the current implementation with `rg`:
+   - `MetricRollupHourMetric` in `src/entities/IMetricRollupHour.ts`
+   - `MetricsRecorder` in `src/metrics/MetricsRecorder.ts`
+   - `MetricsDb` in `src/metrics/MetricsDb.ts`
+   - community API code in `src/api-serverless/src/community-metrics/`
+   - OpenAPI contract in `src/api-serverless/openapi.yaml`
+3. Add the enum value to `MetricRollupHourMetric`. Keep the persisted enum string identical to the enum key.
+4. Add a focused `MetricsRecorder` method. Use `metricsDb.upsertMetricRollupHour` with the current rollup fields:
+   - `event_count` for occurrence counts
+   - `value_sum` for numeric totals or latest samples
+   - `scope`, `key1`, and `key2` for dimensions or distinct counting
+   - `overwrite: true` for latest-state metrics such as profile counts or network TDH
+5. Wire the recorder after the primary action succeeds. Pass the existing `RequestContext` so timers and transactions are preserved.
+6. Expose the metric only where needed:
+   - update `src/api-serverless/openapi.yaml` response schemas for summary, series, or mint metrics
+   - run `cd src/api-serverless && npm run restructure-openapi && npm run generate`
+   - update `CommunityMetricsService` aggregation and mapping
+   - update `community-metrics.routes.ts` only when route validation or query behavior changes
+7. Add or update tests next to the changed code. Prefer focused service/DB tests; use `src/profiles/abusiveness-check.db.test.ts` as the pattern for DB/repository tests.
+8. Run `npm run lint` from the repo root after changes.
+
+## Backfills
+
+Do not create a migration by default. If the user explicitly asks for historical data or the feature would be misleading without it, create a data-only backfill migration:
+
+```bash
+npm run migrate:new backfill-metric-name-metric
+```
+
+Write SQL in the `up` migration only, delete the generated `.down.sql`, and leave the JS `down()` implementation as a no-op. The repo is entities-first for schema/table changes: prefer TypeORM entities plus `dbMigrationsLoop` sync, and avoid schema migrations unless the user explicitly asks for one. Reserve migrations primarily for one-off data backfills or rare view changes.
+
+## Aggregation Patterns
+
+- Simple counter: increment `event_count: 1`, read summed `event_count`.
+- Numeric total: set `value_sum` to the numeric delta, read summed `value_sum`.
+- Latest sample: set `event_count: 1`, `value_sum`, and `overwrite: true`, then read the latest sample in the requested period.
+- Per-identity or per-entity metric: store the dimension in `scope`; use `key1` and `key2` only when a second or third dimension is needed.
+- Distinct activity: record dimensions consistently and aggregate with `getMetricBucketDistinctCounts` or a purpose-built query.
+
+## Validation
+
+- [ ] Metric name, dimensions, aggregation, and backfill behavior are clear.
+- [ ] Enum value added to `MetricRollupHourMetric` in `src/entities/IMetricRollupHour.ts`.
+- [ ] Recording function created in `MetricsRecorder`.
+- [ ] Recording function called in all identified locations.
+- [ ] Backfill migration created only if explicitly required.
+- [ ] OpenAPI schema updated and generated types refreshed when API output changes.
+- [ ] Aggregation logic added to `CommunityMetricsService`.
+- [ ] Tests cover recording and exposed aggregation behavior.
+- [ ] `npm run lint` passes.

--- a/.agents/skills/database-skill/SKILL.md
+++ b/.agents/skills/database-skill/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: database-skill
+description: Implement database-related changes in this repository, including schema changes via TypeORM entities, repository/query patterns, request-context transactions, DB tests, and explicit data migrations. Use when working on DB schema updates, repositories or *Db classes, SQL queries, transactions, data backfills, or app logic that reads or writes MySQL data.
+---
+
+# Database Workflow
+
+Apply this skill any time work involves database schema, queries, repositories, or migrations.
+
+## Environment
+
+1. Assume MySQL 8+ in all target environments.
+2. Assume Aurora MySQL in staging/production.
+3. Assume Docker MySQL locally.
+
+## Schema Changes
+
+1. Implement schema changes through TypeORM entities in `src/entities`.
+2. Keep entity file naming pattern:
+   - file name prefixed with `I`, example: `IMyThing.ts`
+   - class name without `I` and suffixed with `Entity`, example: `MyThingEntity`
+3. Export every new entity from `src/entities/entities.ts`.
+4. Treat edits to existing entities as high risk and check for possible data loss before changing types or columns.
+5. Never use foreign keys.
+6. Prefer UUID primary keys unless sequential IDs are strictly required.
+7. Prefer `bigint` Unix epoch milliseconds for time fields over SQL `datetime`/`date`.
+8. For every new `@Entity(TABLE_NAME)`, add or use a table constant in `src/constants/db-tables.ts`.
+9. Keep entity class/file names singular and table names plural.
+
+## Queries And Repositories
+
+1. Isolate DB access inside repository-style classes, usually `*Repository` or `*Db`.
+2. Use caller-level transactions only when work must span multiple repositories:
+   ```typescript
+   await sqlExecutor.executeNativeQueriesInTransaction(async (connection) => {
+     const txCtx: RequestContext = { ...ctx, connection };
+     await firstRepository.doWork(txCtx);
+     await secondRepository.doMoreWork(txCtx);
+   });
+   ```
+3. Make `ctx: RequestContext` the last argument of new repository functions unless the surrounding class has an established incompatible pattern.
+4. Time new repository functions:
+   ```typescript
+   const timerName = `${this.constructor.name}->methodName`;
+   try {
+     ctx.timer?.start(timerName);
+     // query work
+   } finally {
+     ctx.timer?.stop(timerName);
+   }
+   ```
+5. Use `ctx.connection` when present so operations participate in caller-provided transactions:
+   ```typescript
+   const rows = await this.db.execute<MyEntity>(
+     `select * from ${MY_TABLE} where id = :id`,
+     { id },
+     ctx.connection ? { wrappedConnection: ctx.connection } : undefined
+   );
+   ```
+   For TypeORM transaction blocks, obtain repositories from the transaction manager passed by the transaction callback instead of the global data source.
+6. Never use generated `Api*` classes in repositories.
+7. Allow callers to use entity classes and repository-defined types.
+8. Use constants from `src/constants/db-tables.ts` instead of hardcoded table names whenever possible.
+9. Prefer typed queries via `execute<T>()` and `oneOrNull<T>()`.
+10. Always pass an explicit comparator to `Array.prototype.sort`, including string sorts.
+
+## Data Migrations
+
+1. Use db-migrate only for explicit data migrations or view/one-off changes requested by the user.
+2. Avoid db-migrate for schema changes unless the user explicitly asks for a migration; schema/table changes should normally come from TypeORM entities and `dbMigrationsLoop` sync.
+3. Create migrations with:
+   ```bash
+   npm run migrate:new migration-name
+   ```
+4. Edit files created under `migrations/`.
+5. Delete the generated `.down.sql` file and leave `exports.down` present as a no-op; do not implement revert logic.
+
+## Tests
+
+Place DB/repository tests next to the file under test and name them with lowercase hyphenated words ending in `.test.ts`. For DB integration patterns, follow `src/profiles/abusiveness-check.db.test.ts`.
+
+## Validation
+
+- [ ] Kept schema changes in entity classes unless the user explicitly requested a schema migration.
+- [ ] Preserved entity naming convention and exported new entities.
+- [ ] Checked entity edits for data-loss risk.
+- [ ] Avoided foreign keys.
+- [ ] Used UUID primary keys unless sequential ID was required.
+- [ ] Used epoch-millis `bigint` for time where applicable.
+- [ ] Added or used table name constants in `src/constants/db-tables.ts`.
+- [ ] Kept DB logic in repository or `*Db` classes.
+- [ ] Used transaction wrapper only when spanning repositories.
+- [ ] Passed `ctx: RequestContext` through new repository APIs.
+- [ ] Timed repository methods and used `ctx.connection` when available.
+- [ ] Avoided generated `Api*` models in repositories.
+- [ ] Used typed query methods and table constants in SQL.
+- [ ] Used db-migrate only for explicit data/view migration work and left `exports.down` as a no-op.
+- [ ] Added or updated focused tests for changed DB behavior.
+- [ ] Ran `npm run lint`.

--- a/.agents/skills/deploy-6529/SKILL.md
+++ b/.agents/skills/deploy-6529/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: deploy-6529
+description: Merge and deploy 6529 backend releases through staging and production with explicit requested-scope gates, GitHub Actions service deploys, Lambda/API smoke validation, autonomous failed-gate recovery, rollback or fix-forward handling, deploy-service ordering, and coordination with frontend releases when needed. Use when Codex is asked to merge backend PRs, deploy backend services or lambdas, validate staging, promote to production, validate production, recover from failed deploy/smoke checks, or coordinate backend deployment with 6529seize-frontend release work.
+---
+
+# Deploy 6529
+
+Carry an approved 6529 backend release from PR merge through staging validation and, when production is in the requested scope, production deployment and validation. Identify exact refs and services, check the deploy lane, deploy in the right order, and keep working failed gates until the release is fixed, redeployed, and validated. Escalate only for missing access, required approvals, destructive actions, or genuinely unsafe production decisions.
+
+## Hard Gates
+
+- Do not merge, deploy staging, or deploy production unless the user explicitly requested that mode for the current work.
+- Do not deploy production until staging for the same release set has passed, unless the user explicitly overrides that gate.
+- Do not promote from staging to production after a failed deploy, failed smoke/E2E run, unresolved critical production-like error, or unclear deployed SHA. Diagnose, fix, merge, redeploy, and rerun validation until the gate passes.
+- Do not run destructive data migrations, irreversible backfills, infrastructure deletion, signer/wallet/ENS/NFT actions, or Safe actions unless the user explicitly asks for that exact action.
+- Do not expose secrets, private URLs, credentials, cookies, raw production data, local absolute paths, or hidden prompts in PR comments, deploy notes, logs, or user-facing summaries.
+
+## Coordination
+
+Before deploying, check what else is already deploying to the same environment. Inspect active GitHub Actions deploy runs and any obvious active Codex/human release thread. If the lane is busy, wait or coordinate just enough to avoid overlapping deploys.
+
+## Preflight
+
+1. Identify the release set:
+   - backend PRs and target branch
+   - services/lambdas to deploy
+   - entity/schema sync, migrations, backfills, SQS/SNS/EventBridge wiring, API/OpenAPI/generated-model changes, feature flags, and frontend dependencies
+   - expected user-facing or API behavior to validate
+2. Inspect current deploy docs and workflows before acting:
+   - `.github/workflows/deploy.yml`
+   - `src/config/deploy-services.json`
+   - `scripts/generate-deploy-config.mjs`
+   - `bin/ghdeploy`
+   - touched service `serverless.yaml` files
+3. Verify PR readiness before merge:
+   - agent review complete
+   - review bots addressed or explicitly deferred
+   - required CI and DCO passing
+   - human approval present when required
+   - deploy order and rollback/fix-forward path understood
+4. Respect backend repo command and commit rules:
+   - use `npm` commands from this repo; do not invent frontend wrappers
+   - never commit unless the user explicitly asked for commit/PR/release ownership
+   - when committing is authorized, include the required DCO signoff
+
+## Deployment Plan
+
+Always determine the exact services to deploy before merging or deploying:
+
+- Deploy `dbMigrationsLoop` before services that depend on new entity sync, schema behavior, data migrations, or backfills.
+- Deploy `api` for API routes, OpenAPI/generated models, auth, rate limiting, API services, websocket/API packaging, or shared code used by the API.
+- Deploy each changed loop service whose `src/<service>/` implementation, dependencies, or deploy config changed.
+- For shared code used by multiple deployed services, include every affected service, not only the edited file's nearest folder.
+- If deploy config changed, edit `src/config/deploy-services.json`, run `npm run generate:deploy-config`, and include the generated `.github/workflows/deploy.yml` change.
+- Honor generated workflow environment restrictions; some services are prod-only or staging-only.
+
+## Merge
+
+1. Confirm the PR is the one the user asked to ship.
+2. Re-check latest head SHA, approvals, required checks, and unresolved review threads.
+3. Merge using the repo-approved GitHub path and record the PR number, merge commit SHA, target branch, and deploy service list.
+4. If merge fails, resolve the merge blocker through the normal PR cycle before deployment. Re-check CI and review state after every fix.
+
+## Staging Deployment
+
+1. Confirm no active staging deploy is already using the same backend deploy lane.
+2. Deploy the exact intended backend merge commit to staging through `.github/workflows/deploy.yml`. The workflow dispatch accepts `environment=staging` and one `service` at a time.
+3. Deploy services in the plan order, with one workflow dispatch per service. Use `bin/ghdeploy` from a clean, upstream-synced branch when it fits; otherwise trigger `deploy.yml` with an explicit verified ref and service.
+4. Watch each staging deploy to a terminal state. Capture the run URL, status, service, environment, and deployed SHA.
+5. If a staging deploy fails, inspect logs, identify the owner layer, fix through the normal PR cycle, merge the fix, and redeploy from the new SHA. Keep iterating until staging deploys cleanly or a safety/access boundary requires user input.
+
+## Staging Validation
+
+1. Run the strongest staging validation available for the changed surface:
+   - API health and changed endpoints
+   - affected loop invocation or observable loop output when safe
+   - migration/backfill result checks for `dbMigrationsLoop`
+   - queue/topic/event behavior when touched
+   - frontend smoke on staging when the backend release supports frontend-visible behavior
+2. Avoid unsafe writes, public posts, purchases, transfers, irreversible backfills, or destructive data operations unless the user explicitly requested that live action.
+3. If staging validation fails, hold production promotion and work the fix loop:
+   - release bug: fix backend, test locally, open/update PR, merge, redeploy staging, and rerun validation
+   - environment/data issue: document evidence, coordinate owner, apply or request the correction, and rerun after correction
+   - flaky test/tool issue: rerun once with evidence, then harden the test or investigate the service if the signal repeats
+   - user-visible/API breakage: treat it as a release bug even if the automated signal is noisy
+
+## Production Deployment
+
+1. Proceed to production when the user already asked to take the release through production, such as "take it all the way through prod." Ask only when the current request did not include production deployment.
+2. Reconfirm staging passed for the same backend release set and service order.
+3. Confirm no active production deploy is in progress for the same service lane.
+4. Deploy production through `.github/workflows/deploy.yml` with `environment=prod`, one workflow dispatch per planned service, in order.
+5. When coordinating with frontend, deploy backend production before frontend production when frontend depends on new backend behavior. Prefer backward-compatible backend changes so frontend and backend can roll independently.
+6. Watch each production deploy to completion. Record workflow run URL, service, environment, and deployed SHA/version evidence.
+
+## Production Validation And Watch
+
+1. Validate production after each service reports healthy.
+2. Run production-safe smoke checks for changed behavior. Avoid live writes or irreversible data operations unless the user explicitly requested them.
+3. Check high-signal production health:
+   - changed API endpoints succeed
+   - critical Lambda errors are absent for changed services
+   - queue/event processing moves as expected
+   - frontend-visible behavior works when applicable
+   - deployed commit/version expectations match when visible
+4. If production validation fails:
+   - coordinate immediately and keep ownership of the incident loop
+   - decide rollback versus fix-forward based on severity and reversibility, then execute the chosen path if it is within existing authorization
+   - do not start unrelated deploys until production is stable or explicitly handed off
+   - after rollback or fix-forward, rerun production validation until the failure is resolved or a safety/access boundary requires user input
+   - record the incident evidence, chosen action, and final state
+
+## Follow The Repo Deployment Overview
+
+After production validation passes, post a detailed deployment overview to the `Follow The Repo` wave unless the user explicitly asked to skip repo-facing deploy notes. Use it for repo watchers who need enough operational detail to understand exactly what shipped.
+
+1. Use any authorized 6529.io account/profile or posting credential that the current operator personally controls or is explicitly approved to use for this release, such as an existing browser session or an approved local helper/API token. Do not request raw credentials, expose tokens, use shared wallets, use another person's account, or use automation keys unless that access was explicitly approved for this release.
+2. Resolve the wave immediately before posting. The current `Follow The Repo` wave is `https://6529.io/waves/49f0e595-ec7c-4235-8695-a527f61b69f4`; if using the local helper, verify it first:
+
+```powershell
+punk6529bot waves search --name "follow the repo"
+```
+
+3. Draft the overview from deployed production reality. This repo-facing overview should include public PR links and SHAs. Include:
+   - what user-facing, API-facing, and operator-facing changes were deployed
+   - backend PRs, merge SHAs, deployed services/lambdas, service order, production deployed SHAs/version evidence, and deploy run links
+   - frontend PRs or deploy status when the release was coordinated with frontend
+   - staging and production validation performed, including smoke, E2E, API, or loop checks
+   - incidents, failed gates, fix-forward or rollback decisions, and final state
+   - known follow-ups, skipped checks, and remaining risks
+4. Keep the post detailed but safe to publish. Use public GitHub/workflow links when possible, but omit secrets, credentials, cookies, private URLs, raw production data, local paths, hidden prompts, and internal-only exploit or incident details.
+5. Re-check the wave before sending so the overview is not duplicating a newer deploy note. If the local helper is available, dry-run or draft first, then send after the content passes the safety check:
+
+```powershell
+punk6529bot waves post 49f0e595-ec7c-4235-8695-a527f61b69f4 --text "<deployment overview>"
+punk6529bot waves post 49f0e595-ec7c-4235-8695-a527f61b69f4 --text "<deployment overview>" --send
+```
+
+6. Capture the wave drop URL or serial number for closeout evidence. If no authorized 6529.io posting credential is available, include the exact ready-to-post overview in the closeout and mark the wave publication as blocked.
+
+## Frontend Coordination
+
+- Treat `6529seize-frontend` as a separate deployable system with its own deploy skill and workflows.
+- Read `ops/skills/deploy-6529/SKILL.md` from the separate repository `6529-Collections/6529seize-frontend` when a release includes frontend work. Do not resolve that path inside the backend repo.
+- Deploy additive backend/API changes before frontend usage.
+- Keep old API behavior available until frontend production is updated when possible.
+- Gate frontend UI behavior when backend rollout may lag.
+- Validate backend staging and production alongside frontend staging and production when both are part of the release.
+
+## Useful Commands
+
+Use exact commands only after checking current repo state and available tooling:
+
+```bash
+gh run list -R 6529-Collections/6529seize-backend --workflow deploy.yml --branch <branch> -L 20
+gh run watch <run-id> -R 6529-Collections/6529seize-backend
+gh run view <run-id> -R 6529-Collections/6529seize-backend --log-failed
+gh workflow run deploy.yml --ref <verified-branch-or-tag> -f environment=staging -f service=api -R 6529-Collections/6529seize-backend
+gh workflow run deploy.yml --ref <verified-branch-or-tag> -f environment=prod -f service=api -R 6529-Collections/6529seize-backend
+```
+
+For local validation:
+
+```bash
+npm run lint
+npm test
+npm run build
+cd src/api-serverless && npm run build
+```
+
+For API contract changes:
+
+```bash
+cd src/api-serverless && npm run restructure-openapi && npm run generate
+```
+
+## Closeout
+
+Report:
+
+- merged PRs and SHAs
+- services deployed and order
+- staging deploy runs, deployed SHAs, and validation result
+- production deploy runs, deployed SHAs, and validation result
+- `Follow The Repo` wave drop URL or serial number, or the ready-to-post overview if publication was blocked
+- frontend deploy status when involved
+- failures encountered and fixes or rollbacks performed
+- remaining risks, skipped checks, and any human follow-up required

--- a/.agents/skills/deploy-6529/SKILL.md
+++ b/.agents/skills/deploy-6529/SKILL.md
@@ -89,9 +89,10 @@ Always determine the exact services to deploy before merging or deploying:
 1. Proceed to production when the user already asked to take the release through production, such as "take it all the way through prod." Ask only when the current request did not include production deployment.
 2. Reconfirm staging passed for the same backend release set and service order.
 3. Confirm no active production deploy is in progress for the same service lane.
-4. Deploy production through `.github/workflows/deploy.yml` with `environment=prod`, one workflow dispatch per planned service, in order.
-5. When coordinating with frontend, deploy backend production before frontend production when frontend depends on new backend behavior. Prefer backward-compatible backend changes so frontend and backend can roll independently.
-6. Watch each production deploy to completion. Record workflow run URL, service, environment, and deployed SHA/version evidence.
+4. Before each production workflow dispatch, get explicit human confirmation for the exact service, environment, and ref/SHA to deploy.
+5. Deploy production through `.github/workflows/deploy.yml` with `environment=prod`, one workflow dispatch per planned service, in order.
+6. When coordinating with frontend, deploy backend production before frontend production when frontend depends on new backend behavior. Prefer backward-compatible backend changes so frontend and backend can roll independently.
+7. Watch each production deploy to completion. Record workflow run URL, service, environment, and deployed SHA/version evidence.
 
 ## Production Validation And Watch
 
@@ -115,7 +116,7 @@ Always determine the exact services to deploy before merging or deploying:
 After production validation passes, post a detailed deployment overview to the `Follow The Repo` wave unless the user explicitly asked to skip repo-facing deploy notes. Use it for repo watchers who need enough operational detail to understand exactly what shipped.
 
 1. Use any authorized 6529.io account/profile or posting credential that the current operator personally controls or is explicitly approved to use for this release, such as an existing browser session or an approved local helper/API token. Do not request raw credentials, expose tokens, use shared wallets, use another person's account, or use automation keys unless that access was explicitly approved for this release.
-2. Resolve the wave immediately before posting. The current `Follow The Repo` wave is `https://6529.io/waves/49f0e595-ec7c-4235-8695-a527f61b69f4`; if using the local helper, verify it first:
+2. Resolve the current `Follow The Repo` wave immediately before posting and use the resolved wave ID in every post command. Do not reuse a previously documented wave UUID without confirming it is still current. If using the local helper, verify it first:
 
 ```powershell
 punk6529bot waves search --name "follow the repo"
@@ -132,8 +133,8 @@ punk6529bot waves search --name "follow the repo"
 5. Re-check the wave before sending so the overview is not duplicating a newer deploy note. If the local helper is available, dry-run or draft first, then send after the content passes the safety check:
 
 ```powershell
-punk6529bot waves post 49f0e595-ec7c-4235-8695-a527f61b69f4 --text "<deployment overview>"
-punk6529bot waves post 49f0e595-ec7c-4235-8695-a527f61b69f4 --text "<deployment overview>" --send
+punk6529bot waves post <resolved-wave-id> --text "<deployment overview>"
+punk6529bot waves post <resolved-wave-id> --text "<deployment overview>" --send
 ```
 
 6. Capture the wave drop URL or serial number for closeout evidence. If no authorized 6529.io posting credential is available, include the exact ready-to-post overview in the closeout and mark the wave publication as blocked.
@@ -141,7 +142,7 @@ punk6529bot waves post 49f0e595-ec7c-4235-8695-a527f61b69f4 --text "<deployment 
 ## Frontend Coordination
 
 - Treat `6529seize-frontend` as a separate deployable system with its own deploy skill and workflows.
-- Read `ops/skills/deploy-6529/SKILL.md` from the separate repository `6529-Collections/6529seize-frontend` when a release includes frontend work. Do not resolve that path inside the backend repo.
+- Read the deploy skill from the separate repository `6529-Collections/6529seize-frontend` when a release includes frontend work. Do not resolve that path inside the backend repo.
 - Deploy additive backend/API changes before frontend usage.
 - Keep old API behavior available until frontend production is updated when possible.
 - Gate frontend UI behavior when backend rollout may lag.

--- a/.agents/skills/deploy-6529/agents/openai.yaml
+++ b/.agents/skills/deploy-6529/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Deploy 6529"
+  short_description: "Run 6529 backend staging and production deploys."
+  default_prompt: "Use $deploy-6529 to merge, deploy, validate, and coordinate a 6529 backend release."

--- a/.agents/skills/identity-notifications/SKILL.md
+++ b/.agents/skills/identity-notifications/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: identity-notifications
+description: Add or change identity notification types in the 6529 SEIZE backend by updating notification causes, domain data types, DB-to-domain mappers, UserNotifier creation methods, push notification rendering/settings, notification API mappings, OpenAPI enums, and tests. Use when adding new notification types, creating identity notifications, changing notification payloads, or extending push/API notification behavior.
+---
+
+# Identity Notifications
+
+Use this workflow when a new event should appear in identity notification lists, push notifications, or both.
+
+## Workflow
+
+1. Define the notification contract before editing:
+   - cause enum in `UPPER_SNAKE_CASE`
+   - recipient, actor, related drop(s), wave, visibility group, and custom `additional_data`
+   - trigger location and transaction boundary
+   - whether self-notifications must be skipped
+   - API related identities/drops needed by the frontend
+   - push title, body, image, deep link, and settings key
+2. Update the core domain files:
+   - add the cause to `IdentityNotificationCause` in `src/entities/IIdentityNotification.ts`
+   - add a data interface and full notification interface in `src/notifications/user-notification.types.ts`
+   - add the new interface to the `UserNotification` union
+3. Update `src/notifications/user-notification.mapper.ts`:
+   - add a switch case in `entityToNotification()`
+   - map entity columns and `additional_data` into the new typed payload
+   - use non-null assertions only for columns guaranteed by the notifier
+4. Add or update `UserNotifier` in `src/notifications/user.notifier.ts`:
+   - insert `identity_id` as the recipient
+   - insert `additional_identity_id` as the actor when there is one
+   - fill `related_drop_id`, `related_drop_part_no`, `related_drop_2_id`, `related_drop_2_part_no`, and `wave_id` consistently
+   - store only custom fields in `additional_data`
+   - pass `visibility_group_id`
+   - pass `connection` or `ctx.connection` when inside a transaction
+   - skip self-notifications where the existing notification semantics do
+5. Wire the notifier call after the primary action succeeds. Decide deliberately whether notification failure should fail the parent operation.
+6. Update push notification behavior in `src/pushNotificationsHandler/identityPushNotifications.ts` when the cause should produce a push:
+   - add a `CAUSE_TO_SETTING_KEY` entry when users should be able to disable it with an existing or new setting
+   - add a `generateNotificationData()` switch case
+   - add a focused handler that returns `{ title, body, data, imageUrl }` or the skip sentinel when appropriate
+   - use existing helpers such as `getDropSerialNo`, `getDropPart`, `getDrop`, and `getWaveEntityOrThrow`
+   - handle deleted or missing related entities deliberately
+7. Update API notification mapping in `src/api-serverless/src/notifications/notifications.api.service.ts`:
+   - add related IDs in `getAllRelatedIds()`
+   - update `mapToApiNotificationV2WithoutRelatedWave()` or related V2 helpers
+   - update legacy `mapToApiNotification()` if the V1 route still exposes the cause
+   - keep `enums.resolveOrThrow(ApiNotificationCause, notificationCause)` compatible with generated enum values
+8. Update `src/api-serverless/openapi.yaml`:
+   - add the cause to `ApiNotificationCause`
+   - add or update response fields only if the API shape changes
+   - run `cd src/api-serverless && npm run restructure-openapi && npm run generate`
+9. Add or update focused tests:
+   - `src/notifications/user-notification-mapper.test.ts`
+   - `src/notifications/user.notifier.test.ts`
+   - `src/pushNotificationsHandler/*push-notification*.test.ts` when push output changes
+   - `src/api-serverless/src/notifications/notifications-api-service.test.ts`
+10. Run `npm run lint` from the repo root.
+
+## Storage Fields
+
+Prefer existing columns before adding schema:
+
+- `identity_id`: recipient
+- `additional_identity_id`: actor or related identity
+- `related_drop_id` and `related_drop_part_no`: primary drop
+- `related_drop_2_id` and `related_drop_2_part_no`: secondary drop
+- `wave_id`: wave context
+- `visibility_group_id`: notification visibility restriction
+- `additional_data`: custom JSON fields only
+
+## Common Patterns
+
+- Identity action: recipient in `identity_id`, actor in `additional_identity_id`, no drop.
+- Drop action: recipient is the drop author, actor in `additional_identity_id`, primary drop in `related_drop_id`, wave in `wave_id`.
+- Reply/quote action: new drop in `related_drop_id`, original drop in `related_drop_2_id`.
+- Wave action: affected identities in `identity_id`, actor in `additional_identity_id`, wave in `wave_id`.
+
+## Validation
+
+- [ ] Enum value added to `IdentityNotificationCause` in `src/entities/IIdentityNotification.ts`.
+- [ ] Data interface created in `src/notifications/user-notification.types.ts`.
+- [ ] Notification interface created and added to `UserNotification` union.
+- [ ] Mapper case added in `src/notifications/user-notification.mapper.ts`.
+- [ ] Notifier method created in `src/notifications/user.notifier.ts`.
+- [ ] Notifier wired up in trigger location.
+- [ ] Push settings and handler updated in `src/pushNotificationsHandler/identityPushNotifications.ts` when push applies.
+- [ ] `getAllRelatedIds()` case added in notifications API service.
+- [ ] V2 API mapping updated, and V1 mapping updated if still exposed.
+- [ ] OpenAPI schema updated with new enum value.
+- [ ] Types regenerated with `cd src/api-serverless && npm run restructure-openapi && npm run generate`.
+- [ ] Tests cover mapper, notifier, push output, and API mapping as applicable.
+- [ ] `npm run lint` passes.

--- a/.agents/skills/write-prs/SKILL.md
+++ b/.agents/skills/write-prs/SKILL.md
@@ -9,9 +9,9 @@ description: Write, open, iterate, and prepare pull requests in the 6529 SEIZE b
 
 1. Determine the requested completion mode:
    - `review-ready`: create or update the PR and stop once available review bots and the agent are satisfied.
-   - `merge`: do everything in `review-ready`, then hand off to `ops/skills/deploy-6529/SKILL.md` for merge execution when required checks and approvals allow it.
-   - `staging`: prepare release notes and hand off to `ops/skills/deploy-6529/SKILL.md` for merge, staging deployment, and smoke validation.
-   - `prod`: prepare release notes and hand off to `ops/skills/deploy-6529/SKILL.md` for staging verification, production deployment, and production smoke validation.
+   - `merge`: do everything in `review-ready`, then hand off to `.agents/skills/deploy-6529/SKILL.md` for merge execution when required checks and approvals allow it.
+   - `staging`: prepare release notes and hand off to `.agents/skills/deploy-6529/SKILL.md` for merge, staging deployment, and smoke validation.
+   - `prod`: prepare release notes and hand off to `.agents/skills/deploy-6529/SKILL.md` for staging verification, production deployment, and production smoke validation.
    If the user did not explicitly request merge or deployment, stop at `review-ready`.
 
 2. Inspect the change before writing:
@@ -90,14 +90,14 @@ description: Write, open, iterate, and prepare pull requests in the 6529 SEIZE b
 ## Deployment Gates
 
 - Never merge, deploy staging, or deploy production unless the user explicitly asked for that mode or repo standing instructions require it.
-- Use `ops/skills/deploy-6529/SKILL.md` for actual merge execution, staging deployment, production deployment, frontend coordination, failed-gate recovery, and deployed-environment validation.
+- Use `.agents/skills/deploy-6529/SKILL.md` for actual merge execution, staging deployment, production deployment, frontend coordination, failed-gate recovery, and deployed-environment validation.
 - Always list all lambdas/services that need redeployment and their deployment order when finishing development or writing the PR.
-- Use `ops/skills/deploy-6529/SKILL.md` as the source of truth for deployment workflow dispatch mechanics.
+- Use `.agents/skills/deploy-6529/SKILL.md` as the source of truth for deployment workflow dispatch mechanics.
 - Deploy `dbMigrationsLoop` before services that depend on new schema/entity sync or data backfills.
 - Deploy `api` for API route, OpenAPI, auth, API service, generated-model, or API packaging changes.
 - Deploy each changed loop service whose `src/<loopName>/` implementation, dependencies, or deploy config changed.
 - For shared code used by multiple deployed services, include every affected service in the deployment plan.
-- If deployment or smoke validation fails, hand off to `ops/skills/deploy-6529/SKILL.md` to diagnose, fix, redeploy, and rerun validation before proceeding.
+- If deployment or smoke validation fails, hand off to `.agents/skills/deploy-6529/SKILL.md` to diagnose, fix, redeploy, and rerun validation before proceeding.
 
 ## Anti-Patterns
 

--- a/.agents/skills/write-prs/SKILL.md
+++ b/.agents/skills/write-prs/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: write-prs
+description: Write, open, iterate, and prepare pull requests in the 6529 SEIZE backend for merge or deployment with clear PR descriptions, safe validation notes, review-bot follow-up, DCO-signed commits only when explicitly requested, backend/API checks, lambda deployment planning, and deployment handoff notes. Use when preparing PR bodies, creating PRs, responding to CodeRabbit or Codex review bots, deciding whether a PR is ready, or preparing a backend/API PR for merge, staging, or production rollout; use deploy-6529 for actual deployment execution.
+---
+
+# Write PRs
+
+## Workflow
+
+1. Determine the requested completion mode:
+   - `review-ready`: create or update the PR and stop once available review bots and the agent are satisfied.
+   - `merge`: do everything in `review-ready`, then hand off to `ops/skills/deploy-6529/SKILL.md` for merge execution when required checks and approvals allow it.
+   - `staging`: prepare release notes and hand off to `ops/skills/deploy-6529/SKILL.md` for merge, staging deployment, and smoke validation.
+   - `prod`: prepare release notes and hand off to `ops/skills/deploy-6529/SKILL.md` for staging verification, production deployment, and production smoke validation.
+   If the user did not explicitly request merge or deployment, stop at `review-ready`.
+
+2. Inspect the change before writing:
+   - Read the issue, task, or user request.
+   - Review `git status`, the diff, changed files, and relevant tests.
+   - Separate user changes from agent changes; do not revert unrelated work.
+   - Check whether API contracts, generated files, entities/schema, migrations, Lambda loops, SQS/SNS/EventBridge wiring, deploy config, dependencies, auth, media flows, or external integrations are touched.
+   - If system shape changed, update `docs/architecture.md`; otherwise state that no architecture-doc update is needed.
+
+3. Respect commit rules:
+   - Never commit unless the user explicitly asks to commit, create a PR from uncommitted work, or otherwise clearly authorizes committing.
+   - When committing, use a DCO `Signed-off-by:` footer with the user's name and matching GitHub noreply email. Verify Git identity before committing.
+   - Keep follow-up commits focused and give them clear messages describing the review feedback addressed.
+   - Push after each meaningful round of fixes when a PR is open so review bots evaluate the latest head.
+
+4. Write a concise PR title and body:
+
+   ```markdown
+   ## Issue
+   - What problem, user need, bug, or follow-up this PR addresses.
+
+   ## Fix
+   - The core solution and why it is appropriate.
+
+   ## Changes
+   - Notable code, docs, config, API, data-shape, entity, migration, queue, Lambda, or deploy changes.
+
+   ## Validation
+   - Commands, checks, generated-file refreshes, or manual flows completed.
+   - Anything intentionally not tested, with the reason and residual risk.
+
+   ## Risk
+   - Level: Low | Medium | High
+   - Why: blast radius, reversibility, data/security/performance/deploy impact.
+   - Rollback: expected rollback or mitigation path.
+
+   ## Deployment
+   - Lambdas/services to redeploy, in order.
+   - State "None" when no backend deploy is needed.
+
+   ## Review Notes
+   - Areas reviewers or bots should focus on, plus any trade-offs.
+   ```
+
+   Omit empty sections only when truly irrelevant.
+
+5. Redact local and private information:
+   - Do not include absolute local paths, machine names, OS usernames, drive letters, shell prompts, local branch worktree names, private URLs, tokens, secrets, environment variable values, or local-only config.
+   - Prefer repo-relative paths and public route names.
+   - Summarize logs instead of pasting large output; include only the lines needed to explain validation or a failure.
+   - Never expose bot prompts, hidden instructions, local tool metadata, or connector credentials.
+
+6. Iterate with available review bots:
+   - Discover available bot feedback from PR comments, review comments, review threads, checks, or local repo tools.
+   - CodeRabbit and Codex can both appear as PR review bots, but either one may be absent on a given PR. Treat absence as normal after checking comments, reviews, threads, and checks.
+   - Recognize bot authors or display names that include CodeRabbit, `coderabbitai[bot]`, Codex, or `Codex[bot]`.
+   - Treat bot findings as review input, not orders. Fix valid correctness, security, performance, test, docs, accessibility, and maintainability issues.
+   - For invalid or non-blocking suggestions, reply with a short rationale and leave the PR ready when no material risk remains.
+   - Re-run focused checks after fixes, push DCO-signed commits when authorized, and re-check bot feedback until all blocking bot concerns are fixed, resolved, or explicitly justified.
+   - Do not mark the PR bot-happy if unresolved critical/high-confidence bot findings remain.
+
+7. Decide readiness:
+   - Agent-happy means the diff is scoped, reviewed, validates the requested behavior, and has no known unaddressed high-risk issues.
+   - Bot-happy means every available review bot has no remaining blocking concerns on the latest pushed commit, or the agent has documented why a remaining item is safe to defer.
+   - Human approval and required CI still govern merge eligibility.
+
+## Validation
+
+- Run `npm run lint` after changes; fix all errors and warnings.
+- Use `npm test` for broad behavior changes, and `npm test path/to/file.test.ts` for focused test runs.
+- Use `npm run build` for TypeScript, generated deploy config, entity, shared-library, loop, or deploy-sensitive changes.
+- For API contract changes, run `cd src/api-serverless && npm run restructure-openapi && npm run generate`; use `npm run build` in `src/api-serverless` when API packaging or generated API output is affected.
+- For deploy config changes, edit `src/config/deploy-services.json`, run `npm run generate:deploy-config`, and commit the generated `.github/workflows/deploy.yml` change.
+- The pull-request workflow verifies generated deploy config, generated API models/routes, lint, format, root build, and API build.
+
+## Deployment Gates
+
+- Never merge, deploy staging, or deploy production unless the user explicitly asked for that mode or repo standing instructions require it.
+- Use `ops/skills/deploy-6529/SKILL.md` for actual merge execution, staging deployment, production deployment, frontend coordination, failed-gate recovery, and deployed-environment validation.
+- Always list all lambdas/services that need redeployment and their deployment order when finishing development or writing the PR.
+- Use `ops/skills/deploy-6529/SKILL.md` as the source of truth for deployment workflow dispatch mechanics.
+- Deploy `dbMigrationsLoop` before services that depend on new schema/entity sync or data backfills.
+- Deploy `api` for API route, OpenAPI, auth, API service, generated-model, or API packaging changes.
+- Deploy each changed loop service whose `src/<loopName>/` implementation, dependencies, or deploy config changed.
+- For shared code used by multiple deployed services, include every affected service in the deployment plan.
+- If deployment or smoke validation fails, hand off to `ops/skills/deploy-6529/SKILL.md` to diagnose, fix, redeploy, and rerun validation before proceeding.
+
+## Anti-Patterns
+
+- Do not write PR bodies that only say "updated files" or force reviewers to infer the issue from the diff.
+- Do not hide untested paths; state what was not tested and why.
+- Do not paste local environment details, secrets, huge logs, or private machine paths.
+- Do not commit, push, merge, or deploy without explicit authorization for that action.
+- Do not endlessly chase low-value bot suggestions. Use judgment, explain deferrals, and keep the PR moving when risk is low.
+- Do not merge with unresolved blocking bot, CI, or agent concerns.

--- a/.agents/skills/write-prs/agents/openai.yaml
+++ b/.agents/skills/write-prs/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Write PRs"
+  short_description: "Create backend PR descriptions, iterate with review bots, and plan lambda deployments."
+  default_prompt: "Use $write-prs to prepare this backend change for PR review, document validation and deployment order, iterate on available bot feedback, and stop at the requested completion mode."

--- a/.agents/skills/write-skills/SKILL.md
+++ b/.agents/skills/write-skills/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: write-skills
+description: Create, improve, or review Codex/OpenAI Agent Skills and SKILL.md files. Use when writing a new skill, updating an existing skill, designing skill frontmatter and trigger behavior, choosing scripts/references/assets, validating skill structure, or turning repeatable Codex workflows into reusable skills.
+---
+
+# Write Skills
+
+## Principles
+
+- Keep each skill focused on one job. Split broad workflows into separate skills or references.
+- Treat frontmatter as the routing surface. Put all "when to use this skill" guidance in `description`, because the body is only loaded after the skill triggers.
+- Assume Codex is already capable. Add only procedural knowledge, repo-specific context, examples, scripts, and constraints that materially improve repeatability.
+- Prefer clear instructions over scripts unless deterministic behavior, external tooling, or repeated code would reduce mistakes.
+- Use progressive disclosure: keep `SKILL.md` lean, put large details in directly linked `references/`, and keep output templates or reusable files in `assets/`.
+- Write imperative steps with explicit inputs, outputs, and validation.
+- Test trigger behavior with prompts that should invoke the skill and prompts that should not.
+
+## Topics To Cover
+
+When writing or reviewing a skill, decide whether each topic belongs in the skill:
+
+- Frontmatter and trigger behavior
+- Skill name and folder layout
+- Task scope, anti-scope, and adjacent non-triggers
+- Required inputs and expected outputs
+- Step-by-step workflow
+- Tool, command, or file conventions
+- Scripts, references, and assets
+- Validation and forward-testing
+- Safety constraints, permissions, and destructive-action guardrails
+- Maintenance notes, only when they change future use of the skill
+
+If a topic is not needed for the skill's job, omit it. A short complete skill is better than a broad checklist pasted everywhere.
+
+## Workflow
+
+1. Clarify the target job
+
+   Identify the narrow repeatable task, likely users, concrete prompts, expected outputs, and adjacent prompts that should not trigger the skill. If the job is ambiguous, ask for one or two examples before writing.
+
+2. Choose name and location
+
+   Use lowercase letters, digits, and hyphens only. Keep the folder name identical to the skill name. In this repo, place repo-local skills under `ops/skills/<skill-name>/SKILL.md` unless the user asks for another skill location.
+
+3. Plan resources
+
+   Use only resources that directly help the skill execute:
+
+   - `scripts/`: deterministic tooling or repeated code that should not be rewritten each time.
+   - `references/`: detailed docs, schemas, policies, API notes, or examples that should be read only when needed.
+   - `assets/`: templates, images, fonts, boilerplate, or files used in final outputs.
+
+4. Write `SKILL.md`
+
+   Include only YAML `name` and `description` in frontmatter. In the body, describe the shortest reliable workflow, decision points, resource usage, and validation. Avoid a "when to use" body section because it cannot affect triggering.
+
+5. Validate and iterate
+
+   Check the folder name, frontmatter, trigger specificity, resource links, examples, and absence of unfinished placeholders. For complex skills, forward-test with realistic prompts and improve the skill based on failures.
+
+## Frontmatter
+
+Put frontmatter at the very top of `SKILL.md`:
+
+```yaml
+---
+name: write-useful-skill
+description: Create useful widgets from CSV exports. Use when Codex needs to turn a CSV, spreadsheet export, or tabular report into a small interactive widget with filtering, sorting, and validation.
+---
+```
+
+Rules:
+
+- Use exactly one skill name and one description.
+- Keep `name` lowercase with letters, digits, and hyphens.
+- Make the folder name match `name`.
+- Write `description` as both capability and trigger policy: what the skill does, when to use it, file types, tools, common phrases, and important exclusions when needed.
+- Do not rely on the body to explain when the skill should be used.
+- Do not invent extra frontmatter fields unless the target skill system explicitly requires them.
+
+Good descriptions are specific enough to route:
+
+```yaml
+description: Create, edit, and validate Solidity audit checklists for this repository. Use when reviewing Stream smart contracts, triaging security findings, writing remediation tasks, or preparing audit notes for Solidity changes.
+```
+
+Weak descriptions are too broad:
+
+```yaml
+description: Helps with engineering tasks.
+```
+
+## Body Topics
+
+Use the body for instructions loaded after the skill triggers:
+
+- `Workflow`: ordered actions the agent should follow.
+- `Decision points`: how to choose between valid approaches.
+- `Resource use`: when to read references, run scripts, or use assets.
+- `Validation`: commands, checks, review criteria, and expected evidence.
+- `Examples`: short examples only when they clarify trigger behavior or output shape.
+- `Anti-patterns`: mistakes the skill is specifically meant to prevent.
+
+Avoid generic tutorials. If Codex can infer it, leave it out.
+
+## SKILL.md Template
+
+```markdown
+---
+name: concise-skill-name
+description: Do the specific repeatable job. Use when Codex needs to handle concrete scenario A, scenario B, or scenario C; include important file types, tools, or trigger phrases here.
+---
+
+# Concise Skill Name
+
+## Workflow
+
+1. Do the first required action.
+2. Choose between options using explicit criteria.
+3. Use linked resources only when the task needs them.
+4. Validate the result with named checks.
+
+## Resources
+
+- Read `references/example.md` only when ...
+- Run `scripts/example.py` when ...
+- Use `assets/template.ext` when ...
+```
+
+Delete unused resource sections. Do not create placeholder resources.
+
+## Quality Checklist
+
+- The skill has exactly one required `SKILL.md`.
+- The frontmatter contains only `name` and `description`.
+- The description names the job and trigger contexts clearly enough for routing.
+- The body is concise, procedural, and under 500 lines.
+- Long details are moved into directly linked reference files.
+- Scripts, if present, have been run or otherwise validated.
+- Assets, if present, are files the skill actually uses in outputs.
+- No README, changelog, installation guide, or process-history files were added inside the skill folder unless the user explicitly requested them.
+- Positive trigger prompts and negative trigger prompts have been considered.
+- The skill avoids hardcoded local assumptions unless it is intentionally repo-specific.
+
+## Trigger Test Prompts
+
+Before considering the skill done, write or mentally check a small prompt set:
+
+- Positive explicit: "Use `$skill-name` to ..."
+- Positive implicit: "Help me do the task this skill exists for ..."
+- Contextual: a realistic request with extra details that should still trigger.
+- Negative adjacent: a nearby task that should not trigger this skill.
+
+If the skill would trigger too broadly, narrow the description. If it would not trigger for the intended prompts, add concrete trigger phrases or file/task contexts to the description.
+
+## Anti-Patterns
+
+- Do not write broad skills like "do engineering better" or "help with docs."
+- Do not bury trigger conditions in the body.
+- Do not include generic advice Codex already knows.
+- Do not duplicate detailed reference content in `SKILL.md`.
+- Do not add generated build outputs, logs, or cache files as skill resources.
+- Do not claim validation happened unless commands or review actually confirmed it.

--- a/.agents/skills/write-skills/SKILL.md
+++ b/.agents/skills/write-skills/SKILL.md
@@ -40,7 +40,7 @@ If a topic is not needed for the skill's job, omit it. A short complete skill is
 
 2. Choose name and location
 
-   Use lowercase letters, digits, and hyphens only. Keep the folder name identical to the skill name. In this repo, place repo-local skills under `ops/skills/<skill-name>/SKILL.md` unless the user asks for another skill location.
+   Use lowercase letters, digits, and hyphens only. Keep the folder name identical to the skill name. In this repo, place agent framework and meta-skills under `.agents/skills/<skill-name>/SKILL.md`; place operational guidance or external-reference skills under `ops/skills/<skill-name>/SKILL.md` unless the user asks for another skill location.
 
 3. Plan resources
 

--- a/.agents/skills/write-skills/agents/openai.yaml
+++ b/.agents/skills/write-skills/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Write Skills"
+  short_description: "Create effective Codex SKILL.md files."
+  default_prompt: "Create or improve a Codex skill for this repository."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Commiting to Git
 
-Use DCO signoff commits. Before committing, verify `git config user.name` and `git config user.email`. Commit with `git commit -s -m "<message>"` so Git appends `Signed-off-by: <user.name> <user.email>`.
+Use DCO signoff commits. Before committing, verify `git config user.name` and `git config user.email`; for GitHub commits, `user.email` should be the matching `accountcode+username@users.noreply.github.com` address unless the user explicitly wants another verified email. Commit with `git commit -s -m "<message>"` so Git appends `Signed-off-by: <user.name> <user.email>`.
 
 # Writing unit tests
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,13 +1,6 @@
 # Commiting to Git
 
-**NEVER commit unless explicitly asked to by the user.** Do not assume the user wants you to commit. Wait for explicit instructions like "commit" or "commit this".
-
-When you DO commit (only when explicitly asked), add a DCO signature to footer with my name and the corresponding accountcode+username@users.noreply.github.com email address. Example:
-
-```
-Add tests for address comparison
-Signed-off-by: IAmAUser <1234567+IAmAUser@users.noreply.github.com>
-```
+Use DCO signoff commits. Before committing, verify `git config user.name` and `git config user.email`. Commit with `git commit -s -m "<message>"` so Git appends `Signed-off-by: <user.name> <user.email>`.
 
 # Writing unit tests
 


### PR DESCRIPTION
## Issue
- Repository-level agent guidance is split between `AGENTS.md` and reusable skill files, but the root agent skill directory was not present in the repo.

## Fix
- Add the `.agents/skills` guidance files for API, database, community metrics, identity notifications, PR writing, skill writing, and deployment workflows.
- Simplify `AGENTS.md` commit guidance to rely on verified local Git identity plus `git commit -s` DCO signoff.

## Changes
- Added `.agents/skills/*/SKILL.md` files and small OpenAI agent config files for relevant workflows.
- Updated `AGENTS.md` DCO commit instructions.
- No application code, OpenAPI contracts, entities, migrations, Lambda wiring, queues, deploy config, or external integrations changed.
- No architecture-doc update needed because this is repo guidance only and does not change system shape.

## Validation
- `npm run lint`

## Risk
- Level: Low
- Why: Documentation and agent configuration only; no runtime behavior changes.
- Rollback: Revert the commit to remove the guidance updates.

## Deployment
- None. No backend deploy is needed.

## Review Notes
- Review the new `.agents/skills` content for consistency with the existing `ops/skills` workflow guidance and expected bot naming.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive development workflow guides for API development, database work, community metrics, identity notifications, and deployment processes.
  * Added new skill documentation for pull request writing and skill authoring best practices.
  * Configured new agent interfaces for development workflows.

* **Chores**
  * Updated commit guidelines with DCO signoff requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->