### PR TITLE
Cache eligible wave groups per profile

### DIFF
--- a/src/api-serverless/src/community-members/user-groups-service.test.ts
+++ b/src/api-serverless/src/community-members/user-groups-service.test.ts
@@ -1,0 +1,247 @@
+import { UserGroupsService } from './user-groups.service';
+import { UserGroupsDb } from '@/user-groups/user-groups.db';
+import {
+  GroupTdhInclusionStrategy,
+  UserGroupEntity
+} from '@/entities/IUserGroup';
+import { getRedisClient, WAVE_GROUPS_VERSION_CACHE_KEY } from '@/redis';
+import { Time } from '@/time';
+import * as mcache from 'memory-cache';
+import { AbusivenessCheckService } from '@/profiles/abusiveness-check.service';
+import { MetricsRecorder } from '@/metrics/MetricsRecorder';
+
+jest.mock('@/redis', () => ({
+  ...jest.requireActual('@/redis'),
+  getRedisClient: jest.fn()
+}));
+
+type RedisMock = {
+  get: jest.Mock;
+  set: jest.Mock;
+  del: jest.Mock;
+};
+
+const PROFILE_ID = 'profile-1';
+const GROUP_ID = 'group-1';
+const ELIGIBLE_GROUPS_CACHE_KEY = `cache_6529_eligible_groups:${PROFILE_ID}`;
+
+function buildRedisMock(): RedisMock {
+  return {
+    get: jest.fn(),
+    set: jest.fn().mockResolvedValue('OK'),
+    del: jest.fn().mockResolvedValue(1)
+  };
+}
+
+function buildUserGroup(): UserGroupEntity {
+  return {
+    id: GROUP_ID,
+    name: 'Group 1',
+    cic_min: null,
+    cic_max: null,
+    cic_user: null,
+    cic_direction: null,
+    rep_min: null,
+    rep_max: null,
+    rep_user: null,
+    rep_direction: null,
+    rep_category: null,
+    tdh_min: null,
+    tdh_max: null,
+    tdh_inclusion_strategy: GroupTdhInclusionStrategy.TDH,
+    level_min: null,
+    level_max: null,
+    created_at: new Date(),
+    created_by: PROFILE_ID,
+    visible: true,
+    owns_meme: false,
+    owns_meme_tokens: null,
+    owns_gradient: false,
+    owns_gradient_tokens: null,
+    owns_nextgen: false,
+    owns_nextgen_tokens: null,
+    owns_lab: false,
+    owns_lab_tokens: null,
+    profile_group_id: 'profile-group-1',
+    excluded_profile_group_id: null,
+    is_pure_profile_group: true,
+    is_private: false,
+    is_direct_message: false,
+    is_beneficiary_of_grant_id: null
+  } as UserGroupEntity;
+}
+
+function buildUserGroupsDbMock() {
+  return {
+    getLatestProfileGroupChangeMillis: jest.fn().mockResolvedValue(null),
+    getAllWaveRelatedGroups: jest.fn().mockResolvedValue([GROUP_ID]),
+    getIdentityByProfileId: jest.fn().mockResolvedValue({
+      profile_id: PROFILE_ID,
+      rep: 0,
+      cic: 0,
+      tdh: 0,
+      xtdh: 0,
+      level_raw: 0
+    }),
+    getByIds: jest.fn().mockResolvedValue([buildUserGroup()]),
+    getGroupsUserIsEligibleByIdentity: jest.fn().mockResolvedValue([GROUP_ID]),
+    getGroupsUserIsExcludedFromByIdentity: jest.fn().mockResolvedValue([])
+  };
+}
+
+function buildService(userGroupsDb = buildUserGroupsDbMock()) {
+  return new UserGroupsService(
+    userGroupsDb as unknown as UserGroupsDb,
+    {} as unknown as AbusivenessCheckService,
+    {} as unknown as MetricsRecorder
+  );
+}
+
+describe('UserGroupsService eligibility cache', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+    mcache.clear();
+    delete process.env.USER_GROUPS_ELIGIBILITY_CACHE_TTL_SEC;
+  });
+
+  it('returns valid Redis profile cache without loading wave groups', async () => {
+    const redis = buildRedisMock();
+    redis.get.mockImplementation((key: string) => {
+      if (key === WAVE_GROUPS_VERSION_CACHE_KEY) {
+        return Promise.resolve('7');
+      }
+      if (key === ELIGIBLE_GROUPS_CACHE_KEY) {
+        return Promise.resolve(
+          JSON.stringify({
+            eligibleGroupIds: [GROUP_ID],
+            computedAtMillis: 1_000,
+            waveGroupsVersion: 7
+          })
+        );
+      }
+      return Promise.resolve(null);
+    });
+    (getRedisClient as jest.Mock).mockReturnValue(redis);
+
+    const userGroupsDb = buildUserGroupsDbMock();
+    const service = buildService(userGroupsDb);
+
+    await expect(
+      service.getGroupsUserIsEligibleFor(PROFILE_ID)
+    ).resolves.toEqual([GROUP_ID]);
+    expect(userGroupsDb.getAllWaveRelatedGroups).not.toHaveBeenCalled();
+    expect(userGroupsDb.getByIds).not.toHaveBeenCalled();
+    expect(redis.set).not.toHaveBeenCalled();
+  });
+
+  it('ignores Redis profile cache when profile groups changed later', async () => {
+    jest.spyOn(Time, 'currentMillis').mockReturnValue(3_000);
+    const redis = buildRedisMock();
+    redis.get.mockImplementation((key: string) => {
+      if (key === WAVE_GROUPS_VERSION_CACHE_KEY) {
+        return Promise.resolve('7');
+      }
+      if (key === ELIGIBLE_GROUPS_CACHE_KEY) {
+        return Promise.resolve(
+          JSON.stringify({
+            eligibleGroupIds: ['stale-group'],
+            computedAtMillis: 1_000,
+            waveGroupsVersion: 7
+          })
+        );
+      }
+      return Promise.resolve(null);
+    });
+    (getRedisClient as jest.Mock).mockReturnValue(redis);
+
+    const userGroupsDb = buildUserGroupsDbMock();
+    userGroupsDb.getLatestProfileGroupChangeMillis.mockResolvedValue(2_000);
+    const service = buildService(userGroupsDb);
+
+    await expect(
+      service.getGroupsUserIsEligibleFor(PROFILE_ID)
+    ).resolves.toEqual([GROUP_ID]);
+    expect(userGroupsDb.getAllWaveRelatedGroups).toHaveBeenCalledTimes(1);
+    expect(redis.set).toHaveBeenCalledWith(
+      ELIGIBLE_GROUPS_CACHE_KEY,
+      JSON.stringify({
+        eligibleGroupIds: [GROUP_ID],
+        computedAtMillis: 3_000,
+        waveGroupsVersion: 7
+      }),
+      { EX: 60 }
+    );
+  });
+
+  it('ignores Redis profile cache when wave groups version differs', async () => {
+    const redis = buildRedisMock();
+    redis.get.mockImplementation((key: string) => {
+      if (key === WAVE_GROUPS_VERSION_CACHE_KEY) {
+        return Promise.resolve('8');
+      }
+      if (key === ELIGIBLE_GROUPS_CACHE_KEY) {
+        return Promise.resolve(
+          JSON.stringify({
+            eligibleGroupIds: ['stale-group'],
+            computedAtMillis: 1_000,
+            waveGroupsVersion: 7
+          })
+        );
+      }
+      return Promise.resolve(null);
+    });
+    (getRedisClient as jest.Mock).mockReturnValue(redis);
+
+    const userGroupsDb = buildUserGroupsDbMock();
+    const service = buildService(userGroupsDb);
+
+    await expect(
+      service.getGroupsUserIsEligibleFor(PROFILE_ID)
+    ).resolves.toEqual([GROUP_ID]);
+    expect(userGroupsDb.getAllWaveRelatedGroups).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to computation when Redis profile cache is malformed', async () => {
+    const redis = buildRedisMock();
+    redis.get.mockImplementation((key: string) => {
+      if (key === WAVE_GROUPS_VERSION_CACHE_KEY) {
+        return Promise.resolve('7');
+      }
+      if (key === ELIGIBLE_GROUPS_CACHE_KEY) {
+        return Promise.resolve('{');
+      }
+      return Promise.resolve(null);
+    });
+    (getRedisClient as jest.Mock).mockReturnValue(redis);
+
+    const userGroupsDb = buildUserGroupsDbMock();
+    const service = buildService(userGroupsDb);
+
+    await expect(
+      service.getGroupsUserIsEligibleFor(PROFILE_ID)
+    ).resolves.toEqual([GROUP_ID]);
+    expect(userGroupsDb.getAllWaveRelatedGroups).toHaveBeenCalledTimes(1);
+  });
+
+  it('collapses concurrent same-profile computations inside one process', async () => {
+    (getRedisClient as jest.Mock).mockReturnValue(null);
+    const userGroupsDb = buildUserGroupsDbMock();
+    let resolveGroups: (groups: string[]) => void = () => undefined;
+    const groupsPromise = new Promise<string[]>((resolve) => {
+      resolveGroups = resolve;
+    });
+    userGroupsDb.getAllWaveRelatedGroups.mockReturnValue(groupsPromise);
+    const service = buildService(userGroupsDb);
+
+    const first = service.getGroupsUserIsEligibleFor(PROFILE_ID);
+    const second = service.getGroupsUserIsEligibleFor(PROFILE_ID);
+    resolveGroups([GROUP_ID]);
+
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      [GROUP_ID],
+      [GROUP_ID]
+    ]);
+    expect(userGroupsDb.getAllWaveRelatedGroups).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/api-serverless/src/community-members/user-groups.service.ts
+++ b/src/api-serverless/src/community-members/user-groups.service.ts
@@ -62,7 +62,12 @@ import { identitiesDb } from '@/identities/identities.db';
 import { enums } from '@/enums';
 import { ids } from '@/ids';
 import { collections } from '@/collections';
