### PR TITLE
Re-add core review bots to backend initial fanout

### DIFF
--- a/.github/6529bot.yml
+++ b/.github/6529bot.yml
@@ -3,7 +3,7 @@ enabled: true
 
 reviewKinds:
   allowed: [general, followup, wcag, i18n, security, deploy-actions, auth-api, db-lambda, media-external, glm-swarm]
-  initial: [deploy-actions, auth-api, db-lambda, media-external]
+  initial: [general, security, deploy-actions, auth-api, db-lambda, media-external, glm-swarm]
   followup: [followup]
 
 commands:
@@ -14,7 +14,7 @@ lanes:
     model: claude-opus-4-8
 
 limits:
-  maxJobsPerDelivery: 4
+  maxJobsPerDelivery: 7
 
 admission:
   publicRepoMode: trusted


### PR DESCRIPTION
## Summary
- add `general`, `security`, and `glm-swarm` back to the automatic initial reviewbot set
- raise `maxJobsPerDelivery` from 4 to 7 so all configured initial bots can run

## Notes
- keeps the four backend-specialist bots in the initial set
- no application code changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated bot configuration to improve job delivery efficiency and expand initial review categorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->