### PR TITLE
[codex] Add profile CMS gallery package generator

### DIFF
--- a/docs/_manager/profile-cms-gallery-generator/README.md
+++ b/docs/_manager/profile-cms-gallery-generator/README.md
@@ -1,0 +1,33 @@
+# Profile CMS Gallery Generator Workstream
+
+## Charter
+
+Own the backend library that turns a normalized wallet/NFT snapshot into a CMS
+V1 package for profile-native galleries.
+
+## Owned Paths
+
+- `src/profile-cms/profile-cms-gallery-package-generator.ts`
+- `src/profile-cms/profile-cms-gallery-package-generator.test.ts`
+- `docs/profile-cms-gallery-generator.md`
+- `docs/profile-cms-packages.md`
+- `docs/_manager/profile-cms-gallery-generator/*`
+
+## Constraints
+
+- Preserve the existing CMS V1 package schema and validation contract.
+- Keep generation pure and deterministic so it can run offline/decentralized.
+- Keep fixture signature/storage clearly marked as preview-only.
+- Do not add API routes or persistence without coordinating with the profile CMS stack owner.
+
+## Validation Standard
+
+- Focused Jest coverage for deterministic output, route collisions, grouping,
+  NFT detail pages, media references, and CMS validation pass/fail.
+- `npm run lint` after code/doc changes.
+- `codex-diff-check` before PR publication.
+
+## Escalation
+
+Escalate if the snapshot lane changes required fields, if FE needs a route before
+the backend API boundary is approved, or if CMS V1 schema changes are requested.

--- a/docs/_manager/profile-cms-gallery-generator/active-context.md
+++ b/docs/_manager/profile-cms-gallery-generator/active-context.md
@@ -1,0 +1,36 @@
+# Active Context
+
+First file to read after compaction: this file.
+
+## Goal
+
+Phase 5 backend gallery package generator lane for profile-native CMS.
+
+## Branch
+
+`codex/cms-gallery-generator`, based on
+`origin/codex/profile-cms-decentralized-publish`.
+
+## Current State
+
+- Library-only generator implemented under `src/profile-cms`.
+- Generator accepts `ProfileCmsGalleryPackageGenerationInput` and returns a CMS
+  V1 `CmsPackageV1`.
+- Fixture snapshot fallback is available for FE preview work until the wallet
+  snapshot service is ready.
+- Dedicated docs describe the FE-facing contract and future
+  `POST /api/profile-cms/packages/generate-gallery` boundary.
+
+## Open Notes
+
+- No API route is added in this PR.
+- Production publish still requires replacing fixture signature/storage with
+  EIP-712 signature and canonical IPFS/Arweave receipt.
+- `npm ci --ignore-scripts` was needed locally because `serverless`
+  postinstall failed after an interrupted install.
+
+## Next Actions
+
+- Run lint/typecheck checks.
+- Update run log with final validation evidence.
+- Commit, push, open PR, and request bot feedback.

--- a/docs/_manager/profile-cms-gallery-generator/run-log.md
+++ b/docs/_manager/profile-cms-gallery-generator/run-log.md
@@ -1,0 +1,44 @@
+# Run Log
+
+## 2026-06-18
+
+- Read autonomous-manager playbook from the frontend repo.
+- Created branch `codex/cms-gallery-generator` from
+  `origin/codex/profile-cms-decentralized-publish`.
+- Implemented pure backend gallery generator:
+  - normalized snapshot input contract with fixture fallback
+  - generated gallery home, collections index, collection pages, and NFT detail pages
+  - deterministic route slugging and collision handling
+  - curation controls for hide, feature, and reorder
+  - media asset, NFT media profile, display variant, poster, and social image mapping
+  - CMS V1 hash computation and fixture signature/storage for preview validation
+- Added focused Jest tests for deterministic generation, curation/grouping,
+  NFT media/detail pages, validation pass/fail, and route collision uniqueness.
+- Added `docs/profile-cms-gallery-generator.md` with the FE handoff contract and
+  future library-to-API boundary.
+- Focused validation:
+  - `npm test -- src/profile-cms/profile-cms-gallery-package-generator.test.ts --runInBand`
+    passed 5 tests.
+  - `$env:NODE_OPTIONS='--max-old-space-size=8192'; npx eslint src/profile-cms/profile-cms-gallery-package-generator.ts src/profile-cms/profile-cms-gallery-package-generator.test.ts --max-warnings=0`
+    passed.
+  - `npm run lint` passed when launched through WSL Bash so the POSIX
+    `NODE_OPTIONS=...` script syntax could run as authored.
+  - `npx prettier --check src/profile-cms/profile-cms-gallery-package-generator.ts src/profile-cms/profile-cms-gallery-package-generator.test.ts`
+    passed.
+  - Markdown Prettier check for generator docs and manager memory passed.
+  - `codex-diff-check` passed.
+- Validation caveats:
+  - Direct `npm run lint` from PowerShell failed because the script uses POSIX
+    `NODE_OPTIONS=...` syntax; WSL Bash invocation passed.
+  - `node scripts/check-changed.mjs --base=origin/codex/profile-cms-decentralized-publish --skip-typecheck`
+    failed before checks because it calls `spawnSync('npm')` with `shell:false`,
+    which does not resolve `npm.cmd` in this shell.
+  - `node .\node_modules\typescript\bin\tsc -p tsconfig.json --noEmit --pretty false`
+    failed on unrelated nested `src/api-serverless` dependency declarations
+    (`@serverless/typescript`, `swagger-ui-express`, `pdf-lib`,
+    `@aws-sdk/client-managedblockchain`, and `js-yaml` types).
+- Local dependency note:
+  - Initial `npm install` timed out and left `node_modules` incomplete.
+  - Cleaned only this worktree's generated `node_modules` after path verification.
+  - Reinstalled with `npm ci --ignore-scripts`; normal postinstall was avoided
+    due `serverless` postinstall failure in the interrupted tree.

--- a/docs/_manager/profile-cms-gallery-generator/run-log.md
+++ b/docs/_manager/profile-cms-gallery-generator/run-log.md
@@ -42,3 +42,23 @@
   - Cleaned only this worktree's generated `node_modules` after path verification.
   - Reinstalled with `npm ci --ignore-scripts`; normal postinstall was avoided
     due `serverless` postinstall failure in the interrupted tree.
+- PR follow-up:
+  - Opened draft PR #1652 and requested CodeRabbit review with
+    `@coderabbitai review`.
+  - SonarQube Cloud reported one security hotspot on a trailing-slash regex in
+    the canonical URL helper.
+  - Replaced the regex with linear slash trimming and prepared the amended
+    branch update.
+  - Addressed 6529bot general review follow-up:
+    - `featured_page_ids` now stays empty when no NFT is explicitly featured.
+    - zero-NFT snapshots generate home/collections-index pages and pass draft
+      CMS validation.
+    - duplicate media asset lookup keys and empty/non-finite token IDs are
+      rejected at the generator boundary.
+    - fixture MIME fallback now emits valid MIME strings for all CMS asset
+      kinds.
+    - route slug and token-id sorting invariants have local comments.
+    - route uniqueness property coverage now runs 100 cases and fuzzes token
+      IDs, collection titles, and simple media roles.
+    - FE handoff docs now spell out the canonical `collection_nft_order`
+      collection-key derivation.

--- a/docs/_manager/profile-cms-gallery-generator/run-log.md
+++ b/docs/_manager/profile-cms-gallery-generator/run-log.md
@@ -62,3 +62,7 @@
       IDs, collection titles, and simple media roles.
     - FE handoff docs now spell out the canonical `collection_nft_order`
       collection-key derivation.
+  - Addressed 6529bot follow-up:
+    - property test now asserts unique route paths, page ids, and asset ids.
+    - fixture MIME fallback now has an exhaustive `assertNever` guard.
+    - metadata truncation now avoids splitting surrogate pairs.

--- a/docs/profile-cms-gallery-generator.md
+++ b/docs/profile-cms-gallery-generator.md
@@ -107,6 +107,18 @@ by `asset_key` and emit CMS `role`, `crop_mode`, `background`, and
 Sorting is deterministic. Explicit order wins, then numeric `order`, then
 featured status, then stable collection/NFT keys.
 
+Canonical collection keys are derived by
+`toProfileCmsGalleryCollectionKey(nft)`:
+
+1. Use `nft.collection.key` when present.
+2. Otherwise use
+   `{chain_id}:{lowercase_contract}:{nft.collection.id ?? nft.collection.slug ?? routeSlug(nft.collection.name ?? "Collected NFTs")}`.
+
+`collection_nft_order` must use that canonical collection key. NFT order values
+inside each collection accept the same NFT aliases as `nft_order`: `key`, `id`,
+`{lowercase_contract}:{token_id}`, or
+`{chain_id}:{lowercase_contract}:{token_id}`.
+
 ## Generated Routes
 
 The generator always emits:
@@ -133,6 +145,11 @@ The package uses only existing CMS V1 fields:
   display variants are included only when referenced assets are complete.
 - `payload.navigation`, `payload.taxonomies`, `payload.source_packets`, and `payload.build_manifest`.
 - `integrity.payload_hash` and `integrity.package_hash` computed with the existing CMS V1 hash helpers.
+
+The home page `generated_wallet_gallery.featured_page_ids` list contains only
+NFTs explicitly featured by snapshot item flags, collection flags, or
+`featured_nft_keys`. When nothing is featured, the list is empty; consumers
+should use `page_ids` for the full gallery.
 
 By default the generator adds fixture signature/storage receipts so offline and
 preview callers can validate deterministically with:

