### PR TITLE
Fix help bot interaction readback consistency

### DIFF
--- a/src/help-bot/help-bot-interactions-db.test.ts
+++ b/src/help-bot/help-bot-interactions-db.test.ts
@@ -9,9 +9,13 @@ import {
 } from './help-bot-interactions.db';
 import { Time } from '@/time';
 import { HELP_BOT_ANSWERING_LEASE_MS } from './help-bot.config';
+import { ConnectionWrapper } from '@/sql-executor';
 
 describe('HelpBotInteractionsDb', () => {
   const ctx = {} as RequestContext;
+  const transactionConnection: ConnectionWrapper<string> = {
+    connection: 'transaction-connection'
+  };
 
   afterEach(() => {
     jest.restoreAllMocks();
@@ -50,6 +54,11 @@ describe('HelpBotInteractionsDb', () => {
   }) {
     return {
       execute: jest.fn().mockResolvedValue(executeResult),
+      executeNativeQueriesInTransaction: jest.fn(
+        async <T>(
+          executable: (connection: ConnectionWrapper<any>) => Promise<T>
+        ) => executable(transactionConnection)
+      ),
       oneOrNull: jest.fn().mockResolvedValue(row),
       getAffectedRows: jest.fn((result: unknown) => {
         if (
@@ -89,6 +98,38 @@ describe('HelpBotInteractionsDb', () => {
 
     expect(result.created).toBe(true);
     expect(sqlExecutor.getAffectedRows).toHaveBeenCalledWith([0, 1]);
+  });
+
+  it('inserts and reads back seen interactions on one transactional connection', async () => {
+    const sqlExecutor = createSqlExecutor({ executeResult: [0, 1] });
+    const db = createDb(sqlExecutor);
+
+    await db.insertSeen(
+      {
+        triggerDropId: 'trigger-drop',
+        targetDropId: 'trigger-drop',
+        waveId: 'wave-1',
+        authorProfileId: 'author-1',
+        triggerType: HelpBotInteractionTriggerType.MENTION,
+        question: 'what is tdh',
+        parentBotDropId: null
+      },
+      ctx
+    );
+
+    expect(sqlExecutor.executeNativeQueriesInTransaction).toHaveBeenCalledTimes(
+      1
+    );
+    expect(sqlExecutor.execute).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT IGNORE INTO help_bot_interactions'),
+      expect.anything(),
+      { wrappedConnection: transactionConnection }
+    );
+    expect(sqlExecutor.oneOrNull).toHaveBeenCalledWith(
+      expect.stringContaining('WHERE trigger_drop_id = :triggerDropId'),
+      { triggerDropId: 'trigger-drop' },
+      { wrappedConnection: transactionConnection }
+    );
   });
 
   it('treats API mysql insert metadata arrays without affected rows as duplicates', async () => {

--- a/src/help-bot/help-bot-interactions.db.ts
+++ b/src/help-bot/help-bot-interactions.db.ts
@@ -56,6 +56,12 @@ export class HelpBotInteractionsDb extends LazyDbAccessCompatibleService {
     request: InsertHelpBotInteractionRequest,
     ctx: RequestContext
   ): Promise<InsertHelpBotInteractionResult> {
+    if (!ctx.connection) {
+      return await this.executeNativeQueriesInTransaction((connection) =>
+        this.insertSeen(request, { ...ctx, connection })
+      );
+    }
+
     const now = Time.currentMillis();
     const id = randomUUID();
     const result = await this.db.execute(


### PR DESCRIPTION
## Summary
- Pin Help6529 interaction insert/readback to one transaction when the trigger path does not already have a DB connection.
- Add regression coverage that verifies the insert and lookup use the same wrapped connection.

## Why
Production can use separate read/write pools. The Help6529 API trigger path inserted a `help_bot_interactions` row and immediately read it back by `trigger_drop_id`; on prod this could miss the fresh write and log `Help bot interaction not found`, causing no reaction/reply for an otherwise valid mention.

## Validation
- `DOCKER_HOST=unix:///Users/prxt/.colima/default/docker.sock TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock npm test -- --runInBand src/help-bot/help-bot-interactions-db.test.ts`
- `npx eslint src/help-bot/help-bot-interactions.db.ts src/help-bot/help-bot-interactions-db.test.ts --max-warnings=0`

## Deploy note
- Redeploy `api` after merge. No schema change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when marking help bot interactions as seen, especially in cases where a database connection was not already available.
  * Ensured the update now completes consistently using a single transactional operation, reducing the chance of partial writes or missed state changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->