### PR TITLE
[codex] Validate drop group mention metadata

### DIFF
--- a/pr-reports/1676.md
+++ b/pr-reports/1676.md
@@ -11,9 +11,9 @@ This change prevents malformed drop creation payloads from creating `ALL` group 
 ## What Changed
 
 - Added backend normalization for drop group mentions before drop validation.
-- Added a second normalization pass before drop persistence and notification recipient calculation.
-- Preserved valid standalone `@all` mentions while stripping hidden metadata and embedded false positives such as `@alliance`.
-- Added focused coverage for missing, valid, and embedded `@all` content.
+- Kept a defensive, idempotent normalization pass before drop persistence and notification recipient calculation.
+- Preserved valid standalone `@all` mentions, including later drop parts and case variants, while stripping hidden metadata and embedded false positives such as `@alliance`.
+- Added focused coverage for missing metadata, valid `@all` content, embedded false positives, and non-`ALL` group preservation.
 
 ## Backend Impact
 

--- a/pr-reports/1676.md
+++ b/pr-reports/1676.md
@@ -19,7 +19,6 @@ This change prevents malformed drop creation payloads from creating `ALL` group 
 
 - New services: None
 - Changed services: `api`
-- Planned/deployed services: `api` staging deploy triggered from `1a-staging`
 - API: Drop creation/update behavior now ignores `ALL` group mention metadata unless content includes standalone `@all`.
 - DB/entities/migrations: No schema or migration changes.
 - Queues/events/integrations: Existing identity notification and push paths receive sanitized group mention recipients.
@@ -28,14 +27,6 @@ This change prevents malformed drop creation payloads from creating `ALL` group 
 
 None.
 