--- a/docs/profile-cms-gallery-generator.md
+++ b/docs/profile-cms-gallery-generator.md
@@ -1,0 +1,177 @@
+# Profile CMS Gallery Generator
+
+The backend gallery generator is the durable wallet-snapshot to CMS V1 package
+source of truth for profile-native gallery pages. The implementation lives in
+`src/profile-cms/profile-cms-gallery-package-generator.ts` and exports:
+
+```ts
+generateProfileCmsGalleryPackage(
+  input?: ProfileCmsGalleryPackageGenerationInput
+): CmsPackageV1
+```
+
+It is library-only in this PR. It does not add an API route, persistence write,
+or new CMS schema field. The generated object is a normal CMS V1 package and is
+validated by the existing backend `validateCmsPackageV1` path.
+
+## Snapshot Input Contract
+
+`ProfileCmsGalleryPackageGenerationInput.snapshot` is the narrow adapter
+contract expected from the wallet snapshot lane. If `snapshot` is omitted, the
+generator uses a deterministic fixture snapshot so FE and BE can keep preview
+work unblocked until the snapshot service is wired.
+
+Required profile fields:
+
+| Field                        | Required | Meaning                                                      |
+| ---------------------------- | -------: | ------------------------------------------------------------ |
+| `profile.handle`             |      yes | Profile handle. All generated paths live under `/{handle}/`. |
+| `profile.profile_id`         |       no | Backend profile id copied into `package.profile.profile_id`. |
+| `profile.primary_wallet`     |       no | Primary wallet copied into `package.profile.primary_wallet`. |
+| `profile.display_name`       |       no | Preferred site title. Falls back to `{handle} Gallery`.      |
+| `profile.description`        |       no | Preferred site/page description.                             |
+| `profile.canonical_base_url` |       no | Canonical URL origin. Defaults to `https://6529.io`.         |
+
+Snapshot metadata fields:
+
+| Field          | Required | Meaning                                                        |
+| -------------- | -------: | -------------------------------------------------------------- |
+| `owner`        |       no | Snapshot owner wallet included in the wallet source packet.    |
+| `wallets`      |       no | Consolidated wallet list included in the wallet source packet. |
+| `block_number` |       no | Chain block height included in the wallet source packet.       |
+| `captured_at`  |       no | ISO timestamp used for package provenance and source packet.   |
+| `nfts`         |      yes | Normalized NFT records to render.                              |
+
+NFT fields:
+
+| Field         | Required | Meaning                                                              |
+| ------------- | -------: | -------------------------------------------------------------------- |
+| `key`         |       no | Stable curation key. Defaults to `{chain_id}:{contract}:{token_id}`. |
+| `id`          |       no | Alias accepted by hide/feature/order controls.                       |
+| `chain_id`    |      yes | Chain id for CMS NFT media profile and NFT reference blocks.         |
+| `contract`    |      yes | Ethereum contract address. Normalized to lowercase.                  |
+| `token_id`    |      yes | Token id rendered as a string.                                       |
+| `name`        |       no | NFT title. Falls back to `{collection.name} #{token_id}`.            |
+| `description` |       no | Detail-page description and rich text.                               |
+| `collection`  |       no | Collection grouping metadata.                                        |
+| `media`       |       no | Media assets, display variants, and metadata URI/hash.               |
+| `hidden`      |       no | Item-level hide flag.                                                |
+| `featured`    |       no | Item-level feature flag.                                             |
+| `order`       |       no | Numeric item order before stable fallback sorting.                   |
+
+Collection fields:
+
+| Field         | Required | Meaning                                                      |
+| ------------- | -------: | ------------------------------------------------------------ |
+| `key`         |       no | Stable collection key. Defaults to chain/contract/name data. |
+| `id`          |       no | Alias accepted by controls and preferred route-slug source.  |
+| `slug`        |       no | Alias accepted by controls and preferred route-slug source.  |
+| `name`        |      yes | Collection title.                                            |
+| `description` |       no | Collection page summary.                                     |
+| `artist`      |       no | Reserved for future renderer use.                            |
+| `hidden`      |       no | Collection-level hide flag.                                  |
+| `featured`    |       no | Collection-level feature flag.                               |
+| `order`       |       no | Numeric collection order before stable fallback sorting.     |
+
+Media fields:
+
+| Field                      | Required | Meaning                                                    |
+| -------------------------- | -------: | ---------------------------------------------------------- |
+| `media.metadata_uri`       |       no | Safe metadata URI for the CMS NFT media profile.           |
+| `media.metadata_hash`      |       no | CMS `sha256:` metadata hash.                               |
+| `media.assets[]`           |       no | Asset records to copy into `payload.assets`.               |
+| `media.display_variants[]` |       no | Role mapping into `nft_media_profiles[].display_variants`. |
+| `media.poster_asset_key`   |       no | Asset key used as the media profile poster.                |
+
+Each `media.assets[]` item needs `uri`, `content_hash`, and `mime_type`.
+Image, video, and social-image assets also need `width` and `height`; otherwise
+the generator skips that asset rather than inventing media dimensions. Asset
+`roles` map directly to CMS V1 asset roles. Display variants reference assets
+by `asset_key` and emit CMS `role`, `crop_mode`, `background`, and
+`source_asset_id` where present.
+
+## Curation Controls
+
+`ProfileCmsGalleryPackageGenerationInput.curation` accepts:
+
+| Field                      | Meaning                                                                              |
+| -------------------------- | ------------------------------------------------------------------------------------ |
+| `hidden_nft_keys`          | Removes matching NFTs by `key`, `id`, `{contract}:{token_id}`, or canonical NFT key. |
+| `hidden_collection_keys`   | Removes matching collections by `key`, `id`, `slug`, generated slug, or title.       |
+| `featured_nft_keys`        | Marks matching NFTs as featured on the gallery home page.                            |
+| `featured_collection_keys` | Marks matching collections as featured on the collections index.                     |
+| `nft_order`                | Global NFT ordering by NFT key/alias.                                                |
+| `collection_order`         | Collection ordering by collection key/alias.                                         |
+| `collection_nft_order`     | Per-collection NFT ordering keyed by canonical collection key.                       |
+
+Sorting is deterministic. Explicit order wins, then numeric `order`, then
+featured status, then stable collection/NFT keys.
+
+## Generated Routes
+
+The generator always emits:
+
+- `/{handle}/index.html` gallery home page.
+- `/{handle}/collections/index.html` collections index.
+- `/{handle}/collections/{collection-slug}/index.html` for each visible collection.
+- `/{handle}/nfts/{nft-slug}/index.html` for each visible NFT.
+
+Route slugs are lowercase ASCII, collapse non-alphanumeric runs to `-`, and cap
+at 72 characters before collision suffixing. Collection collisions receive a
+stable suffix derived from the collection key. NFT collisions receive a stable
+suffix derived from the contract tail and then a numeric fallback if needed.
+Unit tests assert stable output from shuffled input and no route collisions.
+
+## Generated CMS Package Shape
+
+The package uses only existing CMS V1 fields:
+
+- `payload.pages` for gallery home, collections index, collection pages, and NFT detail pages.
+- `payload.routes` for one page route per page.
+- `payload.assets` for complete media assets.
+- `payload.nft_media_profiles` whenever NFT `media` exists; asset-backed
+  display variants are included only when referenced assets are complete.
+- `payload.navigation`, `payload.taxonomies`, `payload.source_packets`, and `payload.build_manifest`.
+- `integrity.payload_hash` and `integrity.package_hash` computed with the existing CMS V1 hash helpers.
+
+By default the generator adds fixture signature/storage receipts so offline and
+preview callers can validate deterministically with:
+
+```ts
+validateCmsPackageV1(cmsPackage, {
+  allowFixtureSignatures: true,
+  allowFixtureStorage: true,
+  enforceHashes: true
+});
+```
+
+Production publish behavior is unchanged. Before calling the existing publish
+path, callers must replace fixture signature/storage with a profile wallet
+EIP-712 signature and a canonical IPFS or Arweave receipt whose
+`content_hash` equals `integrity.package_hash`.
+
+## Future API Boundary
+
+The intended service boundary is:
+
+```http
+POST /api/profile-cms/packages/generate-gallery
+```
+
+Request body should be the same `ProfileCmsGalleryPackageGenerationInput`
+contract documented above. Response should return:
+
+```json
+{
+  "cms_package": {},
+  "validation_result": {}
+}
+```
+
+The endpoint should be side-effect free by default, running generation and CMS
+validation only. A later save/publish flow can pass the generated package into
+the existing `POST /profile-cms/packages` draft endpoint, preserving the current
+CMS V1 package contract and storage/publish hardening.
+
+Until that API exists, FE preview adapters can consume the documented snapshot
+contract and compare their package output against the backend generator tests.

--- a/docs/profile-cms-packages.md
+++ b/docs/profile-cms-packages.md
@@ -7,6 +7,12 @@ rules are owned by the frontend protocol package in
 test vectors for canonical JSON, payload hash, package hash, and package hash
 exclusions.
 
+The profile gallery package generator is documented in
+`docs/profile-cms-gallery-generator.md`. It defines the wallet snapshot input
+contract, stable route slug rules, media profile/display variant mapping,
+hide/feature/reorder controls, and the future API boundary for FE to replace
+temporary preview adapters.
+
 ## Public Primary Lookup
 
 Frontend `/handle/index.html` integration should use:
@@ -116,21 +122,21 @@ The exact EIP-712 domain is:
 `verifyingContract` is omitted when the request does not provide one. The exact
 primary type is `ProfileCmsPublish`:
 
-| Field | Type | Meaning |
-|---|---|---|
-| `action` | `string` | Literal `publish`; prevents signature reuse across future actions. |
-| `profileId` | `string` | Target profile id. |
-| `handle` | `string` | Live profile handle resolved by the backend. |
-| `packageId` | `string` | CMS package protocol id. |
-| `version` | `uint256` | CMS package version. |
-| `draftId` | `string` | Backend package row id being published. |
-| `payloadHash` | `string` | CMS V1 payload hash. |
-| `packageHash` | `string` | CMS V1 package hash. |
-| `primaryPath` | `string` | Expected public path, e.g. `/handle/index.html`. |
-| `storageProvider` | `string` | Canonical decentralized receipt provider. |
-| `storageUri` | `string` | Canonical decentralized receipt URI. |
-| `storageContentHash` | `string` | Canonical receipt content hash. |
-| `deadline` | `uint256` | Epoch-millis replay window end. |
+| Field                | Type      | Meaning                                                            |
+| -------------------- | --------- | ------------------------------------------------------------------ |
+| `action`             | `string`  | Literal `publish`; prevents signature reuse across future actions. |
+| `profileId`          | `string`  | Target profile id.                                                 |
+| `handle`             | `string`  | Live profile handle resolved by the backend.                       |
+| `packageId`          | `string`  | CMS package protocol id.                                           |
+| `version`            | `uint256` | CMS package version.                                               |
+| `draftId`            | `string`  | Backend package row id being published.                            |
+| `payloadHash`        | `string`  | CMS V1 payload hash.                                               |
+| `packageHash`        | `string`  | CMS V1 package hash.                                               |
+| `primaryPath`        | `string`  | Expected public path, e.g. `/handle/index.html`.                   |
+| `storageProvider`    | `string`  | Canonical decentralized receipt provider.                          |
+| `storageUri`         | `string`  | Canonical decentralized receipt URI.                               |
+| `storageContentHash` | `string`  | Canonical receipt content hash.                                    |
+| `deadline`           | `uint256` | Epoch-millis replay window end.                                    |
 
 EOA signatures are recovered server-side and must match `signer_address` and a
 wallet consolidated into the target profile. Safe/EIP-1271 signatures set

--- a/src/profile-cms/profile-cms-gallery-package-generator.test.ts
+++ b/src/profile-cms/profile-cms-gallery-package-generator.test.ts
@@ -6,10 +6,19 @@ import {
   createFixtureProfileCmsGallerySnapshot,
   generateProfileCmsGalleryPackage,
   ProfileCmsGallerySnapshotNft,
-  ProfileCmsGalleryWalletSnapshot
+  ProfileCmsGalleryWalletSnapshot,
+  toProfileCmsGalleryCollectionKey
 } from './profile-cms-gallery-package-generator';
 
 const CHECKED_AT = '2026-06-18T00:00:00.000Z';
