### PR TITLE
Fix profile CMS pointer migration execution

### DIFF
--- a/migrations/20260617222400-profile-cms-pointer-events.js
+++ b/migrations/20260617222400-profile-cms-pointer-events.js
@@ -1,16 +1,30 @@
 const fs = require('fs');
 const path = require('path');
 
-exports.up = async function (db) {
-  const filePath = path.join(
-    __dirname,
-    'sqls',
-    '20260617222400-profile-cms-pointer-events-up.sql'
-  );
+async function runSqlFile(db, fileName) {
+  const filePath = path.join(__dirname, 'sqls', fileName);
   const data = fs.readFileSync(filePath, { encoding: 'utf8' });
   await db.runSql(data);
+}
+
+exports.up = async function (db) {
+  await runSqlFile(
+    db,
+    '20260617222400-profile-cms-pointer-events-up.sql'
+  );
+  await runSqlFile(
+    db,
+    '20260617222400-profile-cms-publish-signatures-up.sql'
+  );
 };
 
-exports.down = async function () {
-  return null;
+exports.down = async function (db) {
+  await runSqlFile(
+    db,
+    '20260617222400-profile-cms-publish-signatures-down.sql'
+  );
+  await runSqlFile(
+    db,
+    '20260617222400-profile-cms-pointer-events-down.sql'
+  );
 };

--- a/migrations/sqls/20260617222400-profile-cms-pointer-events-down.sql
+++ b/migrations/sqls/20260617222400-profile-cms-pointer-events-down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS profile_cms_pointer_events;

--- a/migrations/sqls/20260617222400-profile-cms-pointer-events-up.sql
+++ b/migrations/sqls/20260617222400-profile-cms-pointer-events-up.sql
@@ -1,4 +1,4 @@
-CREATE TABLE profile_cms_pointer_events (
+CREATE TABLE IF NOT EXISTS profile_cms_pointer_events (
   id varchar(100) NOT NULL,
   event_type varchar(25) NOT NULL,
   profile_id varchar(100) NOT NULL,
@@ -20,20 +20,4 @@ CREATE TABLE profile_cms_pointer_events (
   PRIMARY KEY (id),
   KEY idx_profile_cms_pointer_events_profile_created (profile_id, created_at, event_sequence),
   KEY idx_profile_cms_pointer_events_package (package_db_id)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-
-CREATE TABLE profile_cms_publish_signatures (
-  id varchar(100) NOT NULL,
-  typed_data_hash varchar(100) NOT NULL,
-  profile_id varchar(100) NOT NULL,
-  package_db_id varchar(100) NOT NULL,
-  package_id varchar(128) NOT NULL,
-  package_version int NOT NULL,
-  package_hash varchar(100) NOT NULL,
-  signer_address varchar(42) NOT NULL,
-  deadline bigint NOT NULL,
-  created_at bigint NOT NULL,
-  PRIMARY KEY (id),
-  UNIQUE KEY idx_profile_cms_publish_signatures_hash (typed_data_hash),
-  KEY idx_profile_cms_publish_signatures_profile_created (profile_id, created_at)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/migrations/sqls/20260617222400-profile-cms-publish-signatures-down.sql
+++ b/migrations/sqls/20260617222400-profile-cms-publish-signatures-down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS profile_cms_publish_signatures;

--- a/migrations/sqls/20260617222400-profile-cms-publish-signatures-up.sql
+++ b/migrations/sqls/20260617222400-profile-cms-publish-signatures-up.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS profile_cms_publish_signatures (
+  id varchar(100) NOT NULL,
+  typed_data_hash varchar(100) NOT NULL,
+  profile_id varchar(100) NOT NULL,
+  package_db_id varchar(100) NOT NULL,
+  package_id varchar(128) NOT NULL,
+  package_version int NOT NULL,
+  package_hash varchar(100) NOT NULL,
+  signer_address varchar(42) NOT NULL,
+  deadline bigint NOT NULL,
+  created_at bigint NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE KEY idx_profile_cms_publish_signatures_hash (typed_data_hash),
+  KEY idx_profile_cms_publish_signatures_profile_created (profile_id, created_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;


### PR DESCRIPTION
## Summary
- Fix the profile CMS pointer migration so db-migrate executes each CREATE TABLE statement separately.
- Make the new pointer/signature table creates idempotent so rerunning after the failed staging migration is safe.

## Validation
- node mock migration runner confirms two sequential runSql calls
- git diff --check --ignore-cr-at-eol
- npm run lint -- --max-warnings=0

Release train: profile-cms-phase-0-8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database migration reliability. Migrations now handle existing tables gracefully without failure, making deployments and re-runs more robust.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->