-import { clearWaveGroupsCache, getRedisClient } from '@/redis';
+import {
+  clearWaveGroupsCache,
+  getRedisClient,
+  WAVE_GROUPS_CACHE_KEY,
+  WAVE_GROUPS_VERSION_CACHE_KEY
+} from '@/redis';
 import { env } from '@/env';
 import { ApiGroupTdhInclusionStrategy } from '../generated/models/ApiGroupTdhInclusionStrategy';
 import { assertUnreachable } from '@/assertions';
@@ -83,6 +88,21 @@ type GClean = Omit<
   | 'excluded_identity_group_identities_count'
   | 'is_beneficiary_of_grant'
 >;
+
+type EligibleGroupsCacheEntry = {
+  readonly eligibleGroupIds: string[];
+  readonly computedAtMillis: number;
+  readonly waveGroupsVersion: number;
+};
+
+const DEFAULT_ELIGIBLE_GROUPS_CACHE_TTL_SEC = 60;
+const ELIGIBLE_GROUPS_MEMORY_CACHE_PREFIX = 'eligible-groups-v2';
+const ELIGIBLE_GROUPS_REDIS_CACHE_PREFIX = 'cache_6529_eligible_groups';
+const ELIGIBLE_GROUPS_REDIS_LOCK_PREFIX = 'cache_6529_eligible_groups_lock';
+const ELIGIBLE_GROUPS_REDIS_LOCK_TTL_MS = 10_000;
+const ELIGIBLE_GROUPS_REDIS_LOCK_WAIT_RETRIES = 4;
+const ELIGIBLE_GROUPS_REDIS_LOCK_WAIT_MS = 75;
+const eligibleGroupsPromisesByProfileId = new Map<string, Promise<string[]>>();
 
 export class UserGroupsService {
   public static readonly GENERATED_VIEW = 'user_groups_view';
@@ -368,7 +388,6 @@ export class UserGroupsService {
   ): Promise<UserGroupEntity[]> {
     const timerPrefix =
       'whichOfGivenGroupsIsUserEligibleFor->getGivenGroupEntities';
-    const cacheKey = 'cache_6529_wave_groups';
     const ttlSec = env.getIntOrNull('WAVE_GROUPS_CACHE_TTL_SEC') ?? 60;
     const redisClient = getRedisClient();
     if (!redisClient) {
@@ -385,7 +404,7 @@ export class UserGroupsService {
     const cachedValue = await this.timeAsync(
       timer,
       `${timerPrefix}->redisGet`,
-      () => redisClient.get(cacheKey)
+      () => redisClient.get(WAVE_GROUPS_CACHE_KEY)
     );
     if (cachedValue) {
       return this.timeSync(timer, `${timerPrefix}->redisJsonParse`, () =>
@@ -407,7 +426,7 @@ export class UserGroupsService {
       () => JSON.stringify(value)
     );
     await this.timeAsync(timer, `${timerPrefix}->redisSet`, () =>
-      redisClient.set(cacheKey, payload, {
+      redisClient.set(WAVE_GROUPS_CACHE_KEY, payload, {
         EX: Time.seconds(ttlSec).toSeconds()
       })
     );
@@ -741,8 +760,15 @@ export class UserGroupsService {
   }
 
   public async invalidateGroupsUserIsEligibleFor(profileId: string) {
-    const key = `eligible-groups-${profileId}`;
-    mcache.del(key);
+    mcache.del(this.getEligibleGroupsMemoryCacheKey(profileId));
+    eligibleGroupsPromisesByProfileId.delete(profileId);
+    const redisClient = getRedisClient();
+    if (!redisClient) {
+      return;
+    }
+    await redisClient
+      .del(this.getEligibleGroupsRedisCacheKey(profileId))
+      .catch(() => undefined);
   }
 
   public async getGroupsUserIsEligibleFor(
@@ -754,40 +780,330 @@ export class UserGroupsService {
     }
     const timerKey = 'getGroupsUserIsEligibleFor';
     return this.timeAsync(timer, timerKey, async () => {
-      const key = `eligible-groups-${profileId}`;
-      const ignoreCache = await this.timeAsync(
-        timer,
-        `${timerKey}->profileHasRecentGroupChanges`,
-        () =>
-          this.userGroupsDb.profileHasRecentGroupChanges(
-            profileId,
-            Time.minutes(1)
-          )
-      );
-      if (!ignoreCache) {
-        const cachedGroupsUserIsEligibleFor = this.timeSync(
+      const existingPromise = eligibleGroupsPromisesByProfileId.get(profileId);
+      if (existingPromise) {
+        return await this.timeAsync(
           timer,
-          `${timerKey}->memoryCacheLookup`,
-          () => mcache.get(key) as string[] | null
+          `${timerKey}->localInFlightWait`,
+          () => existingPromise
         );
-        if (cachedGroupsUserIsEligibleFor) {
-          return cachedGroupsUserIsEligibleFor;
-        }
       }
-      const groups = await this.timeAsync(
-        timer,
-        `${timerKey}->getAllWaveRelatedGroups`,
-        () => this.userGroupsDb.getAllWaveRelatedGroups({ timer })
-      );
-      const results = await this.whichOfGivenGroupsIsUserEligibleFor(
-        { profileId, givenGroups: groups, allWaveGroups: true },
+
+      const promise = this.getGroupsUserIsEligibleForWithCache(
+        profileId,
         timer
       );
-      this.timeSync(timer, `${timerKey}->memoryCachePut`, () =>
-        mcache.put(key, results, Time.minutes(1).toMillis())
-      );
-      return results;
+      eligibleGroupsPromisesByProfileId.set(profileId, promise);
+      try {
+        return await promise;
+      } finally {
+        if (eligibleGroupsPromisesByProfileId.get(profileId) === promise) {
+          eligibleGroupsPromisesByProfileId.delete(profileId);
+        }
+      }
     });
+  }
+
+  private async getGroupsUserIsEligibleForWithCache(
+    profileId: string,
+    timer?: Timer | undefined
+  ): Promise<string[]> {
+    const timerKey = 'getGroupsUserIsEligibleFor';
+    const ttlSec = this.getEligibleGroupsCacheTtlSec();
+    const computedAtMillis = Time.currentMillis();
+    const [latestProfileGroupChangeMillis, waveGroupsVersion] =
+      await Promise.all([
+        this.timeAsync(
+          timer,
+          `${timerKey}->getLatestProfileGroupChangeMillis`,
+          () => this.userGroupsDb.getLatestProfileGroupChangeMillis(profileId)
+        ),
+        this.getWaveGroupsCacheVersion(timer)
+      ]);
+
+    const memoryCacheEntry = this.timeSync(
+      timer,
+      `${timerKey}->memoryCacheLookup`,
+      () =>
+        mcache.get(
+          this.getEligibleGroupsMemoryCacheKey(profileId)
+        ) as EligibleGroupsCacheEntry | null
+    );
+    if (
+      this.isEligibleGroupsCacheEntryValid(
+        memoryCacheEntry,
+        latestProfileGroupChangeMillis,
+        waveGroupsVersion
+      )
+    ) {
+      return memoryCacheEntry.eligibleGroupIds;
+    }
+
+    const redisCacheEntry = await this.getEligibleGroupsRedisCacheEntry(
+      profileId,
+      timer
+    );
+    if (
+      this.isEligibleGroupsCacheEntryValid(
+        redisCacheEntry,
+        latestProfileGroupChangeMillis,
+        waveGroupsVersion
+      )
+    ) {
+      this.putEligibleGroupsMemoryCache(profileId, redisCacheEntry, ttlSec);
+      return redisCacheEntry.eligibleGroupIds;
+    }
+
+    const acquiredRedisLock = await this.tryAcquireEligibleGroupsRedisLock(
+      profileId,
+      timer
+    );
+    if (!acquiredRedisLock) {
+      const waitedCacheEntry = await this.waitForEligibleGroupsRedisCacheEntry({
+        profileId,
+        latestProfileGroupChangeMillis,
+        waveGroupsVersion,
+        ttlSec,
+        timer
+      });
+      if (waitedCacheEntry) {
+        return waitedCacheEntry.eligibleGroupIds;
+      }
+    }
+
+    const results = await this.computeGroupsUserIsEligibleFor(profileId, timer);
+    const cacheEntry: EligibleGroupsCacheEntry = {
+      eligibleGroupIds: results,
+      computedAtMillis,
+      waveGroupsVersion
+    };
+    this.putEligibleGroupsMemoryCache(profileId, cacheEntry, ttlSec);
+    await this.putEligibleGroupsRedisCache(
+      profileId,
+      cacheEntry,
+      ttlSec,
+      timer
+    );
+    return results;
+  }
+
+  private async computeGroupsUserIsEligibleFor(
+    profileId: string,
+    timer?: Timer | undefined
+  ): Promise<string[]> {
+    const timerKey = 'getGroupsUserIsEligibleFor';
+    const groups = await this.timeAsync(
+      timer,
+      `${timerKey}->getAllWaveRelatedGroups`,
+      () => this.userGroupsDb.getAllWaveRelatedGroups({ timer })
+    );
+    return await this.whichOfGivenGroupsIsUserEligibleFor(
+      { profileId, givenGroups: groups, allWaveGroups: true },
+      timer
+    );
+  }
+
+  private getEligibleGroupsCacheTtlSec(): number {
+    return Math.max(
+      1,
+      env.getIntOrNull('USER_GROUPS_ELIGIBILITY_CACHE_TTL_SEC') ??
+        DEFAULT_ELIGIBLE_GROUPS_CACHE_TTL_SEC
+    );
+  }
+
+  private getEligibleGroupsMemoryCacheKey(profileId: string): string {
+    return `${ELIGIBLE_GROUPS_MEMORY_CACHE_PREFIX}-${profileId}`;
+  }
+
+  private getEligibleGroupsRedisCacheKey(profileId: string): string {
+    return `${ELIGIBLE_GROUPS_REDIS_CACHE_PREFIX}:${profileId}`;
+  }
+
+  private getEligibleGroupsRedisLockKey(profileId: string): string {
+    return `${ELIGIBLE_GROUPS_REDIS_LOCK_PREFIX}:${profileId}`;
+  }
+
+  private putEligibleGroupsMemoryCache(
+    profileId: string,
+    cacheEntry: EligibleGroupsCacheEntry,
+    ttlSec: number
+  ) {
+    this.timeSync(undefined, 'getGroupsUserIsEligibleFor->memoryCachePut', () =>
+      mcache.put(
+        this.getEligibleGroupsMemoryCacheKey(profileId),
+        cacheEntry,
+        Time.seconds(ttlSec).toMillis()
+      )
+    );
+  }
+
+  private async getWaveGroupsCacheVersion(
+    timer?: Timer | undefined
+  ): Promise<number> {
+    const redisClient = getRedisClient();
+    if (!redisClient) {
+      return 0;
+    }
+    return await this.timeAsync(
+      timer,
+      'getGroupsUserIsEligibleFor->waveGroupsVersionRedisGet',
+      async () => {
+        const cachedVersion = await redisClient
+          .get(WAVE_GROUPS_VERSION_CACHE_KEY)
+          .catch(() => null);
+        const parsed = Number(cachedVersion);
+        return Number.isFinite(parsed) ? parsed : 0;
+      }
+    );
+  }
+
+  private async getEligibleGroupsRedisCacheEntry(
+    profileId: string,
+    timer?: Timer | undefined
+  ): Promise<EligibleGroupsCacheEntry | null> {
+    const redisClient = getRedisClient();
+    if (!redisClient) {
+      return null;
+    }
+    return await this.timeAsync(
+      timer,
+      'getGroupsUserIsEligibleFor->redisCacheGet',
+      async () => {
+        const cachedValue = await redisClient
+          .get(this.getEligibleGroupsRedisCacheKey(profileId))
+          .catch(() => null);
+        return this.parseEligibleGroupsCacheEntry(cachedValue);
+      }
+    );
+  }
+
+  private async putEligibleGroupsRedisCache(
+    profileId: string,
+    cacheEntry: EligibleGroupsCacheEntry,
+    ttlSec: number,
+    timer?: Timer | undefined
+  ) {
+    const redisClient = getRedisClient();
+    if (!redisClient) {
+      return;
+    }
+    await this.timeAsync(
+      timer,
+      'getGroupsUserIsEligibleFor->redisCacheSet',
+      async () => {
+        await redisClient
+          .set(
+            this.getEligibleGroupsRedisCacheKey(profileId),
+            JSON.stringify(cacheEntry),
+            { EX: ttlSec }
+          )
+          .catch(() => undefined);
+      }
+    );
+  }
+
+  private async tryAcquireEligibleGroupsRedisLock(
+    profileId: string,
+    timer?: Timer | undefined
+  ): Promise<boolean> {
+    const redisClient = getRedisClient();
+    if (!redisClient) {
+      return true;
+    }
+    return await this.timeAsync(
+      timer,
+      'getGroupsUserIsEligibleFor->redisLockSet',
+      async () => {
+        const response = await redisClient
+          .set(this.getEligibleGroupsRedisLockKey(profileId), '1', {
+            PX: ELIGIBLE_GROUPS_REDIS_LOCK_TTL_MS,
+            NX: true
+          })
+          .catch(() => 'OK');
+        return response === 'OK';
+      }
+    );
+  }
+
+  private async waitForEligibleGroupsRedisCacheEntry({
+    profileId,
+    latestProfileGroupChangeMillis,
+    waveGroupsVersion,
+    ttlSec,
+    timer
+  }: {
+    profileId: string;
+    latestProfileGroupChangeMillis: number | null;
+    waveGroupsVersion: number;
+    ttlSec: number;
+    timer?: Timer | undefined;
+  }): Promise<EligibleGroupsCacheEntry | null> {
+    for (let i = 0; i < ELIGIBLE_GROUPS_REDIS_LOCK_WAIT_RETRIES; i++) {
+      await Time.millis(ELIGIBLE_GROUPS_REDIS_LOCK_WAIT_MS).sleep();
+      const cacheEntry = await this.getEligibleGroupsRedisCacheEntry(
+        profileId,
+        timer
+      );
+      if (
+        this.isEligibleGroupsCacheEntryValid(
+          cacheEntry,
+          latestProfileGroupChangeMillis,
+          waveGroupsVersion
+        )
+      ) {
+        this.putEligibleGroupsMemoryCache(profileId, cacheEntry, ttlSec);
+        return cacheEntry;
+      }
+    }
+    return null;
+  }
+
+  private parseEligibleGroupsCacheEntry(
+    cachedValue: string | null
+  ): EligibleGroupsCacheEntry | null {
+    if (!cachedValue) {
+      return null;
+    }
+    try {
+      const parsed = JSON.parse(
+        cachedValue
+      ) as Partial<EligibleGroupsCacheEntry>;
+      if (
+        parsed &&
+        Array.isArray(parsed.eligibleGroupIds) &&
+        parsed.eligibleGroupIds.every((it) => typeof it === 'string') &&
+        typeof parsed.computedAtMillis === 'number' &&
+        Number.isFinite(parsed.computedAtMillis) &&
+        typeof parsed.waveGroupsVersion === 'number' &&
+        Number.isFinite(parsed.waveGroupsVersion)
+      ) {
+        return {
+          eligibleGroupIds: parsed.eligibleGroupIds,
+          computedAtMillis: parsed.computedAtMillis,
+          waveGroupsVersion: parsed.waveGroupsVersion
+        };
+      }
+    } catch {
+      return null;
+    }
+    return null;
+  }
+
+  private isEligibleGroupsCacheEntryValid(
+    cacheEntry: EligibleGroupsCacheEntry | null,
+    latestProfileGroupChangeMillis: number | null,
+    waveGroupsVersion: number
+  ): cacheEntry is EligibleGroupsCacheEntry {
+    if (!cacheEntry) {
+      return false;
+    }
+    if (cacheEntry.waveGroupsVersion !== waveGroupsVersion) {
+      return false;
+    }
+    return (
+      latestProfileGroupChangeMillis === null ||
+      cacheEntry.computedAtMillis > latestProfileGroupChangeMillis
+    );
   }
 
   async changeVisibility(

--- a/src/redis.ts
+++ b/src/redis.ts
@@ -5,6 +5,9 @@ import { Time } from './time';
 
 let redis: Redis;
 
+export const WAVE_GROUPS_CACHE_KEY = 'cache_6529_wave_groups';
+export const WAVE_GROUPS_VERSION_CACHE_KEY = 'cache_6529_wave_groups_version';
+
 export async function redisGet<T>(key: string): Promise<T | null> {
   if (!redis) {
     return null;
@@ -211,7 +214,13 @@ export async function initRedis() {
 }
 
 export async function clearWaveGroupsCache() {
-  await evictKeyFromRedisCache('cache_6529_wave_groups');
+  if (!redis) {
+    return;
+  }
+  await Promise.all([
+    redis.del(WAVE_GROUPS_CACHE_KEY),
+    redis.incr(WAVE_GROUPS_VERSION_CACHE_KEY)
+  ]);
 }
 
 export function getRedisClient(): Redis | null {

--- a/src/user-groups/user-groups.db.ts
+++ b/src/user-groups/user-groups.db.ts
@@ -858,16 +858,31 @@ export class UserGroupsDb extends LazyDbAccessCompatibleService {
   }
 
   async profileHasRecentGroupChanges(profileId: string, interval: Time) {
+    const latestChangeMillis =
+      await this.getLatestProfileGroupChangeMillis(profileId);
+    return (
+      latestChangeMillis !== null &&
+      latestChangeMillis > Time.now().minus(interval).toMillis()
+    );
+  }
+
+  async getLatestProfileGroupChangeMillis(
+    profileId: string
+  ): Promise<number | null> {
     return await this.db
       .oneOrNull<{
-        profile_id: string;
+        chg_time: number | string | null;
       }>(
-        `select profile_id from ${PROFILE_GROUP_CHANGES} where profile_id = :profileId and chg_time > :limit limit 1`,
-        { limit: Time.now().minus(interval).toMillis(), profileId },
+        `select max(chg_time) as chg_time from ${PROFILE_GROUP_CHANGES} where profile_id = :profileId`,
+        { profileId },
         { forcePool: DbPoolName.WRITE }
       )
       .then((it) => {
-        return !!it?.profile_id;
+        if (it?.chg_time === null || it?.chg_time === undefined) {
+          return null;
+        }
+        const parsed = Number(it.chg_time);
+        return Number.isFinite(parsed) ? parsed : null;
       });
   }
 


### PR DESCRIPTION
## Issue
- Opening notifications and related wave/drop views can fan out into many eligibility checks.
- Under Lambda concurrency, those checks repeatedly read the large `cache_6529_wave_groups` Redis value, causing multi-second Redis read latency and high ElastiCache egress.

## Fix
- Adds a Redis L2 cache for final eligible group IDs per profile, validated by latest profile group-change time and a wave-groups version key.
- Keeps the existing wave-groups entity blob as the miss-path helper instead of the hot-path payload.
- Adds local in-process promise coalescing and a short Redis lock to reduce same-profile cache stampedes.

## Changes
- Adds profile-level eligibility cache keys with a 60s default TTL via `USER_GROUPS_ELIGIBILITY_CACHE_TTL_SEC`.
- Bumps a wave-groups version key whenever `clearWaveGroupsCache()` clears the shared wave-group blob.
- Adds exact latest profile group-change timestamp lookup for cache freshness validation.
- Adds focused coverage for cache hits, profile-change invalidation, wave-version invalidation, malformed cache fallback, and local in-flight coalescing.
- No public API contract, schema, migration, deploy config, queue, or Lambda boundary changes. No architecture-doc update needed.

## Validation
- `npm test -- src/api-serverless/src/community-members/user-groups-service.test.ts --runInBand`
- `npm run lint`
- `npm run tsc -- --noEmit`
- `npm run build`
- `cd src/api-serverless && npm run build`

## Risk
- Level: Medium
- Why: shared eligibility code affects API authorization/filtering paths and push notification filtering, but the cache is version/timestamp validated and falls back to existing computation on miss or malformed cache values.
- Rollback: revert this PR and redeploy the same services; Redis keys are additive and TTL-bounded.

## Deployment
- Deploy staging services in this order:
  1. `api`
  2. `pushNotificationsHandler`
- No `dbMigrationsLoop` deployment required.

## Review Notes
- Focus on cache correctness around profile group changes and wave/group mutations.
- The intended production signal is lower ElastiCache `NetworkBytesOut / GetTypeCmds` and lower `SuccessfulReadRequestLatency` p95/p99 during notifications/waves bursts.