### PR TITLE
[codex] Run specialized Opus reviewbot lanes on PRs

### DIFF
--- a/.github/6529bot.yml
+++ b/.github/6529bot.yml
@@ -2,8 +2,8 @@ version: 1
 enabled: true
 
 reviewKinds:
-  allowed: [general, followup, wcag, i18n, security, glm-swarm]
-  initial: [general, security]
+  allowed: [general, followup, wcag, i18n, security, deploy-actions, auth-api, db-lambda, media-external, glm-swarm]
+  initial: [deploy-actions, auth-api, db-lambda, media-external]
   followup: [followup]
 
 commands:


### PR DESCRIPTION
## Summary

Configures `6529bot` for this backend repo to run exactly four specialized initial PR reviews:

- `deploy-actions`
- `auth-api`
- `db-lambda`
- `media-external`

All four use the existing single Anthropic lane, `claude-opus-4-8`, and keep `maxJobsPerDelivery: 4`, so an opened/reopened/ready PR queues four jobs. Follow-up commits still use the existing `followup` kind.

## Dependency

Depends on 6529-Collections/6529reviewbot#407 being merged and deployed first. This PR is intentionally draft until that deployment happens; older reviewbot deployments that do not know these kinds will reject this config.

## Validation

- `node D:\repos\6529reviewbot-specialized-bots\bin\validate-repository-config.cjs D:\repos\6529seize-backend-specialized-bots\.github\6529bot.yml`
- `codex-diff-check -- .github/6529bot.yml`
- GitHub Actions `Build backend and API` passed
- DCO passed
- SonarCloud passed
- Snyk passed