### PR TITLE
Allow desktop connection-share bridge credentialed CORS

### DIFF
--- a/src/api-serverless/src/api-constants.test.ts
+++ b/src/api-serverless/src/api-constants.test.ts
@@ -41,6 +41,19 @@ describe('api CORS constants', () => {
     });
   });
 
+  it('uses exact credentialed CORS for the legacy desktop connection-share bridge', () => {
+    expect(
+      getCorsOptionsForRequest(
+        '/api/auth/connection-share/legacy-desktop',
+        'https://6529.io',
+        'api.6529.io'
+      )
+    ).toMatchObject({
+      origin: 'https://6529.io',
+      credentials: true
+    });
+  });
+
   it('matches default API hosts when the Host header includes a port', () => {
     expect(
       getCorsOptionsForRequest(

--- a/src/api-serverless/src/api-constants.ts
+++ b/src/api-serverless/src/api-constants.ts
@@ -38,6 +38,7 @@ const WEB_AUTH_CREDENTIAL_ROUTE_PATHS = new Set([
   '/api/auth/session-refresh',
   '/api/auth/session-logout',
   '/api/auth/connection-share',
+  '/api/auth/connection-share/legacy-desktop',
   '/api/auth/connection-share/redeem'
 ]);
 


### PR DESCRIPTION
## Summary
- Add the legacy Desktop connection-share bridge to the web-session credentialed CORS route allowlist.
- Add a focused CORS unit test for `/api/auth/connection-share/legacy-desktop`.

## Notes
- Backend-only change; affected deploy service: `api`.
- Focused test could not run locally because this new worktree has no installed Jest binary (`jest: command not found`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added support for credentialed CORS on the legacy desktop connection-share route.
  * Requests to this route now use the same allowed-origin and credentials behavior as other authenticated web routes.
* **Tests**
  * Added coverage to confirm the expected CORS settings for the new route.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->