### PR TITLE
Support followed subwave parent containers in wave APIs

### DIFF
--- a/src/api-serverless/openapi.yaml
+++ b/src/api-serverless/openapi.yaml
@@ -7758,8 +7758,9 @@ paths:
         - name: only_waves_followed_by_authenticated_user
           in: query
           description: >-
-            If true then result only includes waves what authenticated user
-            follows
+            If true then result only includes waves the authenticated user
+            follows, plus root parent containers for subwaves the authenticated
+            user follows where the parent is visible.
           required: false
           schema:
             type: boolean
@@ -7839,7 +7840,8 @@ paths:
           in: query
           description: >-
             If true then result excludes waves the authenticated user already
-            follows
+            follows, plus root parent containers for subwaves the authenticated
+            user follows where the parent is visible.
           required: false
           schema:
             type: boolean
@@ -8833,7 +8835,8 @@ paths:
           in: query
           description: >-
             OVERVIEW view only. If true then result only includes waves that the
-            authenticated user follows.
+            authenticated user follows, plus root parent containers for subwaves
+            the authenticated user follows where the parent is visible.
           required: false
           schema:
             type: boolean
@@ -8898,7 +8901,9 @@ paths:
           description: >-
             HOT view and OVERVIEW view with
             overview_type=SCORED_RECENTLY_DROPPED_TO only. If true then result
-            excludes waves the authenticated user already follows.
+            excludes waves the authenticated user already follows, plus root
+            parent containers for subwaves the authenticated user follows where
+            the parent is visible.
           required: false
           schema:
             type: boolean
@@ -18243,6 +18248,18 @@ components:
           type: integer
           format: int64
         first_unread_drop_serial_no:
+          type: integer
+          format: int64
+        followed_subwaves_count:
+          type: integer
+          format: int64
+        latest_followed_subwave_activity_timestamp:
+          type: integer
+          format: int64
+        hidden_followed_subwave_unread_drops:
+          type: integer
+          format: int64
+        first_hidden_followed_subwave_unread_drop_serial_no:
           type: integer
           format: int64
         muted:

--- a/src/api-serverless/src/generated/models/ApiWaveOverviewContextProfileContext.ts
+++ b/src/api-serverless/src/generated/models/ApiWaveOverviewContextProfileContext.ts
@@ -19,6 +19,10 @@ export class ApiWaveOverviewContextProfileContext {
     'next_drop_allowed'?: number;
     'unread_drops': number;
     'first_unread_drop_serial_no'?: number;
+    'followed_subwaves_count'?: number;
+    'latest_followed_subwave_activity_timestamp'?: number;
+    'hidden_followed_subwave_unread_drops'?: number;
+    'first_hidden_followed_subwave_unread_drop_serial_no'?: number;
     'muted': boolean;
 
     static readonly discriminator: string | undefined = undefined;
@@ -59,6 +63,30 @@ export class ApiWaveOverviewContextProfileContext {
         {
             "name": "first_unread_drop_serial_no",
             "baseName": "first_unread_drop_serial_no",
+            "type": "number",
+            "format": "int64"
+        },
+        {
+            "name": "followed_subwaves_count",
+            "baseName": "followed_subwaves_count",
+            "type": "number",
+            "format": "int64"
+        },
+        {
+            "name": "latest_followed_subwave_activity_timestamp",
+            "baseName": "latest_followed_subwave_activity_timestamp",
+            "type": "number",
+            "format": "int64"
+        },
+        {
+            "name": "hidden_followed_subwave_unread_drops",
+            "baseName": "hidden_followed_subwave_unread_drops",
+            "type": "number",
+            "format": "int64"
+        },
+        {
+            "name": "first_hidden_followed_subwave_unread_drop_serial_no",
+            "baseName": "first_hidden_followed_subwave_unread_drop_serial_no",
             "type": "number",
             "format": "int64"
         },

--- a/src/api-serverless/src/waves/api-wave-overview-mapper.test.ts
+++ b/src/api-serverless/src/waves/api-wave-overview-mapper.test.ts
@@ -117,7 +117,10 @@ function createMapper() {
     findVisibleParentWavesByChildWaveIds: jest.fn().mockResolvedValue({}),
     findWaveIdsWithVisibleSubwaves: jest
       .fn()
-      .mockResolvedValue(new Set<string>())
+      .mockResolvedValue(new Set<string>()),
+    findFollowedSubwaveOverviewContextsByParentWaveId: jest
+      .fn()
+      .mockResolvedValue({})
   };
   const dropsDb = {
     getDropPartOnes: jest.fn().mockResolvedValue({}),
@@ -441,6 +444,8 @@ describe('ApiWaveOverviewMapper', () => {
         can_chat: true,
         unread_drops: 7,
         first_unread_drop_serial_no: 19,
+        followed_subwaves_count: 0,
+        hidden_followed_subwave_unread_drops: 0,
         muted: true
       },
       ...expectedNeutralWaveRepAndScore()
@@ -486,8 +491,60 @@ describe('ApiWaveOverviewMapper', () => {
       can_chat: false,
       next_drop_allowed: nextDropTimestamp,
       unread_drops: 0,
+      followed_subwaves_count: 0,
+      hidden_followed_subwave_unread_drops: 0,
       muted: false
     });
+  });
+
+  it('maps followed subwave aggregate context without changing parent state', async () => {
+    const { mapper, deps } = createMapper();
+    deps.wavesApiDb.findWavesMetricsByWaveIds.mockResolvedValue({
+      'wave-1': makeMetric({
+        wave_id: 'wave-1',
+        latest_drop_timestamp: 111
+      })
+    });
+    deps.wavesApiDb.findFollowedSubwaveOverviewContextsByParentWaveId.mockResolvedValue(
+      {
+        'wave-1': {
+          followed_subwaves_count: 2,
+          latest_followed_subwave_activity_timestamp: 999,
+          hidden_followed_subwave_unread_drops: 5,
+          first_hidden_followed_subwave_unread_drop_serial_no: 77
+        }
+      }
+    );
+
+    const result = await mapper.mapWaves([makeWave()], {
+      authenticationContext: AuthenticationContext.fromProfileId('viewer-1')
+    });
+
+    expect(
+      deps.wavesApiDb.findFollowedSubwaveOverviewContextsByParentWaveId
+    ).toHaveBeenCalledWith(
+      {
+        identityId: 'viewer-1',
+        parentWaveIds: ['wave-1'],
+        eligibleGroups: []
+      },
+      expect.any(Object)
+    );
+    expect(result['wave-1']).toEqual(
+      expect.objectContaining({
+        last_drop_time: 111,
+        context_profile_context: expect.objectContaining({
+          subscribed: false,
+          pinned: false,
+          unread_drops: 0,
+          followed_subwaves_count: 2,
+          latest_followed_subwave_activity_timestamp: 999,
+          hidden_followed_subwave_unread_drops: 5,
+          first_hidden_followed_subwave_unread_drop_serial_no: 77,
+          muted: false
+        })
+      })
+    );
   });
 });
 

