### PR TITLE
Normalize object-stream PDFs before publishing

### DIFF
--- a/src/attachments/attachments-processing-service.test.ts
+++ b/src/attachments/attachments-processing-service.test.ts
@@ -1,4 +1,4 @@
-import { PDFDocument } from 'pdf-lib';
+import { PDFDocument, rgb, StandardFonts } from 'pdf-lib';
 import { AttachmentsProcessingService } from './attachments-processing.service';
 import { AttachmentKind } from '@/entities/IAttachment';
 
@@ -42,6 +42,28 @@ describe('AttachmentsProcessingService PDF validation', () => {
     const fileBuffer = await createPdf(1);
 
     await expect(validatePdf(fileBuffer)).resolves.toBe(fileBuffer);
+  });
+
+  it('accepts and normalizes parseable PDFs with object streams', async () => {
+    const document = await PDFDocument.create();
+    const page = document.addPage([200, 120]);
+    const font = await document.embedFont(StandardFonts.Helvetica);
+    page.drawText('object stream smoke', {
+      x: 20,
+      y: 70,
+      size: 12,
+      font,
+      color: rgb(0, 0, 0)
+    });
+    const fileBuffer = Buffer.from(await document.save());
+
+    expect(fileBuffer.toString('latin1').toLowerCase()).toContain('/objstm');
+
+    const validated = await validatePdf(fileBuffer);
+
+    expect(validated).not.toBe(fileBuffer);
+    expect(validated.toString('latin1').toLowerCase()).not.toContain('/objstm');
+    await expect(PDFDocument.load(validated)).resolves.toBeDefined();
   });
 
   it('rejects malformed PDFs even when the signature is present', async () => {

--- a/src/attachments/attachments-processing-service.test.ts
+++ b/src/attachments/attachments-processing-service.test.ts
@@ -28,6 +28,20 @@ describe('AttachmentsProcessingService PDF validation', () => {
     return Buffer.from(await document.save({ useObjectStreams: false }));
   }
 
+  async function createPdfWithObjectStreams(): Promise<Buffer> {
+    const document = await PDFDocument.create();
+    const page = document.addPage([200, 120]);
+    const font = await document.embedFont(StandardFonts.Helvetica);
+    page.drawText('object stream smoke', {
+      x: 20,
+      y: 70,
+      size: 12,
+      font,
+      color: rgb(0, 0, 0)
+    });
+    return Buffer.from(await document.save());
+  }
+
   async function validatePdf(fileBuffer: Buffer): Promise<Buffer> {
     return await validatePdfMethod.call(service, fileBuffer);
   }
@@ -45,18 +59,9 @@ describe('AttachmentsProcessingService PDF validation', () => {
   });
 
   it('accepts and normalizes parseable PDFs with object streams', async () => {
-    const document = await PDFDocument.create();
-    const page = document.addPage([200, 120]);
-    const font = await document.embedFont(StandardFonts.Helvetica);
-    page.drawText('object stream smoke', {
-      x: 20,
-      y: 70,
-      size: 12,
-      font,
-      color: rgb(0, 0, 0)
-    });
-    const fileBuffer = Buffer.from(await document.save());
-
+    const fileBuffer = await createPdfWithObjectStreams();
+    // pdf-lib currently emits object streams by default for this document shape;
+    // that mirrors the staging compatibility failure this test guards.
     expect(fileBuffer.toString('latin1').toLowerCase()).toContain('/objstm');
 
     const validated = await validatePdf(fileBuffer);
@@ -64,6 +69,36 @@ describe('AttachmentsProcessingService PDF validation', () => {
     expect(validated).not.toBe(fileBuffer);
     expect(validated.toString('latin1').toLowerCase()).not.toContain('/objstm');
     await expect(PDFDocument.load(validated)).resolves.toBeDefined();
+  });
+
+  it('rejects when object stream normalization fails', async () => {
+    const fileBuffer = await createPdfWithObjectStreams();
+    const saveSpy = jest
+      .spyOn(PDFDocument.prototype, 'save')
+      .mockRejectedValueOnce(new Error('save failed'));
+
+    try {
+      await expect(validatePdf(fileBuffer)).rejects.toThrow(
+        'PDF object streams could not be normalized safely'
+      );
+    } finally {
+      saveSpy.mockRestore();
+    }
+  });
+
+  it('rejects when object streams survive normalization', async () => {
+    const fileBuffer = await createPdfWithObjectStreams();
+    const saveSpy = jest
+      .spyOn(PDFDocument.prototype, 'save')
+      .mockResolvedValueOnce(fileBuffer);
+
+    try {
+      await expect(validatePdf(fileBuffer)).rejects.toThrow(
+        'PDF object streams could not be normalized safely'
+      );
+    } finally {
+      saveSpy.mockRestore();
+    }
   });
 
   it('rejects malformed PDFs even when the signature is present', async () => {

--- a/src/attachments/attachments-processing.service.ts
+++ b/src/attachments/attachments-processing.service.ts
@@ -47,9 +47,9 @@ const PDF_BLOCKLIST_MARKERS = [
   '/EmbeddedFile',
   '/RichMedia',
   '/XFA',
-  '/Encrypt',
-  '/ObjStm'
+  '/Encrypt'
 ];
+const PDF_OBJECT_STREAM_MARKER = '/ObjStm';
 
 function formatByteLimit(byteLimit: number): string {
   return byteLimit.toLocaleString();
@@ -253,21 +253,32 @@ export class AttachmentsProcessingService {
         `PDF exceeds the ${formatByteLimit(MAX_PDF_BYTES)} byte limit`
       );
     }
-    const text = this.normalizePdfText(fileBuffer);
-    for (const marker of PDF_BLOCKLIST_MARKERS) {
-      if (text.includes(marker.toLowerCase())) {
-        throw new ContentViolationError(
-          `PDF contains blocked feature ${marker}`
-        );
-      }
-    }
-    const pageCount = await this.getPdfPageCount(fileBuffer);
+
+    const hasObjectStreams = this.pdfContainsMarker(
+      fileBuffer,
+      PDF_OBJECT_STREAM_MARKER
+    );
+    this.assertPdfDoesNotContainBlockedMarkers(fileBuffer);
+
+    const { pageCount, normalizedBuffer } = await this.loadPdfForValidation(
+      fileBuffer,
+      { normalizeObjectStreams: hasObjectStreams }
+    );
     if (pageCount > MAX_PDF_PAGES) {
       throw new ContentViolationError(
         `PDF exceeds the ${MAX_PDF_PAGES} page limit`
       );
     }
-    return fileBuffer;
+    if (!normalizedBuffer) {
+      return fileBuffer;
+    }
+    if (normalizedBuffer.byteLength > MAX_PDF_BYTES) {
+      throw new ContentViolationError(
+        `PDF exceeds the ${formatByteLimit(MAX_PDF_BYTES)} byte limit`
+      );
+    }
+    this.assertPdfDoesNotContainBlockedMarkers(normalizedBuffer);
+    return normalizedBuffer;
   }
 
   private async createSafeCsv(fileBuffer: Buffer): Promise<Buffer> {
@@ -401,7 +412,25 @@ export class AttachmentsProcessingService {
       .toLowerCase();
   }
 
-  private async getPdfPageCount(fileBuffer: Buffer): Promise<number> {
+  private pdfContainsMarker(fileBuffer: Buffer, marker: string): boolean {
+    return this.normalizePdfText(fileBuffer).includes(marker.toLowerCase());
+  }
+
+  private assertPdfDoesNotContainBlockedMarkers(fileBuffer: Buffer): void {
+    const text = this.normalizePdfText(fileBuffer);
+    for (const marker of PDF_BLOCKLIST_MARKERS) {
+      if (text.includes(marker.toLowerCase())) {
+        throw new ContentViolationError(
+          `PDF contains blocked feature ${marker}`
+        );
+      }
+    }
+  }
+
+  private async loadPdfForValidation(
+    fileBuffer: Buffer,
+    { normalizeObjectStreams }: { normalizeObjectStreams: boolean }
+  ): Promise<{ pageCount: number; normalizedBuffer: Buffer | null }> {
     try {
       const pdfDocument = await PDFDocument.load(fileBuffer, {
         ignoreEncryption: false,
@@ -411,7 +440,10 @@ export class AttachmentsProcessingService {
       if (pageCount === 0) {
         throw new ContentViolationError('PDF must contain at least one page');
       }
-      return pageCount;
+      const normalizedBuffer = normalizeObjectStreams
+        ? Buffer.from(await pdfDocument.save({ useObjectStreams: false }))
+        : null;
+      return { pageCount, normalizedBuffer };
     } catch (error) {
       if (this.isContentViolationError(error)) {
         throw error;

--- a/src/attachments/attachments-processing.service.ts
+++ b/src/attachments/attachments-processing.service.ts
@@ -254,11 +254,12 @@ export class AttachmentsProcessingService {
       );
     }
 
-    const hasObjectStreams = this.pdfContainsMarker(
-      fileBuffer,
+    const pdfText = this.normalizePdfText(fileBuffer);
+    const hasObjectStreams = this.pdfTextContainsMarker(
+      pdfText,
       PDF_OBJECT_STREAM_MARKER
     );
-    this.assertPdfDoesNotContainBlockedMarkers(fileBuffer);
+    this.assertPdfTextDoesNotContainBlockedMarkers(pdfText);
 
     const { pageCount, normalizedBuffer } = await this.loadPdfForValidation(
       fileBuffer,
@@ -277,7 +278,15 @@ export class AttachmentsProcessingService {
         `PDF exceeds the ${formatByteLimit(MAX_PDF_BYTES)} byte limit`
       );
     }
-    this.assertPdfDoesNotContainBlockedMarkers(normalizedBuffer);
+    const normalizedPdfText = this.normalizePdfText(normalizedBuffer);
+    if (
+      this.pdfTextContainsMarker(normalizedPdfText, PDF_OBJECT_STREAM_MARKER)
+    ) {
+      throw new ContentViolationError(
+        'PDF object streams could not be normalized safely'
+      );
+    }
+    this.assertPdfTextDoesNotContainBlockedMarkers(normalizedPdfText);
     return normalizedBuffer;
   }
 
@@ -412,14 +421,13 @@ export class AttachmentsProcessingService {
       .toLowerCase();
   }
 
-  private pdfContainsMarker(fileBuffer: Buffer, marker: string): boolean {
-    return this.normalizePdfText(fileBuffer).includes(marker.toLowerCase());
+  private pdfTextContainsMarker(pdfText: string, marker: string): boolean {
+    return pdfText.includes(marker.toLowerCase());
   }
 
-  private assertPdfDoesNotContainBlockedMarkers(fileBuffer: Buffer): void {
-    const text = this.normalizePdfText(fileBuffer);
+  private assertPdfTextDoesNotContainBlockedMarkers(pdfText: string): void {
     for (const marker of PDF_BLOCKLIST_MARKERS) {
-      if (text.includes(marker.toLowerCase())) {
+      if (this.pdfTextContainsMarker(pdfText, marker)) {
         throw new ContentViolationError(
           `PDF contains blocked feature ${marker}`
         );
@@ -431,28 +439,41 @@ export class AttachmentsProcessingService {
     fileBuffer: Buffer,
     { normalizeObjectStreams }: { normalizeObjectStreams: boolean }
   ): Promise<{ pageCount: number; normalizedBuffer: Buffer | null }> {
+    let pdfDocument: PDFDocument;
     try {
-      const pdfDocument = await PDFDocument.load(fileBuffer, {
+      pdfDocument = await PDFDocument.load(fileBuffer, {
         ignoreEncryption: false,
         updateMetadata: false
       });
-      const pageCount = pdfDocument.getPageCount();
-      if (pageCount === 0) {
-        throw new ContentViolationError('PDF must contain at least one page');
-      }
-      const normalizedBuffer = normalizeObjectStreams
-        ? Buffer.from(await pdfDocument.save({ useObjectStreams: false }))
-        : null;
-      return { pageCount, normalizedBuffer };
     } catch (error) {
-      if (this.isContentViolationError(error)) {
-        throw error;
-      }
       if (this.isEncryptedPdfError(error)) {
         throw new ContentViolationError('Encrypted PDFs are not supported');
       }
       throw new ContentViolationError('PDF could not be parsed safely');
     }
+    let pageCount: number;
+    try {
+      pageCount = pdfDocument.getPageCount();
+    } catch {
+      throw new ContentViolationError('PDF could not be parsed safely');
+    }
+    if (pageCount === 0) {
+      throw new ContentViolationError('PDF must contain at least one page');
+    }
+    if (!normalizeObjectStreams) {
+      return { pageCount, normalizedBuffer: null };
+    }
+    let normalizedBuffer: Buffer;
+    try {
+      normalizedBuffer = Buffer.from(
+        await pdfDocument.save({ useObjectStreams: false })
+      );
+    } catch {
+      throw new ContentViolationError(
+        'PDF object streams could not be normalized safely'
+      );
+    }
+    return { pageCount, normalizedBuffer };
   }
 
   private isEncryptedPdfError(error: unknown): boolean {


### PR DESCRIPTION
## Summary
- normalize parseable PDFs that use object streams before public IPFS publication
- scan normalized PDF bytes for the existing risky feature blocklist before accepting them
- add focused coverage for text-bearing `pdf-lib` PDFs that use `/ObjStm`

## Why
Staging validation of #1653 proved the deployed pipeline was live, but a normal `pdf-lib` generated PDF was blocked with `PDF contains blocked feature /ObjStm`. Object streams are a common PDF storage feature, not active content by themselves. This keeps the safety intent while avoiding unnecessary rejection of ordinary PDFs.

## Validation
- `npm test -- src/attachments/attachments-processing-service.test.ts --runInBand`
- `npx tsc -p tsconfig.json --noEmit`
- `npm test -- src/attachments/attachments-processing-service.test.ts src/api-serverless/src/attachments/attachments-mappers.test.ts src/attachments/attachments-status-notifier.test.ts --runInBand`
- `npm run lint` via Git Bash script shell on Windows
- `codex-diff-check -- src/attachments/attachments-processing.service.ts src/attachments/attachments-processing-service.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PDF processing to detect and safely normalize PDFs that use object stream compression, ensuring blocked features are checked against the normalized content.
  * Enhanced validation to enforce page-count and size limits after normalization, and to reject PDFs when object streams can’t be normalized safely.
* **Tests**
  * Added coverage for object-stream PDFs and normalization failure scenarios to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->