### PR TITLE
Enable GLM swarm reviewbot command lane

### DIFF
--- a/.github/6529bot.yml
+++ b/.github/6529bot.yml
@@ -2,7 +2,7 @@ version: 1
 enabled: true
 
 reviewKinds:
-  allowed: [general, followup, wcag, i18n, security]
+  allowed: [general, followup, wcag, i18n, security, glm-swarm]
   initial: [general, security]
   followup: [followup]
 


### PR DESCRIPTION
## Summary
- allow the advisory `glm-swarm` review kind in `.github/6529bot.yml`
- keep existing initial/followup review kinds unchanged

## Rollout
This makes `/6529bot glm-swarm` available to trusted command users without adding GLM to automatic PR-opened reviews.