### PR TITLE
[codex] Fix TDH wording in agent docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,7 +126,7 @@ The backend consists of independent "loop" services that run as AWS Lambda funct
 - `nftOwnersLoop` - Tracks NFT ownership changes
 - `nftHistoryLoop` - Maintains NFT ownership history
 - `transactionsProcessingLoop` - Processes blockchain transactions
-- `tdhHistoryLoop` - Calculates TDH (The Destructive Hemisphere) scores
+- `tdhHistoryLoop` - Calculates TDH (Total Days Held) scores
 - `delegationsLoop` - Processes delegation.cash delegations
 - `marketStatsLoop` - Aggregates NFT market statistics
 - `aggregatedActivityLoop` - Calculates aggregated activity metrics
@@ -215,9 +215,9 @@ The API (`src/api-serverless/src/`) is an Express application with:
 - **Ratings** - Reputation system with categories (CIC, REP)
 - **Identities** - User profiles with proxy support
 
-**TDH (The Destructive Hemisphere):**
-- Scoring system based on NFT ownership and community participation
-- Consolidated calculations across wallet consolidations
+**TDH (Total Days Held):**
+- Scoring system based on eligible NFT ownership duration
+- Per-wallet calculations and consolidated calculations across wallet consolidations
 - Historical tracking in `tdh_history` and `tdh_global_history`
 
 **Delegations:**


### PR DESCRIPTION
## Summary
- Correct TDH expansion in AGENTS.md from the joke text to Total Days Held.
- Adjust the short TDH description to focus on eligible NFT ownership duration and wallet consolidation.

## Why
A contributor noticed the agent context described TDH incorrectly. The public 6529 docs and backend API docs use Total Days Held.

## Validation
- `codex-diff-check -- AGENTS.md`
- `npm run lint` via Git Bash script shell after `npm ci`

## Deployment
Docs-only change. No lambdas need redeploying.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified TDH (Total Days Held) documentation, defining it as a scoring system that measures NFT ownership duration with support for both per-wallet and consolidated calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->