### PR TITLE
Cache eligible wave groups per profile

### DIFF
--- a/src/api-serverless/src/community-members/user-groups-service.test.ts
+++ b/src/api-serverless/src/community-members/user-groups-service.test.ts
@@ -9,6 +9,7 @@ import { Time } from '@/time';
 import * as mcache from 'memory-cache';
 import { AbusivenessCheckService } from '@/profiles/abusiveness-check.service';
 import { MetricsRecorder } from '@/metrics/MetricsRecorder';
+import fc from 'fast-check';
 
 jest.mock('@/redis', () => ({
   ...jest.requireActual('@/redis'),
@@ -96,6 +97,15 @@ function buildService(userGroupsDb = buildUserGroupsDbMock()) {
     {} as unknown as AbusivenessCheckService,
     {} as unknown as MetricsRecorder
   );
+}
+
+function isInvalidJson(value: string): boolean {
+  try {
+    JSON.parse(value);
+    return false;
+  } catch {
+    return true;
+  }
 }
 
 describe('UserGroupsService eligibility cache', () => {
@@ -277,25 +287,55 @@ describe('UserGroupsService eligibility cache', () => {
   });
 
   it('falls back to computation when Redis profile cache is malformed', async () => {
-    const redis = buildRedisMock();
-    redis.get.mockImplementation((key: string) => {
-      if (key === WAVE_GROUPS_VERSION_CACHE_KEY) {
-        return Promise.resolve('7');
-      }
-      if (key === ELIGIBLE_GROUPS_CACHE_KEY) {
-        return Promise.resolve('{');
-      }
-      return Promise.resolve(null);
-    });
-    (getRedisClient as jest.Mock).mockReturnValue(redis);
+    await fc.assert(
+      fc.asyncProperty(
+        fc.oneof(
+          fc.string().filter(isInvalidJson),
+          fc.constantFrom(
+            JSON.stringify(null),
+            JSON.stringify([]),
+            JSON.stringify({
+              eligibleGroupIds: GROUP_ID,
+              computedAtMillis: 1_000,
+              waveGroupsVersion: 7
+            }),
+            JSON.stringify({
+              eligibleGroupIds: [GROUP_ID],
+              computedAtMillis: '1_000',
+              waveGroupsVersion: 7
+            }),
+            JSON.stringify({
+              eligibleGroupIds: [GROUP_ID],
+              computedAtMillis: 1_000,
+              waveGroupsVersion: '7'
+            })
+          )
+        ),
+        async (malformedPayload) => {
+          mcache.clear();
+          const redis = buildRedisMock();
+          redis.get.mockImplementation((key: string) => {
+            if (key === WAVE_GROUPS_VERSION_CACHE_KEY) {
+              return Promise.resolve('7');
+            }
+            if (key === ELIGIBLE_GROUPS_CACHE_KEY) {
+              return Promise.resolve(malformedPayload);
+            }
+            return Promise.resolve(null);
+          });
+          (getRedisClient as jest.Mock).mockReturnValue(redis);
 
-    const userGroupsDb = buildUserGroupsDbMock();
-    const service = buildService(userGroupsDb);
+          const userGroupsDb = buildUserGroupsDbMock();
+          const service = buildService(userGroupsDb);
 
-    await expect(
-      service.getGroupsUserIsEligibleFor(PROFILE_ID)
-    ).resolves.toEqual([GROUP_ID]);
-    expect(userGroupsDb.getAllWaveRelatedGroups).toHaveBeenCalledTimes(1);
+          await expect(
+            service.getGroupsUserIsEligibleFor(PROFILE_ID)
+          ).resolves.toEqual([GROUP_ID]);
+          expect(userGroupsDb.getAllWaveRelatedGroups).toHaveBeenCalledTimes(1);
+        }
+      ),
+      { numRuns: 25 }
+    );
   });
 
   it('collapses concurrent same-profile computations inside one process', async () => {

--- a/src/api-serverless/src/community-members/user-groups-service.test.ts
+++ b/src/api-serverless/src/community-members/user-groups-service.test.ts
@@ -1,0 +1,247 @@
+import { UserGroupsService } from './user-groups.service';
+import { UserGroupsDb } from '@/user-groups/user-groups.db';
+import {
+  GroupTdhInclusionStrategy,
+  UserGroupEntity
+} from '@/entities/IUserGroup';
+import { getRedisClient, WAVE_GROUPS_VERSION_CACHE_KEY } from '@/redis';
+import { Time } from '@/time';
+import * as mcache from 'memory-cache';
+import { AbusivenessCheckService } from '@/profiles/abusiveness-check.service';
+import { MetricsRecorder } from '@/metrics/MetricsRecorder';
+
+jest.mock('@/redis', () => ({
+  ...jest.requireActual('@/redis'),
+  getRedisClient: jest.fn()
+}));
+
+type RedisMock = {
+  get: jest.Mock;
+  set: jest.Mock;
+  del: jest.Mock;
+};
+
+const PROFILE_ID = 'profile-1';
+const GROUP_ID = 'group-1';
+const ELIGIBLE_GROUPS_CACHE_KEY = `cache_6529_eligible_groups:${PROFILE_ID}`;
+
+function buildRedisMock(): RedisMock {
+  return {
+    get: jest.fn(),
+    set: jest.fn().mockResolvedValue('OK'),
+    del: jest.fn().mockResolvedValue(1)
+  };
+}
+
+function buildUserGroup(): UserGroupEntity {
+  return {
+    id: GROUP_ID,
+    name: 'Group 1',
+    cic_min: null,
+    cic_max: null,
+    cic_user: null,
+    cic_direction: null,
+    rep_min: null,
+    rep_max: null,
+    rep_user: null,
+    rep_direction: null,
+    rep_category: null,
+    tdh_min: null,
+    tdh_max: null,
+    tdh_inclusion_strategy: GroupTdhInclusionStrategy.TDH,
+    level_min: null,
+    level_max: null,
+    created_at: new Date(),
+    created_by: PROFILE_ID,
+    visible: true,
+    owns_meme: false,
+    owns_meme_tokens: null,
+    owns_gradient: false,
+    owns_gradient_tokens: null,
+    owns_nextgen: false,
+    owns_nextgen_tokens: null,
+    owns_lab: false,
+    owns_lab_tokens: null,
+    profile_group_id: 'profile-group-1',
+    excluded_profile_group_id: null,
+    is_pure_profile_group: true,
+    is_private: false,
+    is_direct_message: false,
+    is_beneficiary_of_grant_id: null
+  } as UserGroupEntity;
+}
+
+function buildUserGroupsDbMock() {
+  return {
+    getLatestProfileGroupChangeMillis: jest.fn().mockResolvedValue(null),
+    getAllWaveRelatedGroups: jest.fn().mockResolvedValue([GROUP_ID]),
+    getIdentityByProfileId: jest.fn().mockResolvedValue({
+      profile_id: PROFILE_ID,
+      rep: 0,
+      cic: 0,
+      tdh: 0,
+      xtdh: 0,
+      level_raw: 0
+    }),
+    getByIds: jest.fn().mockResolvedValue([buildUserGroup()]),
+    getGroupsUserIsEligibleByIdentity: jest.fn().mockResolvedValue([GROUP_ID]),
+    getGroupsUserIsExcludedFromByIdentity: jest.fn().mockResolvedValue([])
+  };
+}
+
+function buildService(userGroupsDb = buildUserGroupsDbMock()) {
+  return new UserGroupsService(
+    userGroupsDb as unknown as UserGroupsDb,
+    {} as unknown as AbusivenessCheckService,
+    {} as unknown as MetricsRecorder
+  );
+}
+
+describe('UserGroupsService eligibility cache', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+    mcache.clear();
+    delete process.env.USER_GROUPS_ELIGIBILITY_CACHE_TTL_SEC;
+  });
+
+  it('returns valid Redis profile cache without loading wave groups', async () => {
+    const redis = buildRedisMock();
+    redis.get.mockImplementation((key: string) => {
+      if (key === WAVE_GROUPS_VERSION_CACHE_KEY) {
+        return Promise.resolve('7');
+      }
+      if (key === ELIGIBLE_GROUPS_CACHE_KEY) {
+        return Promise.resolve(
+          JSON.stringify({
+            eligibleGroupIds: [GROUP_ID],
+            computedAtMillis: 1_000,
+            waveGroupsVersion: 7
+          })
+        );
+      }
+      return Promise.resolve(null);
+    });
+    (getRedisClient as jest.Mock).mockReturnValue(redis);
+
+    const userGroupsDb = buildUserGroupsDbMock();
+    const service = buildService(userGroupsDb);
+
+    await expect(
+      service.getGroupsUserIsEligibleFor(PROFILE_ID)
+    ).resolves.toEqual([GROUP_ID]);
+    expect(userGroupsDb.getAllWaveRelatedGroups).not.toHaveBeenCalled();
+    expect(userGroupsDb.getByIds).not.toHaveBeenCalled();
+    expect(redis.set).not.toHaveBeenCalled();
+  });
+
+  it('ignores Redis profile cache when profile groups changed later', async () => {
+    jest.spyOn(Time, 'currentMillis').mockReturnValue(3_000);
+    const redis = buildRedisMock();
+    redis.get.mockImplementation((key: string) => {
+      if (key === WAVE_GROUPS_VERSION_CACHE_KEY) {
+        return Promise.resolve('7');
+      }
+      if (key === ELIGIBLE_GROUPS_CACHE_KEY) {
+        return Promise.resolve(
+          JSON.stringify({
+            eligibleGroupIds: ['stale-group'],
+            computedAtMillis: 1_000,
+            waveGroupsVersion: 7
+          })
+        );
+      }
+      return Promise.resolve(null);
+    });
+    (getRedisClient as jest.Mock).mockReturnValue(redis);
+
+    const userGroupsDb = buildUserGroupsDbMock();
+    userGroupsDb.getLatestProfileGroupChangeMillis.mockResolvedValue(2_000);
+    const service = buildService(userGroupsDb);
+
+    await expect(
+      service.getGroupsUserIsEligibleFor(PROFILE_ID)
+    ).resolves.toEqual([GROUP_ID]);
+    expect(userGroupsDb.getAllWaveRelatedGroups).toHaveBeenCalledTimes(1);
+    expect(redis.set).toHaveBeenCalledWith(
+      ELIGIBLE_GROUPS_CACHE_KEY,
+      JSON.stringify({
+        eligibleGroupIds: [GROUP_ID],
+        computedAtMillis: 3_000,
+        waveGroupsVersion: 7
+      }),
+      { EX: 60 }
+    );
+  });
+
+  it('ignores Redis profile cache when wave groups version differs', async () => {
+    const redis = buildRedisMock();
+    redis.get.mockImplementation((key: string) => {
+      if (key === WAVE_GROUPS_VERSION_CACHE_KEY) {
+        return Promise.resolve('8');
+      }
+      if (key === ELIGIBLE_GROUPS_CACHE_KEY) {
+        return Promise.resolve(
+          JSON.stringify({
+            eligibleGroupIds: ['stale-group'],
+            computedAtMillis: 1_000,
+            waveGroupsVersion: 7
+          })
+        );
+      }
+      return Promise.resolve(null);
+    });
+    (getRedisClient as jest.Mock).mockReturnValue(redis);
+
+    const userGroupsDb = buildUserGroupsDbMock();
+    const service = buildService(userGroupsDb);
+
+    await expect(
+      service.getGroupsUserIsEligibleFor(PROFILE_ID)
+    ).resolves.toEqual([GROUP_ID]);
+    expect(userGroupsDb.getAllWaveRelatedGroups).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to computation when Redis profile cache is malformed', async () => {
+    const redis = buildRedisMock();
+    redis.get.mockImplementation((key: string) => {
+      if (key === WAVE_GROUPS_VERSION_CACHE_KEY) {
+        return Promise.resolve('7');
+      }
+      if (key === ELIGIBLE_GROUPS_CACHE_KEY) {
+        return Promise.resolve('{');
+      }
+      return Promise.resolve(null);
+    });
+    (getRedisClient as jest.Mock).mockReturnValue(redis);
+
+    const userGroupsDb = buildUserGroupsDbMock();
+    const service = buildService(userGroupsDb);
+
+    await expect(
+      service.getGroupsUserIsEligibleFor(PROFILE_ID)
+    ).resolves.toEqual([GROUP_ID]);
+    expect(userGroupsDb.getAllWaveRelatedGroups).toHaveBeenCalledTimes(1);
+  });
+
+  it('collapses concurrent same-profile computations inside one process', async () => {
+    (getRedisClient as jest.Mock).mockReturnValue(null);
+    const userGroupsDb = buildUserGroupsDbMock();
+    let resolveGroups: (groups: string[]) => void = () => undefined;
+    const groupsPromise = new Promise<string[]>((resolve) => {
+      resolveGroups = resolve;
+    });
+    userGroupsDb.getAllWaveRelatedGroups.mockReturnValue(groupsPromise);
+    const service = buildService(userGroupsDb);
+
+    const first = service.getGroupsUserIsEligibleFor(PROFILE_ID);
+    const second = service.getGroupsUserIsEligibleFor(PROFILE_ID);
+    resolveGroups([GROUP_ID]);
+
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      [GROUP_ID],
+      [GROUP_ID]
+    ]);
+    expect(userGroupsDb.getAllWaveRelatedGroups).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/api-serverless/src/community-members/user-groups-service.test.ts
+++ b/src/api-serverless/src/community-members/user-groups-service.test.ts
@@ -24,6 +24,7 @@ type RedisMock = {
 const PROFILE_ID = 'profile-1';
 const GROUP_ID = 'group-1';
 const ELIGIBLE_GROUPS_CACHE_KEY = `cache_6529_eligible_groups:${PROFILE_ID}`;
+const ELIGIBLE_GROUPS_LOCK_KEY = `cache_6529_eligible_groups_lock:${PROFILE_ID}`;
 
 function buildRedisMock(): RedisMock {
   return {
@@ -174,6 +175,41 @@ describe('UserGroupsService eligibility cache', () => {
     );
   });
 
+  it('does not cache computed results when profile groups change during computation', async () => {
+    jest.spyOn(Time, 'currentMillis').mockReturnValue(3_000);
+    const redis = buildRedisMock();
+    redis.get.mockImplementation((key: string) => {
+      if (key === WAVE_GROUPS_VERSION_CACHE_KEY) {
+        return Promise.resolve('7');
+      }
+      if (key === ELIGIBLE_GROUPS_CACHE_KEY) {
+        return Promise.resolve(null);
+      }
+      return Promise.resolve(null);
+    });
+    (getRedisClient as jest.Mock).mockReturnValue(redis);
+
+    const userGroupsDb = buildUserGroupsDbMock();
+    userGroupsDb.getLatestProfileGroupChangeMillis
+      .mockResolvedValueOnce(1_000)
+      .mockResolvedValueOnce(2_500);
+    const service = buildService(userGroupsDb);
+
+    await expect(
+      service.getGroupsUserIsEligibleFor(PROFILE_ID)
+    ).resolves.toEqual([GROUP_ID]);
+    expect(userGroupsDb.getAllWaveRelatedGroups).toHaveBeenCalledTimes(1);
+    expect(redis.set).toHaveBeenCalledWith(ELIGIBLE_GROUPS_LOCK_KEY, '1', {
+      PX: 10_000,
+      NX: true
+    });
+    expect(redis.set).not.toHaveBeenCalledWith(
+      ELIGIBLE_GROUPS_CACHE_KEY,
+      expect.any(String),
+      expect.anything()
+    );
+  });
+
   it('ignores Redis profile cache when wave groups version differs', async () => {
     const redis = buildRedisMock();
     redis.get.mockImplementation((key: string) => {
@@ -200,6 +236,44 @@ describe('UserGroupsService eligibility cache', () => {
       service.getGroupsUserIsEligibleFor(PROFILE_ID)
     ).resolves.toEqual([GROUP_ID]);
     expect(userGroupsDb.getAllWaveRelatedGroups).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses Redis profile cache produced by peer when lock is already held', async () => {
+    const redis = buildRedisMock();
+    let eligibleGroupsCacheReads = 0;
+    redis.get.mockImplementation((key: string) => {
+      if (key === WAVE_GROUPS_VERSION_CACHE_KEY) {
+        return Promise.resolve('7');
+      }
+      if (key === ELIGIBLE_GROUPS_CACHE_KEY) {
+        eligibleGroupsCacheReads++;
+        if (eligibleGroupsCacheReads === 1) {
+          return Promise.resolve(null);
+        }
+        return Promise.resolve(
+          JSON.stringify({
+            eligibleGroupIds: [GROUP_ID],
+            computedAtMillis: 3_000,
+            waveGroupsVersion: 7
+          })
+        );
+      }
+      return Promise.resolve(null);
+    });
+    redis.set.mockResolvedValueOnce(null);
+    (getRedisClient as jest.Mock).mockReturnValue(redis);
+
+    const userGroupsDb = buildUserGroupsDbMock();
+    const service = buildService(userGroupsDb);
+
+    await expect(
+      service.getGroupsUserIsEligibleFor(PROFILE_ID)
+    ).resolves.toEqual([GROUP_ID]);
+    expect(userGroupsDb.getAllWaveRelatedGroups).not.toHaveBeenCalled();
+    expect(redis.set).toHaveBeenCalledWith(ELIGIBLE_GROUPS_LOCK_KEY, '1', {
+      PX: 10_000,
+      NX: true
+    });
   });
 
   it('falls back to computation when Redis profile cache is malformed', async () => {

--- a/src/api-serverless/src/community-members/user-groups.service.ts
+++ b/src/api-serverless/src/community-members/user-groups.service.ts
@@ -62,7 +62,12 @@ import { identitiesDb } from '@/identities/identities.db';
 import { enums } from '@/enums';
 import { ids } from '@/ids';
 import { collections } from '@/collections';
-import { clearWaveGroupsCache, getRedisClient } from '@/redis';
+import {
+  clearWaveGroupsCache,
+  getRedisClient,
+  WAVE_GROUPS_CACHE_KEY,
+  WAVE_GROUPS_VERSION_CACHE_KEY
+} from '@/redis';
 import { env } from '@/env';
 import { ApiGroupTdhInclusionStrategy } from '../generated/models/ApiGroupTdhInclusionStrategy';
 import { assertUnreachable } from '@/assertions';
@@ -83,6 +88,21 @@ type GClean = Omit<
   | 'excluded_identity_group_identities_count'
   | 'is_beneficiary_of_grant'
 >;
+
+type EligibleGroupsCacheEntry = {
+  readonly eligibleGroupIds: string[];
+  readonly computedAtMillis: number;
+  readonly waveGroupsVersion: number;
+};
+
+const DEFAULT_ELIGIBLE_GROUPS_CACHE_TTL_SEC = 60;
+const ELIGIBLE_GROUPS_MEMORY_CACHE_PREFIX = 'eligible-groups-v2';
+const ELIGIBLE_GROUPS_REDIS_CACHE_PREFIX = 'cache_6529_eligible_groups';
+const ELIGIBLE_GROUPS_REDIS_LOCK_PREFIX = 'cache_6529_eligible_groups_lock';
+const ELIGIBLE_GROUPS_REDIS_LOCK_TTL_MS = 10_000;
+const ELIGIBLE_GROUPS_REDIS_LOCK_WAIT_RETRIES = 4;
+const ELIGIBLE_GROUPS_REDIS_LOCK_WAIT_MS = 75;
+const eligibleGroupsPromisesByProfileId = new Map<string, Promise<string[]>>();
 
 export class UserGroupsService {
   public static readonly GENERATED_VIEW = 'user_groups_view';
@@ -368,7 +388,6 @@ export class UserGroupsService {
   ): Promise<UserGroupEntity[]> {
     const timerPrefix =
       'whichOfGivenGroupsIsUserEligibleFor->getGivenGroupEntities';
-    const cacheKey = 'cache_6529_wave_groups';
     const ttlSec = env.getIntOrNull('WAVE_GROUPS_CACHE_TTL_SEC') ?? 60;
     const redisClient = getRedisClient();
     if (!redisClient) {
@@ -385,7 +404,7 @@ export class UserGroupsService {
     const cachedValue = await this.timeAsync(
       timer,
       `${timerPrefix}->redisGet`,
-      () => redisClient.get(cacheKey)
+      () => redisClient.get(WAVE_GROUPS_CACHE_KEY)
     );
     if (cachedValue) {
       return this.timeSync(timer, `${timerPrefix}->redisJsonParse`, () =>
@@ -407,7 +426,7 @@ export class UserGroupsService {
       () => JSON.stringify(value)
     );
     await this.timeAsync(timer, `${timerPrefix}->redisSet`, () =>
-      redisClient.set(cacheKey, payload, {
+      redisClient.set(WAVE_GROUPS_CACHE_KEY, payload, {
         EX: Time.seconds(ttlSec).toSeconds()
       })
     );
@@ -741,8 +760,15 @@ export class UserGroupsService {
   }
 
   public async invalidateGroupsUserIsEligibleFor(profileId: string) {
-    const key = `eligible-groups-${profileId}`;
-    mcache.del(key);
+    mcache.del(this.getEligibleGroupsMemoryCacheKey(profileId));
+    eligibleGroupsPromisesByProfileId.delete(profileId);
+    const redisClient = getRedisClient();
+    if (!redisClient) {
+      return;
+    }
+    await redisClient
+      .del(this.getEligibleGroupsRedisCacheKey(profileId))
+      .catch(() => undefined);
   }
 
   public async getGroupsUserIsEligibleFor(
@@ -754,40 +780,330 @@ export class UserGroupsService {
     }
     const timerKey = 'getGroupsUserIsEligibleFor';
     return this.timeAsync(timer, timerKey, async () => {
-      const key = `eligible-groups-${profileId}`;
-      const ignoreCache = await this.timeAsync(
-        timer,
-        `${timerKey}->profileHasRecentGroupChanges`,
-        () =>
-          this.userGroupsDb.profileHasRecentGroupChanges(
-            profileId,
-            Time.minutes(1)
-          )
-      );
-      if (!ignoreCache) {
-        const cachedGroupsUserIsEligibleFor = this.timeSync(
+      const existingPromise = eligibleGroupsPromisesByProfileId.get(profileId);
+      if (existingPromise) {
+        return await this.timeAsync(
           timer,
-          `${timerKey}->memoryCacheLookup`,
-          () => mcache.get(key) as string[] | null
+          `${timerKey}->localInFlightWait`,
+          () => existingPromise
         );
-        if (cachedGroupsUserIsEligibleFor) {
-          return cachedGroupsUserIsEligibleFor;
-        }
       }
-      const groups = await this.timeAsync(
-        timer,
-        `${timerKey}->getAllWaveRelatedGroups`,
-        () => this.userGroupsDb.getAllWaveRelatedGroups({ timer })
-      );
-      const results = await this.whichOfGivenGroupsIsUserEligibleFor(
-        { profileId, givenGroups: groups, allWaveGroups: true },
+
+      const promise = this.getGroupsUserIsEligibleForWithCache(
+        profileId,
         timer
       );
-      this.timeSync(timer, `${timerKey}->memoryCachePut`, () =>
-        mcache.put(key, results, Time.minutes(1).toMillis())
-      );
-      return results;
+      eligibleGroupsPromisesByProfileId.set(profileId, promise);
+      try {
+        return await promise;
+      } finally {
+        if (eligibleGroupsPromisesByProfileId.get(profileId) === promise) {
+          eligibleGroupsPromisesByProfileId.delete(profileId);
+        }
+      }
     });
+  }
+
+  private async getGroupsUserIsEligibleForWithCache(
+    profileId: string,
+    timer?: Timer | undefined
+  ): Promise<string[]> {
+    const timerKey = 'getGroupsUserIsEligibleFor';
+    const ttlSec = this.getEligibleGroupsCacheTtlSec();
+    const computedAtMillis = Time.currentMillis();
+    const [latestProfileGroupChangeMillis, waveGroupsVersion] =
+      await Promise.all([
+        this.timeAsync(
+          timer,
+          `${timerKey}->getLatestProfileGroupChangeMillis`,
+          () => this.userGroupsDb.getLatestProfileGroupChangeMillis(profileId)
+        ),
+        this.getWaveGroupsCacheVersion(timer)
+      ]);
+
+    const memoryCacheEntry = this.timeSync(
+      timer,
+      `${timerKey}->memoryCacheLookup`,
+      () =>
+        mcache.get(
+          this.getEligibleGroupsMemoryCacheKey(profileId)
+        ) as EligibleGroupsCacheEntry | null
+    );
+    if (
+      this.isEligibleGroupsCacheEntryValid(
+        memoryCacheEntry,
+        latestProfileGroupChangeMillis,
+        waveGroupsVersion
+      )
+    ) {
+      return memoryCacheEntry.eligibleGroupIds;
+    }
+
+    const redisCacheEntry = await this.getEligibleGroupsRedisCacheEntry(
+      profileId,
+      timer
+    );
+    if (
+      this.isEligibleGroupsCacheEntryValid(
+        redisCacheEntry,
+        latestProfileGroupChangeMillis,
+        waveGroupsVersion
+      )
+    ) {
+      this.putEligibleGroupsMemoryCache(profileId, redisCacheEntry, ttlSec);
+      return redisCacheEntry.eligibleGroupIds;
+    }
+
+    const acquiredRedisLock = await this.tryAcquireEligibleGroupsRedisLock(
+      profileId,
+      timer
+    );
+    if (!acquiredRedisLock) {
+      const waitedCacheEntry = await this.waitForEligibleGroupsRedisCacheEntry({
+        profileId,
+        latestProfileGroupChangeMillis,
+        waveGroupsVersion,
+        ttlSec,
+        timer
+      });
+      if (waitedCacheEntry) {
+        return waitedCacheEntry.eligibleGroupIds;
+      }
+    }
+
+    const results = await this.computeGroupsUserIsEligibleFor(profileId, timer);
+    const cacheEntry: EligibleGroupsCacheEntry = {
+      eligibleGroupIds: results,
+      computedAtMillis,
+      waveGroupsVersion
+    };
+    this.putEligibleGroupsMemoryCache(profileId, cacheEntry, ttlSec);
+    await this.putEligibleGroupsRedisCache(
+      profileId,
+      cacheEntry,
+      ttlSec,
+      timer
+    );
+    return results;
+  }
+
+  private async computeGroupsUserIsEligibleFor(
+    profileId: string,
+    timer?: Timer | undefined
+  ): Promise<string[]> {
+    const timerKey = 'getGroupsUserIsEligibleFor';
+    const groups = await this.timeAsync(
+      timer,
+      `${timerKey}->getAllWaveRelatedGroups`,
+      () => this.userGroupsDb.getAllWaveRelatedGroups({ timer })
+    );
+    return await this.whichOfGivenGroupsIsUserEligibleFor(
+      { profileId, givenGroups: groups, allWaveGroups: true },
+      timer
+    );
+  }
+
+  private getEligibleGroupsCacheTtlSec(): number {
+    return Math.max(
+      1,
+      env.getIntOrNull('USER_GROUPS_ELIGIBILITY_CACHE_TTL_SEC') ??
+        DEFAULT_ELIGIBLE_GROUPS_CACHE_TTL_SEC
+    );
+  }
+
+  private getEligibleGroupsMemoryCacheKey(profileId: string): string {
+    return `${ELIGIBLE_GROUPS_MEMORY_CACHE_PREFIX}-${profileId}`;
+  }
+
+  private getEligibleGroupsRedisCacheKey(profileId: string): string {
+    return `${ELIGIBLE_GROUPS_REDIS_CACHE_PREFIX}:${profileId}`;
+  }
+
+  private getEligibleGroupsRedisLockKey(profileId: string): string {
+    return `${ELIGIBLE_GROUPS_REDIS_LOCK_PREFIX}:${profileId}`;
+  }
+
+  private putEligibleGroupsMemoryCache(
+    profileId: string,
+    cacheEntry: EligibleGroupsCacheEntry,
+    ttlSec: number
+  ) {
+    this.timeSync(undefined, 'getGroupsUserIsEligibleFor->memoryCachePut', () =>
+      mcache.put(
+        this.getEligibleGroupsMemoryCacheKey(profileId),
+        cacheEntry,
+        Time.seconds(ttlSec).toMillis()
+      )
+    );
+  }
+
+  private async getWaveGroupsCacheVersion(
+    timer?: Timer | undefined
+  ): Promise<number> {
+    const redisClient = getRedisClient();
+    if (!redisClient) {
+      return 0;
+    }
+    return await this.timeAsync(
+      timer,
+      'getGroupsUserIsEligibleFor->waveGroupsVersionRedisGet',
+      async () => {
+        const cachedVersion = await redisClient
+          .get(WAVE_GROUPS_VERSION_CACHE_KEY)
+          .catch(() => null);
+        const parsed = Number(cachedVersion);
+        return Number.isFinite(parsed) ? parsed : 0;
+      }
+    );
+  }
+
+  private async getEligibleGroupsRedisCacheEntry(
+    profileId: string,
+    timer?: Timer | undefined
+  ): Promise<EligibleGroupsCacheEntry | null> {
+    const redisClient = getRedisClient();
+    if (!redisClient) {
+      return null;
+    }
+    return await this.timeAsync(
+      timer,
+      'getGroupsUserIsEligibleFor->redisCacheGet',
+      async () => {
+        const cachedValue = await redisClient
+          .get(this.getEligibleGroupsRedisCacheKey(profileId))
+          .catch(() => null);
+        return this.parseEligibleGroupsCacheEntry(cachedValue);
+      }
+    );
+  }
+
+  private async putEligibleGroupsRedisCache(
+    profileId: string,
+    cacheEntry: EligibleGroupsCacheEntry,
+    ttlSec: number,
+    timer?: Timer | undefined
+  ) {
+    const redisClient = getRedisClient();
+    if (!redisClient) {
+      return;
+    }
+    await this.timeAsync(
+      timer,
+      'getGroupsUserIsEligibleFor->redisCacheSet',
+      async () => {
+        await redisClient
+          .set(
+            this.getEligibleGroupsRedisCacheKey(profileId),
+            JSON.stringify(cacheEntry),
+            { EX: ttlSec }
+          )
+          .catch(() => undefined);
+      }
+    );
+  }
+
+  private async tryAcquireEligibleGroupsRedisLock(
+    profileId: string,
+    timer?: Timer | undefined
+  ): Promise<boolean> {
+    const redisClient = getRedisClient();
+    if (!redisClient) {
+      return true;
+    }
+    return await this.timeAsync(
+      timer,
+      'getGroupsUserIsEligibleFor->redisLockSet',
+      async () => {
+        const response = await redisClient
+          .set(this.getEligibleGroupsRedisLockKey(profileId), '1', {
+            PX: ELIGIBLE_GROUPS_REDIS_LOCK_TTL_MS,
+            NX: true
+          })
+          .catch(() => 'OK');
+        return response === 'OK';
+      }
+    );
+  }
+
+  private async waitForEligibleGroupsRedisCacheEntry({
+    profileId,
+    latestProfileGroupChangeMillis,
+    waveGroupsVersion,
+    ttlSec,
+    timer
+  }: {
+    profileId: string;
+    latestProfileGroupChangeMillis: number | null;
+    waveGroupsVersion: number;
+    ttlSec: number;
+    timer?: Timer | undefined;
+  }): Promise<EligibleGroupsCacheEntry | null> {
+    for (let i = 0; i < ELIGIBLE_GROUPS_REDIS_LOCK_WAIT_RETRIES; i++) {
+      await Time.millis(ELIGIBLE_GROUPS_REDIS_LOCK_WAIT_MS).sleep();
+      const cacheEntry = await this.getEligibleGroupsRedisCacheEntry(
+        profileId,
+        timer
+      );
+      if (
+        this.isEligibleGroupsCacheEntryValid(
+          cacheEntry,
+          latestProfileGroupChangeMillis,
+          waveGroupsVersion
+        )
+      ) {
+        this.putEligibleGroupsMemoryCache(profileId, cacheEntry, ttlSec);
+        return cacheEntry;
+      }
+    }
+    return null;
+  }
+
+  private parseEligibleGroupsCacheEntry(
+    cachedValue: string | null
+  ): EligibleGroupsCacheEntry | null {
+    if (!cachedValue) {
+      return null;
+    }
+    try {
+      const parsed = JSON.parse(
+        cachedValue
+      ) as Partial<EligibleGroupsCacheEntry>;
+      if (
+        parsed &&
+        Array.isArray(parsed.eligibleGroupIds) &&
+        parsed.eligibleGroupIds.every((it) => typeof it === 'string') &&
+        typeof parsed.computedAtMillis === 'number' &&
+        Number.isFinite(parsed.computedAtMillis) &&
+        typeof parsed.waveGroupsVersion === 'number' &&
+        Number.isFinite(parsed.waveGroupsVersion)
+      ) {
+        return {
+          eligibleGroupIds: parsed.eligibleGroupIds,
+          computedAtMillis: parsed.computedAtMillis,
+          waveGroupsVersion: parsed.waveGroupsVersion
+        };
+      }
+    } catch {
+      return null;
+    }
+    return null;
+  }
+
+  private isEligibleGroupsCacheEntryValid(
+    cacheEntry: EligibleGroupsCacheEntry | null,
+    latestProfileGroupChangeMillis: number | null,
+    waveGroupsVersion: number
+  ): cacheEntry is EligibleGroupsCacheEntry {
+    if (!cacheEntry) {
+      return false;
+    }
+    if (cacheEntry.waveGroupsVersion !== waveGroupsVersion) {
+      return false;
+    }
+    return (
+      latestProfileGroupChangeMillis === null ||
+      cacheEntry.computedAtMillis > latestProfileGroupChangeMillis
+    );
   }
 
   async changeVisibility(

--- a/src/api-serverless/src/community-members/user-groups.service.ts
+++ b/src/api-serverless/src/community-members/user-groups.service.ts
@@ -781,7 +781,7 @@ export class UserGroupsService {
     const timerKey = 'getGroupsUserIsEligibleFor';
     return this.timeAsync(timer, timerKey, async () => {
       const existingPromise = eligibleGroupsPromisesByProfileId.get(profileId);
-      if (existingPromise) {
+      if (existingPromise !== undefined) {
         return await this.timeAsync(
           timer,
           `${timerKey}->localInFlightWait`,

--- a/src/api-serverless/src/community-members/user-groups.service.ts
+++ b/src/api-serverless/src/community-members/user-groups.service.ts
@@ -1068,7 +1068,7 @@ export class UserGroupsService {
     latestProfileGroupChangeMillis: number | null;
     waveGroupsVersion: number;
     ttlSec: number;
-    timer?: Timer | undefined;
+    timer?: Timer;
   }): Promise<EligibleGroupsCacheEntry | null> {
     for (let i = 0; i < ELIGIBLE_GROUPS_REDIS_LOCK_WAIT_RETRIES; i++) {
       await Time.millis(ELIGIBLE_GROUPS_REDIS_LOCK_WAIT_MS).sleep();

--- a/src/api-serverless/src/community-members/user-groups.service.ts
+++ b/src/api-serverless/src/community-members/user-groups.service.ts
@@ -76,6 +76,7 @@ import { xTdhRepository } from '@/xtdh/xtdh.repository';
 import { XTdhGrantStatus, XTdhGrantTokenMode } from '@/entities/IXTdhGrant';
 import { xTdhGrantsFinder } from '@/xtdh/xtdh-grants.finder';
 import { xTdhGrantApiConverter } from '../xtdh/grants/xtdh-grant.api-converter';
+import { Logger } from '@/logging';
 
 export type NewUserGroupEntity = Omit<
   UserGroupEntity,
@@ -103,6 +104,7 @@ const ELIGIBLE_GROUPS_REDIS_LOCK_TTL_MS = 10_000;
 const ELIGIBLE_GROUPS_REDIS_LOCK_WAIT_RETRIES = 4;
 const ELIGIBLE_GROUPS_REDIS_LOCK_WAIT_MS = 75;
 const eligibleGroupsPromisesByProfileId = new Map<string, Promise<string[]>>();
+const logger = Logger.get('USER_GROUPS_SERVICE');
 
 export class UserGroupsService {
   public static readonly GENERATED_VIEW = 'user_groups_view';
@@ -810,7 +812,6 @@ export class UserGroupsService {
   ): Promise<string[]> {
     const timerKey = 'getGroupsUserIsEligibleFor';
     const ttlSec = this.getEligibleGroupsCacheTtlSec();
-    const computedAtMillis = Time.currentMillis();
     const [latestProfileGroupChangeMillis, waveGroupsVersion] =
       await Promise.all([
         this.timeAsync(
@@ -872,6 +873,21 @@ export class UserGroupsService {
     }
 
     const results = await this.computeGroupsUserIsEligibleFor(profileId, timer);
+    const computedAtMillis = Time.currentMillis();
+    const latestProfileGroupChangeMillisAfterCompute = await this.timeAsync(
+      timer,
+      `${timerKey}->getLatestProfileGroupChangeMillisAfterCompute`,
+      () => this.userGroupsDb.getLatestProfileGroupChangeMillis(profileId)
+    );
+    if (
+      this.hasProfileGroupChangeAdvanced(
+        latestProfileGroupChangeMillis,
+        latestProfileGroupChangeMillisAfterCompute
+      )
+    ) {
+      return results;
+    }
+
     const cacheEntry: EligibleGroupsCacheEntry = {
       eligibleGroupIds: results,
       computedAtMillis,
@@ -885,6 +901,19 @@ export class UserGroupsService {
       timer
     );
     return results;
+  }
+
+  private hasProfileGroupChangeAdvanced(
+    beforeMillis: number | null,
+    afterMillis: number | null
+  ): boolean {
+    if (afterMillis === null) {
+      return false;
+    }
+    if (beforeMillis === null) {
+      return true;
+    }
+    return afterMillis > beforeMillis;
   }
 
   private async computeGroupsUserIsEligibleFor(
@@ -1019,7 +1048,10 @@ export class UserGroupsService {
             PX: ELIGIBLE_GROUPS_REDIS_LOCK_TTL_MS,
             NX: true
           })
-          .catch(() => 'OK');
+          .catch((err) => {
+            logger.warn('Failed to acquire eligible groups Redis lock', err);
+            return null;
+          });
         return response === 'OK';
       }
     );

--- a/src/redis.ts
+++ b/src/redis.ts
@@ -5,6 +5,9 @@ import { Time } from './time';
 
 let redis: Redis;
 
+export const WAVE_GROUPS_CACHE_KEY = 'cache_6529_wave_groups';
+export const WAVE_GROUPS_VERSION_CACHE_KEY = 'cache_6529_wave_groups_version';
+
 export async function redisGet<T>(key: string): Promise<T | null> {
   if (!redis) {
     return null;
@@ -211,7 +214,13 @@ export async function initRedis() {
 }
 
 export async function clearWaveGroupsCache() {
-  await evictKeyFromRedisCache('cache_6529_wave_groups');
+  if (!redis) {
+    return;
+  }
+  await Promise.all([
+    redis.del(WAVE_GROUPS_CACHE_KEY),
+    redis.incr(WAVE_GROUPS_VERSION_CACHE_KEY)
+  ]);
 }
 
 export function getRedisClient(): Redis | null {

--- a/src/user-groups/user-groups.db.ts
+++ b/src/user-groups/user-groups.db.ts
@@ -858,16 +858,31 @@ export class UserGroupsDb extends LazyDbAccessCompatibleService {
   }
 
   async profileHasRecentGroupChanges(profileId: string, interval: Time) {
+    const latestChangeMillis =
+      await this.getLatestProfileGroupChangeMillis(profileId);
+    return (
+      latestChangeMillis !== null &&
+      latestChangeMillis > Time.now().minus(interval).toMillis()
+    );
+  }
+
+  async getLatestProfileGroupChangeMillis(
+    profileId: string
+  ): Promise<number | null> {
     return await this.db
       .oneOrNull<{
-        profile_id: string;
+        chg_time: number | string | null;
       }>(
-        `select profile_id from ${PROFILE_GROUP_CHANGES} where profile_id = :profileId and chg_time > :limit limit 1`,
-        { limit: Time.now().minus(interval).toMillis(), profileId },
+        `select max(chg_time) as chg_time from ${PROFILE_GROUP_CHANGES} where profile_id = :profileId`,
+        { profileId },
         { forcePool: DbPoolName.WRITE }
       )
       .then((it) => {
-        return !!it?.profile_id;
+        if (it?.chg_time === null || it?.chg_time === undefined) {
+          return null;
+        }
+        const parsed = Number(it.chg_time);
+        return Number.isFinite(parsed) ? parsed : null;
       });
   }
 


### PR DESCRIPTION
## Summary
- Cache final eligible wave group IDs per profile in Redis to avoid repeatedly reading/parsing the large `cache_6529_wave_groups` blob during notifications/waves fanout.
- Version profile eligibility cache entries with the wave-groups cache version and invalidate them when the profile's group-change timestamp is newer.
- Collapse concurrent same-profile eligibility computations within a Lambda process and keep the existing large wave-groups cache as a miss-path fallback.

## Tests
- `npm test -- src/api-serverless/src/community-members/user-groups-service.test.ts --runInBand`
- `npm run lint`
- `npm run tsc -- --noEmit`

## Deploy Plan
- No DB migration.
- Deploy `api` first so request paths and group/wave mutation invalidation start bumping `cache_6529_wave_groups_version`.
- Deploy `pushNotificationsHandler` second because it imports the shared eligibility service.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Implemented multi-tier caching for user group eligibility checks to reduce latency and database load during peak usage.
  * Added concurrent request deduplication to prevent redundant group computations when handling simultaneous eligibility checks.
  * Enhanced cache validation against profile changes to maintain data consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->