--- a/src/api-serverless/src/waves/api-wave-overview.mapper.ts
+++ b/src/api-serverless/src/waves/api-wave-overview.mapper.ts
@@ -36,7 +36,11 @@ import {
   WaveDisplayOverride
 } from '@/api/waves/direct-message-wave-display.service';
 import { getWaveReadContextProfileId } from '@/api/waves/wave-access.helpers';
-import { wavesApiDb, WavesApiDb } from '@/api/waves/waves.api.db';
+import {
+  FollowedSubwaveOverviewContext,
+  wavesApiDb,
+  WavesApiDb
+} from '@/api/waves/waves.api.db';
 import {
   mapWaveRepSummary,
   mapWaveScore
@@ -119,6 +123,9 @@ export class ApiWaveOverviewMapper {
         (wave) => wave.id
       );
       const waveIds = relatedEntities.map((wave) => wave.id);
+      const rootWaveIds = relatedEntities
+        .filter((wave) => wave.parent_wave_id === null)
+        .map((wave) => wave.id);
       const descriptionDropIds = collections.distinct(
         relatedEntities.map((wave) => wave.description_drop_id)
       );
@@ -140,6 +147,7 @@ export class ApiWaveOverviewMapper {
         firstUnreadDropSerialNoByWaveId,
         chatDropCooldownsByWaveId,
         waveIdsWithVisibleSubwaves,
+        followedSubwaveContextsByParentWaveId,
         profilesById
       ] = await Promise.all([
         this.wavesApiDb.findWavesMetricsByWaveIds(waveIds, ctx),
@@ -214,6 +222,18 @@ export class ApiWaveOverviewMapper {
           groupIdsUserIsEligibleFor,
           ctx
         ),
+        contextProfileId
+          ? this.wavesApiDb.findFollowedSubwaveOverviewContextsByParentWaveId(
+              {
+                identityId: contextProfileId,
+                parentWaveIds: rootWaveIds,
+                eligibleGroups: groupIdsUserIsEligibleFor
+              },
+              ctx
+            )
+          : Promise.resolve(
+              {} as Record<string, FollowedSubwaveOverviewContext>
+            ),
         creatorIds.length
           ? this.identityFetcher.getOverviewsByIds(creatorIds, ctx)
           : Promise.resolve({} as Record<string, ApiProfileMin>)
@@ -235,6 +255,8 @@ export class ApiWaveOverviewMapper {
             unreadDropsCount: unreadDropsCountByWaveId[wave.id] ?? 0,
             firstUnreadDropSerialNo:
               firstUnreadDropSerialNoByWaveId[wave.id] ?? undefined,
+            followedSubwaveContext:
+              followedSubwaveContextsByParentWaveId[wave.id],
             nextDropTimestamp:
               chatDropCooldownsByWaveId[wave.id]?.next_drop_timestamp,
             hasSubwaves: waveIdsWithVisibleSubwaves.has(wave.id),
@@ -275,6 +297,7 @@ export class ApiWaveOverviewMapper {
     readerMetric,
     unreadDropsCount,
     firstUnreadDropSerialNo,
+    followedSubwaveContext,
     nextDropTimestamp,
     hasSubwaves,
     profilesById
@@ -291,6 +314,7 @@ export class ApiWaveOverviewMapper {
     readerMetric?: WaveReaderMetricEntity;
     unreadDropsCount: number;
     firstUnreadDropSerialNo?: number;
+    followedSubwaveContext?: FollowedSubwaveOverviewContext;
     nextDropTimestamp?: number;
     hasSubwaves: boolean;
     profilesById: Record<string, ApiProfileMin>;
@@ -334,6 +358,7 @@ export class ApiWaveOverviewMapper {
         readerMetric,
         unreadDropsCount,
         firstUnreadDropSerialNo,
+        followedSubwaveContext,
         contextProfileId,
         nextDropTimestamp
       });
@@ -388,6 +413,7 @@ export class ApiWaveOverviewMapper {
     readerMetric,
     unreadDropsCount,
     firstUnreadDropSerialNo,
+    followedSubwaveContext,
     contextProfileId,
     nextDropTimestamp
   }: {
@@ -398,6 +424,7 @@ export class ApiWaveOverviewMapper {
     readerMetric?: WaveReaderMetricEntity;
     unreadDropsCount: number;
     firstUnreadDropSerialNo?: number;
+    followedSubwaveContext?: FollowedSubwaveOverviewContext;
     contextProfileId: string;
     nextDropTimestamp?: number;
   }): ApiWaveOverviewContextProfileContext {
@@ -416,6 +443,10 @@ export class ApiWaveOverviewMapper {
           groupIdsUserIsEligibleFor.includes(wave.chat_group_id)) &&
         nextDropAllowed === undefined,
       unread_drops: unreadDropsCount,
+      followed_subwaves_count:
+        followedSubwaveContext?.followed_subwaves_count ?? 0,
+      hidden_followed_subwave_unread_drops:
+        followedSubwaveContext?.hidden_followed_subwave_unread_drops ?? 0,
       muted: readerMetric?.muted ?? false
     };
 
@@ -425,6 +456,25 @@ export class ApiWaveOverviewMapper {
 
     if (firstUnreadDropSerialNo !== undefined) {
       result.first_unread_drop_serial_no = firstUnreadDropSerialNo;
+    }
+
+    if (
+      followedSubwaveContext?.latest_followed_subwave_activity_timestamp !==
+        undefined &&
+      followedSubwaveContext.latest_followed_subwave_activity_timestamp !== null
+    ) {
+      result.latest_followed_subwave_activity_timestamp =
+        followedSubwaveContext.latest_followed_subwave_activity_timestamp;
+    }
+
+    if (
+      followedSubwaveContext?.first_hidden_followed_subwave_unread_drop_serial_no !==
+        undefined &&
+      followedSubwaveContext.first_hidden_followed_subwave_unread_drop_serial_no !==
+        null
+    ) {
+      result.first_hidden_followed_subwave_unread_drop_serial_no =
+        followedSubwaveContext.first_hidden_followed_subwave_unread_drop_serial_no;
     }
 
     return result;

--- a/src/api-serverless/src/waves/waves-api-db.test.ts
+++ b/src/api-serverless/src/waves/waves-api-db.test.ts
@@ -105,6 +105,46 @@ const publicSubwaveOfHiddenParent = aWave(
   { id: 'wave-hidden-parent-child', serial_no: 14, name: 'Visible Child' }
 );
 
+const followedRootWave = aWave(
+  {
+    created_by: author.profile_id!
+  },
+  { id: 'wave-followed-root', serial_no: 15, name: 'Followed Root Wave' }
+);
+
+const unfollowedDiscoveryWave = aWave(
+  {
+    created_by: author.profile_id!
+  },
+  { id: 'wave-unfollowed-discovery', serial_no: 16, name: 'Unfollowed Wave' }
+);
+
+const mutedContainerParentWave = aWave(
+  {
+    created_by: author.profile_id!
+  },
+  { id: 'wave-muted-container-parent', serial_no: 17, name: 'Muted Parent' }
+);
+
+const mutedContainerSubwave = aWave(
+  {
+    created_by: author.profile_id!,
+    parent_wave_id: mutedContainerParentWave.id
+  },
+  {
+    id: 'wave-muted-container-child',
+    serial_no: 18,
+    name: 'Muted Parent Child'
+  }
+);
+
+const mutedContainerComparatorWave = aWave(
+  {
+    created_by: author.profile_id!
+  },
+  { id: 'wave-muted-container-comparator', serial_no: 19, name: 'Comparator' }
+);
+
 describeWithSeed(
   'WavesApiDb read visibility',
   [
@@ -194,6 +234,427 @@ describeWithSeed(
         expect.objectContaining({ id: privateWave.id }),
         expect.objectContaining({ id: publicWave.id })
       ]);
+    });
+  }
+);
+
+describeWithSeed(
+  'WavesApiDb followed subwave overview containers',
+  [
+    withIdentities([author]),
+    withWaves([
+      parentWave,
+      alphaSubwave,
+      betaSubwave,
+      hiddenParentWave,
+      publicSubwaveOfHiddenParent,
+      followedRootWave,
+      unfollowedDiscoveryWave
+    ]),
+    {
+      table: WAVE_METRICS_TABLE,
+      rows: [
+        {
+          wave_id: parentWave.id,
+          latest_drop_timestamp: 100,
+          wave_visibility_tier: ApiWaveVisibilityTier.TrustedVisible,
+          wave_visibility_rank: 1,
+          wave_visibility_score: 60,
+          wave_quality_score: 60,
+          wave_hotness_score: 60,
+          wave_rep_sort_score: 60
+        },
+        {
+          wave_id: alphaSubwave.id,
+          latest_drop_timestamp: 900,
+          wave_visibility_tier: ApiWaveVisibilityTier.TrustedVisible,
+          wave_visibility_rank: 1,
+          wave_visibility_score: 99,
+          wave_quality_score: 99,
+          wave_hotness_score: 99,
+          wave_rep_sort_score: 99
+        },
+        {
+          wave_id: betaSubwave.id,
+          latest_drop_timestamp: 1000,
+          wave_visibility_tier: ApiWaveVisibilityTier.TrustedVisible,
+          wave_visibility_rank: 1,
+          wave_visibility_score: 95,
+          wave_quality_score: 95,
+          wave_hotness_score: 95,
+          wave_rep_sort_score: 95
+        },
+        {
+          wave_id: hiddenParentWave.id,
+          latest_drop_timestamp: 50,
+          wave_visibility_tier: ApiWaveVisibilityTier.TrustedVisible,
+          wave_visibility_rank: 1,
+          wave_visibility_score: 80,
+          wave_quality_score: 80,
+          wave_hotness_score: 80,
+          wave_rep_sort_score: 80
+        },
+        {
+          wave_id: publicSubwaveOfHiddenParent.id,
+          latest_drop_timestamp: 1100,
+          wave_visibility_tier: ApiWaveVisibilityTier.TrustedVisible,
+          wave_visibility_rank: 1,
+          wave_visibility_score: 90,
+          wave_quality_score: 90,
+          wave_hotness_score: 90,
+          wave_rep_sort_score: 90
+        },
+        {
+          wave_id: followedRootWave.id,
+          latest_drop_timestamp: 500,
+          wave_visibility_tier: ApiWaveVisibilityTier.TrustedVisible,
+          wave_visibility_rank: 1,
+          wave_visibility_score: 70,
+          wave_quality_score: 70,
+          wave_hotness_score: 70,
+          wave_rep_sort_score: 70
+        },
+        {
+          wave_id: unfollowedDiscoveryWave.id,
+          latest_drop_timestamp: 200,
+          wave_visibility_tier: ApiWaveVisibilityTier.TrustedVisible,
+          wave_visibility_rank: 1,
+          wave_visibility_score: 50,
+          wave_quality_score: 50,
+          wave_hotness_score: 50,
+          wave_rep_sort_score: 50
+        }
+      ]
+    },
+    {
+      table: IDENTITY_SUBSCRIPTIONS_TABLE,
+      rows: [
+        {
+          subscriber_id: author.profile_id!,
+          target_id: alphaSubwave.id,
+          target_type: ActivityEventTargetType.WAVE,
+          target_action: ActivityEventAction.DROP_CREATED,
+          wave_id: alphaSubwave.id,
+          subscribed_to_all_drops: false
+        },
+        {
+          subscriber_id: author.profile_id!,
+          target_id: betaSubwave.id,
+          target_type: ActivityEventTargetType.WAVE,
+          target_action: ActivityEventAction.DROP_CREATED,
+          wave_id: betaSubwave.id,
+          subscribed_to_all_drops: false
+        },
+        {
+          subscriber_id: author.profile_id!,
+          target_id: publicSubwaveOfHiddenParent.id,
+          target_type: ActivityEventTargetType.WAVE,
+          target_action: ActivityEventAction.DROP_CREATED,
+          wave_id: publicSubwaveOfHiddenParent.id,
+          subscribed_to_all_drops: false
+        },
+        {
+          subscriber_id: author.profile_id!,
+          target_id: followedRootWave.id,
+          target_type: ActivityEventTargetType.WAVE,
+          target_action: ActivityEventAction.DROP_CREATED,
+          wave_id: followedRootWave.id,
+          subscribed_to_all_drops: false
+        }
+      ]
+    },
+    {
+      table: WAVE_READER_METRICS_TABLE,
+      rows: [
+        {
+          wave_id: alphaSubwave.id,
+          reader_id: author.profile_id!,
+          latest_read_timestamp: 800,
+          muted: false
+        },
+        {
+          wave_id: betaSubwave.id,
+          reader_id: author.profile_id!,
+          latest_read_timestamp: 800,
+          muted: true
+        }
+      ]
+    },
+    {
+      table: DROPS_TABLE,
+      rows: [
+        {
+          id: 'alpha-unread-drop-1',
+          wave_id: alphaSubwave.id,
+          author_id: author.profile_id!,
+          created_at: 850,
+          updated_at: null,
+          title: null,
+          parts_count: 1,
+          reply_to_drop_id: null,
+          reply_to_part_id: null,
+          drop_type: DropType.CHAT,
+          signature: null,
+          hide_link_preview: false
+        },
+        {
+          id: 'alpha-unread-drop-2',
+          wave_id: alphaSubwave.id,
+          author_id: author.profile_id!,
+          created_at: 900,
+          updated_at: null,
+          title: null,
+          parts_count: 1,
+          reply_to_drop_id: null,
+          reply_to_part_id: null,
+          drop_type: DropType.CHAT,
+          signature: null,
+          hide_link_preview: false
+        },
+        {
+          id: 'beta-muted-drop',
+          wave_id: betaSubwave.id,
+          author_id: author.profile_id!,
+          created_at: 1000,
+          updated_at: null,
+          title: null,
+          parts_count: 1,
+          reply_to_drop_id: null,
+          reply_to_part_id: null,
+          drop_type: DropType.CHAT,
+          signature: null,
+          hide_link_preview: false
+        }
+      ]
+    }
+  ],
+  () => {
+    it('returns parent containers for followed subwaves in activity order', async () => {
+      const waves = await repo.findRecentlyDroppedToWaves({
+        authenticated_user_id: author.profile_id!,
+        only_waves_followed_by_authenticated_user: true,
+        offset: 0,
+        limit: 10,
+        eligibleGroups: [],
+        direct_message: false,
+        pinned: null
+      });
+
+      expect(waves.map((wave) => wave.id)).toEqual([
+        parentWave.id,
+        followedRootWave.id
+      ]);
+    });
+
+    it('uses parent score for followed-subwave containers in scored overviews', async () => {
+      const waves = await repo.findScoredRecentlyDroppedToWaves({
+        authenticated_user_id: author.profile_id!,
+        only_waves_followed_by_authenticated_user: true,
+        offset: 0,
+        limit: 10,
+        eligibleGroups: [],
+        direct_message: false,
+        pinned: null,
+        score_sort: ApiWaveScoreSort.Quality,
+        exclude_followed: false
+      });
+
+      expect(waves.map((wave) => wave.id)).toEqual([
+        followedRootWave.id,
+        parentWave.id
+      ]);
+    });
+
+    it('excludes parents with followed subwaves from scored discovery', async () => {
+      const waves = await repo.findScoredRecentlyDroppedToWaves({
+        authenticated_user_id: author.profile_id!,
+        only_waves_followed_by_authenticated_user: false,
+        offset: 0,
+        limit: 10,
+        eligibleGroups: [],
+        direct_message: false,
+        pinned: null,
+        score_sort: ApiWaveScoreSort.Quality,
+        exclude_followed: true
+      });
+
+      expect(waves.map((wave) => wave.id)).toEqual([
+        unfollowedDiscoveryWave.id
+      ]);
+    });
+
+    it('summarizes hidden followed subwave activity and unread counts', async () => {
+      const contexts =
+        await repo.findFollowedSubwaveOverviewContextsByParentWaveId(
+          {
+            identityId: author.profile_id!,
+            parentWaveIds: [parentWave.id],
+            eligibleGroups: []
+          },
+          ctx
+        );
+
+      expect(contexts[parentWave.id]).toEqual({
+        followed_subwaves_count: 2,
+        latest_followed_subwave_activity_timestamp: 900,
+        hidden_followed_subwave_unread_drops: 2,
+        first_hidden_followed_subwave_unread_drop_serial_no: expect.any(Number)
+      });
+    });
+
+    it('does not surface followed child aggregates for hidden parents', async () => {
+      const contexts =
+        await repo.findFollowedSubwaveOverviewContextsByParentWaveId(
+          {
+            identityId: author.profile_id!,
+            parentWaveIds: [hiddenParentWave.id],
+            eligibleGroups: []
+          },
+          ctx
+        );
+
+      expect(contexts[hiddenParentWave.id]).toBeUndefined();
+    });
+  }
+);
+
+describeWithSeed(
+  'WavesApiDb followed subwave muted parent containers',
+  [
+    withIdentities([author]),
+    withWaves([
+      mutedContainerParentWave,
+      mutedContainerSubwave,
+      mutedContainerComparatorWave
+    ]),
+    {
+      table: WAVE_METRICS_TABLE,
+      rows: [
+        {
+          wave_id: mutedContainerParentWave.id,
+          latest_drop_timestamp: 10,
+          wave_visibility_tier: ApiWaveVisibilityTier.TrustedVisible,
+          wave_visibility_rank: 1,
+          wave_visibility_score: 60,
+          wave_quality_score: 60,
+          wave_hotness_score: 60,
+          wave_rep_sort_score: 60
+        },
+        {
+          wave_id: mutedContainerSubwave.id,
+          latest_drop_timestamp: 900,
+          wave_visibility_tier: ApiWaveVisibilityTier.TrustedVisible,
+          wave_visibility_rank: 1,
+          wave_visibility_score: 95,
+          wave_quality_score: 95,
+          wave_hotness_score: 95,
+          wave_rep_sort_score: 95
+        },
+        {
+          wave_id: mutedContainerComparatorWave.id,
+          latest_drop_timestamp: 500,
+          wave_visibility_tier: ApiWaveVisibilityTier.TrustedVisible,
+          wave_visibility_rank: 1,
+          wave_visibility_score: 70,
+          wave_quality_score: 70,
+          wave_hotness_score: 70,
+          wave_rep_sort_score: 70
+        }
+      ]
+    },
+    {
+      table: IDENTITY_SUBSCRIPTIONS_TABLE,
+      rows: [
+        {
+          subscriber_id: author.profile_id!,
+          target_id: mutedContainerSubwave.id,
+          target_type: ActivityEventTargetType.WAVE,
+          target_action: ActivityEventAction.DROP_CREATED,
+          wave_id: mutedContainerSubwave.id,
+          subscribed_to_all_drops: false
+        },
+        {
+          subscriber_id: author.profile_id!,
+          target_id: mutedContainerComparatorWave.id,
+          target_type: ActivityEventTargetType.WAVE,
+          target_action: ActivityEventAction.DROP_CREATED,
+          wave_id: mutedContainerComparatorWave.id,
+          subscribed_to_all_drops: false
+        }
+      ]
+    },
+    {
+      table: WAVE_READER_METRICS_TABLE,
+      rows: [
+        {
+          wave_id: mutedContainerParentWave.id,
+          reader_id: author.profile_id!,
+          latest_read_timestamp: 0,
+          muted: true
+        },
+        {
+          wave_id: mutedContainerSubwave.id,
+          reader_id: author.profile_id!,
+          latest_read_timestamp: 100,
+          muted: false
+        }
+      ]
+    },
+    {
+      table: DROPS_TABLE,
+      rows: [
+        {
+          id: 'muted-parent-child-unread-drop',
+          wave_id: mutedContainerSubwave.id,
+          author_id: author.profile_id!,
+          created_at: 900,
+          updated_at: null,
+          title: null,
+          parts_count: 1,
+          reply_to_drop_id: null,
+          reply_to_part_id: null,
+          drop_type: DropType.CHAT,
+          signature: null,
+          hide_link_preview: false
+        }
+      ]
+    }
+  ],
+  () => {
+    it('does not let followed child activity lift a muted parent container', async () => {
+      const waves = await repo.findRecentlyDroppedToWaves({
+        authenticated_user_id: author.profile_id!,
+        only_waves_followed_by_authenticated_user: true,
+        offset: 0,
+        limit: 10,
+        eligibleGroups: [],
+        direct_message: false,
+        pinned: null
+      });
+
+      expect(waves.map((wave) => wave.id)).toEqual([
+        mutedContainerComparatorWave.id,
+        mutedContainerParentWave.id
+      ]);
+    });
+
+    it('does not surface hidden child unread counts for a muted parent', async () => {
+      const contexts =
+        await repo.findFollowedSubwaveOverviewContextsByParentWaveId(
+          {
+            identityId: author.profile_id!,
+            parentWaveIds: [mutedContainerParentWave.id],
+            eligibleGroups: []
+          },
+          ctx
+        );
+
+      expect(contexts[mutedContainerParentWave.id]).toEqual({
+        followed_subwaves_count: 1,
+        latest_followed_subwave_activity_timestamp: null,
+        hidden_followed_subwave_unread_drops: 0,
+        first_hidden_followed_subwave_unread_drop_serial_no: null
+      });
     });
   }
 );
@@ -289,6 +750,24 @@ describeWithSeed(
       });
 
       expect(waves.map((wave) => wave.id)).toEqual([visibleScoredWave.id]);
+    });
+
+    it('rejects conflicting followed-only and exclude-followed scored filters', async () => {
+      await expect(
+        repo.findScoredRecentlyDroppedToWaves({
+          authenticated_user_id: author.profile_id!,
+          only_waves_followed_by_authenticated_user: true,
+          offset: 0,
+          limit: 10,
+          eligibleGroups: [],
+          direct_message: false,
+          pinned: null,
+          score_sort: ApiWaveScoreSort.Quality,
+          exclude_followed: true
+        })
+      ).rejects.toThrow(
+        'Cannot request followed-only waves and exclude-followed waves together'
+      );
     });
   }
 );

