### PR TITLE
Fix rememes S3 loop convergence

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "mysql": "^2.18.1",
         "node-cron": "^4.0.0",
         "node-emoji": "^2.2.0",
-        "node-fetch": "^2.7.0",
+        "node-fetch": "2.7.0",
         "openai": "^6.42.0",
         "passport": "^0.7.0",
         "passport-anonymous": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "mysql": "^2.18.1",
     "node-cron": "^4.0.0",
     "node-emoji": "^2.2.0",
-    "node-fetch": "^2.7.0",
+    "node-fetch": "2.7.0",
     "openai": "^6.42.0",
     "passport": "^0.7.0",
     "passport-anonymous": "^1.0.1",

--- a/src/db-api.ts
+++ b/src/db-api.ts
@@ -1360,7 +1360,7 @@ export const fetchNFTMedia = async (
   const queries = {
     [MEMES_CONTRACT]: `SELECT id, image, scaled as image_compact, animation, compressed_animation as animation_compact FROM ${NFTS_TABLE} WHERE contract=:contract ORDER BY RAND()`,
     [GRADIENT_CONTRACT]: `SELECT id, image, scaled as image_compact, animation, compressed_animation as animation_compact FROM ${NFTS_TABLE} WHERE contract=:contract ORDER BY RAND()`,
-    rememes: `SELECT id, image, s3_image_scaled as image_compact, NULLIF(animation, '') as animation FROM ${REMEMES_TABLE} ORDER BY RAND() LIMIT 100`,
+    rememes: `SELECT id, image, COALESCE(s3_image_scaled, s3_image_thumbnail, s3_image_original, image) as image_compact, NULLIF(animation, '') as animation FROM ${REMEMES_TABLE} ORDER BY RAND() LIMIT 100`,
     [MEMELAB_CONTRACT]: `SELECT id, image, scaled as image_compact, animation, compressed_animation as animation_compact FROM ${NFTS_MEME_LAB_TABLE} ORDER BY RAND() LIMIT 100`,
     nextgen: `SELECT image_url as image, REPLACE(image_url, '/png/', '/png1k/') as image_compact, animation_url as animation FROM ${NEXTGEN_TOKENS_TABLE} ORDER BY RAND() LIMIT 100`
   };

--- a/src/db.ts
+++ b/src/db.ts
@@ -5,6 +5,7 @@ import {
   IsNull,
   LessThan,
   MoreThanOrEqual,
+  Brackets,
   QueryRunner
 } from 'typeorm';
 import { consolidationTools } from './consolidation-tools';
@@ -54,7 +55,12 @@ import {
   NFTHistoryClaim
 } from './entities/INFTHistory';
 import { Profile } from './entities/IProfile';
-import { Rememe, RememeUpload } from './entities/IRememe';
+import {
+  REMEME_S3_MAX_PROCESSING_ATTEMPTS,
+  Rememe,
+  RememeS3ProcessingStatus,
+  RememeUpload
+} from './entities/IRememe';
 import { RoyaltiesUpload } from './entities/IRoyalties';
 import { MemesSeason } from './entities/ISeason';
 import {
@@ -1526,11 +1532,30 @@ export async function fetchRememes() {
 }
 
 export async function fetchMissingS3Rememes() {
-  return await AppDataSource.getRepository(Rememe).find({
-    where: {
-      s3_image_original: IsNull()
-    }
-  });
+  return await AppDataSource.getRepository(Rememe)
+    .createQueryBuilder('rememe')
+    .where('rememe.s3_image_original IS NULL')
+    .andWhere(
+      new Brackets((qb) => {
+        qb.where('rememe.s3_image_processing_status IS NULL').orWhere(
+          'rememe.s3_image_processing_status = :retryableStatus',
+          {
+            retryableStatus: RememeS3ProcessingStatus.TRANSIENT_ERROR
+          }
+        );
+      })
+    )
+    .andWhere(
+      new Brackets((qb) => {
+        qb.where('rememe.s3_image_processing_attempts IS NULL').orWhere(
+          'rememe.s3_image_processing_attempts < :maxAttempts',
+          { maxAttempts: REMEME_S3_MAX_PROCESSING_ATTEMPTS }
+        );
+      })
+    )
+    .orderBy('rememe.updated_at', 'ASC')
+    .take(50)
+    .getMany();
 }
 
 export async function persistTDHHistory(date: Date, tdhHistory: TDHHistory[]) {

--- a/src/db.ts
+++ b/src/db.ts
@@ -1532,15 +1532,27 @@ export async function fetchRememes() {
 }
 
 export async function fetchMissingS3Rememes() {
+  const retryBefore = Time.hoursAgo(6).toDate();
+
   return await AppDataSource.getRepository(Rememe)
     .createQueryBuilder('rememe')
-    .where('rememe.s3_image_original IS NULL')
+    .where(
+      new Brackets((qb) => {
+        qb.where('rememe.s3_image_original IS NULL')
+          .orWhere('rememe.s3_image_scaled IS NULL')
+          .orWhere('rememe.s3_image_thumbnail IS NULL')
+          .orWhere('rememe.s3_image_icon IS NULL');
+      })
+    )
     .andWhere(
       new Brackets((qb) => {
         qb.where('rememe.s3_image_processing_status IS NULL').orWhere(
-          'rememe.s3_image_processing_status = :retryableStatus',
+          'rememe.s3_image_processing_status IN (:...retryableStatuses)',
           {
-            retryableStatus: RememeS3ProcessingStatus.TRANSIENT_ERROR
+            retryableStatuses: [
+              RememeS3ProcessingStatus.TRANSIENT_ERROR,
+              RememeS3ProcessingStatus.PARTIAL
+            ]
           }
         );
       })
@@ -1550,6 +1562,14 @@ export async function fetchMissingS3Rememes() {
         qb.where('rememe.s3_image_processing_attempts IS NULL').orWhere(
           'rememe.s3_image_processing_attempts < :maxAttempts',
           { maxAttempts: REMEME_S3_MAX_PROCESSING_ATTEMPTS }
+        );
+      })
+    )
+    .andWhere(
+      new Brackets((qb) => {
+        qb.where('rememe.s3_image_last_attempt_at IS NULL').orWhere(
+          'rememe.s3_image_last_attempt_at < :retryBefore',
+          { retryBefore }
         );
       })
     )

--- a/src/entities/IRememe.ts
+++ b/src/entities/IRememe.ts
@@ -12,6 +12,16 @@ export enum RememeSource {
   SEIZE = 'seize'
 }
 
+export enum RememeS3ProcessingStatus {
+  COMPLETE = 'complete',
+  PARTIAL = 'partial',
+  UNSUPPORTED = 'unsupported',
+  TRANSIENT_ERROR = 'transient_error',
+  PERMANENT_ERROR = 'permanent_error'
+}
+
+export const REMEME_S3_MAX_PROCESSING_ATTEMPTS = 3;
+
 @Entity(REMEMES_TABLE)
 export class Rememe {
   @CreateDateColumn()
@@ -64,6 +74,18 @@ export class Rememe {
 
   @Column({ type: 'text', nullable: true, default: null })
   s3_image_icon!: string | null;
+
+  @Column({ type: 'varchar', length: 50, nullable: true, default: null })
+  s3_image_processing_status?: RememeS3ProcessingStatus | null;
+
+  @Column({ type: 'text', nullable: true, default: null })
+  s3_image_processing_error?: string | null;
+
+  @Column({ type: 'datetime', nullable: true, default: null })
+  s3_image_last_attempt_at?: Date | null;
+
+  @Column({ type: 'int', nullable: true, default: 0 })
+  s3_image_processing_attempts?: number | null;
 
   @Column({
     type: 'enum',

--- a/src/rememe-media-source.ts
+++ b/src/rememe-media-source.ts
@@ -1,0 +1,27 @@
+import { Rememe } from './entities/IRememe';
+import { ipfs } from './ipfs';
+
+export function resolveRememeFetchImageUrl(r: Rememe): string | undefined {
+  return resolveRememeFetchImageUrlFromParts(r.image, r.media?.gateway);
+}
+
+export function resolveRememeFetchImageUrlFromParts(
+  image: string | undefined,
+  gateway: string | undefined
+): string | undefined {
+  const metadataImage = ipfs
+    .ifIpfsThenCloudflareElsePreserveOrEmptyIfUndefined(image)
+    .trim();
+  if (isFetchableUrl(metadataImage)) {
+    return metadataImage;
+  }
+
+  const trimmedGateway = gateway?.trim();
+  const resolved = trimmedGateway?.length ? trimmedGateway : metadataImage;
+  const trimmed = resolved.trim();
+  return trimmed.length ? trimmed : undefined;
+}
+
+function isFetchableUrl(url: string): boolean {
+  return /^https?:\/\//i.test(url);
+}

--- a/src/rememe-media-source.ts
+++ b/src/rememe-media-source.ts
@@ -1,16 +1,25 @@
 import { Rememe } from './entities/IRememe';
 import { ipfs } from './ipfs';
 
-export function resolveRememeFetchImageUrl(r: Rememe): string | undefined {
-  return resolveRememeFetchImageUrlFromParts(r.image, r.media?.gateway);
+export type RememeMediaGateway = {
+  gateway?: string | null;
+};
+
+export function resolveRememeFetchImageUrl(
+  r: Pick<Rememe, 'image' | 'media'>
+): string | undefined {
+  return resolveRememeFetchImageUrlFromParts(
+    r.image,
+    gatewayFromMedia(r.media)
+  );
 }
 
 export function resolveRememeFetchImageUrlFromParts(
-  image: string | undefined,
-  gateway: string | undefined
+  image: string | null | undefined,
+  gateway: string | null | undefined
 ): string | undefined {
   const metadataImage = ipfs
-    .ifIpfsThenCloudflareElsePreserveOrEmptyIfUndefined(image)
+    .ifIpfsThenCloudflareElsePreserveOrEmptyIfUndefined(image ?? undefined)
     .trim();
   if (isFetchableUrl(metadataImage)) {
     return metadataImage;
@@ -20,6 +29,32 @@ export function resolveRememeFetchImageUrlFromParts(
   const resolved = trimmedGateway?.length ? trimmedGateway : metadataImage;
   const trimmed = resolved.trim();
   return trimmed.length ? trimmed : undefined;
+}
+
+export function isRememeFetchSourceUnchanged(
+  existing: Pick<Rememe, 'image' | 'media'> | undefined,
+  image: string | null | undefined,
+  media: RememeMediaGateway | null | undefined
+): boolean {
+  if (!existing) {
+    return false;
+  }
+
+  const nextGateway = gatewayFromMedia(media);
+  if (!nextGateway && existing.image === image) {
+    return true;
+  }
+
+  return (
+    resolveRememeFetchImageUrl(existing) ===
+    resolveRememeFetchImageUrlFromParts(image, nextGateway)
+  );
+}
+
+function gatewayFromMedia(
+  media: Rememe['media'] | RememeMediaGateway | null | undefined
+): string | undefined {
+  return typeof media?.gateway === 'string' ? media.gateway : undefined;
 }
 
 function isFetchableUrl(url: string): boolean {

--- a/src/rememe-media-source.ts
+++ b/src/rememe-media-source.ts
@@ -41,6 +41,8 @@ export function isRememeFetchSourceUnchanged(
   }
 
   const nextGateway = gatewayFromMedia(media);
+  // Missing gateway on refresh is not a new source signal. Alchemy gateway URLs
+  // can be absent transiently, so preserve S3 state when the metadata image is unchanged.
   if (!nextGateway && existing.image === image) {
     return true;
   }

--- a/src/rememes-loop.test.ts
+++ b/src/rememes-loop.test.ts
@@ -14,7 +14,7 @@ describe('rememeS3FieldsForRefresh', () => {
       s3_image_processing_status: RememeS3ProcessingStatus.TRANSIENT_ERROR,
       s3_image_processing_error: 'temporary failure',
       s3_image_last_attempt_at: lastAttempt,
-      s3_image_processing_attempts: null
+      s3_image_processing_attempts: undefined
     } as Rememe;
 
     expect(rememeS3FieldsForRefresh(existing, 'ipfs://unchanged')).toEqual({
@@ -25,7 +25,7 @@ describe('rememeS3FieldsForRefresh', () => {
       s3_image_processing_status: RememeS3ProcessingStatus.TRANSIENT_ERROR,
       s3_image_processing_error: 'temporary failure',
       s3_image_last_attempt_at: lastAttempt,
-      s3_image_processing_attempts: null
+      s3_image_processing_attempts: 0
     });
   });
 

--- a/src/rememes-loop.test.ts
+++ b/src/rememes-loop.test.ts
@@ -1,0 +1,56 @@
+import { Rememe, RememeS3ProcessingStatus } from './entities/IRememe';
+import { rememeS3FieldsForRefresh } from './rememesLoop';
+
+describe('rememeS3FieldsForRefresh', () => {
+  it('preserves existing S3 state when the metadata image URL is unchanged', () => {
+    const lastAttempt = new Date('2026-06-26T00:00:00.000Z');
+    const existing = {
+      image: 'ipfs://unchanged',
+      media: {},
+      s3_image_original: 'https://cdn.test/original.webp',
+      s3_image_scaled: 'https://cdn.test/scaled.webp',
+      s3_image_thumbnail: 'https://cdn.test/thumbnail.webp',
+      s3_image_icon: 'https://cdn.test/icon.webp',
+      s3_image_processing_status: RememeS3ProcessingStatus.TRANSIENT_ERROR,
+      s3_image_processing_error: 'temporary failure',
+      s3_image_last_attempt_at: lastAttempt,
+      s3_image_processing_attempts: null
+    } as Rememe;
+
+    expect(rememeS3FieldsForRefresh(existing, 'ipfs://unchanged')).toEqual({
+      s3_image_original: 'https://cdn.test/original.webp',
+      s3_image_scaled: 'https://cdn.test/scaled.webp',
+      s3_image_thumbnail: 'https://cdn.test/thumbnail.webp',
+      s3_image_icon: 'https://cdn.test/icon.webp',
+      s3_image_processing_status: RememeS3ProcessingStatus.TRANSIENT_ERROR,
+      s3_image_processing_error: 'temporary failure',
+      s3_image_last_attempt_at: lastAttempt,
+      s3_image_processing_attempts: null
+    });
+  });
+
+  it('resets S3 state when the metadata image URL changes', () => {
+    const existing = {
+      image: 'ipfs://old',
+      s3_image_original: 'https://cdn.test/original.webp',
+      s3_image_scaled: 'https://cdn.test/scaled.webp',
+      s3_image_thumbnail: 'https://cdn.test/thumbnail.webp',
+      s3_image_icon: 'https://cdn.test/icon.webp',
+      s3_image_processing_status: RememeS3ProcessingStatus.COMPLETE,
+      s3_image_processing_error: null,
+      s3_image_last_attempt_at: new Date('2026-06-26T00:00:00.000Z'),
+      s3_image_processing_attempts: 0
+    } as Rememe;
+
+    expect(rememeS3FieldsForRefresh(existing, 'ipfs://new')).toEqual({
+      s3_image_original: null,
+      s3_image_scaled: null,
+      s3_image_thumbnail: null,
+      s3_image_icon: null,
+      s3_image_processing_status: null,
+      s3_image_processing_error: null,
+      s3_image_last_attempt_at: null,
+      s3_image_processing_attempts: 0
+    });
+  });
+});

--- a/src/rememes-loop.test.ts
+++ b/src/rememes-loop.test.ts
@@ -2,7 +2,7 @@ import { Rememe, RememeS3ProcessingStatus } from './entities/IRememe';
 import { rememeS3FieldsForRefresh } from './rememesLoop';
 
 describe('rememeS3FieldsForRefresh', () => {
-  it('preserves existing S3 state when the metadata image URL is unchanged', () => {
+  it('preserves existing S3 state when the fetch source URL is unchanged', () => {
     const lastAttempt = new Date('2026-06-26T00:00:00.000Z');
     const existing = {
       image: 'ipfs://unchanged',
@@ -25,6 +25,70 @@ describe('rememeS3FieldsForRefresh', () => {
       s3_image_processing_status: RememeS3ProcessingStatus.TRANSIENT_ERROR,
       s3_image_processing_error: 'temporary failure',
       s3_image_last_attempt_at: lastAttempt,
+      s3_image_processing_attempts: 0
+    });
+  });
+
+  it('preserves S3 state when an HTTP metadata image is unchanged and only gateway changes', () => {
+    const existing = {
+      image: 'https://example.test/rememe.png',
+      media: {
+        gateway: 'https://gateway.old.test/rememe.png'
+      },
+      s3_image_original: 'https://cdn.test/original.webp',
+      s3_image_scaled: 'https://cdn.test/scaled.webp',
+      s3_image_thumbnail: 'https://cdn.test/thumbnail.webp',
+      s3_image_icon: 'https://cdn.test/icon.webp',
+      s3_image_processing_status: RememeS3ProcessingStatus.COMPLETE,
+      s3_image_processing_error: null,
+      s3_image_last_attempt_at: null,
+      s3_image_processing_attempts: 1
+    } as Rememe;
+
+    expect(
+      rememeS3FieldsForRefresh(existing, 'https://example.test/rememe.png', {
+        gateway: 'https://gateway.new.test/rememe.png'
+      })
+    ).toEqual({
+      s3_image_original: 'https://cdn.test/original.webp',
+      s3_image_scaled: 'https://cdn.test/scaled.webp',
+      s3_image_thumbnail: 'https://cdn.test/thumbnail.webp',
+      s3_image_icon: 'https://cdn.test/icon.webp',
+      s3_image_processing_status: RememeS3ProcessingStatus.COMPLETE,
+      s3_image_processing_error: null,
+      s3_image_last_attempt_at: null,
+      s3_image_processing_attempts: 1
+    });
+  });
+
+  it('resets S3 state when a non-fetchable metadata image uses a changed gateway', () => {
+    const existing = {
+      image: 'ar://raw-rememe-image',
+      media: {
+        gateway: 'https://gateway.old.test/rememe.png'
+      },
+      s3_image_original: 'https://cdn.test/original.webp',
+      s3_image_scaled: 'https://cdn.test/scaled.webp',
+      s3_image_thumbnail: 'https://cdn.test/thumbnail.webp',
+      s3_image_icon: 'https://cdn.test/icon.webp',
+      s3_image_processing_status: RememeS3ProcessingStatus.COMPLETE,
+      s3_image_processing_error: null,
+      s3_image_last_attempt_at: new Date('2026-06-26T00:00:00.000Z'),
+      s3_image_processing_attempts: 0
+    } as Rememe;
+
+    expect(
+      rememeS3FieldsForRefresh(existing, 'ar://raw-rememe-image', {
+        gateway: 'https://gateway.new.test/rememe.png'
+      })
+    ).toEqual({
+      s3_image_original: null,
+      s3_image_scaled: null,
+      s3_image_thumbnail: null,
+      s3_image_icon: null,
+      s3_image_processing_status: null,
+      s3_image_processing_error: null,
+      s3_image_last_attempt_at: null,
       s3_image_processing_attempts: 0
     });
   });

--- a/src/rememes-loop.test.ts
+++ b/src/rememes-loop.test.ts
@@ -93,6 +93,36 @@ describe('rememeS3FieldsForRefresh', () => {
     });
   });
 
+  it('preserves S3 state when a non-fetchable metadata image temporarily loses gateway', () => {
+    const existing = {
+      image: 'ar://raw-rememe-image',
+      media: {
+        gateway: 'https://gateway.old.test/rememe.png'
+      },
+      s3_image_original: 'https://cdn.test/original.webp',
+      s3_image_scaled: 'https://cdn.test/scaled.webp',
+      s3_image_thumbnail: 'https://cdn.test/thumbnail.webp',
+      s3_image_icon: 'https://cdn.test/icon.webp',
+      s3_image_processing_status: RememeS3ProcessingStatus.COMPLETE,
+      s3_image_processing_error: null,
+      s3_image_last_attempt_at: null,
+      s3_image_processing_attempts: 2
+    } as Rememe;
+
+    expect(
+      rememeS3FieldsForRefresh(existing, 'ar://raw-rememe-image', {})
+    ).toEqual({
+      s3_image_original: 'https://cdn.test/original.webp',
+      s3_image_scaled: 'https://cdn.test/scaled.webp',
+      s3_image_thumbnail: 'https://cdn.test/thumbnail.webp',
+      s3_image_icon: 'https://cdn.test/icon.webp',
+      s3_image_processing_status: RememeS3ProcessingStatus.COMPLETE,
+      s3_image_processing_error: null,
+      s3_image_last_attempt_at: null,
+      s3_image_processing_attempts: 2
+    });
+  });
+
   it('resets S3 state when the metadata image URL changes', () => {
     const existing = {
       image: 'ipfs://old',

--- a/src/rememesLoop/index.ts
+++ b/src/rememesLoop/index.ts
@@ -239,7 +239,7 @@ async function buildRememe(
           : ''
       : '';
 
-    const s3Fields = rememeS3FieldsForRefresh(existing, image, media);
+    const s3Fields = rememeS3FieldsForRefresh(existing, image);
 
     const r: Rememe = {
       contract: contract,
@@ -265,13 +265,12 @@ async function buildRememe(
   }
 }
 
-function rememeS3FieldsForRefresh(
+export function rememeS3FieldsForRefresh(
   existing: Rememe | undefined,
-  image: string,
-  media: any
+  image: string
 ): RememeS3RefreshFields {
-  const sourceMediaUnchanged =
-    existing?.image === image && existing?.media?.gateway === media?.gateway;
+  // Alchemy gateway URLs can be absent or volatile; the metadata image URL is the stable source key.
+  const sourceMediaUnchanged = existing?.image === image;
 
   if (existing && sourceMediaUnchanged) {
     return {
@@ -282,7 +281,8 @@ function rememeS3FieldsForRefresh(
       s3_image_processing_status: existing.s3_image_processing_status ?? null,
       s3_image_processing_error: existing.s3_image_processing_error ?? null,
       s3_image_last_attempt_at: existing.s3_image_last_attempt_at ?? null,
-      s3_image_processing_attempts: existing.s3_image_processing_attempts ?? 0
+      s3_image_processing_attempts:
+        existing.s3_image_processing_attempts ?? null
     };
   }
 

--- a/src/rememesLoop/index.ts
+++ b/src/rememesLoop/index.ts
@@ -281,8 +281,7 @@ export function rememeS3FieldsForRefresh(
       s3_image_processing_status: existing.s3_image_processing_status ?? null,
       s3_image_processing_error: existing.s3_image_processing_error ?? null,
       s3_image_last_attempt_at: existing.s3_image_last_attempt_at ?? null,
-      s3_image_processing_attempts:
-        existing.s3_image_processing_attempts ?? null
+      s3_image_processing_attempts: existing.s3_image_processing_attempts ?? 0
     };
   }
 

--- a/src/rememesLoop/index.ts
+++ b/src/rememesLoop/index.ts
@@ -290,6 +290,9 @@ export function rememeS3FieldsForRefresh(
     };
   }
 
+  // A changed fetch source invalidates every derived S3 URL and queues the row
+  // for regeneration; unchanged metadata images are preserved above to avoid
+  // churn from volatile gateway URLs.
   return {
     s3_image_original: null,
     s3_image_scaled: null,

--- a/src/rememesLoop/index.ts
+++ b/src/rememesLoop/index.ts
@@ -15,6 +15,10 @@ import { persistRememesS3 } from '../s3_rememes';
 import { Logger } from '../logging';
 import * as sentryContext from '../sentry.context';
 import { equalIgnoreCase } from '../strings';
+import {
+  resolveRememeFetchImageUrl,
+  resolveRememeFetchImageUrlFromParts
+} from '../rememe-media-source';
 
 const Arweave = require('arweave');
 const csvParser = require('csv-parser');
@@ -239,7 +243,7 @@ async function buildRememe(
           : ''
       : '';
 
-    const s3Fields = rememeS3FieldsForRefresh(existing, image);
+    const s3Fields = rememeS3FieldsForRefresh(existing, image, media);
 
     const r: Rememe = {
       contract: contract,
@@ -267,10 +271,13 @@ async function buildRememe(
 
 export function rememeS3FieldsForRefresh(
   existing: Rememe | undefined,
-  image: string
+  image: string,
+  media?: Rememe['media']
 ): RememeS3RefreshFields {
-  // Alchemy gateway URLs can be absent or volatile; the metadata image URL is the stable source key.
-  const sourceMediaUnchanged = existing?.image === image;
+  const sourceMediaUnchanged =
+    !!existing &&
+    resolveRememeFetchImageUrl(existing) ===
+      resolveRememeFetchImageUrlFromParts(image, media?.gateway);
 
   if (existing && sourceMediaUnchanged) {
     return {

--- a/src/rememesLoop/index.ts
+++ b/src/rememesLoop/index.ts
@@ -2,7 +2,7 @@ import { createReadStream } from 'fs';
 import { doInDbContext } from '../secrets';
 import { Rememe, RememeSource, RememeUpload } from '../entities/IRememe';
 import { Alchemy } from '@/alchemy-sdk';
-import { ALCHEMY_SETTINGS, CLOUDFRONT_LINK } from '@/constants';
+import { ALCHEMY_SETTINGS } from '@/constants';
 import {
   deleteRememes,
   fetchMissingS3Rememes,
@@ -15,7 +15,6 @@ import { persistRememesS3 } from '../s3_rememes';
 import { Logger } from '../logging';
 import * as sentryContext from '../sentry.context';
 import { equalIgnoreCase } from '../strings';
-import { mediaChecker } from '../media-checker';
 
 const Arweave = require('arweave');
 const csvParser = require('csv-parser');
@@ -29,6 +28,18 @@ interface CSVData {
   id: string;
   memes: number[];
 }
+
+type RememeS3RefreshFields = Pick<
+  Rememe,
+  | 's3_image_original'
+  | 's3_image_scaled'
+  | 's3_image_thumbnail'
+  | 's3_image_icon'
+  | 's3_image_processing_status'
+  | 's3_image_processing_error'
+  | 's3_image_last_attempt_at'
+  | 's3_image_processing_attempts'
+>;
 
 const myarweave = Arweave.init({
   host: 'arweave.net',
@@ -162,7 +173,7 @@ async function refreshRememes(rememes: Rememe[]) {
   await Promise.all(
     rememes.map(async (d) => {
       try {
-        const r = await buildRememe(d.contract, d.id, d.meme_references);
+        const r = await buildRememe(d.contract, d.id, d.meme_references, d);
         if (r) {
           updateRememesList.push(r);
         }
@@ -178,7 +189,7 @@ async function refreshRememes(rememes: Rememe[]) {
   await Promise.all(
     retryRememesList.map(async (d) => {
       try {
-        const r = await buildRememe(d.contract, d.id, d.meme_references);
+        const r = await buildRememe(d.contract, d.id, d.meme_references, d);
         if (r) {
           updateRememesList.push(r);
         }
@@ -195,7 +206,12 @@ async function refreshRememes(rememes: Rememe[]) {
   logger.info(`[REFRESH COMPLETE] [REFRESHED ${updateRememesList.length}]`);
 }
 
-async function buildRememe(contract: string, id: string, memes: number[]) {
+async function buildRememe(
+  contract: string,
+  id: string,
+  memes: number[],
+  existing?: Rememe
+) {
   const nftMeta = await alchemy.nft.getNftMetadata(contract, id, {
     refreshCache: true
   });
@@ -223,19 +239,7 @@ async function buildRememe(contract: string, id: string, memes: number[]) {
           : ''
       : '';
 
-    const originalFormat = await mediaChecker.getContentType(image);
-
-    let s3Original: string | null = null;
-    let s3Scaled: string | null = null;
-    let s3Thumbnail: string | null = null;
-    let s3Icon: string | null = null;
-
-    if (originalFormat) {
-      s3Original = `${CLOUDFRONT_LINK}/rememes/images/original/${contract}-${id}.${originalFormat}`;
-      s3Scaled = `${CLOUDFRONT_LINK}/rememes/images/scaled/${contract}-${id}.${originalFormat}`;
-      s3Thumbnail = `${CLOUDFRONT_LINK}/rememes/images/thumbnail/${contract}-${id}.${originalFormat}`;
-      s3Icon = `${CLOUDFRONT_LINK}/rememes/images/icon/${contract}-${id}.${originalFormat}`;
-    }
+    const s3Fields = rememeS3FieldsForRefresh(existing, image, media);
 
     const r: Rememe = {
       contract: contract,
@@ -249,10 +253,7 @@ async function buildRememe(contract: string, id: string, memes: number[]) {
       animation,
       contract_opensea_data: contractOpenseaData,
       media: media,
-      s3_image_original: s3Original,
-      s3_image_scaled: s3Scaled,
-      s3_image_thumbnail: s3Thumbnail,
-      s3_image_icon: s3Icon,
+      ...s3Fields,
       source: RememeSource.FILE
     };
     return r;
@@ -262,6 +263,39 @@ async function buildRememe(contract: string, id: string, memes: number[]) {
     );
     return undefined;
   }
+}
+
+function rememeS3FieldsForRefresh(
+  existing: Rememe | undefined,
+  image: string,
+  media: any
+): RememeS3RefreshFields {
+  const sourceMediaUnchanged =
+    existing?.image === image && existing?.media?.gateway === media?.gateway;
+
+  if (existing && sourceMediaUnchanged) {
+    return {
+      s3_image_original: existing.s3_image_original ?? null,
+      s3_image_scaled: existing.s3_image_scaled ?? null,
+      s3_image_thumbnail: existing.s3_image_thumbnail ?? null,
+      s3_image_icon: existing.s3_image_icon ?? null,
+      s3_image_processing_status: existing.s3_image_processing_status ?? null,
+      s3_image_processing_error: existing.s3_image_processing_error ?? null,
+      s3_image_last_attempt_at: existing.s3_image_last_attempt_at ?? null,
+      s3_image_processing_attempts: existing.s3_image_processing_attempts ?? 0
+    };
+  }
+
+  return {
+    s3_image_original: null,
+    s3_image_scaled: null,
+    s3_image_thumbnail: null,
+    s3_image_icon: null,
+    s3_image_processing_status: null,
+    s3_image_processing_error: null,
+    s3_image_last_attempt_at: null,
+    s3_image_processing_attempts: 0
+  };
 }
 
 async function upload(rememes: Rememe[]) {

--- a/src/rememesLoop/index.ts
+++ b/src/rememesLoop/index.ts
@@ -15,10 +15,7 @@ import { persistRememesS3 } from '../s3_rememes';
 import { Logger } from '../logging';
 import * as sentryContext from '../sentry.context';
 import { equalIgnoreCase } from '../strings';
-import {
-  resolveRememeFetchImageUrl,
-  resolveRememeFetchImageUrlFromParts
-} from '../rememe-media-source';
+import { isRememeFetchSourceUnchanged } from '../rememe-media-source';
 
 const Arweave = require('arweave');
 const csvParser = require('csv-parser');
@@ -274,10 +271,11 @@ export function rememeS3FieldsForRefresh(
   image: string,
   media?: Rememe['media']
 ): RememeS3RefreshFields {
-  const sourceMediaUnchanged =
-    !!existing &&
-    resolveRememeFetchImageUrl(existing) ===
-      resolveRememeFetchImageUrlFromParts(image, media?.gateway);
+  const sourceMediaUnchanged = isRememeFetchSourceUnchanged(
+    existing,
+    image,
+    media
+  );
 
   if (existing && sourceMediaUnchanged) {
     return {

--- a/src/rememesLoop/serverless.yaml
+++ b/src/rememesLoop/serverless.yaml
@@ -11,7 +11,7 @@ provider:
   runtime: nodejs22.x
   memorySize: 2048
   timeout: 900
-  architecture: arm64
+  architecture: x86_64
   logRetentionInDays: 60
 
 functions:
@@ -34,6 +34,7 @@ functions:
   rememesRefreshMetadataLoop:
     handler: index.handler
     name: rememesRefreshMetadataLoop
+    architecture: x86_64
     description: ${env:VERSION_DESCRIPTION}
     role: arn:aws:iam::987989283142:role/lambda-vpc-role
     reservedConcurrency: 1
@@ -49,6 +50,7 @@ functions:
   rememesFileLoop:
     handler: index.handler
     name: rememesFileLoop
+    architecture: x86_64
     description: ${env:VERSION_DESCRIPTION}
     role: arn:aws:iam::987989283142:role/lambda-vpc-role
     reservedConcurrency: 1

--- a/src/s3-rememes.test.ts
+++ b/src/s3-rememes.test.ts
@@ -166,8 +166,21 @@ describe('persistRememesS3', () => {
       .mocked(resizeImageBufferToHeight)
       .mockResolvedValue(Buffer.from('resized-image'));
 
-    await persistRememesS3([buildRememe()]);
+    await persistRememesS3([
+      buildRememe({
+        media: {
+          gateway: 'https://gateway.example.test/different-rememe.png'
+        }
+      })
+    ]);
 
+    expect(mediaChecker.getContentType).toHaveBeenCalledWith(
+      'https://example.test/rememe.png'
+    );
+    expect(withArweaveFallback).toHaveBeenCalledWith(
+      'https://example.test/rememe.png',
+      expect.any(Function)
+    );
     expect(PutObjectCommand).toHaveBeenCalledTimes(4);
     expect(PutObjectCommand).toHaveBeenNthCalledWith(
       1,

--- a/src/s3-rememes.test.ts
+++ b/src/s3-rememes.test.ts
@@ -96,14 +96,18 @@ describe('persistRememesS3', () => {
     ]);
   });
 
-  it('persists unsupported video originals without trying to resize them', async () => {
+  it('persists unsupported video originals without trying to resize them or incrementing attempts', async () => {
     mockS3Objects({
       [`rememes/images/original/${BASE_KEY}`]: [
         `rememes/images/original/${BASE_KEY}mp4`
       ]
     });
 
-    await persistRememesS3([buildRememe()]);
+    await persistRememesS3([
+      buildRememe({
+        s3_image_processing_attempts: 2
+      })
+    ]);
 
     expect(mediaChecker.getContentType).not.toHaveBeenCalled();
     expect(withArweaveFallback).not.toHaveBeenCalled();
@@ -116,7 +120,7 @@ describe('persistRememesS3', () => {
         s3_image_thumbnail: null,
         s3_image_icon: null,
         s3_image_processing_status: RememeS3ProcessingStatus.UNSUPPORTED,
-        s3_image_processing_attempts: 1,
+        s3_image_processing_attempts: 2,
         s3_image_processing_error: 'Unsupported rememe media format: mp4'
       })
     ]);

--- a/src/s3-rememes.test.ts
+++ b/src/s3-rememes.test.ts
@@ -1,0 +1,193 @@
+const sendMock = jest.fn();
+
+jest.mock('@aws-sdk/client-s3', () => ({
+  S3Client: jest.fn(() => ({
+    send: sendMock
+  })),
+  ListObjectsV2Command: jest.fn((input) => ({
+    commandName: 'ListObjectsV2Command',
+    input
+  })),
+  PutObjectCommand: jest.fn((input) => ({
+    commandName: 'PutObjectCommand',
+    input
+  }))
+}));
+
+jest.mock('./db', () => ({
+  persistRememes: jest.fn()
+}));
+
+jest.mock('@/media/image-resize', () => ({
+  resizeImageBufferToHeight: jest.fn()
+}));
+
+jest.mock('@/arweave-gateway-fallback', () => ({
+  withArweaveFallback: jest.fn()
+}));
+
+jest.mock('./media-checker', () => ({
+  mediaChecker: {
+    getContentType: jest.fn()
+  }
+}));
+
+jest.mock('./ipfs', () => ({
+  ipfs: {
+    ifIpfsThenCloudflareElsePreserveOrEmptyIfUndefined: jest.fn(
+      (url?: string) => url ?? ''
+    )
+  }
+}));
+
+import { ListObjectsV2Command, PutObjectCommand } from '@aws-sdk/client-s3';
+import { withArweaveFallback } from '@/arweave-gateway-fallback';
+import { CLOUDFRONT_LINK } from '@/constants';
+import { resizeImageBufferToHeight } from '@/media/image-resize';
+import { persistRememes } from './db';
+import {
+  Rememe,
+  RememeS3ProcessingStatus,
+  RememeSource
+} from './entities/IRememe';
+import { mediaChecker } from './media-checker';
+import { persistRememesS3 } from './s3_rememes';
+
+const BASE_KEY = '0xabc-1.';
+
+describe('persistRememesS3', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.AWS_6529_IMAGES_BUCKET_NAME = 'test-bucket';
+  });
+
+  it('persists existing legacy S3 assets without probing or uploading', async () => {
+    mockS3Objects({
+      [`rememes/images/original/${BASE_KEY}`]: [
+        `rememes/images/original/${BASE_KEY}png`
+      ],
+      [`rememes/images/scaled/${BASE_KEY}`]: [
+        `rememes/images/scaled/${BASE_KEY}png`
+      ],
+      [`rememes/images/thumbnail/${BASE_KEY}`]: [
+        `rememes/images/thumbnail/${BASE_KEY}png`
+      ],
+      [`rememes/images/icon/${BASE_KEY}`]: [
+        `rememes/images/icon/${BASE_KEY}png`
+      ]
+    });
+
+    await persistRememesS3([buildRememe()]);
+
+    expect(mediaChecker.getContentType).not.toHaveBeenCalled();
+    expect(withArweaveFallback).not.toHaveBeenCalled();
+    expect(resizeImageBufferToHeight).not.toHaveBeenCalled();
+    expect(PutObjectCommand).not.toHaveBeenCalled();
+    expect(ListObjectsV2Command).toHaveBeenCalledTimes(4);
+    expect(persistRememes).toHaveBeenCalledWith([
+      expect.objectContaining({
+        s3_image_original: `${CLOUDFRONT_LINK}/rememes/images/original/${BASE_KEY}png`,
+        s3_image_scaled: `${CLOUDFRONT_LINK}/rememes/images/scaled/${BASE_KEY}png`,
+        s3_image_thumbnail: `${CLOUDFRONT_LINK}/rememes/images/thumbnail/${BASE_KEY}png`,
+        s3_image_icon: `${CLOUDFRONT_LINK}/rememes/images/icon/${BASE_KEY}png`,
+        s3_image_processing_status: RememeS3ProcessingStatus.COMPLETE,
+        s3_image_processing_attempts: 0
+      })
+    ]);
+  });
+
+  it('persists unsupported video originals without trying to resize them', async () => {
+    mockS3Objects({
+      [`rememes/images/original/${BASE_KEY}`]: [
+        `rememes/images/original/${BASE_KEY}mp4`
+      ]
+    });
+
+    await persistRememesS3([buildRememe()]);
+
+    expect(mediaChecker.getContentType).not.toHaveBeenCalled();
+    expect(withArweaveFallback).not.toHaveBeenCalled();
+    expect(resizeImageBufferToHeight).not.toHaveBeenCalled();
+    expect(PutObjectCommand).not.toHaveBeenCalled();
+    expect(persistRememes).toHaveBeenCalledWith([
+      expect.objectContaining({
+        s3_image_original: `${CLOUDFRONT_LINK}/rememes/images/original/${BASE_KEY}mp4`,
+        s3_image_scaled: null,
+        s3_image_thumbnail: null,
+        s3_image_icon: null,
+        s3_image_processing_status: RememeS3ProcessingStatus.UNSUPPORTED,
+        s3_image_processing_attempts: 1,
+        s3_image_processing_error: 'Unsupported rememe media format: mp4'
+      })
+    ]);
+  });
+
+  it('marks repeatedly unresolved media as a permanent error', async () => {
+    mockS3Objects({});
+    jest.mocked(mediaChecker.getContentType).mockResolvedValue(null);
+
+    await persistRememesS3([
+      buildRememe({
+        s3_image_processing_attempts: 2
+      })
+    ]);
+
+    expect(withArweaveFallback).not.toHaveBeenCalled();
+    expect(resizeImageBufferToHeight).not.toHaveBeenCalled();
+    expect(PutObjectCommand).not.toHaveBeenCalled();
+    expect(persistRememes).toHaveBeenCalledWith([
+      expect.objectContaining({
+        s3_image_original: null,
+        s3_image_scaled: null,
+        s3_image_thumbnail: null,
+        s3_image_icon: null,
+        s3_image_processing_status: RememeS3ProcessingStatus.PERMANENT_ERROR,
+        s3_image_processing_attempts: 3,
+        s3_image_processing_error: 'Could not resolve rememe media format'
+      })
+    ]);
+  });
+});
+
+function buildRememe(overrides: Partial<Rememe> = {}): Rememe {
+  return {
+    contract: '0xabc',
+    id: '1',
+    deployer: '0xdeployer',
+    token_uri: 'https://example.test/token',
+    token_type: 'ERC721',
+    image: 'https://example.test/rememe.png',
+    animation: '',
+    meme_references: [1],
+    metadata: {},
+    contract_opensea_data: {},
+    media: {
+      gateway: 'https://example.test/rememe.png'
+    },
+    s3_image_original: null,
+    s3_image_scaled: null,
+    s3_image_thumbnail: null,
+    s3_image_icon: null,
+    s3_image_processing_attempts: 0,
+    source: RememeSource.FILE,
+    ...overrides
+  };
+}
+
+function mockS3Objects(objectsByPrefix: Record<string, string[]>) {
+  sendMock.mockImplementation(async (command) => {
+    if (command.commandName === 'ListObjectsV2Command') {
+      return {
+        Contents: (objectsByPrefix[command.input.Prefix] ?? []).map((Key) => ({
+          Key
+        }))
+      };
+    }
+
+    return {
+      $metadata: {
+        httpStatusCode: 200
+      }
+    };
+  });
+}

--- a/src/s3-rememes.test.ts
+++ b/src/s3-rememes.test.ts
@@ -147,6 +147,87 @@ describe('persistRememesS3', () => {
       })
     ]);
   });
+
+  it('normalizes MIME content types and stores allow-listed S3 content types', async () => {
+    mockS3Objects({});
+    jest.mocked(mediaChecker.getContentType).mockResolvedValue('image/png');
+    jest.mocked(withArweaveFallback).mockResolvedValue(
+      buildFetchResponse({
+        body: Buffer.from('image-bytes'),
+        contentLength: '11',
+        contentType: 'text/html'
+      })
+    );
+    jest
+      .mocked(resizeImageBufferToHeight)
+      .mockResolvedValue(Buffer.from('resized-image'));
+
+    await persistRememesS3([buildRememe()]);
+
+    expect(PutObjectCommand).toHaveBeenCalledTimes(4);
+    expect(PutObjectCommand).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        Key: `rememes/images/original/${BASE_KEY}png`,
+        ContentType: 'image/png'
+      })
+    );
+    expect(PutObjectCommand).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        Key: `rememes/images/scaled/${BASE_KEY}webp`,
+        ContentType: 'image/webp'
+      })
+    );
+    expect(PutObjectCommand).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({
+        Key: `rememes/images/thumbnail/${BASE_KEY}webp`,
+        ContentType: 'image/webp'
+      })
+    );
+    expect(PutObjectCommand).toHaveBeenNthCalledWith(
+      4,
+      expect.objectContaining({
+        Key: `rememes/images/icon/${BASE_KEY}webp`,
+        ContentType: 'image/webp'
+      })
+    );
+    expect(persistRememes).toHaveBeenCalledWith([
+      expect.objectContaining({
+        s3_image_original: `${CLOUDFRONT_LINK}/rememes/images/original/${BASE_KEY}png`,
+        s3_image_scaled: `${CLOUDFRONT_LINK}/rememes/images/scaled/${BASE_KEY}webp`,
+        s3_image_thumbnail: `${CLOUDFRONT_LINK}/rememes/images/thumbnail/${BASE_KEY}webp`,
+        s3_image_icon: `${CLOUDFRONT_LINK}/rememes/images/icon/${BASE_KEY}webp`,
+        s3_image_processing_status: RememeS3ProcessingStatus.COMPLETE
+      })
+    ]);
+  });
+
+  it('does not buffer oversized remote media responses', async () => {
+    const arrayBuffer = jest.fn();
+    mockS3Objects({});
+    jest.mocked(mediaChecker.getContentType).mockResolvedValue('png');
+    jest.mocked(withArweaveFallback).mockResolvedValue(
+      buildFetchResponse({
+        arrayBuffer,
+        contentLength: '200000000'
+      })
+    );
+
+    await persistRememesS3([buildRememe()]);
+
+    expect(arrayBuffer).not.toHaveBeenCalled();
+    expect(PutObjectCommand).not.toHaveBeenCalled();
+    expect(persistRememes).toHaveBeenCalledWith([
+      expect.objectContaining({
+        s3_image_original: null,
+        s3_image_processing_status: RememeS3ProcessingStatus.TRANSIENT_ERROR,
+        s3_image_processing_attempts: 1,
+        s3_image_processing_error: expect.stringContaining('too large')
+      })
+    ]);
+  });
 });
 
 function buildRememe(overrides: Partial<Rememe> = {}): Rememe {
@@ -175,13 +256,20 @@ function buildRememe(overrides: Partial<Rememe> = {}): Rememe {
 }
 
 function mockS3Objects(objectsByPrefix: Record<string, string[]>) {
+  const storedKeys = new Set(
+    Object.values(objectsByPrefix).flatMap((keys) => keys)
+  );
   sendMock.mockImplementation(async (command) => {
     if (command.commandName === 'ListObjectsV2Command') {
       return {
-        Contents: (objectsByPrefix[command.input.Prefix] ?? []).map((Key) => ({
-          Key
-        }))
+        Contents: Array.from(storedKeys)
+          .filter((Key) => Key.startsWith(command.input.Prefix))
+          .map((Key) => ({ Key }))
       };
+    }
+
+    if (command.commandName === 'PutObjectCommand') {
+      storedKeys.add(command.input.Key);
     }
 
     return {
@@ -190,4 +278,42 @@ function mockS3Objects(objectsByPrefix: Record<string, string[]>) {
       }
     };
   });
+}
+
+function buildFetchResponse({
+  arrayBuffer,
+  body,
+  contentLength,
+  contentType
+}: {
+  arrayBuffer?: jest.Mock;
+  body?: Buffer;
+  contentLength?: string;
+  contentType?: string;
+}) {
+  const responseBody = body ?? Buffer.alloc(0);
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    headers: {
+      get: (name: string) => {
+        if (name === 'content-length') {
+          return contentLength ?? responseBody.byteLength.toString();
+        }
+        if (name === 'content-type') {
+          return contentType ?? null;
+        }
+        return null;
+      }
+    },
+    arrayBuffer:
+      arrayBuffer ??
+      jest.fn(async () =>
+        responseBody.buffer.slice(
+          responseBody.byteOffset,
+          responseBody.byteOffset + responseBody.byteLength
+        )
+      )
+  };
 }

--- a/src/s3-rememes.test.ts
+++ b/src/s3-rememes.test.ts
@@ -221,6 +221,44 @@ describe('persistRememesS3', () => {
     ]);
   });
 
+  it('falls back to the media gateway when metadata image is not fetchable', async () => {
+    mockS3Objects({});
+    jest.mocked(mediaChecker.getContentType).mockResolvedValue('image/png');
+    jest.mocked(withArweaveFallback).mockResolvedValue(
+      buildFetchResponse({
+        body: Buffer.from('image-bytes'),
+        contentLength: '11',
+        contentType: 'image/png'
+      })
+    );
+    jest
+      .mocked(resizeImageBufferToHeight)
+      .mockResolvedValue(Buffer.from('resized-image'));
+
+    await persistRememesS3([
+      buildRememe({
+        image: 'ar://raw-rememe-image',
+        media: {
+          gateway: 'https://gateway.example.test/rememe.png'
+        }
+      })
+    ]);
+
+    expect(mediaChecker.getContentType).toHaveBeenCalledWith(
+      'https://gateway.example.test/rememe.png'
+    );
+    expect(withArweaveFallback).toHaveBeenCalledWith(
+      'https://gateway.example.test/rememe.png',
+      expect.any(Function)
+    );
+    expect(PutObjectCommand).toHaveBeenCalledTimes(4);
+    expect(persistRememes).toHaveBeenCalledWith([
+      expect.objectContaining({
+        s3_image_processing_status: RememeS3ProcessingStatus.COMPLETE
+      })
+    ]);
+  });
+
   it('does not buffer oversized remote media responses', async () => {
     const arrayBuffer = jest.fn();
     mockS3Objects({});

--- a/src/s3_rememes.ts
+++ b/src/s3_rememes.ts
@@ -439,6 +439,7 @@ async function readResponseBufferWithLimit(
     return Buffer.from(blob);
   }
 
+  // node-fetch v2 response.body is a Node Readable: async-iterable and destroyable.
   const stream = response.body as unknown as AsyncIterable<unknown>;
   const destroyableStream = response.body as unknown as {
     destroy?: () => void;
@@ -501,7 +502,10 @@ function assetUrl(key: string | null): string | null {
 
 function nextAttemptCount(r: Rememe, status: RememeS3ProcessingStatus): number {
   const currentAttempts = r.s3_image_processing_attempts ?? 0;
-  if (status === RememeS3ProcessingStatus.COMPLETE) {
+  if (
+    status === RememeS3ProcessingStatus.COMPLETE ||
+    status === RememeS3ProcessingStatus.UNSUPPORTED
+  ) {
     return currentAttempts;
   }
   return currentAttempts + 1;

--- a/src/s3_rememes.ts
+++ b/src/s3_rememes.ts
@@ -148,17 +148,21 @@ async function processRememeS3Unsafe(r: Rememe) {
 }
 
 function resolveRememeImageUrl(r: Rememe): string | undefined {
-  const metadataImage = ipfs.ifIpfsThenCloudflareElsePreserveOrEmptyIfUndefined(
-    r.image
-  );
-  const resolved = metadataImage.trim().length
-    ? metadataImage
-    : r.media?.gateway;
-  if (!resolved) {
-    return undefined;
+  const metadataImage = ipfs
+    .ifIpfsThenCloudflareElsePreserveOrEmptyIfUndefined(r.image)
+    .trim();
+  if (isFetchableUrl(metadataImage)) {
+    return metadataImage;
   }
+
+  const gateway = r.media?.gateway?.trim();
+  const resolved = gateway?.length ? gateway : metadataImage;
   const trimmed = resolved.trim();
   return trimmed.length ? trimmed : undefined;
+}
+
+function isFetchableUrl(url: string): boolean {
+  return /^https?:\/\//i.test(url);
 }
 
 async function persistUnsupportedOriginal(

--- a/src/s3_rememes.ts
+++ b/src/s3_rememes.ts
@@ -1,10 +1,14 @@
 import {
-  HeadObjectCommand,
+  ListObjectsV2Command,
   PutObjectCommand,
   S3Client
 } from '@aws-sdk/client-s3';
-import { RequestInfo, RequestInit } from 'node-fetch';
-import { Rememe } from './entities/IRememe';
+import { RequestInfo, RequestInit, Response } from 'node-fetch';
+import {
+  REMEME_S3_MAX_PROCESSING_ATTEMPTS,
+  Rememe,
+  RememeS3ProcessingStatus
+} from './entities/IRememe';
 import { CLOUDFRONT_LINK } from '@/constants';
 import { resizeImageBufferToHeight } from '@/media/image-resize';
 import { withArweaveFallback } from '@/arweave-gateway-fallback';
@@ -23,16 +27,54 @@ const ICON_HEIGHT = 60;
 const THUMBNAIL_HEIGHT = 450;
 const SCALED_HEIGHT = 1000;
 const REMEME_CONCURRENCY = 5;
+const FETCH_TIMEOUT_MS = 30_000;
+const LIST_OBJECTS_MAX_KEYS = 25;
+const PROCESSING_ERROR_MAX_LENGTH = 1000;
+
+const RASTER_IMAGE_FORMATS = new Set(['gif', 'jpeg', 'jpg', 'png', 'webp']);
+const EXTENSION_PRIORITY = [
+  'webp',
+  'png',
+  'jpg',
+  'jpeg',
+  'gif',
+  'mp4',
+  'webm',
+  'mov',
+  'svg'
+];
 
 let s3: S3Client;
 let myBucket: string;
 
+type RememeAssetKeys = {
+  original: string | null;
+  scaled: string | null;
+  thumbnail: string | null;
+  icon: string | null;
+};
+
+type RememeDesiredKeys = {
+  original: string;
+  scaled: string;
+  thumbnail: string;
+  icon: string;
+};
+
+type FetchedMedia = {
+  buffer: Buffer;
+  contentType: string;
+};
+
 export const persistRememesS3 = async (rememes: Rememe[]) => {
   s3 = new S3Client({ region: 'eu-west-1' });
+  myBucket = process.env.AWS_6529_IMAGES_BUCKET_NAME!;
+
+  if (!myBucket) {
+    throw new Error('AWS_6529_IMAGES_BUCKET_NAME is required');
+  }
 
   logger.info(`[PROCESSING ASSETS FOR ${rememes.length} REMEMES]`);
-
-  myBucket = process.env.AWS_6529_IMAGES_BUCKET_NAME!;
 
   const limit = pLimit(REMEME_CONCURRENCY);
   const results = await Promise.allSettled(
@@ -42,63 +84,70 @@ export const persistRememesS3 = async (rememes: Rememe[]) => {
   const failures = results.filter(
     (result): result is PromiseRejectedResult => result.status === 'rejected'
   );
-  if (!failures.length) {
-    return;
-  }
-
   failures.forEach((failure) =>
     logger.error(`[REMEME PROCESSING FAILED]`, failure.reason)
-  );
-  throw new Error(
-    `Failed processing ${failures.length} of ${rememes.length} rememes`
   );
 };
 
 async function processRememeS3(r: Rememe) {
+  try {
+    await processRememeS3Unsafe(r);
+  } catch (error) {
+    logger.error(
+      `[REMEME PROCESSING ERROR] [CONTRACT ${r.contract}] [ID ${r.id}]`,
+      error
+    );
+    await persistRememeS3Result(r, emptyAssetKeysFromRememe(r), {
+      status: retryStatusFor(r),
+      error
+    });
+  }
+}
+
+async function processRememeS3Unsafe(r: Rememe) {
   const image = resolveRememeImageUrl(r);
   if (!image?.length) {
     logger.warn(
       `[REMEME IMAGE URL MISSING] [CONTRACT ${r.contract}] [ID ${r.id}]`
     );
+    await persistRememeS3Result(r, emptyAssetKeysFromRememe(r), {
+      status: RememeS3ProcessingStatus.PERMANENT_ERROR,
+      error: 'Missing image URL'
+    });
     return;
   }
 
-  const format = await mediaChecker.getContentType(image);
-  if (!format) {
-    logger.error(`[ERROR ${r.contract} #${r.id}] [INVALID FORMAT ${image}]`);
+  const existingAssets = await findExistingRememeAssets(r);
+  if (hasCompleteRasterAssetSet(existingAssets)) {
+    logger.info(`[EXISTS ${r.contract} #${r.id}] [PERSISTING S3 URLS]`);
+    await persistRememeS3Result(r, existingAssets, {
+      status: RememeS3ProcessingStatus.COMPLETE
+    });
     return;
   }
 
-  const scaledToWebp = format.toLowerCase() !== 'gif';
-  const derivativeFormat = scaledToWebp ? 'webp' : format;
-  const keys = getRememeImageKeys(r, format, derivativeFormat);
-  const initialPresence = await getRememeAssetPresence(keys);
-
-  if (initialPresence.allPresent) {
-    logger.info(`[EXISTS ${r.contract} #${r.id}] [SKIPPING UPLOAD]`);
-  } else {
-    logger.info(
-      `[PARTIAL OR MISSING REMEME S3 ASSETS] [CONTRACT ${r.contract}] [ID ${r.id}] [original=${initialPresence.original}] [scaled=${initialPresence.scaled}] [thumbnail=${initialPresence.thumbnail}] [icon=${initialPresence.icon}]`
+  const originalFormat =
+    getFormatFromKey(existingAssets.original) ??
+    normalizeFormat(await mediaChecker.getContentType(image));
+  if (!originalFormat) {
+    logger.error(
+      `[ERROR ${r.contract} #${r.id}] [UNRESOLVED MEDIA FORMAT] [URL ${redactUrlForLog(
+        image
+      )}]`
     );
-    await uploadMissingRememeAssets(
-      r,
-      image,
-      format,
-      derivativeFormat,
-      keys,
-      initialPresence
-    );
-  }
-
-  const assetPresence = await getRememeAssetPresence(keys);
-  if (!assetPresence.allPresent) {
-    logger.warn(
-      `[INCOMPLETE REMEME S3 ASSETS] [CONTRACT ${r.contract}] [ID ${r.id}] [original=${assetPresence.original}] [scaled=${assetPresence.scaled}] [thumbnail=${assetPresence.thumbnail}] [icon=${assetPresence.icon}] [SKIPPING DB URL PERSIST]`
-    );
+    await persistRememeS3Result(r, existingAssets, {
+      status: retryStatusFor(r),
+      error: 'Could not resolve rememe media format'
+    });
     return;
   }
 
-  await persistRememeS3Links(r, keys);
+  if (!isRasterImageFormat(originalFormat)) {
+    await persistUnsupportedOriginal(r, image, originalFormat, existingAssets);
+    return;
+  }
+
+  await persistRasterRememe(r, image, originalFormat, existingAssets);
 }
 
 function resolveRememeImageUrl(r: Rememe): string | undefined {
@@ -112,157 +161,332 @@ function resolveRememeImageUrl(r: Rememe): string | undefined {
   return trimmed.length ? trimmed : undefined;
 }
 
-type RememeImageKeys = {
-  originalKey: string;
-  scaledKey: string;
-  thumbnailKey: string;
-  iconKey: string;
-};
-
-type RememeAssetPresence = {
-  original: boolean;
-  scaled: boolean;
-  thumbnail: boolean;
-  icon: boolean;
-  allPresent: boolean;
-};
-
-function getRememeImageKeys(
-  r: Rememe,
-  originalFormat: string,
-  derivativeFormat: string
-): RememeImageKeys {
-  return {
-    originalKey: `rememes/images/original/${r.contract}-${r.id}.${originalFormat.toLowerCase()}`,
-    scaledKey: `rememes/images/scaled/${r.contract}-${r.id}.${derivativeFormat.toLowerCase()}`,
-    thumbnailKey: `rememes/images/thumbnail/${r.contract}-${r.id}.${derivativeFormat.toLowerCase()}`,
-    iconKey: `rememes/images/icon/${r.contract}-${r.id}.${derivativeFormat.toLowerCase()}`
-  };
-}
-
-async function uploadMissingRememeAssets(
+async function persistUnsupportedOriginal(
   r: Rememe,
   imageUrl: string,
   originalFormat: string,
-  derivativeFormat: string,
-  keys: RememeImageKeys,
-  existingPresence: RememeAssetPresence
+  existingAssets: RememeAssetKeys
 ) {
-  logger.info(`[MISSING IMAGE] [CONTRACT ${r.contract}] [ID ${r.id}]`);
+  logger.warn(
+    `[UNSUPPORTED REMEME MEDIA FORMAT] [CONTRACT ${r.contract}] [ID ${r.id}] [FORMAT ${originalFormat}]`
+  );
 
-  const res = await withArweaveFallback(imageUrl, (u) => fetch(u));
-  if (!res.ok) {
-    throw new Error(
-      `Failed to fetch rememe image ${imageUrl}: ${res.status} ${res.statusText}`
+  const assets = { ...existingAssets };
+  if (!assets.original) {
+    const desiredOriginalKey = getOriginalKey(r, originalFormat);
+    const media = await fetchRememeMedia(imageUrl, originalFormat);
+    await handleObjectUpload(
+      desiredOriginalKey,
+      contentTypeForFormat(originalFormat, media.contentType),
+      media.buffer
     );
-  }
-  const blob = await res.arrayBuffer();
-  const blobBuffer = Buffer.from(blob);
-
-  if (!existingPresence.original) {
-    await handleImageUpload(keys.originalKey, originalFormat, blob);
+    assets.original = desiredOriginalKey;
   }
 
-  if (!existingPresence.scaled) {
+  await persistRememeS3Result(r, assets, {
+    status: RememeS3ProcessingStatus.UNSUPPORTED,
+    error: `Unsupported rememe media format: ${originalFormat}`
+  });
+}
+
+async function persistRasterRememe(
+  r: Rememe,
+  imageUrl: string,
+  originalFormat: string,
+  existingAssets: RememeAssetKeys
+) {
+  const derivativeFormat = originalFormat === 'gif' ? 'gif' : 'webp';
+  const desiredKeys = getRememeDesiredKeys(r, originalFormat, derivativeFormat);
+  const assets = { ...existingAssets };
+
+  if (!hasCompleteRasterAssetSet(assets)) {
+    logger.info(
+      `[PARTIAL OR MISSING REMEME S3 ASSETS] [CONTRACT ${r.contract}] [ID ${r.id}] [original=${Boolean(
+        assets.original
+      )}] [scaled=${Boolean(assets.scaled)}] [thumbnail=${Boolean(
+        assets.thumbnail
+      )}] [icon=${Boolean(assets.icon)}]`
+    );
+
+    try {
+      const media = await fetchRememeMedia(imageUrl, originalFormat);
+      if (!assets.original) {
+        await handleObjectUpload(
+          desiredKeys.original,
+          contentTypeForFormat(originalFormat, media.contentType),
+          media.buffer
+        );
+        assets.original = desiredKeys.original;
+      }
+
+      await uploadMissingRememeDerivatives(
+        r,
+        media.buffer,
+        derivativeFormat,
+        desiredKeys,
+        assets
+      );
+    } catch (error) {
+      const status = assets.original
+        ? RememeS3ProcessingStatus.PARTIAL
+        : retryStatusFor(r);
+      await persistRememeS3Result(r, assets, {
+        status,
+        error
+      });
+      return;
+    }
+  }
+
+  const currentAssets = await findExistingRememeAssets(r);
+  const mergedAssets = mergeAssetKeys(assets, currentAssets);
+  const status = hasCompleteRasterAssetSet(mergedAssets)
+    ? RememeS3ProcessingStatus.COMPLETE
+    : RememeS3ProcessingStatus.PARTIAL;
+  const error =
+    status === RememeS3ProcessingStatus.PARTIAL
+      ? 'Rememe has an original image but one or more resized derivatives are missing'
+      : undefined;
+
+  await persistRememeS3Result(r, mergedAssets, {
+    status,
+    error
+  });
+}
+
+async function uploadMissingRememeDerivatives(
+  r: Rememe,
+  sourceBuffer: Buffer,
+  derivativeFormat: string,
+  desiredKeys: RememeDesiredKeys,
+  assets: RememeAssetKeys
+) {
+  if (!assets.scaled) {
     const scaledBuffer = await resizeImage(
       r,
-      derivativeFormat.toLowerCase() === 'webp',
-      blobBuffer,
+      derivativeFormat === 'webp',
+      sourceBuffer,
       SCALED_HEIGHT
     );
     if (scaledBuffer) {
-      await handleImageUpload(keys.scaledKey, derivativeFormat, scaledBuffer);
+      await handleObjectUpload(
+        desiredKeys.scaled,
+        contentTypeForFormat(derivativeFormat),
+        scaledBuffer
+      );
+      assets.scaled = desiredKeys.scaled;
     }
   }
 
-  if (!existingPresence.thumbnail) {
+  if (!assets.thumbnail) {
     const thumbnailBuffer = await resizeImage(
       r,
-      derivativeFormat.toLowerCase() === 'webp',
-      blobBuffer,
+      derivativeFormat === 'webp',
+      sourceBuffer,
       THUMBNAIL_HEIGHT
     );
     if (thumbnailBuffer) {
-      await handleImageUpload(
-        keys.thumbnailKey,
-        derivativeFormat,
+      await handleObjectUpload(
+        desiredKeys.thumbnail,
+        contentTypeForFormat(derivativeFormat),
         thumbnailBuffer
       );
+      assets.thumbnail = desiredKeys.thumbnail;
     }
   }
 
-  if (!existingPresence.icon) {
+  if (!assets.icon) {
     const iconBuffer = await resizeImage(
       r,
-      derivativeFormat.toLowerCase() === 'webp',
-      blobBuffer,
+      derivativeFormat === 'webp',
+      sourceBuffer,
       ICON_HEIGHT
     );
     if (iconBuffer) {
-      await handleImageUpload(keys.iconKey, derivativeFormat, iconBuffer);
+      await handleObjectUpload(
+        desiredKeys.icon,
+        contentTypeForFormat(derivativeFormat),
+        iconBuffer
+      );
+      assets.icon = desiredKeys.icon;
     }
   }
 }
 
-async function getRememeAssetPresence(
-  keys: RememeImageKeys
-): Promise<RememeAssetPresence> {
-  const [original, scaled, thumbnail, icon] = await Promise.all([
-    objectExists(myBucket, keys.originalKey),
-    objectExists(myBucket, keys.scaledKey),
-    objectExists(myBucket, keys.thumbnailKey),
-    objectExists(myBucket, keys.iconKey)
-  ]);
-
+function getRememeDesiredKeys(
+  r: Rememe,
+  originalFormat: string,
+  derivativeFormat: string
+): RememeDesiredKeys {
   return {
-    original,
-    scaled,
-    thumbnail,
-    icon,
-    allPresent: original && scaled && thumbnail && icon
+    original: getOriginalKey(r, originalFormat),
+    scaled: `rememes/images/scaled/${r.contract}-${r.id}.${derivativeFormat}`,
+    thumbnail: `rememes/images/thumbnail/${r.contract}-${r.id}.${derivativeFormat}`,
+    icon: `rememes/images/icon/${r.contract}-${r.id}.${derivativeFormat}`
   };
 }
 
-async function persistRememeS3Links(r: Rememe, keys: RememeImageKeys) {
-  r.s3_image_original = `${CLOUDFRONT_LINK}/${keys.originalKey}`;
-  r.s3_image_scaled = `${CLOUDFRONT_LINK}/${keys.scaledKey}`;
-  r.s3_image_thumbnail = `${CLOUDFRONT_LINK}/${keys.thumbnailKey}`;
-  r.s3_image_icon = `${CLOUDFRONT_LINK}/${keys.iconKey}`;
+function getOriginalKey(r: Rememe, originalFormat: string) {
+  return `rememes/images/original/${r.contract}-${r.id}.${originalFormat}`;
+}
+
+async function findExistingRememeAssets(r: Rememe): Promise<RememeAssetKeys> {
+  const baseKey = `${r.contract}-${r.id}.`;
+  const [original, scaled, thumbnail, icon] = await Promise.all([
+    findExistingObjectKey(`rememes/images/original/${baseKey}`),
+    findExistingObjectKey(`rememes/images/scaled/${baseKey}`),
+    findExistingObjectKey(`rememes/images/thumbnail/${baseKey}`),
+    findExistingObjectKey(`rememes/images/icon/${baseKey}`)
+  ]);
+
+  return { original, scaled, thumbnail, icon };
+}
+
+async function findExistingObjectKey(prefix: string): Promise<string | null> {
+  const response = await s3.send(
+    new ListObjectsV2Command({
+      Bucket: myBucket,
+      Prefix: prefix,
+      MaxKeys: LIST_OBJECTS_MAX_KEYS
+    })
+  );
+  const keys =
+    response.Contents?.map((object) => object.Key)
+      .filter((key): key is string => Boolean(key))
+      .map(stripTemporarySuffix) ?? [];
+
+  return pickPreferredObjectKey(Array.from(new Set(keys)));
+}
+
+function pickPreferredObjectKey(keys: string[]): string | null {
+  const sortedKeys = [...keys].sort((a, b) => {
+    const extensionDiff =
+      extensionRank(getFormatFromKey(a)) - extensionRank(getFormatFromKey(b));
+    return extensionDiff === 0 ? a.localeCompare(b) : extensionDiff;
+  });
+  return sortedKeys[0] ?? null;
+}
+
+function extensionRank(format: string | null): number {
+  const index = format ? EXTENSION_PRIORITY.indexOf(format) : -1;
+  return index >= 0 ? index : EXTENSION_PRIORITY.length;
+}
+
+function stripTemporarySuffix(key: string) {
+  return key.endsWith('__temp') ? key.slice(0, -'__temp'.length) : key;
+}
+
+function hasCompleteRasterAssetSet(assets: RememeAssetKeys) {
+  return Boolean(
+    assets.original && assets.scaled && assets.thumbnail && assets.icon
+  );
+}
+
+function mergeAssetKeys(
+  preferred: RememeAssetKeys,
+  fallback: RememeAssetKeys
+): RememeAssetKeys {
+  return {
+    original: preferred.original ?? fallback.original,
+    scaled: preferred.scaled ?? fallback.scaled,
+    thumbnail: preferred.thumbnail ?? fallback.thumbnail,
+    icon: preferred.icon ?? fallback.icon
+  };
+}
+
+async function fetchRememeMedia(
+  imageUrl: string,
+  expectedFormat: string
+): Promise<FetchedMedia> {
+  const response: Response = await withArweaveFallback(imageUrl, (u) =>
+    fetch(u, { timeout: FETCH_TIMEOUT_MS })
+  );
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch rememe media: ${response.status} ${response.statusText}`
+    );
+  }
+
+  const blob = await response.arrayBuffer();
+  const contentType = response.headers.get('content-type') ?? '';
+  return {
+    buffer: Buffer.from(blob),
+    contentType: contentTypeForFormat(expectedFormat, contentType)
+  };
+}
+
+async function persistRememeS3Result(
+  r: Rememe,
+  assets: RememeAssetKeys,
+  result: {
+    status: RememeS3ProcessingStatus;
+    error?: unknown;
+  }
+) {
+  r.s3_image_original = assetUrl(assets.original);
+  r.s3_image_scaled = assetUrl(assets.scaled);
+  r.s3_image_thumbnail = assetUrl(assets.thumbnail);
+  r.s3_image_icon = assetUrl(assets.icon);
+  r.s3_image_processing_status = result.status;
+  r.s3_image_processing_error = result.error
+    ? truncateProcessingError(toErrorMessage(result.error))
+    : null;
+  r.s3_image_last_attempt_at = new Date();
+  r.s3_image_processing_attempts = nextAttemptCount(r, result.status);
+
   await persistRememes([r]);
 }
 
-async function handleImageUpload(
+function assetUrl(key: string | null): string | null {
+  return key ? `${CLOUDFRONT_LINK}/${key}` : null;
+}
+
+function nextAttemptCount(r: Rememe, status: RememeS3ProcessingStatus): number {
+  const currentAttempts = r.s3_image_processing_attempts ?? 0;
+  if (status === RememeS3ProcessingStatus.COMPLETE) {
+    return currentAttempts;
+  }
+  return currentAttempts + 1;
+}
+
+function retryStatusFor(r: Rememe): RememeS3ProcessingStatus {
+  const nextAttempt = (r.s3_image_processing_attempts ?? 0) + 1;
+  return nextAttempt >= REMEME_S3_MAX_PROCESSING_ATTEMPTS
+    ? RememeS3ProcessingStatus.PERMANENT_ERROR
+    : RememeS3ProcessingStatus.TRANSIENT_ERROR;
+}
+
+function emptyAssetKeysFromRememe(r: Rememe): RememeAssetKeys {
+  return {
+    original: keyFromAssetUrl(r.s3_image_original),
+    scaled: keyFromAssetUrl(r.s3_image_scaled),
+    thumbnail: keyFromAssetUrl(r.s3_image_thumbnail),
+    icon: keyFromAssetUrl(r.s3_image_icon)
+  };
+}
+
+function keyFromAssetUrl(assetUrlValue?: string | null): string | null {
+  if (!assetUrlValue?.startsWith(`${CLOUDFRONT_LINK}/`)) {
+    return null;
+  }
+  return assetUrlValue.slice(CLOUDFRONT_LINK.length + 1);
+}
+
+async function handleObjectUpload(
   key: string,
-  format: string,
-  blob: ArrayBuffer | Buffer
+  contentType: string,
+  blob: Buffer
 ) {
-  const body = Buffer.isBuffer(blob) ? blob : Buffer.from(blob);
   const put = await s3.send(
     new PutObjectCommand({
       Bucket: myBucket,
       Key: key,
-      Body: body,
-      ContentType: `image/${format}`
+      Body: blob,
+      ContentType: contentType
     })
   );
 
   logger.info(`[UPLOADED ${key}] [STATUS ${put.$metadata.httpStatusCode}]`);
-}
-
-async function objectExists(myBucket: any, key: any): Promise<boolean> {
-  try {
-    await s3.send(new HeadObjectCommand({ Bucket: myBucket, Key: key }));
-    return true;
-  } catch (error1: any) {
-    try {
-      await s3.send(
-        new HeadObjectCommand({ Bucket: myBucket, Key: `${key}__temp` })
-      );
-      return true;
-    } catch (error2: any) {
-      return false;
-    }
-  }
 }
 
 async function resizeImage(
@@ -281,10 +505,80 @@ async function resizeImage(
       height,
       toWebp: toWEBP
     });
-  } catch (err: any) {
+  } catch (err) {
     logger.error(
       `[RESIZING FOR ${rememe.contract} #${rememe.id}] [TO TARGET HEIGHT ${height}] [FAILED!]`,
       err
     );
   }
+}
+
+function normalizeFormat(format?: string | null): string | null {
+  if (!format) {
+    return null;
+  }
+  const normalized = format.toLowerCase().split(';')[0]?.trim();
+  if (!normalized) {
+    return null;
+  }
+  if (normalized === 'svg+xml') {
+    return 'svg';
+  }
+  return normalized;
+}
+
+function getFormatFromKey(key?: string | null): string | null {
+  if (!key) {
+    return null;
+  }
+  const stripped = stripTemporarySuffix(key);
+  const fileName = stripped.slice(stripped.lastIndexOf('/') + 1);
+  const dotIndex = fileName.lastIndexOf('.');
+  if (dotIndex < 0 || dotIndex === fileName.length - 1) {
+    return null;
+  }
+  return normalizeFormat(fileName.slice(dotIndex + 1));
+}
+
+function isRasterImageFormat(format: string): boolean {
+  return RASTER_IMAGE_FORMATS.has(format);
+}
+
+function contentTypeForFormat(format: string, fallbackContentType?: string) {
+  if (fallbackContentType?.includes('/')) {
+    return fallbackContentType.split(';')[0]?.trim() ?? fallbackContentType;
+  }
+  if (format === 'jpg' || format === 'jpeg') {
+    return 'image/jpeg';
+  }
+  if (format === 'svg') {
+    return 'image/svg+xml';
+  }
+  if (format === 'mp4') {
+    return 'video/mp4';
+  }
+  if (format === 'webm') {
+    return 'video/webm';
+  }
+  if (format === 'mov') {
+    return 'video/quicktime';
+  }
+  return `image/${format}`;
+}
+
+function toErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function truncateProcessingError(error: string): string {
+  return error.length > PROCESSING_ERROR_MAX_LENGTH
+    ? error.slice(0, PROCESSING_ERROR_MAX_LENGTH)
+    : error;
+}
+
+function redactUrlForLog(url: string): string {
+  if (url.length <= 160) {
+    return url;
+  }
+  return `${url.slice(0, 157)}...`;
 }

--- a/src/s3_rememes.ts
+++ b/src/s3_rememes.ts
@@ -14,8 +14,8 @@ import { resizeImageBufferToHeight } from '@/media/image-resize';
 import { withArweaveFallback } from '@/arweave-gateway-fallback';
 import { persistRememes } from './db';
 import { Logger } from './logging';
-import { ipfs } from './ipfs';
 import { mediaChecker } from './media-checker';
+import { resolveRememeFetchImageUrl } from './rememe-media-source';
 import pLimit from 'p-limit';
 
 const logger = Logger.get('S3_REMEMES');
@@ -148,21 +148,7 @@ async function processRememeS3Unsafe(r: Rememe) {
 }
 
 function resolveRememeImageUrl(r: Rememe): string | undefined {
-  const metadataImage = ipfs
-    .ifIpfsThenCloudflareElsePreserveOrEmptyIfUndefined(r.image)
-    .trim();
-  if (isFetchableUrl(metadataImage)) {
-    return metadataImage;
-  }
-
-  const gateway = r.media?.gateway?.trim();
-  const resolved = gateway?.length ? gateway : metadataImage;
-  const trimmed = resolved.trim();
-  return trimmed.length ? trimmed : undefined;
-}
-
-function isFetchableUrl(url: string): boolean {
-  return /^https?:\/\//i.test(url);
+  return resolveRememeFetchImageUrl(r);
 }
 
 async function persistUnsupportedOriginal(

--- a/src/s3_rememes.ts
+++ b/src/s3_rememes.ts
@@ -29,9 +29,11 @@ const SCALED_HEIGHT = 1000;
 const REMEME_CONCURRENCY = 5;
 const FETCH_TIMEOUT_MS = 30_000;
 const LIST_OBJECTS_MAX_KEYS = 25;
+const MAX_REMEME_MEDIA_BYTES = 100 * 1024 * 1024;
 const PROCESSING_ERROR_MAX_LENGTH = 1000;
 
 const RASTER_IMAGE_FORMATS = new Set(['gif', 'jpeg', 'jpg', 'png', 'webp']);
+const UPLOADABLE_UNSUPPORTED_FORMATS = new Set(['mov', 'mp4', 'webm']);
 const EXTENSION_PRIORITY = [
   'webp',
   'png',
@@ -59,11 +61,6 @@ type RememeDesiredKeys = {
   scaled: string;
   thumbnail: string;
   icon: string;
-};
-
-type FetchedMedia = {
-  buffer: Buffer;
-  contentType: string;
 };
 
 export const persistRememesS3 = async (rememes: Rememe[]) => {
@@ -173,12 +170,20 @@ async function persistUnsupportedOriginal(
 
   const assets = { ...existingAssets };
   if (!assets.original) {
+    if (!UPLOADABLE_UNSUPPORTED_FORMATS.has(originalFormat)) {
+      await persistRememeS3Result(r, assets, {
+        status: RememeS3ProcessingStatus.UNSUPPORTED,
+        error: `Unsupported rememe media format: ${originalFormat}`
+      });
+      return;
+    }
+
     const desiredOriginalKey = getOriginalKey(r, originalFormat);
     const media = await fetchRememeMedia(imageUrl, originalFormat);
     await handleObjectUpload(
       desiredOriginalKey,
-      contentTypeForFormat(originalFormat, media.contentType),
-      media.buffer
+      contentTypeForFormat(originalFormat),
+      media
     );
     assets.original = desiredOriginalKey;
   }
@@ -213,15 +218,15 @@ async function persistRasterRememe(
       if (!assets.original) {
         await handleObjectUpload(
           desiredKeys.original,
-          contentTypeForFormat(originalFormat, media.contentType),
-          media.buffer
+          contentTypeForFormat(originalFormat),
+          media
         );
         assets.original = desiredKeys.original;
       }
 
       await uploadMissingRememeDerivatives(
         r,
-        media.buffer,
+        media,
         derivativeFormat,
         desiredKeys,
         assets
@@ -397,7 +402,7 @@ function mergeAssetKeys(
 async function fetchRememeMedia(
   imageUrl: string,
   expectedFormat: string
-): Promise<FetchedMedia> {
+): Promise<Buffer> {
   const response: Response = await withArweaveFallback(imageUrl, (u) =>
     fetch(u, { timeout: FETCH_TIMEOUT_MS })
   );
@@ -407,12 +412,65 @@ async function fetchRememeMedia(
     );
   }
 
-  const blob = await response.arrayBuffer();
-  const contentType = response.headers.get('content-type') ?? '';
-  return {
-    buffer: Buffer.from(blob),
-    contentType: contentTypeForFormat(expectedFormat, contentType)
+  return await readResponseBufferWithLimit(response, expectedFormat);
+}
+
+async function readResponseBufferWithLimit(
+  response: Response,
+  expectedFormat: string
+): Promise<Buffer> {
+  const contentLength = response.headers.get('content-length');
+  if (contentLength) {
+    const parsed = Number(contentLength);
+    if (Number.isFinite(parsed) && parsed > MAX_REMEME_MEDIA_BYTES) {
+      throw new Error(
+        `Rememe ${expectedFormat} media too large (${parsed} bytes > ${MAX_REMEME_MEDIA_BYTES})`
+      );
+    }
+  }
+
+  if (!response.body) {
+    const blob = await response.arrayBuffer();
+    if (blob.byteLength > MAX_REMEME_MEDIA_BYTES) {
+      throw new Error(
+        `Rememe ${expectedFormat} media exceeded max size of ${MAX_REMEME_MEDIA_BYTES} bytes`
+      );
+    }
+    return Buffer.from(blob);
+  }
+
+  const stream = response.body as unknown as AsyncIterable<unknown>;
+  const destroyableStream = response.body as unknown as {
+    destroy?: () => void;
   };
+  const chunks: Buffer[] = [];
+  let total = 0;
+  for await (const chunk of stream) {
+    const buffer = chunkToBuffer(chunk);
+    total += buffer.byteLength;
+    if (total > MAX_REMEME_MEDIA_BYTES) {
+      destroyableStream.destroy?.();
+      throw new Error(
+        `Rememe ${expectedFormat} media exceeded max size of ${MAX_REMEME_MEDIA_BYTES} bytes`
+      );
+    }
+    chunks.push(buffer);
+  }
+
+  return Buffer.concat(chunks, total);
+}
+
+function chunkToBuffer(chunk: unknown): Buffer {
+  if (Buffer.isBuffer(chunk)) {
+    return chunk;
+  }
+  if (chunk instanceof Uint8Array) {
+    return Buffer.from(chunk);
+  }
+  if (chunk instanceof ArrayBuffer) {
+    return Buffer.from(chunk);
+  }
+  return Buffer.from(String(chunk), 'utf8');
 }
 
 async function persistRememeS3Result(
@@ -438,7 +496,7 @@ async function persistRememeS3Result(
 }
 
 function assetUrl(key: string | null): string | null {
-  return key ? `${CLOUDFRONT_LINK}/${key}` : null;
+  return key ? `${cloudfrontPrefix()}${key}` : null;
 }
 
 function nextAttemptCount(r: Rememe, status: RememeS3ProcessingStatus): number {
@@ -466,10 +524,17 @@ function emptyAssetKeysFromRememe(r: Rememe): RememeAssetKeys {
 }
 
 function keyFromAssetUrl(assetUrlValue?: string | null): string | null {
-  if (!assetUrlValue?.startsWith(`${CLOUDFRONT_LINK}/`)) {
+  const prefix = cloudfrontPrefix();
+  if (!assetUrlValue?.startsWith(prefix)) {
     return null;
   }
-  return assetUrlValue.slice(CLOUDFRONT_LINK.length + 1);
+  return assetUrlValue.slice(prefix.length);
+}
+
+function cloudfrontPrefix(): string {
+  return CLOUDFRONT_LINK.endsWith('/')
+    ? CLOUDFRONT_LINK
+    : `${CLOUDFRONT_LINK}/`;
 }
 
 async function handleObjectUpload(
@@ -521,10 +586,16 @@ function normalizeFormat(format?: string | null): string | null {
   if (!normalized) {
     return null;
   }
-  if (normalized === 'svg+xml') {
+  const subtype = normalized.includes('/')
+    ? normalized.split('/').pop()?.trim()
+    : normalized;
+  if (!subtype) {
+    return null;
+  }
+  if (subtype === 'svg+xml') {
     return 'svg';
   }
-  return normalized;
+  return subtype;
 }
 
 function getFormatFromKey(key?: string | null): string | null {
@@ -544,15 +615,9 @@ function isRasterImageFormat(format: string): boolean {
   return RASTER_IMAGE_FORMATS.has(format);
 }
 
-function contentTypeForFormat(format: string, fallbackContentType?: string) {
-  if (fallbackContentType?.includes('/')) {
-    return fallbackContentType.split(';')[0]?.trim() ?? fallbackContentType;
-  }
+function contentTypeForFormat(format: string) {
   if (format === 'jpg' || format === 'jpeg') {
     return 'image/jpeg';
-  }
-  if (format === 'svg') {
-    return 'image/svg+xml';
   }
   if (format === 'mp4') {
     return 'video/mp4';

--- a/src/s3_rememes.ts
+++ b/src/s3_rememes.ts
@@ -102,7 +102,7 @@ async function processRememeS3(r: Rememe) {
 }
 
 async function processRememeS3Unsafe(r: Rememe) {
-  const image = resolveRememeImageUrl(r);
+  const image = resolveRememeFetchImageUrl(r);
   if (!image?.length) {
     logger.warn(
       `[REMEME IMAGE URL MISSING] [CONTRACT ${r.contract}] [ID ${r.id}]`
@@ -145,10 +145,6 @@ async function processRememeS3Unsafe(r: Rememe) {
   }
 
   await persistRasterRememe(r, image, originalFormat, existingAssets);
-}
-
-function resolveRememeImageUrl(r: Rememe): string | undefined {
-  return resolveRememeFetchImageUrl(r);
 }
 
 async function persistUnsupportedOriginal(

--- a/src/s3_rememes.ts
+++ b/src/s3_rememes.ts
@@ -148,9 +148,12 @@ async function processRememeS3Unsafe(r: Rememe) {
 }
 
 function resolveRememeImageUrl(r: Rememe): string | undefined {
-  const resolved = r.media?.gateway
-    ? r.media.gateway
-    : ipfs.ifIpfsThenCloudflareElsePreserveOrEmptyIfUndefined(r.image);
+  const metadataImage = ipfs.ifIpfsThenCloudflareElsePreserveOrEmptyIfUndefined(
+    r.image
+  );
+  const resolved = metadataImage.trim().length
+    ? metadataImage
+    : r.media?.gateway;
   if (!resolved) {
     return undefined;
   }


### PR DESCRIPTION
## Summary
- make `rememesS3Loop` converge by persisting existing legacy S3 assets, recording partial/unsupported media outcomes, and bounding transient retries
- add nullable rememe S3 processing status/error/attempt metadata and limit the S3 queue to unprocessed or retryable rows
- keep rememes loop functions on x86_64 so sharp-backed rememe jobs do not initialize on arm64
- return rememe compact media from scaled, thumbnail, original, then raw image fallback

## Testing
- `npm run lint`
- `npm test -- --runTestsByPath src/s3-rememes.test.ts`
- `npm run tsc -- -p tsconfig.json --noEmit`
- `npm run build`
- `cd src/api-serverless && npm run build`

## Deployment plan
1. Deploy and invoke `dbMigrationsLoop` first so the nullable rememe S3 processing columns exist.
2. Deploy `rememesLoop` next; this updates `rememesS3Loop`, `rememesRefreshMetadataLoop`, and `rememesFileLoop`.
3. Deploy `api` after that so the rememe media endpoint uses the S3 URL fallback query.

## Architecture docs
No `docs/architecture.md` update: this keeps the existing rememes loop/API surfaces and deployment units, with no new lambda, queue/topic, EventBridge trigger, or external integration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved media handling for NFT/rememe images, with better fallback support for available image sizes and formats.
  * Added tracking for media processing status, retries, and errors to make asset handling more reliable.

* **Bug Fixes**
  * Reduced missed image uploads by reusing existing S3 assets more effectively.
  * Improved handling of unsupported or problematic media so items are marked clearly instead of failing silently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->