### PR TITLE
Include subwaves in wave search

### DIFF
--- a/src/api-serverless/src/waves/waves-api-db.test.ts
+++ b/src/api-serverless/src/waves/waves-api-db.test.ts
@@ -804,10 +804,42 @@ describeWithSeed(
     }
   ],
   () => {
-    it('excludes subwaves from top-level search results', async () => {
+    it('includes visible subwaves in search results', async () => {
       const waves = await repo.searchWaves(
         {
           limit: 10,
+          name: 'Subwave',
+          direct_message: false
+        },
+        [],
+        ctx
+      );
+
+      expect(waves.map((wave) => wave.id)).toEqual([
+        betaSubwave.id,
+        alphaSubwave.id
+      ]);
+    });
+
+    it('hides search results for subwaves whose parent is not visible', async () => {
+      const waves = await repo.searchWaves(
+        {
+          limit: 10,
+          name: 'Visible Child',
+          direct_message: false
+        },
+        [],
+        ctx
+      );
+
+      expect(waves.map((wave) => wave.id)).toEqual([]);
+    });
+
+    it('returns subwaves of hidden parents when the parent is visible to the user', async () => {
+      const waves = await repo.searchWaves(
+        {
+          limit: 10,
+          name: 'Visible Child',
           direct_message: false
         },
         ['hidden-parent-group'],
@@ -815,8 +847,7 @@ describeWithSeed(
       );
 
       expect(waves.map((wave) => wave.id)).toEqual([
-        hiddenParentWave.id,
-        parentWave.id
+        publicSubwaveOfHiddenParent.id
       ]);
     });
 

--- a/src/api-serverless/src/waves/waves.api.db.ts
+++ b/src/api-serverless/src/waves/waves.api.db.ts
@@ -895,6 +895,7 @@ export class WavesApiDb extends LazyDbAccessCompatibleService {
       searchParams.serial_no_less_than ?? Number.MAX_SAFE_INTEGER;
     const offset = searchParams.offset ?? 0;
     const sql = `${sqlAndParams.sql} select w.* from ${WAVES_TABLE} w
+           left join ${WAVES_TABLE} parent on parent.id = w.parent_wave_id
 	         join ${
              UserGroupsService.GENERATED_VIEW
            } cm on cm.profile_id = w.created_by
@@ -904,11 +905,12 @@ export class WavesApiDb extends LazyDbAccessCompatibleService {
            searchParams.direct_message !== undefined
              ? ` w.is_direct_message = :direct_message and `
              : ``
-         }(${
-           groupsUserIsEligibleFor.length
-             ? `w.visibility_group_id in (:groupsUserIsEligibleFor) or`
-             : ``
-         } w.visibility_group_id is null) and w.parent_wave_id is null and w.serial_no < :serialNoLessThan order by w.serial_no desc limit ${
+         }${this.getWaveAndParentVisibilityFilter(
+           'w',
+           'parent',
+           groupsUserIsEligibleFor,
+           'groupsUserIsEligibleFor'
+         )} and w.serial_no < :serialNoLessThan order by w.serial_no desc limit ${
            searchParams.limit
          } offset :offset`;
     const params: Record<string, any> = {


### PR DESCRIPTION
## Issue
- Subwaves are not returned from wave search APIs, so the existing #wave-name mention autocomplete cannot suggest subwaves.

## Fix
- Allow wave search to return subwaves while preserving existing read visibility rules for both the subwave and its top-level parent.

## Changes
- Updated the shared wave search query used by legacy GET /waves and V2 GET /v2/waves?view=SEARCH to include visible subwaves.
- Kept hidden-parent protections by requiring the parent wave to be visible before a subwave can appear.
- Updated repository tests for visible subwave search, hidden-parent suppression, and eligible hidden-parent access.

## Validation
- npm test -- src/api-serverless/src/waves/waves-api-db.test.ts
- npm run lint
- npm run build

## Risk
- Level: Low
- Why: narrow read-query behavior change; no schema, migration, OpenAPI shape, auth, or frontend generated-client changes.
- Rollback: revert this PR or redeploy the previous api version.

## Deployment
- Deploy backend service: api.
- Deploy order: backend api before any frontend staging validation. No dbMigrationsLoop, loop, or frontend deploy is required for this change.

## Review Notes
- Please focus on search visibility for subwaves whose parent is hidden. The implementation intentionally reuses the existing parent visibility helper.
- No architecture-doc update is needed because this does not add, remove, rename, or rewire deployable services, queues, API boundaries, runtime patterns, or external integrations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Search results now properly include subwaves that match your search query
  * Subwave visibility in search results now correctly respects visibility settings and access permissions
  * Improved search filtering to handle nested item visibility based on user eligibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->