--- a/src/api-serverless/src/waves/waves.api.db.ts
+++ b/src/api-serverless/src/waves/waves.api.db.ts
@@ -97,6 +97,25 @@ type WaveChatDropCooldownPolicyRow = {
   stored_updated_at: number | string | null;
 };
 
+type FollowedSubwaveActivityRow = {
+  parent_wave_id: string;
+  followed_subwaves_count: number | string;
+  latest_followed_subwave_activity_timestamp: number | string | null;
+};
+
+type HiddenFollowedSubwaveUnreadRow = {
+  parent_wave_id: string;
+  hidden_followed_subwave_unread_drops: number | string;
+  first_hidden_followed_subwave_unread_drop_serial_no: number | string | null;
+};
+
+export interface FollowedSubwaveOverviewContext {
+  readonly followed_subwaves_count: number;
+  readonly latest_followed_subwave_activity_timestamp: number | null;
+  readonly hidden_followed_subwave_unread_drops: number;
+  readonly first_hidden_followed_subwave_unread_drop_serial_no: number | null;
+}
+
 export enum WaveSubwavesSort {
   NAME = 'NAME',
   CREATED_AT = 'CREATED_AT'
@@ -161,6 +180,91 @@ export class WavesApiDb extends LazyDbAccessCompatibleService {
     value: number | string | null | undefined
   ): number | null {
     return value === null || value === undefined ? null : Number(value);
+  }
+
+  private toActivityTimestamp(
+    value: number | string | null | undefined
+  ): number | null {
+    const numericValue = this.toNullableNumber(value);
+    return numericValue !== null && numericValue > 0 ? numericValue : null;
+  }
+
+  private getFollowedSubwaveActivitySelect({
+    groupIds,
+    identityParamName,
+    eligibleGroupsParamName,
+    parentWaveIdsParamName
+  }: {
+    groupIds: readonly string[];
+    identityParamName: string;
+    eligibleGroupsParamName: string;
+    parentWaveIdsParamName?: string;
+  }): string {
+    return `
+      select
+        child.parent_wave_id,
+        count(distinct child.id) as followed_subwaves_count,
+        max(
+          case
+            when coalesce(parent_wrm.muted, false) = true then 0
+            when coalesce(child_wrm.muted, false) = true then 0
+            else coalesce(child_wm.latest_drop_timestamp, 0)
+          end
+        ) as latest_followed_subwave_activity_timestamp
+      from ${WAVES_TABLE} child
+      join ${WAVES_TABLE} parent
+        on parent.id = child.parent_wave_id
+       and parent.parent_wave_id is null
+      join ${IDENTITY_SUBSCRIPTIONS_TABLE} child_follow
+        on child_follow.subscriber_id = :${identityParamName}
+       and child_follow.target_id = child.id
+       and child_follow.target_type = :wave_target_type
+       and child_follow.target_action = :drop_created_action
+      left join ${WAVE_METRICS_TABLE} child_wm
+        on child_wm.wave_id = child.id
+      left join ${WAVE_READER_METRICS_TABLE} parent_wrm
+        on parent_wrm.wave_id = parent.id
+       and parent_wrm.reader_id = :${identityParamName}
+      left join ${WAVE_READER_METRICS_TABLE} child_wrm
+        on child_wrm.wave_id = child.id
+       and child_wrm.reader_id = :${identityParamName}
+      where ${this.getWaveVisibilityFilter(
+        'child',
+        groupIds,
+        eligibleGroupsParamName
+      )}
+        and ${this.getWaveVisibilityFilter(
+          'parent',
+          groupIds,
+          eligibleGroupsParamName
+        )}
+        ${
+          parentWaveIdsParamName
+            ? `and child.parent_wave_id in (:${parentWaveIdsParamName})`
+            : ``
+        }
+      group by child.parent_wave_id
+    `;
+  }
+
+  private getFollowedSubwaveActivityCte({
+    groupIds,
+    identityParamName,
+    eligibleGroupsParamName
+  }: {
+    groupIds: readonly string[];
+    identityParamName: string;
+    eligibleGroupsParamName: string;
+  }): string {
+    return `
+      followed_subwave_activity as (
+        ${this.getFollowedSubwaveActivitySelect({
+          groupIds,
+          identityParamName,
+          eligibleGroupsParamName
+        })}
+      )
+    `;
   }
 
   private resolveWaveChatDropCooldownPolicy(
@@ -956,6 +1060,132 @@ export class WavesApiDb extends LazyDbAccessCompatibleService {
         { wrappedConnection: ctx.connection }
       );
       return new Set(rows.map((row) => row.wave_id));
+    } finally {
+      ctx.timer?.stop(timerKey);
+    }
+  }
+
+  async findFollowedSubwaveOverviewContextsByParentWaveId(
+    {
+      identityId,
+      parentWaveIds,
+      eligibleGroups
+    }: {
+      identityId: string;
+      parentWaveIds: string[];
+      eligibleGroups: string[];
+    },
+    ctx: RequestContext
+  ): Promise<Record<string, FollowedSubwaveOverviewContext>> {
+    if (!parentWaveIds.length) {
+      return {};
+    }
+    const timerKey = `${this.constructor.name}->findFollowedSubwaveOverviewContextsByParentWaveId`;
+    ctx.timer?.start(timerKey);
+    try {
+      const activityRows = await this.db.execute<FollowedSubwaveActivityRow>(
+        `
+            ${this.getFollowedSubwaveActivitySelect({
+              groupIds: eligibleGroups,
+              identityParamName: 'identityId',
+              eligibleGroupsParamName: 'eligibleGroups',
+              parentWaveIdsParamName: 'parentWaveIds'
+            })}
+          `,
+        {
+          identityId,
+          parentWaveIds,
+          eligibleGroups,
+          wave_target_type: ActivityEventTargetType.WAVE,
+          drop_created_action: ActivityEventAction.DROP_CREATED
+        },
+        { wrappedConnection: ctx.connection }
+      );
+
+      const unreadRows = await this.db.execute<HiddenFollowedSubwaveUnreadRow>(
+        `
+            select
+              child.parent_wave_id,
+              count(d.id) as hidden_followed_subwave_unread_drops,
+              min(d.serial_no) as first_hidden_followed_subwave_unread_drop_serial_no
+            from ${WAVES_TABLE} child
+            join ${WAVES_TABLE} parent
+              on parent.id = child.parent_wave_id
+             and parent.parent_wave_id is null
+            left join ${WAVE_READER_METRICS_TABLE} parent_reader
+              on parent_reader.wave_id = parent.id
+             and parent_reader.reader_id = :identityId
+            join ${IDENTITY_SUBSCRIPTIONS_TABLE} child_follow
+              on child_follow.subscriber_id = :identityId
+             and child_follow.target_id = child.id
+             and child_follow.target_type = :waveTargetType
+             and child_follow.target_action = :dropCreatedAction
+            join ${WAVE_READER_METRICS_TABLE} child_reader
+              on child_reader.wave_id = child.id
+             and child_reader.reader_id = :identityId
+             and child_reader.latest_read_timestamp is not null
+             and coalesce(child_reader.muted, false) = false
+            join ${DROPS_TABLE} d
+              on d.wave_id = child.id
+             and d.created_at > child_reader.latest_read_timestamp
+            where child.parent_wave_id in (:parentWaveIds)
+              and coalesce(parent_reader.muted, false) = false
+              and ${this.getWaveVisibilityFilter(
+                'child',
+                eligibleGroups,
+                'eligibleGroups'
+              )}
+              and ${this.getWaveVisibilityFilter(
+                'parent',
+                eligibleGroups,
+                'eligibleGroups'
+              )}
+            group by child.parent_wave_id
+          `,
+        {
+          identityId,
+          parentWaveIds,
+          eligibleGroups,
+          waveTargetType: ActivityEventTargetType.WAVE,
+          dropCreatedAction: ActivityEventAction.DROP_CREATED
+        },
+        { wrappedConnection: ctx.connection }
+      );
+
+      const result = activityRows.reduce(
+        (acc, row) => {
+          acc[row.parent_wave_id] = {
+            followed_subwaves_count: Number(row.followed_subwaves_count),
+            latest_followed_subwave_activity_timestamp:
+              this.toActivityTimestamp(
+                row.latest_followed_subwave_activity_timestamp
+              ),
+            hidden_followed_subwave_unread_drops: 0,
+            first_hidden_followed_subwave_unread_drop_serial_no: null
+          };
+          return acc;
+        },
+        {} as Record<string, FollowedSubwaveOverviewContext>
+      );
+
+      for (const row of unreadRows) {
+        const existing = result[row.parent_wave_id];
+        if (!existing) {
+          continue;
+        }
+        result[row.parent_wave_id] = {
+          ...existing,
+          hidden_followed_subwave_unread_drops: Number(
+            row.hidden_followed_subwave_unread_drops
+          ),
+          first_hidden_followed_subwave_unread_drop_serial_no:
+            this.toNullableNumber(
+              row.first_hidden_followed_subwave_unread_drop_serial_no
+            )
+        };
+      }
+
+      return result;
     } finally {
       ctx.timer?.stop(timerKey);
     }
@@ -1936,10 +2166,23 @@ export class WavesApiDb extends LazyDbAccessCompatibleService {
     direct_message?: boolean;
     pinned: ApiWavesPinFilter | null;
   }): Promise<WaveEntity[]> {
-    const sortExpr = param.authenticated_user_id
+    const useFollowedSubwaveActivity =
+      !!param.authenticated_user_id &&
+      param.only_waves_followed_by_authenticated_user;
+    const rootSortExpr = param.authenticated_user_id
       ? `CASE WHEN COALESCE(wrm.muted, false) = true THEN 0 ELSE wm.latest_drop_timestamp END`
       : `wm.latest_drop_timestamp`;
-    const sql = `with wids as (select w.id, ${sortExpr} as sort_val from ${WAVES_TABLE} w 
+    const sortExpr = useFollowedSubwaveActivity
+      ? `GREATEST(${rootSortExpr}, COALESCE(fsa.latest_followed_subwave_activity_timestamp, 0))`
+      : rootSortExpr;
+    const followedSubwaveActivityCte = useFollowedSubwaveActivity
+      ? `${this.getFollowedSubwaveActivityCte({
+          groupIds: param.eligibleGroups,
+          identityParamName: 'authenticated_user_id',
+          eligibleGroupsParamName: 'eligibleGroups'
+        })},`
+      : ``;
+    const sql = `with ${followedSubwaveActivityCte} wids as (select w.id, ${sortExpr} as sort_val from ${WAVES_TABLE} w
     ${
       param.pinned === ApiWavesPinFilter.Pinned && param.authenticated_user_id
         ? ` join ${PINNED_WAVES_TABLE} pw on pw.wave_id = w.id and pw.profile_id = :authenticated_user_id `
@@ -1952,7 +2195,16 @@ export class WavesApiDb extends LazyDbAccessCompatibleService {
    }
     ${
       param.only_waves_followed_by_authenticated_user
-        ? `join ${IDENTITY_SUBSCRIPTIONS_TABLE} f on f.target_type = 'WAVE' and f.target_action = 'DROP_CREATED' and f.target_id = w.id`
+        ? `left join ${IDENTITY_SUBSCRIPTIONS_TABLE} f
+             on f.subscriber_id = :authenticated_user_id
+            and f.target_type = :wave_target_type
+            and f.target_action = :drop_created_action
+            and f.target_id = w.id`
+        : ``
+    }
+    ${
+      useFollowedSubwaveActivity
+        ? `left join followed_subwave_activity fsa on fsa.parent_wave_id = w.id`
         : ``
     }
     join ${WAVE_METRICS_TABLE} wm on wm.wave_id = w.id 
@@ -1965,7 +2217,7 @@ export class WavesApiDb extends LazyDbAccessCompatibleService {
      ${param.pinned === ApiWavesPinFilter.NotPinned && param.authenticated_user_id ? ` pw.profile_id is null and ` : ``}
     ${
       param.only_waves_followed_by_authenticated_user
-        ? `f.subscriber_id = :authenticated_user_id and`
+        ? `(${useFollowedSubwaveActivity ? `f.id is not null or fsa.parent_wave_id is not null` : `f.id is not null`}) and`
         : ``
     }
      ${
@@ -1978,7 +2230,7 @@ export class WavesApiDb extends LazyDbAccessCompatibleService {
        param.eligibleGroups.length
          ? `or w.visibility_group_id in (:eligibleGroups)`
          : ``
-     }) order by sort_val desc limit :limit offset :offset) select w.* from ${WAVES_TABLE} w join wids on w.id = wids.id order by wids.sort_val desc`;
+     }) order by sort_val desc, w.id desc limit :limit offset :offset) select w.* from ${WAVES_TABLE} w join wids on w.id = wids.id order by wids.sort_val desc, w.id desc`;
     return this.db
       .execute<
         Omit<
@@ -1991,7 +2243,11 @@ export class WavesApiDb extends LazyDbAccessCompatibleService {
           participation_required_metadata: string;
           decisions_strategy: string;
         }
-      >(sql, param)
+      >(sql, {
+        ...param,
+        wave_target_type: ActivityEventTargetType.WAVE,
+        drop_created_action: ActivityEventAction.DROP_CREATED
+      })
       .then((res) =>
         res.map((it) => ({
           ...it,
@@ -2024,6 +2280,18 @@ export class WavesApiDb extends LazyDbAccessCompatibleService {
     min_rep_sort_score?: number;
     visibility_tier?: ApiWaveVisibilityTier;
   }): Promise<WaveEntity[]> {
+    if (
+      param.only_waves_followed_by_authenticated_user &&
+      param.exclude_followed
+    ) {
+      throw new Error(
+        'Cannot request followed-only waves and exclude-followed waves together'
+      );
+    }
+    const useFollowedSubwaveActivity =
+      !!param.authenticated_user_id &&
+      (param.only_waves_followed_by_authenticated_user ||
+        param.exclude_followed);
     const applyMutedScoreFloor = (column: string) =>
       param.authenticated_user_id
         ? `CASE WHEN COALESCE(wrm.muted, false) = true THEN 0 ELSE ${column} END`
@@ -2042,6 +2310,11 @@ export class WavesApiDb extends LazyDbAccessCompatibleService {
     const visibilityTierExpr = param.authenticated_user_id
       ? `CASE WHEN COALESCE(wrm.muted, false) = true THEN NULL ELSE wm.wave_visibility_tier END`
       : `wm.wave_visibility_tier`;
+    const latestActivityExpr =
+      useFollowedSubwaveActivity &&
+      param.only_waves_followed_by_authenticated_user
+        ? `GREATEST(${applyMutedScoreFloor('wm.latest_drop_timestamp')}, COALESCE(fsa.latest_followed_subwave_activity_timestamp, 0))`
+        : `wm.latest_drop_timestamp`;
     const filters = [
       param.min_visibility_score !== undefined
         ? `${visibilityScoreExpr} >= :min_visibility_score`
@@ -2062,12 +2335,19 @@ export class WavesApiDb extends LazyDbAccessCompatibleService {
       .filter((it): it is string => !!it)
       .join(' and ');
     const scoreFilters = filters ? `and ${filters}` : ``;
-    const sql = `with wids as (
+    const followedSubwaveActivityCte = useFollowedSubwaveActivity
+      ? `${this.getFollowedSubwaveActivityCte({
+          groupIds: param.eligibleGroups,
+          identityParamName: 'authenticated_user_id',
+          eligibleGroupsParamName: 'eligibleGroups'
+        })},`
+      : ``;
+    const sql = `with ${followedSubwaveActivityCte} wids as (
       select
         w.id,
         ${tierRankExpr} as tier_rank,
         ${scoreExpr} as sort_val,
-        wm.latest_drop_timestamp
+        ${latestActivityExpr} as latest_drop_timestamp
       from ${WAVES_TABLE} w
       ${
         param.pinned === ApiWavesPinFilter.Pinned && param.authenticated_user_id
@@ -2081,17 +2361,18 @@ export class WavesApiDb extends LazyDbAccessCompatibleService {
           : ``
       }
       ${
-        param.only_waves_followed_by_authenticated_user
-          ? `join ${IDENTITY_SUBSCRIPTIONS_TABLE} f on f.target_type = 'WAVE' and f.target_action = 'DROP_CREATED' and f.target_id = w.id`
+        param.only_waves_followed_by_authenticated_user ||
+        param.exclude_followed
+          ? `left join ${IDENTITY_SUBSCRIPTIONS_TABLE} f
+              on f.subscriber_id = :authenticated_user_id
+             and f.target_id = w.id
+             and f.target_type = :wave_target_type
+             and f.target_action = :drop_created_action`
           : ``
       }
       ${
-        param.exclude_followed
-          ? `left join ${IDENTITY_SUBSCRIPTIONS_TABLE} xf
-              on xf.subscriber_id = :authenticated_user_id
-             and xf.target_id = w.id
-             and xf.target_type = :wave_target_type
-             and xf.target_action = :drop_created_action`
+        useFollowedSubwaveActivity
+          ? `left join followed_subwave_activity fsa on fsa.parent_wave_id = w.id`
           : ``
       }
       join ${WAVE_METRICS_TABLE} wm on wm.wave_id = w.id
@@ -2104,10 +2385,14 @@ export class WavesApiDb extends LazyDbAccessCompatibleService {
         ${param.pinned === ApiWavesPinFilter.NotPinned && param.authenticated_user_id ? ` pw.profile_id is null and ` : ``}
         ${
           param.only_waves_followed_by_authenticated_user
-            ? `f.subscriber_id = :authenticated_user_id and`
+            ? `(${useFollowedSubwaveActivity ? `f.id is not null or fsa.parent_wave_id is not null` : `f.id is not null`}) and`
             : ``
         }
-        ${param.exclude_followed ? `xf.id is null and` : ``}
+        ${
+          param.exclude_followed
+            ? `f.id is null${useFollowedSubwaveActivity ? ` and fsa.parent_wave_id is null` : ``} and`
+            : ``
+        }
         ${
           param.direct_message !== undefined
             ? ` w.is_direct_message = :direct_message and `
@@ -2120,7 +2405,7 @@ export class WavesApiDb extends LazyDbAccessCompatibleService {
             : ``
         })
         ${scoreFilters}
-      order by tier_rank asc, sort_val desc, wm.latest_drop_timestamp desc, w.id desc
+      order by tier_rank asc, sort_val desc, latest_drop_timestamp desc, w.id desc
       limit :limit offset :offset
     )
     select w.*


### PR DESCRIPTION
## Issue
- Following a subwave should make the root wave container visible in followed-wave overview APIs, so the frontend can show the parent in the left sidebar when child activity happens.
- Discovery APIs also need to treat those parent containers as already-known waves for the current viewer.

## Fix
- Add followed-subwave aggregate context to wave overview responses.
- Extend recent/scored overview queries so followed subwaves can lift their visible root parent into the followed feed while preserving parent-local state.
- Keep parent mute authoritative: muted parents do not get lifted by child activity or hidden child unread counts.

## Changes
- Adds `followed_subwaves_count`, `latest_followed_subwave_activity_timestamp`, `hidden_followed_subwave_unread_drops`, and `first_hidden_followed_subwave_unread_drop_serial_no` to the wave overview profile context contract.
- Aggregates followed child activity/unread for visible parent containers.
- Excludes parent containers with followed children from scored discovery when `exclude_followed=true`.
- Updates OpenAPI query descriptions to document followed-subwave parent-container behavior.
- Adds DB and mapper coverage for parent containers, discovery exclusion, parent score preservation, hidden unread aggregation, and muted-parent suppression.

## Validation
- `npm run lint`
- `npm test -- src/api-serverless/src/waves/waves-api-db.test.ts src/api-serverless/src/waves/api-wave-overview-mapper.test.ts` (26 tests)
- `cd src/api-serverless && npm run restructure-openapi && npm run generate && npm run build`
- `codex-diff-check`
- Earlier full `npm run build` passed before the final reviewer-edge patch; final patch was revalidated with focused API build/tests.

## Risk
- Level: Medium
- Why: wave overview SQL changes affect followed/sidebar and discovery query behavior, but response shape is additive and covered by focused integration tests.
- Rollback: revert this PR and redeploy `api`; frontend defaults tolerate missing aggregate fields.

## Review Notes
- Deploy service: `api` only. No DB migration or loop deploy required.
- Frontend companion PR will consume these additive fields for sidebar grouping/sorting.