+const MEDIA_ROLES = [
+  'grid',
+  'detail',
+  'social',
+  'original',
+  'thumbnail'
+] as const;
+const DISPLAY_VARIANT_ROLES = ['grid', 'detail', 'social'] as const;
 
 describe('profile CMS gallery package generator', () => {
   it('generates deterministic CMS V1 packages from shuffled snapshots', () => {
@@ -59,7 +68,9 @@ describe('profile CMS gallery package generator', () => {
       curation: {
         hidden_collection_keys: ['meme-lab'],
         featured_nft_keys: ['meme-2'],
-        nft_order: ['meme-2', 'meme-1']
+        collection_nft_order: {
+          [toProfileCmsGalleryCollectionKey(firstMeme)]: ['meme-2', 'meme-1']
+        }
       }
     });
 
@@ -77,6 +88,52 @@ describe('profile CMS gallery package generator', () => {
       blockById(curatedPackage, 'home-wallet-gallery')?.featured_page_ids
     ).toEqual(['nft-the-memes-2-2']);
     expect(validateForDraft(curatedPackage).valid).toBe(true);
+  });
+
+  it('keeps featured_page_ids empty when no NFTs are explicitly featured', () => {
+    const snapshot = createFixtureProfileCmsGallerySnapshot();
+    const unfeaturedPackage = generateProfileCmsGalleryPackage({
+      snapshot: {
+        ...snapshot,
+        nfts: snapshot.nfts.map((nft) => ({
+          ...nft,
+          featured: false,
+          collection: nft.collection
+            ? { ...nft.collection, featured: false }
+            : undefined
+        }))
+      }
+    });
+
+    expect(
+      blockById(unfeaturedPackage, 'home-wallet-gallery')?.featured_page_ids
+    ).toEqual([]);
+    expect(
+      blockById(unfeaturedPackage, 'home-wallet-gallery')?.page_ids
+    ).toHaveLength(2);
+    expect(validateForDraft(unfeaturedPackage).valid).toBe(true);
+  });
+
+  it('generates a valid empty gallery for zero-NFT snapshots', () => {
+    const snapshot = createFixtureProfileCmsGallerySnapshot();
+    const emptyPackage = generateProfileCmsGalleryPackage({
+      snapshot: { ...snapshot, nfts: [] }
+    });
+
+    expect(routePaths(emptyPackage)).toEqual([
+      '/punk6529bot/index.html',
+      '/punk6529bot/collections/index.html'
+    ]);
+    expect(
+      blockById(emptyPackage, 'home-wallet-gallery')?.featured_page_ids
+    ).toEqual([]);
+    expect(blockById(emptyPackage, 'home-wallet-gallery')?.page_ids).toEqual(
+      []
+    );
+    expect(sourcePacketById(emptyPackage, 'wallet-snapshot')?.nft_count).toBe(
+      0
+    );
+    expect(validateForDraft(emptyPackage).valid).toBe(true);
   });
 
   it('generates NFT detail pages with media profiles and social references when media is complete', () => {
@@ -146,22 +203,68 @@ describe('profile CMS gallery package generator', () => {
     expect(issueCodes(routeValidation)).toContain('route.duplicate_path');
   });
 
+  it('rejects malformed generator inputs before package generation', () => {
+    const snapshot = createFixtureProfileCmsGallerySnapshot();
+    const firstNft = snapshot.nfts[0];
+    const firstMedia = firstNft.media;
+    if (!firstMedia?.assets || firstMedia.assets.length < 2) {
+      throw new Error('Fixture NFT media assets are required for this test.');
+    }
+    const firstAssets = firstMedia.assets;
+    const duplicateAssetKeySnapshot: ProfileCmsGalleryWalletSnapshot = {
+      ...snapshot,
+      nfts: [
+        {
+          ...firstNft,
+          media: {
+            ...firstMedia,
+            assets: [
+              firstAssets[0],
+              { ...firstAssets[1], key: firstAssets[0].key }
+            ]
+          }
+        },
+        snapshot.nfts[1]
+      ]
+    };
+
+    expect(() =>
+      generateProfileCmsGalleryPackage({ snapshot: duplicateAssetKeySnapshot })
+    ).toThrow('Duplicate media asset lookup key');
+    expect(() =>
+      generateProfileCmsGalleryPackage({
+        snapshot: {
+          ...snapshot,
+          nfts: [{ ...firstNft, token_id: Number.POSITIVE_INFINITY }]
+        }
+      })
+    ).toThrow('finite string or number');
+    expect(() =>
+      generateProfileCmsGalleryPackage({
+        snapshot: {
+          ...snapshot,
+          nfts: [{ ...firstNft, token_id: '   ' }]
+        }
+      })
+    ).toThrow('non-empty');
+  });
+
   it('keeps route paths unique for random colliding names', () => {
     fc.assert(
       fc.property(
-        fc.array(fc.string({ maxLength: 40 }), {
+        fc.array(randomNftRecordArbitrary(), {
           minLength: 1,
           maxLength: 8
         }),
-        (names) => {
-          const snapshot = snapshotWithNftNames(names);
+        (records) => {
+          const snapshot = snapshotWithNftRecords(records);
           const cmsPackage = generateProfileCmsGalleryPackage({ snapshot });
 
           expect(hasUniqueRoutes(cmsPackage)).toBe(true);
           expect(validateForDraft(cmsPackage).valid).toBe(true);
         }
       ),
-      { numRuns: 25 }
+      { numRuns: 100 }
     );
   });
 });
@@ -203,30 +306,99 @@ function blockById(cmsPackage: CmsPackageV1, blockId: string) {
     .find((block) => !!block) as Record<string, unknown> | undefined;
 }
 
-function snapshotWithNftNames(
-  names: readonly string[]
+function sourcePacketById(cmsPackage: CmsPackageV1, packetId: string) {
+  return cmsPackage.payload.source_packets?.find(
+    (packet) => packet.id === packetId
+  ) as Record<string, unknown> | undefined;
+}
+
+interface RandomNftRecord {
+  readonly name: string;
+  readonly tokenId: string;
+  readonly collectionName: string;
+  readonly mediaRole?: (typeof MEDIA_ROLES)[number];
+}
+
+function randomNftRecordArbitrary() {
+  const nonEmptyText = fc
+    .string({ minLength: 1, maxLength: 40 })
+    .filter((value) => value.trim().length > 0);
+  return fc.record({
+    name: fc.oneof(
+      fc.constantFrom('Home', 'Collections Index', 'Same!!!', 'NFT'),
+      fc.string({ maxLength: 40 })
+    ),
+    tokenId: fc.oneof(
+      fc.constantFrom('page', 'index', '1', '01', 'collections-index'),
+      fc.integer({ min: 0, max: 1_000_000 }).map(String),
+      nonEmptyText
+    ),
+    collectionName: fc.oneof(
+      fc.constantFrom('Home', 'Collections Index', 'Same Collection'),
+      nonEmptyText
+    ),
+    mediaRole: fc.option(fc.constantFrom(...MEDIA_ROLES), { nil: undefined })
+  });
+}
+
+function snapshotWithNftRecords(
+  records: readonly RandomNftRecord[]
 ): ProfileCmsGalleryWalletSnapshot {
   const fixture = createFixtureProfileCmsGallerySnapshot();
   return {
     ...fixture,
-    nfts: names.map((name, index) => {
-      const tokenId = String(index + 1);
+    nfts: records.map((record, index) => {
       const contract = addressForIndex(index + 1);
       const nft: ProfileCmsGallerySnapshotNft = {
         key: `random-${index}`,
         chain_id: 1,
         contract,
-        token_id: tokenId,
-        name,
+        token_id: record.tokenId,
+        name: record.name,
         collection: {
           key: `collection-${index % 2}`,
-          name: 'Same Collection',
+          name: record.collectionName,
           description: 'A property-test collection.'
-        }
+        },
+        ...(record.mediaRole
+          ? { media: mediaForRecord(index, record.mediaRole) }
+          : {})
       };
       return nft;
     })
   };
+}
+
+function mediaForRecord(
+  index: number,
+  role: (typeof MEDIA_ROLES)[number]
+): NonNullable<ProfileCmsGallerySnapshotNft['media']> {
+  const key = `asset-${index}`;
+  return {
+    assets: [
+      {
+        key,
+        uri: `https://images.6529.io/property/${index}.png`,
+        content_hash: `sha256:${String(index).padStart(64, '0')}`,
+        mime_type: 'image/png',
+        kind: role === 'social' ? 'social_image' : 'image',
+        width: 1000,
+        height: 1000,
+        roles: [role]
+      }
+    ],
+    ...(isDisplayVariantRole(role)
+      ? { display_variants: [{ asset_key: key, role, crop_mode: 'cover' }] }
+      : {})
+  };
+}
+
+function isDisplayVariantRole(
+  role: (typeof MEDIA_ROLES)[number]
+): role is (typeof DISPLAY_VARIANT_ROLES)[number] {
+  return DISPLAY_VARIANT_ROLES.includes(
+    role as (typeof DISPLAY_VARIANT_ROLES)[number]
+  );
 }
 
 function addressForIndex(index: number): string {

--- a/src/profile-cms/profile-cms-gallery-package-generator.test.ts
+++ b/src/profile-cms/profile-cms-gallery-package-generator.test.ts
@@ -1,0 +1,235 @@
+import fc from 'fast-check';
+
+import { CmsPackageV1, validateCmsPackageV1 } from '@/profile-cms/protocol/v1';
+
+import {
+  createFixtureProfileCmsGallerySnapshot,
+  generateProfileCmsGalleryPackage,
+  ProfileCmsGallerySnapshotNft,
+  ProfileCmsGalleryWalletSnapshot
+} from './profile-cms-gallery-package-generator';
+
+const CHECKED_AT = '2026-06-18T00:00:00.000Z';
+
+describe('profile CMS gallery package generator', () => {
+  it('generates deterministic CMS V1 packages from shuffled snapshots', () => {
+    const snapshot = createFixtureProfileCmsGallerySnapshot();
+    const shuffledSnapshot = {
+      ...snapshot,
+      nfts: [...snapshot.nfts].reverse()
+    };
+
+    const firstPackage = generateProfileCmsGalleryPackage({ snapshot });
+    const shuffledPackage = generateProfileCmsGalleryPackage({
+      snapshot: shuffledSnapshot
+    });
+
+    expect(shuffledPackage).toEqual(firstPackage);
+    expect(routePaths(firstPackage)).toEqual([
+      '/punk6529bot/index.html',
+      '/punk6529bot/collections/index.html',
+      '/punk6529bot/collections/the-memes/index.html',
+      '/punk6529bot/collections/meme-lab/index.html',
+      '/punk6529bot/nfts/the-memes-1-1/index.html',
+      '/punk6529bot/nfts/meme-lab-42-42/index.html'
+    ]);
+    expect(hasUniqueRoutes(firstPackage)).toBe(true);
+    expect(validateForDraft(firstPackage).valid).toBe(true);
+  });
+
+  it('groups collections and applies hide, feature, and reorder controls', () => {
+    const snapshot = createFixtureProfileCmsGallerySnapshot();
+    const firstMeme = {
+      ...snapshot.nfts[0],
+      featured: false
+    };
+    const secondMeme: ProfileCmsGallerySnapshotNft = {
+      ...firstMeme,
+      key: 'meme-2',
+      token_id: '2',
+      name: 'The Memes #2',
+      description: 'The second fixture Meme card.',
+      media: undefined
+    };
+    const curatedPackage = generateProfileCmsGalleryPackage({
+      snapshot: {
+        ...snapshot,
+        nfts: [snapshot.nfts[1], firstMeme, secondMeme]
+      },
+      curation: {
+        hidden_collection_keys: ['meme-lab'],
+        featured_nft_keys: ['meme-2'],
+        nft_order: ['meme-2', 'meme-1']
+      }
+    });
+
+    expect(routePaths(curatedPackage)).toEqual([
+      '/punk6529bot/index.html',
+      '/punk6529bot/collections/index.html',
+      '/punk6529bot/collections/the-memes/index.html',
+      '/punk6529bot/nfts/the-memes-2-2/index.html',
+      '/punk6529bot/nfts/the-memes-1-1/index.html'
+    ]);
+    expect(
+      blockById(curatedPackage, 'collection-the-memes-gallery')?.page_ids
+    ).toEqual(['nft-the-memes-2-2', 'nft-the-memes-1-1']);
+    expect(
+      blockById(curatedPackage, 'home-wallet-gallery')?.featured_page_ids
+    ).toEqual(['nft-the-memes-2-2']);
+    expect(validateForDraft(curatedPackage).valid).toBe(true);
+  });
+
+  it('generates NFT detail pages with media profiles and social references when media is complete', () => {
+    const cmsPackage = generateProfileCmsGalleryPackage();
+    const detailPage = pageById(cmsPackage, 'nft-the-memes-1-1');
+    const mediaProfile = cmsPackage.payload.nft_media_profiles?.find(
+      (profile) => profile.id === 'media-the-memes-1-1'
+    );
+
+    expect(detailPage?.type).toBe('nft_detail');
+    expect(detailPage?.metadata.social_image_asset_id).toBe(
+      'asset-the-memes-1-1-social-3'
+    );
+    expect(mediaProfile).toMatchObject({
+      chain_id: 1,
+      token_id: '1',
+      poster_asset_id: 'asset-the-memes-1-1-grid-1',
+      display_variants: [
+        {
+          asset_id: 'asset-the-memes-1-1-grid-1',
+          role: 'grid',
+          crop_mode: 'cover'
+        },
+        {
+          asset_id: 'asset-the-memes-1-1-detail-2',
+          role: 'detail',
+          crop_mode: 'preserve'
+        },
+        {
+          asset_id: 'asset-the-memes-1-1-social-3',
+          role: 'social',
+          crop_mode: 'cover'
+        }
+      ]
+    });
+    expect(blockById(cmsPackage, 'nft-the-memes-1-1-reference')).toMatchObject({
+      block_type: 'nft_reference',
+      nft_media_profile_id: 'media-the-memes-1-1'
+    });
+    expect(validateForDraft(cmsPackage).valid).toBe(true);
+  });
+
+  it('surfaces validation failures for publish-only fixture artifacts and route collisions', () => {
+    const cmsPackage = generateProfileCmsGalleryPackage();
+    const productionValidation = validateCmsPackageV1(cmsPackage, {
+      allowFixtureSignatures: false,
+      allowFixtureStorage: false,
+      enforceHashes: true,
+      checkedAt: CHECKED_AT
+    });
+    const invalidRoutesPackage: CmsPackageV1 = {
+      ...cmsPackage,
+      payload: {
+        ...cmsPackage.payload,
+        routes: [...cmsPackage.payload.routes, cmsPackage.payload.routes[0]]
+      }
+    };
+    const routeValidation = validateForDraft(invalidRoutesPackage);
+
+    expect(productionValidation.valid).toBe(false);
+    expect(issueCodes(productionValidation)).toEqual([
+      'signature.fixture_not_allowed',
+      'storage.decentralized_receipt_required',
+      'storage.fixture_not_allowed'
+    ]);
+    expect(routeValidation.valid).toBe(false);
+    expect(issueCodes(routeValidation)).toContain('route.duplicate_path');
+  });
+
+  it('keeps route paths unique for random colliding names', () => {
+    fc.assert(
+      fc.property(
+        fc.array(fc.string({ maxLength: 40 }), {
+          minLength: 1,
+          maxLength: 8
+        }),
+        (names) => {
+          const snapshot = snapshotWithNftNames(names);
+          const cmsPackage = generateProfileCmsGalleryPackage({ snapshot });
+
+          expect(hasUniqueRoutes(cmsPackage)).toBe(true);
+          expect(validateForDraft(cmsPackage).valid).toBe(true);
+        }
+      ),
+      { numRuns: 25 }
+    );
+  });
+});
+
+function validateForDraft(cmsPackage: CmsPackageV1) {
+  return validateCmsPackageV1(cmsPackage, {
+    allowFixtureSignatures: true,
+    allowFixtureStorage: true,
+    enforceHashes: true,
+    checkedAt: CHECKED_AT
+  });
+}
+
+function routePaths(cmsPackage: CmsPackageV1): string[] {
+  return cmsPackage.payload.routes.map((route) => route.path);
+}
+
+function hasUniqueRoutes(cmsPackage: CmsPackageV1): boolean {
+  const paths = routePaths(cmsPackage);
+  return new Set(paths).size === paths.length;
+}
+
+function issueCodes(
+  validationResult: ReturnType<typeof validateCmsPackageV1>
+): string[] {
+  return validationResult.issues
+    .filter((issue) => issue.severity === 'error')
+    .map((issue) => issue.code)
+    .sort((left, right) => left.localeCompare(right));
+}
+
+function pageById(cmsPackage: CmsPackageV1, pageId: string) {
+  return cmsPackage.payload.pages.find((page) => page.id === pageId);
+}
+
+function blockById(cmsPackage: CmsPackageV1, blockId: string) {
+  return cmsPackage.payload.pages
+    .map((page) => page.blocks.find((block) => block.id === blockId))
+    .find((block) => !!block) as Record<string, unknown> | undefined;
+}
+
+function snapshotWithNftNames(
+  names: readonly string[]
+): ProfileCmsGalleryWalletSnapshot {
+  const fixture = createFixtureProfileCmsGallerySnapshot();
+  return {
+    ...fixture,
+    nfts: names.map((name, index) => {
+      const tokenId = String(index + 1);
+      const contract = addressForIndex(index + 1);
+      const nft: ProfileCmsGallerySnapshotNft = {
+        key: `random-${index}`,
+        chain_id: 1,
+        contract,
+        token_id: tokenId,
+        name,
+        collection: {
+          key: `collection-${index % 2}`,
+          name: 'Same Collection',
+          description: 'A property-test collection.'
+        }
+      };
+      return nft;
+    })
+  };
+}
+
+function addressForIndex(index: number): string {
+  const hex = index.toString(16);
+  return `0x${'0'.repeat(40 - hex.length)}${hex}`;
+}

--- a/src/profile-cms/profile-cms-gallery-package-generator.test.ts
+++ b/src/profile-cms/profile-cms-gallery-package-generator.test.ts
@@ -136,6 +136,22 @@ describe('profile CMS gallery package generator', () => {
     expect(validateForDraft(emptyPackage).valid).toBe(true);
   });
 
+  it('truncates long unicode metadata without splitting surrogate pairs', () => {
+    const snapshot = createFixtureProfileCmsGallerySnapshot();
+    const cmsPackage = generateProfileCmsGalleryPackage({
+      snapshot,
+      site: {
+        title: `${'A'.repeat(159)}😀`,
+        description: `${'B'.repeat(299)}😀`
+      }
+    });
+    const homePage = pageById(cmsPackage, 'home-page');
+
+    expect(homePage?.metadata.title.endsWith('\uD83D')).toBe(false);
+    expect(homePage?.metadata.description.endsWith('\uD83D')).toBe(false);
+    expect(validateForDraft(cmsPackage).valid).toBe(true);
+  });
+
   it('generates NFT detail pages with media profiles and social references when media is complete', () => {
     const cmsPackage = generateProfileCmsGalleryPackage();
     const detailPage = pageById(cmsPackage, 'nft-the-memes-1-1');
@@ -261,6 +277,8 @@ describe('profile CMS gallery package generator', () => {
           const cmsPackage = generateProfileCmsGalleryPackage({ snapshot });
 
           expect(hasUniqueRoutes(cmsPackage)).toBe(true);
+          expect(hasUniquePageIds(cmsPackage)).toBe(true);
+          expect(hasUniqueAssetIds(cmsPackage)).toBe(true);
           expect(validateForDraft(cmsPackage).valid).toBe(true);
         }
       ),
@@ -285,6 +303,16 @@ function routePaths(cmsPackage: CmsPackageV1): string[] {
 function hasUniqueRoutes(cmsPackage: CmsPackageV1): boolean {
   const paths = routePaths(cmsPackage);
   return new Set(paths).size === paths.length;
+}
+
+function hasUniquePageIds(cmsPackage: CmsPackageV1): boolean {
+  const pageIds = cmsPackage.payload.pages.map((page) => page.id);
+  return new Set(pageIds).size === pageIds.length;
+}
+
+function hasUniqueAssetIds(cmsPackage: CmsPackageV1): boolean {
+  const assetIds = cmsPackage.payload.assets.map((asset) => asset.id);
+  return new Set(assetIds).size === assetIds.length;
 }
 
 function issueCodes(

--- a/src/profile-cms/profile-cms-gallery-package-generator.ts
+++ b/src/profile-cms/profile-cms-gallery-package-generator.ts
@@ -648,7 +648,7 @@ function prepareNftPages(
   nfts.forEach((nft) => {
     const baseSlug = toProfileCmsGalleryRouteSlug(
       `${nft.title}-${nft.tokenId}`,
-      `token-${nft.tokenId}`
+      toProfileCmsGalleryRouteSlug(`token-${nft.tokenId}`, 'token')
     );
     // Suffix candidates make slug collisions stable for the sorted NFT set; if
     // membership changes, only the affected collision group can receive new
@@ -1220,6 +1220,8 @@ function fixtureMimeTypeForKind(kind: CmsAssetKind): string {
     case 'image':
     case 'social_image':
       return 'image/png';
+    default:
+      return assertNever(kind);
   }
 }
 
@@ -1473,5 +1475,16 @@ function nonEmptyText(value: string | undefined, fallback: string): string {
 }
 
 function truncateText(value: string, maxLength: number): string {
-  return value.length <= maxLength ? value : value.slice(0, maxLength);
+  if (value.length <= maxLength) {
+    return value;
+  }
+  const truncated = value.slice(0, maxLength);
+  const lastCode = truncated.charCodeAt(truncated.length - 1);
+  return lastCode >= 0xd800 && lastCode <= 0xdbff
+    ? truncated.slice(0, -1)
+    : truncated;
+}
+
+function assertNever(value: never): never {
+  throw new Error(`Unsupported value: ${String(value)}`);
 }

--- a/src/profile-cms/profile-cms-gallery-package-generator.ts
+++ b/src/profile-cms/profile-cms-gallery-package-generator.ts
@@ -1,0 +1,1414 @@
+import {
+  CMS_CANONICALIZATION,
+  CMS_HASH_ALGORITHM,
+  CMS_PACKAGE_SCHEMA,
+  CMS_PAYLOAD_SCHEMA,
+  CmsPackageV1,
+  toCmsSha256Hash,
+  withComputedCmsHashes
+} from '@/profile-cms/protocol/v1';
+
+export const PROFILE_CMS_GALLERY_GENERATOR_NAME =
+  '6529-backend-profile-cms-gallery-generator';
+export const PROFILE_CMS_GALLERY_GENERATOR_VERSION = '0.1.0';
+export const PROFILE_CMS_GALLERY_FIXTURE_TIMESTAMP = '2026-06-18T00:00:00.000Z';
+export const PROFILE_CMS_GALLERY_FIXTURE_ZERO_HASH = `sha256:${'0'.repeat(64)}`;
+
+type CmsAssetV1 = CmsPackageV1['payload']['assets'][number];
+type CmsAssetKind = CmsAssetV1['kind'];
+type CmsAssetRole = NonNullable<CmsAssetV1['roles']>[number];
+type CmsBlockV1 = CmsPackageV1['payload']['pages'][number]['blocks'][number];
+type CmsPageV1 = CmsPackageV1['payload']['pages'][number];
+type CmsDisplayVariantRole = NonNullable<
+  CmsPackageV1['payload']['nft_media_profiles']
+>[number]['display_variants'][number]['role'];
+type CmsSignatureV1 = CmsPackageV1['signatures'][number];
+type CmsStorageReceiptV1 = CmsPackageV1['storage'][number];
+
+export interface ProfileCmsGalleryPackageGenerationInput {
+  readonly snapshot?: ProfileCmsGalleryWalletSnapshot;
+  readonly curation?: ProfileCmsGalleryCurationInput;
+  readonly package_id?: string;
+  readonly site?: ProfileCmsGallerySiteInput;
+  readonly signatures?: readonly CmsSignatureV1[];
+  readonly storage?: readonly CmsStorageReceiptV1[];
+  readonly provenance?: ProfileCmsGalleryProvenanceInput;
+}
+
+export interface ProfileCmsGalleryWalletSnapshot {
+  readonly profile: ProfileCmsGallerySnapshotProfile;
+  readonly owner?: string;
+  readonly wallets?: readonly string[];
+  readonly block_number?: number;
+  readonly captured_at?: string;
+  readonly nfts: readonly ProfileCmsGallerySnapshotNft[];
+}
+
+export interface ProfileCmsGallerySnapshotProfile {
+  readonly handle: string;
+  readonly profile_id?: string;
+  readonly display_name?: string;
+  readonly description?: string;
+  readonly primary_wallet?: string;
+  readonly canonical_base_url?: string;
+}
+
+export interface ProfileCmsGallerySnapshotCollection {
+  readonly key?: string;
+  readonly id?: string;
+  readonly slug?: string;
+  readonly name: string;
+  readonly description?: string;
+  readonly artist?: string;
+  readonly hidden?: boolean;
+  readonly featured?: boolean;
+  readonly order?: number;
+}
+
+export interface ProfileCmsGallerySnapshotNft {
+  readonly key?: string;
+  readonly id?: string;
+  readonly chain_id: number;
+  readonly contract: string;
+  readonly token_id: string | number;
+  readonly name?: string;
+  readonly description?: string;
+  readonly collection?: ProfileCmsGallerySnapshotCollection;
+  readonly media?: ProfileCmsGallerySnapshotNftMedia;
+  readonly hidden?: boolean;
+  readonly featured?: boolean;
+  readonly order?: number;
+}
+
+export interface ProfileCmsGallerySnapshotNftMedia {
+  readonly metadata_uri?: string;
+  readonly metadata_hash?: string;
+  readonly assets?: readonly ProfileCmsGalleryMediaAssetInput[];
+  readonly display_variants?: readonly ProfileCmsGalleryDisplayVariantInput[];
+  readonly poster_asset_key?: string;
+}
+
+export interface ProfileCmsGalleryMediaAssetInput {
+  readonly key?: string;
+  readonly uri: string;
+  readonly content_hash: string;
+  readonly mime_type: string;
+  readonly kind?: CmsAssetKind;
+  readonly width?: number;
+  readonly height?: number;
+  readonly duration_seconds?: number;
+  readonly file_size_bytes?: number;
+  readonly roles?: readonly CmsAssetRole[];
+  readonly alt_text?: string;
+  readonly decorative?: boolean;
+  readonly rights?: string;
+}
+
+export interface ProfileCmsGalleryDisplayVariantInput {
+  readonly asset_key?: string;
+  readonly role: CmsDisplayVariantRole;
+  readonly crop_mode?: 'preserve' | 'cover' | 'contain';
+  readonly background?: string;
+  readonly source_asset_key?: string;
+}
+
+export interface ProfileCmsGalleryCurationInput {
+  readonly hidden_nft_keys?: readonly string[];
+  readonly hidden_collection_keys?: readonly string[];
+  readonly featured_nft_keys?: readonly string[];
+  readonly featured_collection_keys?: readonly string[];
+  readonly nft_order?: readonly string[];
+  readonly collection_order?: readonly string[];
+  readonly collection_nft_order?: Readonly<Record<string, readonly string[]>>;
+}
+
+export interface ProfileCmsGallerySiteInput {
+  readonly title?: string;
+  readonly description?: string;
+  readonly theme?: CmsPackageV1['site']['theme'];
+  readonly canonical_base_url?: string;
+  readonly locale?: string;
+}
+
+export interface ProfileCmsGalleryProvenanceInput {
+  readonly builder?: string;
+  readonly builder_version?: string;
+  readonly created_at?: string;
+  readonly notes?: string;
+}
+
+interface PreparedNft {
+  readonly key: string;
+  readonly aliases: readonly string[];
+  readonly chainId: number;
+  readonly contract: string;
+  readonly tokenId: string;
+  readonly title: string;
+  readonly description: string;
+  readonly collectionKey: string;
+  readonly collectionAliases: readonly string[];
+  readonly collectionTitle: string;
+  readonly collectionDescription: string;
+  readonly media: ProfileCmsGallerySnapshotNftMedia | undefined;
+  readonly hidden: boolean;
+  readonly featured: boolean;
+  readonly order: number | undefined;
+  readonly collectionOrder: number | undefined;
+}
+
+interface PreparedCollection {
+  readonly key: string;
+  readonly aliases: readonly string[];
+  readonly title: string;
+  readonly description: string;
+  readonly hidden: boolean;
+  readonly featured: boolean;
+  readonly order: number | undefined;
+  readonly nfts: readonly PreparedNft[];
+  readonly slug: string;
+  readonly pageId: string;
+  readonly path: string;
+}
+
+interface PreparedNftPage {
+  readonly nft: PreparedNft;
+  readonly slug: string;
+  readonly pageId: string;
+  readonly path: string;
+}
+
+interface GeneratedMedia {
+  readonly assets: readonly CmsAssetV1[];
+  readonly profile?: NonNullable<
+    CmsPackageV1['payload']['nft_media_profiles']
+  >[number];
+  readonly primaryAssetId?: string;
+  readonly socialAssetId?: string;
+}
+
+const DEFAULT_THEME: CmsPackageV1['site']['theme'] = {
+  mode: 'dark',
+  accent: '#29ccff'
+};
+
+export function generateProfileCmsGalleryPackage(
+  input: ProfileCmsGalleryPackageGenerationInput = {}
+): CmsPackageV1 {
+  const snapshot = input.snapshot ?? createFixtureProfileCmsGallerySnapshot();
+  const createdAt =
+    input.provenance?.created_at ??
+    snapshot.captured_at ??
+    PROFILE_CMS_GALLERY_FIXTURE_TIMESTAMP;
+  const packageId =
+    input.package_id ??
+    `${toProfileCmsGalleryRouteSlug(snapshot.profile.handle)}-gallery`;
+  const canonicalBaseUrl =
+    input.site?.canonical_base_url ??
+    snapshot.profile.canonical_base_url ??
+    'https://6529.io';
+  const prepared = prepareGallery(snapshot, input.curation);
+  const pagesByNftKey = prepareNftPages(snapshot.profile.handle, prepared.nfts);
+  const assets: CmsAssetV1[] = [];
+  const nftMediaProfiles: NonNullable<
+    CmsPackageV1['payload']['nft_media_profiles']
+  > = [];
+  const mediaByNftKey = new Map<string, GeneratedMedia>();
+
+  prepared.nfts.forEach((nft) => {
+    const page = pagesByNftKey.get(nft.key);
+    if (!page) {
+      return;
+    }
+    const generatedMedia = generateMediaForNft(nft, page.slug);
+    assets.push(...generatedMedia.assets);
+    if (generatedMedia.profile) {
+      nftMediaProfiles.push(generatedMedia.profile);
+    }
+    mediaByNftKey.set(nft.key, generatedMedia);
+  });
+
+  const homePage = buildHomePage({
+    snapshot,
+    collections: prepared.collections,
+    nftPages: pagesByNftKey,
+    mediaByNftKey,
+    canonicalBaseUrl,
+    siteTitle: getSiteTitle(snapshot, input.site),
+    siteDescription: getSiteDescription(snapshot, input.site)
+  });
+  const collectionsIndexPage = buildCollectionsIndexPage({
+    handle: snapshot.profile.handle,
+    collections: prepared.collections,
+    canonicalBaseUrl,
+    siteTitle: getSiteTitle(snapshot, input.site),
+    socialImageAssetId: getFirstSocialAssetId(prepared.nfts, mediaByNftKey)
+  });
+  const collectionPages = prepared.collections.map((collection) =>
+    buildCollectionPage({
+      collection,
+      nftPages: pagesByNftKey,
+      mediaByNftKey,
+      canonicalBaseUrl
+    })
+  );
+  const nftDetailPages = prepared.nfts
+    .map((nft) => pagesByNftKey.get(nft.key))
+    .filter((page): page is PreparedNftPage => !!page)
+    .map((page) =>
+      buildNftDetailPage({
+        page,
+        media: mediaByNftKey.get(page.nft.key),
+        canonicalBaseUrl
+      })
+    );
+  const pages = [
+    homePage,
+    collectionsIndexPage,
+    ...collectionPages,
+    ...nftDetailPages
+  ];
+  const routes = pages.map((page) => ({
+    path: page.path,
+    kind: 'page' as const,
+    page_id: page.id
+  }));
+  const sourcePacket = buildWalletSourcePacket(snapshot, createdAt);
+  const packageWithoutHashes: CmsPackageV1 = {
+    schema: CMS_PACKAGE_SCHEMA,
+    package_id: packageId,
+    profile: {
+      handle: snapshot.profile.handle,
+      ...(snapshot.profile.profile_id
+        ? { profile_id: snapshot.profile.profile_id }
+        : {}),
+      ...(snapshot.profile.primary_wallet
+        ? {
+            primary_wallet: normalizeEthereumAddress(
+              snapshot.profile.primary_wallet
+            )
+          }
+        : {})
+    },
+    site: {
+      title: truncateText(getSiteTitle(snapshot, input.site), 160),
+      description: truncateText(getSiteDescription(snapshot, input.site), 300),
+      base_path: `/${snapshot.profile.handle}/index.html`,
+      default_locale: input.site?.locale ?? 'en-US',
+      theme: input.site?.theme ?? DEFAULT_THEME,
+      navigation_id: 'main-nav',
+      metadata_defaults: [
+        {
+          scope: { path_prefix: `/${snapshot.profile.handle}/` },
+          values: {
+            locale: input.site?.locale ?? 'en-US',
+            robots: 'index',
+            search: 'include'
+          }
+        }
+      ]
+    },
+    payload: {
+      schema: CMS_PAYLOAD_SCHEMA,
+      routes,
+      pages,
+      assets,
+      ...(nftMediaProfiles.length > 0
+        ? { nft_media_profiles: nftMediaProfiles }
+        : {}),
+      navigation: [
+        {
+          id: 'main-nav',
+          items: [
+            { label: 'Gallery', page_id: homePage.id },
+            { label: 'Collections', page_id: collectionsIndexPage.id }
+          ]
+        }
+      ],
+      taxonomies: [
+        {
+          id: 'collections',
+          name: 'Collections',
+          terms: prepared.collections.map((collection) => ({
+            slug: collection.slug,
+            label: collection.title,
+            page_id: collection.pageId
+          }))
+        }
+      ],
+      source_packets: [sourcePacket],
+      build_manifest: {
+        renderer: PROFILE_CMS_GALLERY_GENERATOR_NAME,
+        renderer_version: PROFILE_CMS_GALLERY_GENERATOR_VERSION,
+        route_count: routes.length,
+        asset_count: assets.length
+      }
+    },
+    integrity: {
+      canonicalization: CMS_CANONICALIZATION,
+      hash_algorithm: CMS_HASH_ALGORITHM,
+      payload_hash: PROFILE_CMS_GALLERY_FIXTURE_ZERO_HASH,
+      package_hash: PROFILE_CMS_GALLERY_FIXTURE_ZERO_HASH
+    },
+    signatures: input.signatures
+      ? [...input.signatures]
+      : [createFixtureGallerySignature(createdAt)],
+    storage: input.storage
+      ? [...input.storage]
+      : [createFixtureGalleryStorageReceipt(createdAt)],
+    provenance: {
+      builder: input.provenance?.builder ?? PROFILE_CMS_GALLERY_GENERATOR_NAME,
+      builder_version:
+        input.provenance?.builder_version ??
+        PROFILE_CMS_GALLERY_GENERATOR_VERSION,
+      created_at: createdAt,
+      ...(input.provenance?.notes ? { notes: input.provenance.notes } : {})
+    }
+  };
+
+  return withPackageHashStorageReceipts(
+    withComputedCmsHashes(packageWithoutHashes),
+    input.storage ? undefined : 'fixture'
+  );
+}
+
+export function createFixtureProfileCmsGallerySnapshot(): ProfileCmsGalleryWalletSnapshot {
+  const primaryWallet = '0xf58fE66AF1A8C792Cd64D8d706edDabAdFCB2FD0';
+  const memesContract = '0x33fd426905f149f8376e227d0c9d3340aad17af1';
+  const labContract = '0x4db52a61dc491e15a2f78f5ac001c14ffe3568cb';
+
+  return {
+    profile: {
+      handle: 'punk6529bot',
+      profile_id: 'profile-1',
+      display_name: 'Punk 6529 Bot',
+      description: 'A deterministic profile-native gallery fixture.',
+      primary_wallet: primaryWallet,
+      canonical_base_url: 'https://6529.io'
+    },
+    owner: primaryWallet,
+    wallets: [primaryWallet],
+    block_number: 22652900,
+    captured_at: PROFILE_CMS_GALLERY_FIXTURE_TIMESTAMP,
+    nfts: [
+      {
+        key: 'meme-1',
+        chain_id: 1,
+        contract: memesContract,
+        token_id: '1',
+        name: 'The Memes #1',
+        description: 'The first fixture Meme card.',
+        featured: true,
+        collection: {
+          key: 'the-memes',
+          id: 'the-memes',
+          slug: 'the-memes',
+          name: 'The Memes',
+          description: 'The Memes by 6529.'
+        },
+        media: {
+          metadata_uri: 'https://metadata.6529.io/memes/1.json',
+          metadata_hash: hashFixtureString('metadata:memes:1'),
+          assets: [
+            createFixtureMediaAsset({
+              key: 'memes-1-grid',
+              uri: 'https://images.6529.io/memes/1-grid.png',
+              role: 'grid',
+              width: 900,
+              height: 1200
+            }),
+            createFixtureMediaAsset({
+              key: 'memes-1-detail',
+              uri: 'https://images.6529.io/memes/1-detail.png',
+              role: 'detail',
+              width: 1800,
+              height: 2400
+            }),
+            createFixtureMediaAsset({
+              key: 'memes-1-social',
+              uri: 'https://images.6529.io/memes/1-social.png',
+              role: 'social',
+              kind: 'social_image',
+              width: 1200,
+              height: 630
+            })
+          ],
+          display_variants: [
+            { asset_key: 'memes-1-grid', role: 'grid', crop_mode: 'cover' },
+            {
+              asset_key: 'memes-1-detail',
+              role: 'detail',
+              crop_mode: 'preserve'
+            },
+            { asset_key: 'memes-1-social', role: 'social', crop_mode: 'cover' }
+          ],
+          poster_asset_key: 'memes-1-grid'
+        }
+      },
+      {
+        key: 'meme-lab-42',
+        chain_id: 1,
+        contract: labContract,
+        token_id: '42',
+        name: 'Meme Lab #42',
+        description: 'A fixture Meme Lab edition.',
+        collection: {
+          key: 'meme-lab',
+          id: 'meme-lab',
+          slug: 'meme-lab',
+          name: 'Meme Lab',
+          description: 'Experimental editions from the Meme Lab.'
+        },
+        media: {
+          metadata_uri: 'https://metadata.6529.io/memelab/42.json',
+          metadata_hash: hashFixtureString('metadata:memelab:42'),
+          assets: [
+            createFixtureMediaAsset({
+              key: 'lab-42-grid',
+              uri: 'https://images.6529.io/memelab/42-grid.png',
+              role: 'grid',
+              width: 1000,
+              height: 1000
+            })
+          ],
+          display_variants: [
+            { asset_key: 'lab-42-grid', role: 'grid', crop_mode: 'cover' }
+          ],
+          poster_asset_key: 'lab-42-grid'
+        }
+      }
+    ]
+  };
+}
+
+export function toProfileCmsGalleryNftKey(
+  nft: Pick<ProfileCmsGallerySnapshotNft, 'chain_id' | 'contract' | 'token_id'>
+): string {
+  return `${nft.chain_id}:${normalizeEthereumAddress(
+    nft.contract
+  )}:${normalizeTokenId(nft.token_id)}`;
+}
+
+export function toProfileCmsGalleryRouteSlug(
+  value: string | number,
+  fallback = 'item'
+): string {
+  const input = String(value).toLowerCase();
+  const chars: string[] = [];
+  let lastWasDash = false;
+  for (let index = 0; index < input.length && chars.length < 72; index++) {
+    const code = input.charCodeAt(index);
+    const isAlphaNumeric =
+      (code >= 48 && code <= 57) || (code >= 97 && code <= 122);
+    if (isAlphaNumeric) {
+      chars.push(input[index]);
+      lastWasDash = false;
+    } else if (!lastWasDash && chars.length > 0) {
+      chars.push('-');
+      lastWasDash = true;
+    }
+  }
+  if (chars.length > 0 && chars[chars.length - 1] === '-') {
+    chars.pop();
+  }
+  return chars.join('') || fallback;
+}
+
+function prepareGallery(
+  snapshot: ProfileCmsGalleryWalletSnapshot,
+  curation: ProfileCmsGalleryCurationInput = {}
+): {
+  readonly collections: readonly PreparedCollection[];
+  readonly nfts: readonly PreparedNft[];
+} {
+  const hiddenNftKeys = toSet(curation.hidden_nft_keys);
+  const hiddenCollectionKeys = toSet(curation.hidden_collection_keys);
+  const featuredNftKeys = toSet(curation.featured_nft_keys);
+  const preparedNfts = snapshot.nfts
+    .map(prepareNft)
+    .map((nft) => ({
+      ...nft,
+      featured: nft.featured || hasAnyAlias(nft.aliases, featuredNftKeys)
+    }))
+    .filter(
+      (nft) =>
+        !nft.hidden &&
+        !hasAnyAlias(nft.aliases, hiddenNftKeys) &&
+        !nft.collectionAliases.some((alias) => hiddenCollectionKeys.has(alias))
+    );
+  const collectionGroups = new Map<string, PreparedNft[]>();
+  preparedNfts.forEach((nft) => {
+    const collectionNfts = collectionGroups.get(nft.collectionKey) ?? [];
+    collectionNfts.push(nft);
+    collectionGroups.set(nft.collectionKey, collectionNfts);
+  });
+  const collectionSlugReservation = new Set<string>();
+  const collectionEntries = Array.from(collectionGroups.entries()).sort(
+    ([leftKey], [rightKey]) => compareStrings(leftKey, rightKey)
+  );
+  const featuredCollectionKeys = toSet(curation.featured_collection_keys);
+  const collections = collectionEntries.map(([collectionKey, nfts]) => {
+    const firstNft = nfts[0];
+    const baseSlug = toProfileCmsGalleryRouteSlug(
+      firstNft.collectionAliases[1] ?? firstNft.collectionTitle,
+      'collection'
+    );
+    const slug = reserveSlug(baseSlug, collectionSlugReservation, [
+      collectionKeySuffix(collectionKey)
+    ]);
+    const sortedNfts = sortNftsForCollection(nfts, collectionKey, curation);
+    return {
+      key: collectionKey,
+      aliases: firstNft.collectionAliases,
+      title: firstNft.collectionTitle,
+      description: firstNft.collectionDescription,
+      hidden: false,
+      featured:
+        firstNft.collectionAliases.some((alias) =>
+          featuredCollectionKeys.has(alias)
+        ) || nfts.some((nft) => nft.featured),
+      order: getFirstDefinedNumber(nfts.map((nft) => nft.collectionOrder)),
+      nfts: sortedNfts,
+      slug,
+      pageId: `collection-${slug}`,
+      path: `/${snapshot.profile.handle}/collections/${slug}/index.html`
+    };
+  });
+  const sortedCollections = sortCollections(collections, curation);
+  const sortedNfts: PreparedNft[] = [];
+  sortedCollections.forEach((collection) => {
+    sortedNfts.push(...collection.nfts);
+  });
+
+  return { collections: sortedCollections, nfts: sortedNfts };
+}
+
+function prepareNft(nft: ProfileCmsGallerySnapshotNft): PreparedNft {
+  const nftKey = nft.key ?? toProfileCmsGalleryNftKey(nft);
+  const tokenId = normalizeTokenId(nft.token_id);
+  const contract = normalizeEthereumAddress(nft.contract);
+  const collectionTitle = nonEmptyText(nft.collection?.name, 'Collected NFTs');
+  const collectionKey =
+    nft.collection?.key ??
+    `${nft.chain_id}:${contract}:${
+      nft.collection?.id ??
+      nft.collection?.slug ??
+      toProfileCmsGalleryRouteSlug(collectionTitle)
+    }`;
+  const collectionAliases = uniqueStrings([
+    collectionKey,
+    nft.collection?.id,
+    nft.collection?.slug,
+    toProfileCmsGalleryRouteSlug(collectionTitle),
+    collectionTitle
+  ]);
+
+  return {
+    key: nftKey,
+    aliases: uniqueStrings([
+      nftKey,
+      nft.id,
+      `${contract}:${tokenId}`,
+      `${nft.chain_id}:${contract}:${tokenId}`
+    ]),
+    chainId: nft.chain_id,
+    contract,
+    tokenId,
+    title: nonEmptyText(nft.name, `${collectionTitle} #${tokenId}`),
+    description: nft.description ?? '',
+    collectionKey,
+    collectionAliases,
+    collectionTitle,
+    collectionDescription: nft.collection?.description ?? '',
+    media: nft.media,
+    hidden: nft.hidden === true || nft.collection?.hidden === true,
+    featured: nft.featured === true || nft.collection?.featured === true,
+    order: nft.order,
+    collectionOrder: nft.collection?.order
+  };
+}
+
+function prepareNftPages(
+  handle: string,
+  nfts: readonly PreparedNft[]
+): Map<string, PreparedNftPage> {
+  const slugReservation = new Set<string>();
+  const pagesByNftKey = new Map<string, PreparedNftPage>();
+  nfts.forEach((nft) => {
+    const baseSlug = toProfileCmsGalleryRouteSlug(
+      `${nft.title}-${nft.tokenId}`,
+      `token-${nft.tokenId}`
+    );
+    const slug = reserveSlug(baseSlug, slugReservation, [
+      toProfileCmsGalleryRouteSlug(nft.contract.slice(-8), 'contract')
+    ]);
+    pagesByNftKey.set(nft.key, {
+      nft,
+      slug,
+      pageId: `nft-${slug}`,
+      path: `/${handle}/nfts/${slug}/index.html`
+    });
+  });
+  return pagesByNftKey;
+}
+
+function sortCollections(
+  collections: readonly PreparedCollection[],
+  curation: ProfileCmsGalleryCurationInput
+): PreparedCollection[] {
+  const order = toOrderMap(curation.collection_order);
+  const featured = toSet(curation.featured_collection_keys);
+  return [...collections].sort((left, right) => {
+    const explicit = compareOrder(
+      getAliasOrder(left.aliases, order),
+      getAliasOrder(right.aliases, order)
+    );
+    if (explicit !== 0) {
+      return explicit;
+    }
+    const inputOrder = compareOrder(left.order, right.order);
+    if (inputOrder !== 0) {
+      return inputOrder;
+    }
+    const featuredCompare = compareBoolean(
+      left.featured || hasAnyAlias(left.aliases, featured),
+      right.featured || hasAnyAlias(right.aliases, featured)
+    );
+    if (featuredCompare !== 0) {
+      return featuredCompare;
+    }
+    return compareStrings(left.key, right.key);
+  });
+}
+
+function sortNftsForCollection(
+  nfts: readonly PreparedNft[],
+  collectionKey: string,
+  curation: ProfileCmsGalleryCurationInput
+): PreparedNft[] {
+  const globalOrder = toOrderMap(curation.nft_order);
+  const collectionOrder = toOrderMap(
+    curation.collection_nft_order?.[collectionKey] ?? []
+  );
+  const featured = toSet(curation.featured_nft_keys);
+  return [...nfts].sort((left, right) => {
+    const collectionExplicit = compareOrder(
+      getAliasOrder(left.aliases, collectionOrder),
+      getAliasOrder(right.aliases, collectionOrder)
+    );
+    if (collectionExplicit !== 0) {
+      return collectionExplicit;
+    }
+    const globalExplicit = compareOrder(
+      getAliasOrder(left.aliases, globalOrder),
+      getAliasOrder(right.aliases, globalOrder)
+    );
+    if (globalExplicit !== 0) {
+      return globalExplicit;
+    }
+    const inputOrder = compareOrder(left.order, right.order);
+    if (inputOrder !== 0) {
+      return inputOrder;
+    }
+    const featuredCompare = compareBoolean(
+      left.featured || hasAnyAlias(left.aliases, featured),
+      right.featured || hasAnyAlias(right.aliases, featured)
+    );
+    if (featuredCompare !== 0) {
+      return featuredCompare;
+    }
+    const contractCompare = compareStrings(left.contract, right.contract);
+    if (contractCompare !== 0) {
+      return contractCompare;
+    }
+    return compareTokenIds(left.tokenId, right.tokenId);
+  });
+}
+
+function generateMediaForNft(
+  nft: PreparedNft,
+  pageSlug: string
+): GeneratedMedia {
+  const inputAssets = nft.media?.assets ?? [];
+  const assetsByInputKey = new Map<string, CmsAssetV1>();
+  const assets: CmsAssetV1[] = [];
+
+  inputAssets.forEach((asset, index) => {
+    const normalized = normalizeMediaAsset(asset, pageSlug, index, nft.title);
+    if (!normalized) {
+      return;
+    }
+    assets.push(normalized);
+    assetsByInputKey.set(asset.key ?? String(index), normalized);
+  });
+
+  if (!nft.media) {
+    return { assets };
+  }
+
+  const variants = (nft.media.display_variants ?? [])
+    .map((variant) => toDisplayVariant(variant, assetsByInputKey))
+    .filter(
+      (
+        variant
+      ): variant is NonNullable<
+        CmsPackageV1['payload']['nft_media_profiles']
+      >[number]['display_variants'][number] => !!variant
+    );
+  const originalAssetIds = assets
+    .filter((asset) => asset.roles?.includes('original'))
+    .map((asset) => asset.id);
+  const posterAssetId = getAssetIdForInputKey(
+    nft.media.poster_asset_key,
+    assetsByInputKey
+  );
+  const profile: NonNullable<
+    CmsPackageV1['payload']['nft_media_profiles']
+  >[number] = {
+    id: `media-${pageSlug}`,
+    chain_id: nft.chainId,
+    contract: nft.contract,
+    token_id: nft.tokenId,
+    ...(nft.media.metadata_uri ? { metadata_uri: nft.media.metadata_uri } : {}),
+    ...(nft.media.metadata_hash
+      ? { metadata_hash: nft.media.metadata_hash }
+      : {}),
+    ...(originalAssetIds.length > 0
+      ? { original_asset_ids: originalAssetIds }
+      : {}),
+    display_variants: variants,
+    ...(posterAssetId ? { poster_asset_id: posterAssetId } : {})
+  };
+  const socialAsset = findAssetForRole(assets, 'social');
+  const primaryAsset = findAssetForRole(assets, 'detail') ?? assets[0];
+
+  return {
+    assets,
+    profile,
+    primaryAssetId: primaryAsset?.id,
+    socialAssetId: socialAsset?.id
+  };
+}
+
+function normalizeMediaAsset(
+  input: ProfileCmsGalleryMediaAssetInput,
+  pageSlug: string,
+  index: number,
+  nftTitle: string
+): CmsAssetV1 | null {
+  const kind = input.kind ?? guessAssetKind(input.mime_type);
+  if (requiresDimensions(kind) && (!input.width || !input.height)) {
+    return null;
+  }
+  const roles = input.roles ?? [];
+  const roleSuffix = roles[0] ?? `asset-${index + 1}`;
+  return {
+    id: `asset-${pageSlug}-${toProfileCmsGalleryRouteSlug(roleSuffix)}-${
+      index + 1
+    }`,
+    kind,
+    uri: input.uri,
+    content_hash: input.content_hash,
+    mime_type: input.mime_type,
+    ...(input.width ? { width: input.width } : {}),
+    ...(input.height ? { height: input.height } : {}),
+    ...(input.duration_seconds !== undefined
+      ? { duration_seconds: input.duration_seconds }
+      : {}),
+    ...(input.file_size_bytes !== undefined
+      ? { file_size_bytes: input.file_size_bytes }
+      : {}),
+    ...(roles.length > 0 ? { roles: [...roles] } : {}),
+    alt_text: input.alt_text ?? nftTitle,
+    ...(input.decorative !== undefined ? { decorative: input.decorative } : {}),
+    ...(input.rights ? { rights: input.rights } : {})
+  };
+}
+
+function toDisplayVariant(
+  input: ProfileCmsGalleryDisplayVariantInput,
+  assetsByInputKey: ReadonlyMap<string, CmsAssetV1>
+):
+  | NonNullable<
+      CmsPackageV1['payload']['nft_media_profiles']
+    >[number]['display_variants'][number]
+  | null {
+  const assetId = getAssetIdForInputKey(input.asset_key, assetsByInputKey);
+  if (!assetId) {
+    return null;
+  }
+  const sourceAssetId = getAssetIdForInputKey(
+    input.source_asset_key,
+    assetsByInputKey
+  );
+  return {
+    asset_id: assetId,
+    role: input.role,
+    ...(input.crop_mode ? { crop_mode: input.crop_mode } : {}),
+    ...(input.background ? { background: input.background } : {}),
+    ...(sourceAssetId ? { source_asset_id: sourceAssetId } : {})
+  };
+}
+
+function buildHomePage({
+  snapshot,
+  collections,
+  nftPages,
+  mediaByNftKey,
+  canonicalBaseUrl,
+  siteTitle,
+  siteDescription
+}: {
+  readonly snapshot: ProfileCmsGalleryWalletSnapshot;
+  readonly collections: readonly PreparedCollection[];
+  readonly nftPages: ReadonlyMap<string, PreparedNftPage>;
+  readonly mediaByNftKey: ReadonlyMap<string, GeneratedMedia>;
+  readonly canonicalBaseUrl: string;
+  readonly siteTitle: string;
+  readonly siteDescription: string;
+}): CmsPageV1 {
+  const visibleNfts: PreparedNft[] = [];
+  collections.forEach((collection) => {
+    visibleNfts.push(...collection.nfts);
+  });
+  const featuredPageIds = visibleNfts
+    .filter((nft) => nft.featured)
+    .map((nft) => nftPages.get(nft.key)?.pageId)
+    .filter((pageId): pageId is string => !!pageId);
+  const allPageIds = visibleNfts
+    .map((nft) => nftPages.get(nft.key)?.pageId)
+    .filter((pageId): pageId is string => !!pageId);
+  const path = `/${snapshot.profile.handle}/index.html`;
+
+  return {
+    id: 'home-page',
+    type: 'gallery',
+    path,
+    metadata: {
+      title: truncateText(siteTitle, 160),
+      description: truncateText(siteDescription, 300),
+      locale: 'en-US',
+      canonical_url: joinCanonicalUrl(canonicalBaseUrl, path),
+      navigation_label: 'Gallery',
+      ...(getFirstSocialAssetId(visibleNfts, mediaByNftKey)
+        ? {
+            social_image_asset_id: getFirstSocialAssetId(
+              visibleNfts,
+              mediaByNftKey
+            )
+          }
+        : {})
+    },
+    source: { source_packet_id: 'wallet-snapshot' },
+    blocks: [
+      headingBlock('home-heading', siteTitle, 1),
+      richTextBlock('home-summary', siteDescription),
+      {
+        id: 'home-wallet-gallery',
+        block_type: 'generated_wallet_gallery',
+        collection_count: collections.length,
+        nft_count: visibleNfts.length,
+        page_ids: allPageIds,
+        featured_page_ids:
+          featuredPageIds.length > 0 ? featuredPageIds : allPageIds
+      } as CmsBlockV1
+    ]
+  };
+}
+
+function buildCollectionsIndexPage({
+  handle,
+  collections,
+  canonicalBaseUrl,
+  siteTitle,
+  socialImageAssetId
+}: {
+  readonly handle: string;
+  readonly collections: readonly PreparedCollection[];
+  readonly canonicalBaseUrl: string;
+  readonly siteTitle: string;
+  readonly socialImageAssetId?: string;
+}): CmsPageV1 {
+  const path = `/${handle}/collections/index.html`;
+  return {
+    id: 'collections-index',
+    type: 'collection',
+    path,
+    metadata: {
+      title: truncateText(`${siteTitle} Collections`, 160),
+      description: truncateText(`Collections in ${siteTitle}.`, 300),
+      locale: 'en-US',
+      canonical_url: joinCanonicalUrl(canonicalBaseUrl, path),
+      navigation_label: 'Collections',
+      ...(socialImageAssetId
+        ? { social_image_asset_id: socialImageAssetId }
+        : {})
+    },
+    source: { source_packet_id: 'wallet-snapshot' },
+    blocks: [
+      headingBlock('collections-heading', 'Collections', 1),
+      {
+        id: 'collections-list',
+        block_type: 'collection_reference',
+        collection_count: collections.length,
+        page_ids: collections.map((collection) => collection.pageId),
+        featured_page_ids: collections
+          .filter((collection) => collection.featured)
+          .map((collection) => collection.pageId)
+      } as CmsBlockV1
+    ]
+  };
+}
+
+function buildCollectionPage({
+  collection,
+  nftPages,
+  mediaByNftKey,
+  canonicalBaseUrl
+}: {
+  readonly collection: PreparedCollection;
+  readonly nftPages: ReadonlyMap<string, PreparedNftPage>;
+  readonly mediaByNftKey: ReadonlyMap<string, GeneratedMedia>;
+  readonly canonicalBaseUrl: string;
+}): CmsPageV1 {
+  const nftPageIds = collection.nfts
+    .map((nft) => nftPages.get(nft.key)?.pageId)
+    .filter((pageId): pageId is string => !!pageId);
+  const assetIds = collection.nfts
+    .map((nft) => mediaByNftKey.get(nft.key)?.primaryAssetId)
+    .filter((assetId): assetId is string => !!assetId);
+  const socialImageAssetId = getFirstSocialAssetId(
+    collection.nfts,
+    mediaByNftKey
+  );
+
+  return {
+    id: collection.pageId,
+    type: 'collection',
+    path: collection.path,
+    metadata: {
+      title: truncateText(collection.title, 160),
+      description: truncateText(
+        collection.description ||
+          `${collection.nfts.length} collected NFT${
+            collection.nfts.length === 1 ? '' : 's'
+          }.`,
+        300
+      ),
+      locale: 'en-US',
+      canonical_url: joinCanonicalUrl(canonicalBaseUrl, collection.path),
+      navigation_label: truncateText(collection.title, 80),
+      ...(socialImageAssetId
+        ? { social_image_asset_id: socialImageAssetId }
+        : {})
+    },
+    source: { source_packet_id: 'wallet-snapshot' },
+    blocks: [
+      headingBlock(`${collection.pageId}-heading`, collection.title, 1),
+      ...(collection.description
+        ? [
+            richTextBlock(
+              `${collection.pageId}-summary`,
+              collection.description
+            )
+          ]
+        : []),
+      {
+        id: `${collection.pageId}-gallery`,
+        block_type: 'lightbox_gallery',
+        page_ids: nftPageIds,
+        asset_ids: assetIds,
+        collection_key: collection.key
+      } as CmsBlockV1
+    ]
+  };
+}
+
+function buildNftDetailPage({
+  page,
+  media,
+  canonicalBaseUrl
+}: {
+  readonly page: PreparedNftPage;
+  readonly media?: GeneratedMedia;
+  readonly canonicalBaseUrl: string;
+}): CmsPageV1 {
+  const blocks: CmsBlockV1[] = [
+    headingBlock(`${page.pageId}-heading`, page.nft.title, 1)
+  ];
+  if (media?.primaryAssetId) {
+    blocks.push({
+      id: `${page.pageId}-media`,
+      block_type: 'image',
+      asset_id: media.primaryAssetId,
+      caption: page.nft.title
+    } as CmsBlockV1);
+  }
+  if (page.nft.description) {
+    blocks.push(
+      richTextBlock(`${page.pageId}-description`, page.nft.description)
+    );
+  }
+  blocks.push({
+    id: `${page.pageId}-reference`,
+    block_type: 'nft_reference',
+    chain_id: page.nft.chainId,
+    contract: page.nft.contract,
+    token_id: page.nft.tokenId,
+    title: page.nft.title,
+    collection_title: page.nft.collectionTitle,
+    ...(media?.profile ? { nft_media_profile_id: media.profile.id } : {})
+  } as CmsBlockV1);
+
+  return {
+    id: page.pageId,
+    type: 'nft_detail',
+    path: page.path,
+    metadata: {
+      title: truncateText(page.nft.title, 160),
+      description: truncateText(
+        page.nft.description ||
+          `${page.nft.collectionTitle} token ${page.nft.tokenId}.`,
+        300
+      ),
+      locale: 'en-US',
+      canonical_url: joinCanonicalUrl(canonicalBaseUrl, page.path),
+      navigation_label: truncateText(page.nft.title, 80),
+      ...(media?.socialAssetId
+        ? { social_image_asset_id: media.socialAssetId }
+        : {})
+    },
+    source: { source_packet_id: 'wallet-snapshot' },
+    blocks
+  };
+}
+
+function buildWalletSourcePacket(
+  snapshot: ProfileCmsGalleryWalletSnapshot,
+  capturedAt: string
+): NonNullable<CmsPackageV1['payload']['source_packets']>[number] {
+  const packet: Record<string, unknown> = {
+    id: 'wallet-snapshot',
+    source_type: 'wallet',
+    captured_at: capturedAt,
+    ...(snapshot.owner ? { owner: snapshot.owner } : {}),
+    ...(snapshot.wallets ? { wallets: [...snapshot.wallets] } : {}),
+    ...(snapshot.block_number !== undefined
+      ? { block_number: snapshot.block_number }
+      : {}),
+    nft_count: snapshot.nfts.length
+  };
+  return packet as NonNullable<
+    CmsPackageV1['payload']['source_packets']
+  >[number];
+}
+
+function headingBlock(id: string, text: string, level: number): CmsBlockV1 {
+  return { id, block_type: 'heading', text, level } as CmsBlockV1;
+}
+
+function richTextBlock(id: string, content: string): CmsBlockV1 {
+  return { id, block_type: 'rich_text', content } as CmsBlockV1;
+}
+
+function createFixtureGallerySignature(signedAt: string): CmsSignatureV1 {
+  return {
+    type: 'fixture',
+    signer: 'fixture',
+    signature: 'fixture',
+    signed_at: signedAt
+  };
+}
+
+function createFixtureGalleryStorageReceipt(
+  recordedAt: string
+): CmsStorageReceiptV1 {
+  return {
+    provider: 'fixture',
+    uri: 'https://fixtures.6529.io/profile-cms/gallery-package.json',
+    content_hash: PROFILE_CMS_GALLERY_FIXTURE_ZERO_HASH,
+    provider_content_id: 'profile-cms-gallery-fixture',
+    pinned: false,
+    canonical: true,
+    recorded_at: recordedAt
+  };
+}
+
+function withPackageHashStorageReceipts(
+  cmsPackage: CmsPackageV1,
+  providerToFill: CmsStorageReceiptV1['provider'] | undefined
+): CmsPackageV1 {
+  if (!providerToFill) {
+    return cmsPackage;
+  }
+  return {
+    ...cmsPackage,
+    storage: cmsPackage.storage.map((receipt) =>
+      receipt.provider === providerToFill
+        ? {
+            ...receipt,
+            content_hash: cmsPackage.integrity.package_hash
+          }
+        : receipt
+    )
+  };
+}
+
+function createFixtureMediaAsset({
+  key,
+  uri,
+  role,
+  kind = 'image',
+  width,
+  height
+}: {
+  readonly key: string;
+  readonly uri: string;
+  readonly role: CmsAssetRole;
+  readonly kind?: CmsAssetKind;
+  readonly width: number;
+  readonly height: number;
+}): ProfileCmsGalleryMediaAssetInput {
+  return {
+    key,
+    uri,
+    kind,
+    content_hash: hashFixtureString(uri),
+    mime_type: kind === 'social_image' || kind === 'image' ? 'image/png' : kind,
+    width,
+    height,
+    roles: [role]
+  };
+}
+
+function hashFixtureString(value: string): string {
+  return toCmsSha256Hash(`fixture:${value}`);
+}
+
+function getSiteTitle(
+  snapshot: ProfileCmsGalleryWalletSnapshot,
+  site?: ProfileCmsGallerySiteInput
+): string {
+  return nonEmptyText(
+    site?.title ?? snapshot.profile.display_name,
+    `${snapshot.profile.handle} Gallery`
+  );
+}
+
+function getSiteDescription(
+  snapshot: ProfileCmsGalleryWalletSnapshot,
+  site?: ProfileCmsGallerySiteInput
+): string {
+  return (
+    site?.description ??
+    snapshot.profile.description ??
+    `${snapshot.profile.handle}'s collected NFT gallery.`
+  );
+}
+
+function getFirstSocialAssetId(
+  nfts: readonly PreparedNft[],
+  mediaByNftKey: ReadonlyMap<string, GeneratedMedia>
+): string | undefined {
+  for (const nft of nfts) {
+    const socialAssetId = mediaByNftKey.get(nft.key)?.socialAssetId;
+    if (socialAssetId) {
+      return socialAssetId;
+    }
+  }
+  return undefined;
+}
+
+function findAssetForRole(
+  assets: readonly CmsAssetV1[],
+  role: CmsAssetRole
+): CmsAssetV1 | undefined {
+  return (
+    assets.find((asset) => asset.roles?.includes(role)) ??
+    (role === 'social'
+      ? assets.find((asset) => asset.kind === 'social_image')
+      : undefined)
+  );
+}
+
+function getAssetIdForInputKey(
+  inputKey: string | undefined,
+  assetsByInputKey: ReadonlyMap<string, CmsAssetV1>
+): string | undefined {
+  if (!inputKey) {
+    return undefined;
+  }
+  return assetsByInputKey.get(inputKey)?.id;
+}
+
+function guessAssetKind(mimeType: string): CmsAssetKind {
+  if (mimeType.startsWith('video/')) {
+    return 'video';
+  }
+  if (mimeType.startsWith('audio/')) {
+    return 'audio';
+  }
+  if (mimeType.startsWith('model/')) {
+    return 'model';
+  }
+  return 'image';
+}
+
+function requiresDimensions(kind: CmsAssetKind): boolean {
+  return kind === 'image' || kind === 'video' || kind === 'social_image';
+}
+
+function reserveSlug(
+  baseSlug: string,
+  reserved: Set<string>,
+  suffixCandidates: readonly string[]
+): string {
+  if (!reserved.has(baseSlug)) {
+    reserved.add(baseSlug);
+    return baseSlug;
+  }
+  for (const suffix of suffixCandidates) {
+    const candidate = `${baseSlug}-${suffix}`;
+    if (!reserved.has(candidate)) {
+      reserved.add(candidate);
+      return candidate;
+    }
+  }
+  let index = 2;
+  while (reserved.has(`${baseSlug}-${index}`)) {
+    index++;
+  }
+  const candidate = `${baseSlug}-${index}`;
+  reserved.add(candidate);
+  return candidate;
+}
+
+function collectionKeySuffix(collectionKey: string): string {
+  return toProfileCmsGalleryRouteSlug(collectionKey.split(':').join('-'));
+}
+
+function normalizeEthereumAddress(address: string): string {
+  return address.toLowerCase();
+}
+
+function normalizeTokenId(tokenId: string | number): string {
+  return String(tokenId).trim();
+}
+
+function toSet(values: readonly string[] | undefined): ReadonlySet<string> {
+  return new Set(values ?? []);
+}
+
+function toOrderMap(
+  values: readonly string[] | undefined
+): ReadonlyMap<string, number> {
+  const order = new Map<string, number>();
+  (values ?? []).forEach((value, index) => {
+    if (!order.has(value)) {
+      order.set(value, index);
+    }
+  });
+  return order;
+}
+
+function getAliasOrder(
+  aliases: readonly string[],
+  order: ReadonlyMap<string, number>
+): number | undefined {
+  for (const alias of aliases) {
+    const aliasOrder = order.get(alias);
+    if (aliasOrder !== undefined) {
+      return aliasOrder;
+    }
+  }
+  return undefined;
+}
+
+function hasAnyAlias(
+  aliases: readonly string[],
+  values: ReadonlySet<string>
+): boolean {
+  return aliases.some((alias) => values.has(alias));
+}
+
+function uniqueStrings(
+  values: readonly (string | undefined)[]
+): readonly string[] {
+  const seen = new Set<string>();
+  const unique: string[] = [];
+  values.forEach((value) => {
+    if (!value || seen.has(value)) {
+      return;
+    }
+    seen.add(value);
+    unique.push(value);
+  });
+  return unique;
+}
+
+function getFirstDefinedNumber(
+  values: readonly (number | undefined)[]
+): number | undefined {
+  return values.find((value): value is number => value !== undefined);
+}
+
+function compareOrder(
+  left: number | undefined,
+  right: number | undefined
+): number {
+  if (left === undefined && right === undefined) {
+    return 0;
+  }
+  if (left === undefined) {
+    return 1;
+  }
+  if (right === undefined) {
+    return -1;
+  }
+  return left - right;
+}
+
+function compareBoolean(left: boolean, right: boolean): number {
+  if (left === right) {
+    return 0;
+  }
+  return left ? -1 : 1;
+}
+
+function compareStrings(left: string, right: string): number {
+  return left.localeCompare(right);
+}
+
+function compareTokenIds(left: string, right: string): number {
+  const normalizedLeft = stripLeadingZeroes(left);
+  const normalizedRight = stripLeadingZeroes(right);
+  if (isIntegerString(normalizedLeft) && isIntegerString(normalizedRight)) {
+    const lengthCompare = normalizedLeft.length - normalizedRight.length;
+    if (lengthCompare !== 0) {
+      return lengthCompare;
+    }
+  }
+  return normalizedLeft.localeCompare(normalizedRight);
+}
+
+function stripLeadingZeroes(value: string): string {
+  const stripped = value.replace(/^0+/, '');
+  return stripped || '0';
+}
+
+function isIntegerString(value: string): boolean {
+  return /^[0-9]+$/.test(value);
+}
+
+function joinCanonicalUrl(baseUrl: string, path: string): string {
+  const trimmedBase = baseUrl.replace(/\/+$/, '');
+  return `${trimmedBase}${path}`;
+}
+
+function nonEmptyText(value: string | undefined, fallback: string): string {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : fallback;
+}
+
+function truncateText(value: string, maxLength: number): string {
+  return value.length <= maxLength ? value : value.slice(0, maxLength);
+}

--- a/src/profile-cms/profile-cms-gallery-package-generator.ts
+++ b/src/profile-cms/profile-cms-gallery-package-generator.ts
@@ -488,6 +488,24 @@ export function toProfileCmsGalleryNftKey(
   )}:${normalizeTokenId(nft.token_id)}`;
 }
 
+export function toProfileCmsGalleryCollectionKey(
+  nft: Pick<
+    ProfileCmsGallerySnapshotNft,
+    'chain_id' | 'contract' | 'collection'
+  >
+): string {
+  if (nft.collection?.key) {
+    return nft.collection.key;
+  }
+  const contract = normalizeEthereumAddress(nft.contract);
+  const collectionTitle = nonEmptyText(nft.collection?.name, 'Collected NFTs');
+  const collectionIdentity =
+    nft.collection?.id ??
+    nft.collection?.slug ??
+    toProfileCmsGalleryRouteSlug(collectionTitle);
+  return `${nft.chain_id}:${contract}:${collectionIdentity}`;
+}
+
 export function toProfileCmsGalleryRouteSlug(
   value: string | number,
   fallback = 'item'
@@ -587,13 +605,7 @@ function prepareNft(nft: ProfileCmsGallerySnapshotNft): PreparedNft {
   const tokenId = normalizeTokenId(nft.token_id);
   const contract = normalizeEthereumAddress(nft.contract);
   const collectionTitle = nonEmptyText(nft.collection?.name, 'Collected NFTs');
-  const collectionKey =
-    nft.collection?.key ??
-    `${nft.chain_id}:${contract}:${
-      nft.collection?.id ??
-      nft.collection?.slug ??
-      toProfileCmsGalleryRouteSlug(collectionTitle)
-    }`;
+  const collectionKey = toProfileCmsGalleryCollectionKey(nft);
   const collectionAliases = uniqueStrings([
     collectionKey,
     nft.collection?.id,
@@ -638,6 +650,9 @@ function prepareNftPages(
       `${nft.title}-${nft.tokenId}`,
       `token-${nft.tokenId}`
     );
+    // Suffix candidates make slug collisions stable for the sorted NFT set; if
+    // membership changes, only the affected collision group can receive new
+    // numeric fallbacks.
     const slug = reserveSlug(baseSlug, slugReservation, [
       toProfileCmsGalleryRouteSlug(nft.contract.slice(-8), 'contract')
     ]);
@@ -730,15 +745,21 @@ function generateMediaForNft(
 ): GeneratedMedia {
   const inputAssets = nft.media?.assets ?? [];
   const assetsByInputKey = new Map<string, CmsAssetV1>();
+  const reservedInputKeys = new Set<string>();
   const assets: CmsAssetV1[] = [];
 
   inputAssets.forEach((asset, index) => {
+    const lookupKey = getMediaAssetLookupKey(asset, index);
+    if (reservedInputKeys.has(lookupKey)) {
+      throw new Error(`Duplicate media asset lookup key "${lookupKey}".`);
+    }
+    reservedInputKeys.add(lookupKey);
     const normalized = normalizeMediaAsset(asset, pageSlug, index, nft.title);
     if (!normalized) {
       return;
     }
     assets.push(normalized);
-    assetsByInputKey.set(asset.key ?? String(index), normalized);
+    assetsByInputKey.set(lookupKey, normalized);
   });
 
   if (!nft.media) {
@@ -908,8 +929,7 @@ function buildHomePage({
         collection_count: collections.length,
         nft_count: visibleNfts.length,
         page_ids: allPageIds,
-        featured_page_ids:
-          featuredPageIds.length > 0 ? featuredPageIds : allPageIds
+        featured_page_ids: featuredPageIds
       } as CmsBlockV1
     ]
   };
@@ -1090,8 +1110,10 @@ function buildWalletSourcePacket(
     id: 'wallet-snapshot',
     source_type: 'wallet',
     captured_at: capturedAt,
-    ...(snapshot.owner ? { owner: snapshot.owner } : {}),
-    ...(snapshot.wallets ? { wallets: [...snapshot.wallets] } : {}),
+    ...(snapshot.owner !== undefined ? { owner: snapshot.owner } : {}),
+    ...(snapshot.wallets !== undefined
+      ? { wallets: [...snapshot.wallets] }
+      : {}),
     ...(snapshot.block_number !== undefined
       ? { block_number: snapshot.block_number }
       : {}),
@@ -1173,11 +1195,32 @@ function createFixtureMediaAsset({
     uri,
     kind,
     content_hash: hashFixtureString(uri),
-    mime_type: kind === 'social_image' || kind === 'image' ? 'image/png' : kind,
+    mime_type: fixtureMimeTypeForKind(kind),
     width,
     height,
     roles: [role]
   };
+}
+
+function fixtureMimeTypeForKind(kind: CmsAssetKind): string {
+  switch (kind) {
+    case 'audio':
+      return 'audio/mpeg';
+    case 'build_manifest':
+    case 'search_index':
+      return 'application/json';
+    case 'document':
+      return 'application/pdf';
+    case 'html':
+      return 'text/html';
+    case 'model':
+      return 'model/gltf-binary';
+    case 'video':
+      return 'video/mp4';
+    case 'image':
+    case 'social_image':
+      return 'image/png';
+  }
 }
 
 function hashFixtureString(value: string): string {
@@ -1240,6 +1283,13 @@ function getAssetIdForInputKey(
   return assetsByInputKey.get(inputKey)?.id;
 }
 
+function getMediaAssetLookupKey(
+  asset: ProfileCmsGalleryMediaAssetInput,
+  index: number
+): string {
+  return asset.key ?? String(index);
+}
+
 function guessAssetKind(mimeType: string): CmsAssetKind {
   if (mimeType.startsWith('video/')) {
     return 'video';
@@ -1291,7 +1341,14 @@ function normalizeEthereumAddress(address: string): string {
 }
 
 function normalizeTokenId(tokenId: string | number): string {
-  return String(tokenId).trim();
+  if (typeof tokenId === 'number' && !Number.isFinite(tokenId)) {
+    throw new Error('NFT token_id must be a finite string or number.');
+  }
+  const normalized = String(tokenId).trim();
+  if (!normalized) {
+    throw new Error('NFT token_id must be non-empty.');
+  }
+  return normalized;
 }
 
 function toSet(values: readonly string[] | undefined): ReadonlySet<string> {
@@ -1379,6 +1436,8 @@ function compareStrings(left: string, right: string): number {
 }
 
 function compareTokenIds(left: string, right: string): number {
+  // Numeric-looking token IDs sort by integer magnitude without coercing to a
+  // JS number, so very large uint256 ids stay precise and deterministic.
   const normalizedLeft = stripLeadingZeroes(left);
   const normalizedRight = stripLeadingZeroes(right);
   if (isIntegerString(normalizedLeft) && isIntegerString(normalizedRight)) {
@@ -1400,7 +1459,11 @@ function isIntegerString(value: string): boolean {
 }
 
 function joinCanonicalUrl(baseUrl: string, path: string): string {
-  const trimmedBase = baseUrl.replace(/\/+$/, '');
+  let endIndex = baseUrl.length;
+  while (endIndex > 0 && baseUrl.charCodeAt(endIndex - 1) === 47) {
+    endIndex -= 1;
+  }
+  const trimmedBase = baseUrl.slice(0, endIndex);
   return `${trimmedBase}${path}`;
 }
 


### PR DESCRIPTION
## Summary

Adds a pure backend generator that turns a normalized wallet/NFT snapshot into a CMS V1 package for profile-native galleries.

- Introduces `generateProfileCmsGalleryPackage` plus the explicit snapshot, curation, media, provenance, and site input contract.
- Generates deterministic gallery home, collections index, collection pages, NFT detail pages, media profile/display variant references, and social-image references when media is available.
- Supports hide, feature, and reorder controls for collections and NFTs without changing the existing CMS V1 package schema.
- Adds a fixture fallback snapshot for FE preview/unblocking until the wallet snapshot lane is fully wired.
- Documents the FE handoff contract and a future library-to-API boundary for exposing the generator later.

## FE Contract Notes

- Stable routes are emitted as `/{handle}/index.html`, `/{handle}/collections/index.html`, `/{handle}/collections/{collection-slug}/index.html`, and `/{handle}/nfts/{nft-slug}/index.html`.
- Slugs are ASCII lowercase, non-alphanumeric collapsed to `-`, max 72 chars, and deterministically suffixed on collisions.
- Media inputs map to package `assets`, `nft_media_profiles`, `display_variants`, page refs, posters, and social-image refs only when complete enough to reference safely.
- Curation inputs are `hidden_nft_keys`, `hidden_collection_keys`, `featured_nft_keys`, `featured_collection_keys`, `nft_order`, `collection_order`, and `collection_nft_order`.
- The generator is library-only in this PR. Future service boundary is documented as `POST /api/profile-cms/packages/generate-gallery` returning `{ cms_package, validation_result }` before any draft persistence.

## Validation

- `npm test -- src/profile-cms/profile-cms-gallery-package-generator.test.ts --runInBand`
- `npm run lint` via WSL Bash
- `$env:NODE_OPTIONS='--max-old-space-size=8192'; npx eslint src/profile-cms/profile-cms-gallery-package-generator.ts src/profile-cms/profile-cms-gallery-package-generator.test.ts --max-warnings=0`
- `npx prettier --check ...` for changed source/docs
- `codex-diff-check` and `codex-diff-check --cached`

## Caveats

- Direct `npm run lint` from PowerShell fails because the repo script uses POSIX `NODE_OPTIONS=...`; WSL Bash invocation passed.
- `node scripts/check-changed.mjs --base=origin/codex/profile-cms-decentralized-publish --skip-typecheck` fails before checks in this Windows shell because `spawnSync('npm')` with `shell:false` does not resolve `npm.cmd`.
- Full root `tsc -p tsconfig.json --noEmit` is blocked by unrelated nested API dependency declaration gaps (`@serverless/typescript`, `swagger-ui-express`, `pdf-lib`, `@aws-sdk/client-managedblockchain`, `js-yaml` types).