-## Backend Deployment
-
-- Deployed API: `api` staging deploy triggered from `1a-staging` at `a0e7cea6a92e6f63bb0b00bdac5d7891c52ffe46`
-- Deployed Lambdas/services: None
-- Not deployed: None
-- Deployment order executed: `api`
-- GitHub Actions run links or run IDs for each backend deploy: [`28352303754`](https://github.com/6529-Collections/6529seize-backend/actions/runs/28352303754)
-
 ## Release Notes
 
 Drops can no longer trigger `@all`/group-mention notifications from hidden or inconsistent `mentioned_groups` metadata. Existing historical rows and already-sent notifications are unchanged.
@@ -43,4 +34,3 @@ Drops can no longer trigger `@all`/group-mention notifications from hidden or in
 ## Risks / Follow-Ups
 
 Existing production drops with stale `drop_mentioned_groups = ALL` metadata remain until cleaned up separately.
-The staging deploy run was still in progress when captured; completion was not waited on by request.

--- a/pr-reports/1676.md
+++ b/pr-reports/1676.md
@@ -13,7 +13,7 @@ This change prevents malformed drop creation payloads from creating `ALL` group 
 - Added backend normalization for drop group mentions before drop validation.
 - Kept a defensive, idempotent normalization pass before drop persistence and notification recipient calculation.
 - Preserved valid standalone `@all` mentions, including later drop parts and case variants, while stripping hidden metadata and embedded false positives such as `@alliance`.
-- Added focused coverage for missing metadata, valid `@all` content, embedded false positives, and non-`ALL` group preservation.
+- Added focused coverage for missing metadata, valid `@all` boundaries, empty parts, idempotency, embedded false positives, and non-`ALL` group preservation.
 
 ## Backend Impact
 

--- a/pr-reports/1676.md
+++ b/pr-reports/1676.md
@@ -19,7 +19,7 @@ This change prevents malformed drop creation payloads from creating `ALL` group 
 
 - New services: None
 - Changed services: `api`
-- Planned/deployed services: `api` planned, not deployed by request
+- Planned/deployed services: `api` staging deploy triggered from `1a-staging`
 - API: Drop creation/update behavior now ignores `ALL` group mention metadata unless content includes standalone `@all`.
 - DB/entities/migrations: No schema or migration changes.
 - Queues/events/integrations: Existing identity notification and push paths receive sanitized group mention recipients.
@@ -30,11 +30,11 @@ None.
 
 ## Backend Deployment
 
-- Deployed API: None
+- Deployed API: `api` staging deploy triggered from `1a-staging` at `a0e7cea6a92e6f63bb0b00bdac5d7891c52ffe46`
 - Deployed Lambdas/services: None
-- Not deployed: `api`, by request.
-- Deployment order executed: None
-- GitHub Actions run links or run IDs for each backend deploy: None
+- Not deployed: None
+- Deployment order executed: `api`
+- GitHub Actions run links or run IDs for each backend deploy: [`28352303754`](https://github.com/6529-Collections/6529seize-backend/actions/runs/28352303754)
 
 ## Release Notes
 
@@ -43,3 +43,4 @@ Drops can no longer trigger `@all`/group-mention notifications from hidden or in
 ## Risks / Follow-Ups
 
 Existing production drops with stale `drop_mentioned_groups = ALL` metadata remain until cleaned up separately.
+The staging deploy run was still in progress when captured; completion was not waited on by request.

--- a/pr-reports/1676.md
+++ b/pr-reports/1676.md
@@ -1,0 +1,45 @@
+# PR Report: Validate drop group mention metadata
+
+PR: https://github.com/6529-Collections/6529seize-backend/pull/1676
+Branch: `codex/validate-drop-group-mentions` -> `main`
+Related PRs: None
+
+## Summary
+
+This change prevents malformed drop creation payloads from creating `ALL` group mention metadata unless the visible drop content contains a standalone `@all` token.
+
+## What Changed
+
+- Added backend normalization for drop group mentions before drop validation.
+- Added a second normalization pass before drop persistence and notification recipient calculation.
+- Preserved valid standalone `@all` mentions while stripping hidden metadata and embedded false positives such as `@alliance`.
+- Added focused coverage for missing, valid, and embedded `@all` content.
+
+## Backend Impact
+
+- New services: None
+- Changed services: `api`
+- Planned/deployed services: `api` planned, not deployed by request
+- API: Drop creation/update behavior now ignores `ALL` group mention metadata unless content includes standalone `@all`.
+- DB/entities/migrations: No schema or migration changes.
+- Queues/events/integrations: Existing identity notification and push paths receive sanitized group mention recipients.
+
+## Config / Env
+
+None.
+
+## Backend Deployment
+
+- Deployed API: None
+- Deployed Lambdas/services: None
+- Not deployed: `api`, by request.
+- Deployment order executed: None
+- GitHub Actions run links or run IDs for each backend deploy: None
+
+## Release Notes
+
+Drops can no longer trigger `@all`/group-mention notifications from hidden or inconsistent `mentioned_groups` metadata. Existing historical rows and already-sent notifications are unchanged.
+
+## Risks / Follow-Ups
+
+Existing production drops with stale `drop_mentioned_groups = ALL` metadata remain until cleaned up separately.

--- a/src/drops/create-or-update-drop-use-case.test.ts
+++ b/src/drops/create-or-update-drop-use-case.test.ts
@@ -305,6 +305,35 @@ describe('CreateOrUpdateDropUseCase', () => {
     ).toEqual([DropGroupMention.ALL]);
   });
 
+  it('keeps ALL group mention metadata when @all is in a later part', () => {
+    expect(
+      normalizeDropGroupMentions({
+        mentionedGroups: [DropGroupMention.ALL],
+        parts: [
+          {
+            content: 'first part'
+          },
+          {
+            content: 'second part with @all'
+          }
+        ]
+      })
+    ).toEqual([DropGroupMention.ALL]);
+  });
+
+  it('keeps ALL group mention metadata for case-insensitive @all tokens', () => {
+    expect(
+      normalizeDropGroupMentions({
+        mentionedGroups: [DropGroupMention.ALL],
+        parts: [
+          {
+            content: 'Heads up @ALL'
+          }
+        ]
+      })
+    ).toEqual([DropGroupMention.ALL]);
+  });
+
   it('does not treat embedded @all text as an ALL group mention', () => {
     expect(
       normalizeDropGroupMentions({
@@ -312,6 +341,45 @@ describe('CreateOrUpdateDropUseCase', () => {
         parts: [
           {
             content: 'email@example.com @alliance hello@all @all_again'
+          }
+        ]
+      })
+    ).toEqual([]);
+  });
+
+  it('preserves non-ALL group mention metadata without @all content', () => {
+    const specificGroup = 'specific-group' as DropGroupMention;
+
+    expect(
+      normalizeDropGroupMentions({
+        mentionedGroups: [specificGroup, DropGroupMention.ALL],
+        parts: [
+          {
+            content: 'no all mention here'
+          }
+        ]
+      })
+    ).toEqual([specificGroup]);
+  });
+
+  it('treats missing group mention metadata as empty', () => {
+    expect(
+      normalizeDropGroupMentions({
+        mentionedGroups: undefined,
+        parts: [
+          {
+            content: '@all'
+          }
+        ]
+      })
+    ).toEqual([]);
+
+    expect(
+      normalizeDropGroupMentions({
+        mentionedGroups: null,
+        parts: [
+          {
+            content: '@all'
           }
         ]
       })

--- a/src/drops/create-or-update-drop-use-case.test.ts
+++ b/src/drops/create-or-update-drop-use-case.test.ts
@@ -18,6 +18,7 @@ import { profilesService } from '@/profiles/profiles.service';
 import { CLOUDFRONT_LINK } from '@/constants';
 import {
   CreateOrUpdateDropUseCase,
+  normalizeDropGroupMentions,
   validateDropMediaAttachment
 } from './create-or-update-drop.use-case';
 
@@ -275,6 +276,46 @@ describe('CreateOrUpdateDropUseCase', () => {
         groupIdsUserIsEligibleFor: []
       })
     ).not.toThrow();
+  });
+
+  it('strips ALL group mention metadata when the drop content has no @all token', () => {
+    expect(
+      normalizeDropGroupMentions({
+        mentionedGroups: [DropGroupMention.ALL],
+        parts: [
+          {
+            content:
+              'Round 10 Vote Reconciliation\n\n@[MoonZoey] and @[QuantumSpirit]'
+          }
+        ]
+      })
+    ).toEqual([]);
+  });
+
+  it('keeps ALL group mention metadata for standalone @all tokens', () => {
+    expect(
+      normalizeDropGroupMentions({
+        mentionedGroups: [DropGroupMention.ALL, DropGroupMention.ALL],
+        parts: [
+          {
+            content: 'Heads up @all: please review this drop.'
+          }
+        ]
+      })
+    ).toEqual([DropGroupMention.ALL]);
+  });
+
+  it('does not treat embedded @all text as an ALL group mention', () => {
+    expect(
+      normalizeDropGroupMentions({
+        mentionedGroups: [DropGroupMention.ALL],
+        parts: [
+          {
+            content: 'email@example.com @alliance hello@all @all_again'
+          }
+        ]
+      })
+    ).toEqual([]);
   });
 
   it('allows wave admins to use group mentions', () => {

--- a/src/drops/create-or-update-drop-use-case.test.ts
+++ b/src/drops/create-or-update-drop-use-case.test.ts
@@ -334,6 +334,19 @@ describe('CreateOrUpdateDropUseCase', () => {
     ).toEqual([DropGroupMention.ALL]);
   });
 
+  it('keeps ALL group mention metadata for line-start @all tokens', () => {
+    expect(
+      normalizeDropGroupMentions({
+        mentionedGroups: [DropGroupMention.ALL],
+        parts: [
+          {
+            content: 'first line\n@all on the next line'
+          }
+        ]
+      })
+    ).toEqual([DropGroupMention.ALL]);
+  });
+
   it('does not treat embedded @all text as an ALL group mention', () => {
     expect(
       normalizeDropGroupMentions({
@@ -343,6 +356,15 @@ describe('CreateOrUpdateDropUseCase', () => {
             content: 'email@example.com @alliance hello@all @all_again'
           }
         ]
+      })
+    ).toEqual([]);
+  });
+
+  it('strips ALL group mention metadata when there are no drop parts', () => {
+    expect(
+      normalizeDropGroupMentions({
+        mentionedGroups: [DropGroupMention.ALL],
+        parts: []
       })
     ).toEqual([]);
   });
@@ -384,6 +406,27 @@ describe('CreateOrUpdateDropUseCase', () => {
         ]
       })
     ).toEqual([]);
+  });
+
+  it('normalizes group mention metadata idempotently', () => {
+    const specificGroup = 'specific-group' as DropGroupMention;
+    const parts = [{ content: 'hello @all' }];
+    const once = normalizeDropGroupMentions({
+      mentionedGroups: [
+        specificGroup,
+        DropGroupMention.ALL,
+        specificGroup,
+        DropGroupMention.ALL
+      ],
+      parts
+    });
+
+    expect(
+      normalizeDropGroupMentions({
+        mentionedGroups: once,
+        parts
+      })
+    ).toEqual(once);
   });
 
   it('allows wave admins to use group mentions', () => {

--- a/src/drops/create-or-update-drop.use-case.ts
+++ b/src/drops/create-or-update-drop.use-case.ts
@@ -1,5 +1,6 @@
 import {
   CreateOrUpdateDropModel,
+  CreateOrUpdateDropPartModel,
   DropPartIdentifierModel,
   DropReferencedNftModel
 } from './create-or-update-drop.model';
@@ -30,6 +31,7 @@ import {
   DropPartEntity,
   DropType
 } from '@/entities/IDrop';
+import { DropGroupMention } from '@/entities/IWaveGroupNotificationSubscription';
 import { AttachmentStatus, DropAttachmentEntity } from '@/entities/IAttachment';
 import {
   identitySubscriptionsDb,
@@ -96,6 +98,25 @@ import { parseDecentralizedMediaRef } from '@/decentralized-media/decentralized-
 
 const TENOR_CHAT_LINK_ORIGIN = 'https://media.tenor.com';
 const ALLOWED_TENOR_CHAT_LINK_EXTENSION_REGEX = /\.(?:gif|mp4|jpg|webp)$/i;
+const ALL_GROUP_MENTION_REGEX = /(^|[^A-Za-z0-9_@])@all(?![A-Za-z0-9_@])/i;
+
+export function normalizeDropGroupMentions({
+  mentionedGroups,
+  parts
+}: {
+  mentionedGroups: readonly DropGroupMention[];
+  parts: readonly Pick<CreateOrUpdateDropPartModel, 'content'>[];
+}): DropGroupMention[] {
+  const hasAllMentionInContent = parts.some((part) =>
+    ALL_GROUP_MENTION_REGEX.test(part.content ?? '')
+  );
+  return collections
+    .distinct([...mentionedGroups])
+    .filter(
+      (mentionedGroup) =>
+        mentionedGroup !== DropGroupMention.ALL || hasAllMentionInContent
+    );
+}
 
 function isActiveIdentityNomination(nomination: { has_won: boolean }): boolean {
   return !nomination.has_won;
@@ -200,6 +221,18 @@ export class CreateOrUpdateDropUseCase {
 
   private getAllDropsNotificationsSubscribersLimit(): number {
     return env.getIntOrNull('ALL_DROPS_NOTIFICATIONS_SUBSCRIBERS_LIMIT') ?? 15;
+  }
+
+  private normalizeMentionedGroups(
+    model: CreateOrUpdateDropModel
+  ): CreateOrUpdateDropModel {
+    return {
+      ...model,
+      mentioned_groups: normalizeDropGroupMentions({
+        mentionedGroups: model.mentioned_groups,
+        parts: model.parts
+      })
+    };
   }
 
   public async execute(
@@ -358,8 +391,9 @@ export class CreateOrUpdateDropUseCase {
     if (model.drop_type === DropType.WINNER) {
       throw new BadRequestException(`Can't modify a winner drop`);
     }
+    const normalizedModel = this.normalizeMentionedGroups(model);
     const { validatedModel, groupIdsUserIsEligibleFor } =
-      await this.validateReferences(model, isDescriptionDrop, {
+      await this.validateReferences(normalizedModel, isDescriptionDrop, {
         timer,
         connection,
         preResolvedIdentityNomination
@@ -1372,7 +1406,7 @@ export class CreateOrUpdateDropUseCase {
 
   private async insertAllDropComponents(
     {
-      model,
+      model: inputModel,
       wave,
       createdAt,
       updatedAt,
@@ -1387,6 +1421,7 @@ export class CreateOrUpdateDropUseCase {
     { connection, timer }: { connection: ConnectionWrapper<any>; timer?: Timer }
   ): Promise<number[]> {
     timer?.start(`${CreateOrUpdateDropUseCase.name}->insertAllDropComponents`);
+    const model = this.normalizeMentionedGroups(inputModel);
     const dropId = this.getRequiredDropId(model);
     const authorId = this.getRequiredAuthorId(model);
     const parts = model.parts;

--- a/src/drops/create-or-update-drop.use-case.ts
+++ b/src/drops/create-or-update-drop.use-case.ts
@@ -98,20 +98,20 @@ import { parseDecentralizedMediaRef } from '@/decentralized-media/decentralized-
 
 const TENOR_CHAT_LINK_ORIGIN = 'https://media.tenor.com';
 const ALLOWED_TENOR_CHAT_LINK_EXTENSION_REGEX = /\.(?:gif|mp4|jpg|webp)$/i;
-const ALL_GROUP_MENTION_REGEX = /(^|[^A-Za-z0-9_@])@all(?![A-Za-z0-9_@])/i;
+const ALL_GROUP_MENTION_REGEX = /(^|[^a-z0-9_@])@all(?![a-z0-9_@])/i;
 
 export function normalizeDropGroupMentions({
   mentionedGroups,
   parts
 }: {
-  mentionedGroups: readonly DropGroupMention[];
+  mentionedGroups?: readonly DropGroupMention[] | null;
   parts: readonly Pick<CreateOrUpdateDropPartModel, 'content'>[];
 }): DropGroupMention[] {
   const hasAllMentionInContent = parts.some((part) =>
     ALL_GROUP_MENTION_REGEX.test(part.content ?? '')
   );
   return collections
-    .distinct([...mentionedGroups])
+    .distinct([...(mentionedGroups ?? [])])
     .filter(
       (mentionedGroup) =>
         mentionedGroup !== DropGroupMention.ALL || hasAllMentionInContent
@@ -1421,6 +1421,8 @@ export class CreateOrUpdateDropUseCase {
     { connection, timer }: { connection: ConnectionWrapper<any>; timer?: Timer }
   ): Promise<number[]> {
     timer?.start(`${CreateOrUpdateDropUseCase.name}->insertAllDropComponents`);
+    // Keep this guard at the persistence boundary too; this method can be
+    // reused independently of execute() and the normalization is idempotent.
     const model = this.normalizeMentionedGroups(inputModel);
     const dropId = this.getRequiredDropId(model);
     const authorId = this.getRequiredAuthorId(model);


### PR DESCRIPTION
## Summary

Prevents malformed drop payloads from creating `ALL` group mention metadata unless the drop content includes a standalone `@all` token.

## Root Cause

The backend trusted client-supplied `mentioned_groups: ["ALL"]` independently of `drops_parts.content`. External callers could therefore create drops that notified users subscribed to `@all` even when the visible text did not mention `@all`.

## What Changed

- Normalizes drop group mentions before drop validation.
- Normalizes again before persistence and notification recipient calculation.
- Preserves valid standalone `@all` group mentions and strips hidden or embedded false positives.
- Adds focused unit coverage for valid, missing, and embedded `@all` cases.

## Validation

- `npx jest src/drops/create-or-update-drop-use-case.test.ts --runInBand --config '{...no DB global setup...}'`
- `npm run lint`
- `git diff --check`

Note: the repo-default Jest path requires a local Testcontainers-compatible container runtime; this environment does not expose one, so the focused unit file was run with an inline no-DB Jest config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed group-mention handling so hidden mention metadata is no longer kept when a drop doesn’t visibly include a standalone `@all`.
  * Preserved valid `@all` mentions when they appear in the drop content, while ignoring false positives like embedded text in email addresses or words.
  * Improved consistency by applying mention cleanup throughout drop creation and updates, reducing unexpected notification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->