### PR TITLE
Add drop id to activity events

### DIFF
--- a/migrations/20260629083000-add-activity-event-drop-id.js
+++ b/migrations/20260629083000-add-activity-event-drop-id.js
@@ -1,0 +1,42 @@
+'use strict';
+
+function ignoreMysqlError(promise, ignoredCodes) {
+  return promise.catch(function(error) {
+    if (error && ignoredCodes.indexOf(error.code) !== -1) {
+      return null;
+    }
+    throw error;
+  });
+}
+
+exports.up = function(db) {
+  return ignoreMysqlError(
+    db.runSql(
+      'ALTER TABLE activity_events ADD COLUMN drop_id varchar(100) DEFAULT NULL AFTER action'
+    ),
+    ['ER_DUP_FIELDNAME']
+  ).then(function() {
+    return ignoreMysqlError(
+      db.runSql(
+        'ALTER TABLE activity_events ADD INDEX activity_events_drop_id_idx (drop_id), ALGORITHM=INPLACE, LOCK=NONE'
+      ),
+      ['ER_DUP_KEYNAME']
+    );
+  });
+};
+
+exports.down = function(db) {
+  return ignoreMysqlError(
+    db.runSql('DROP INDEX activity_events_drop_id_idx ON activity_events'),
+    ['ER_CANT_DROP_FIELD_OR_KEY']
+  ).then(function() {
+    return ignoreMysqlError(
+      db.runSql('ALTER TABLE activity_events DROP COLUMN drop_id'),
+      ['ER_CANT_DROP_FIELD_OR_KEY']
+    );
+  });
+};
+
+exports._meta = {
+  version: 1
+};

--- a/src/activity/activity.recorder.ts
+++ b/src/activity/activity.recorder.ts
@@ -54,6 +54,7 @@ export class ActivityRecorder extends LazyDbAccessCompatibleService {
         target_id: creator_id,
         target_type: ActivityEventTargetType.IDENTITY,
         action: ActivityEventAction.DROP_CREATED,
+        drop_id,
         data: { drop_id, wave_id },
         wave_id,
         visibility_group_id,
@@ -65,6 +66,7 @@ export class ActivityRecorder extends LazyDbAccessCompatibleService {
         target_id: wave_id,
         target_type: ActivityEventTargetType.WAVE,
         action: ActivityEventAction.DROP_CREATED,
+        drop_id,
         data: { drop_id, creator_id },
         wave_id,
         visibility_group_id,
@@ -75,6 +77,7 @@ export class ActivityRecorder extends LazyDbAccessCompatibleService {
         target_id: reply_to.drop_id,
         target_type: ActivityEventTargetType.DROP,
         action: ActivityEventAction.DROP_REPLIED,
+        drop_id,
         data: {
           replier_id: creator_id,
           drop_part_id: reply_to.part_id,
@@ -107,6 +110,7 @@ export class ActivityRecorder extends LazyDbAccessCompatibleService {
         target_id: creator_id,
         target_type: ActivityEventTargetType.IDENTITY,
         action: ActivityEventAction.WAVE_CREATED,
+        drop_id: null,
         data: { wave_id },
         wave_id,
         visibility_group_id,
@@ -131,6 +135,7 @@ export class ActivityRecorder extends LazyDbAccessCompatibleService {
             target_id,
             target_type,
             action,
+            drop_id,
             data,
             visibility_group_id,
             created_at,
@@ -142,8 +147,8 @@ export class ActivityRecorder extends LazyDbAccessCompatibleService {
               `(${mysql.escape(event.target_id)}, ${mysql.escape(
                 event.target_type
               )}, ${mysql.escape(event.action)}, ${mysql.escape(
-                JSON.stringify(event.data)
-              )}, ${mysql.escape(
+                event.drop_id
+              )}, ${mysql.escape(JSON.stringify(event.data))}, ${mysql.escape(
                 event.visibility_group_id
               )}, ${now}, ${mysql.escape(event.wave_id)}, ${mysql.escape(
                 event.action_author_id

--- a/src/activity/new-activity-event.ts
+++ b/src/activity/new-activity-event.ts
@@ -2,7 +2,8 @@ import { ActivityEventEntity } from '../entities/IActivityEvent';
 
 export interface NewActivityEvent extends Omit<
   ActivityEventEntity,
-  'id' | 'created_at' | 'data'
+  'id' | 'created_at' | 'data' | 'drop_id'
 > {
+  readonly drop_id: string | null;
   readonly data: object;
 }

--- a/src/entities/IActivityEvent.ts
+++ b/src/entities/IActivityEvent.ts
@@ -14,6 +14,9 @@ export class ActivityEventEntity {
   @Index('activity_events_action_idx')
   @Column({ type: 'varchar', length: 50, nullable: false })
   readonly action!: ActivityEventAction;
+  @Index('activity_events_drop_id_idx', { synchronize: false })
+  @Column({ type: 'varchar', length: 100, nullable: true, default: null })
+  readonly drop_id!: string | null;
   @Column({ type: 'json', nullable: false })
   readonly data!: string;
   @Column({ type: 'varchar', length: 100, nullable: true, default: null })


### PR DESCRIPTION
## Summary
- Adds nullable indexed `activity_events.drop_id` to support phase 2 indexed cleanup of drop-related activity events.
- Writes `drop_id` for newly recorded drop-created and drop-replied activity events.
- Leaves existing deletion behavior unchanged so old rows and current reads remain compatible until the backfill/switch PR.

## Deployment
- Deploy `dbMigrationsLoop` first so the nullable column is present and the migration-owned `activity_events_drop_id_idx` index is created with online DDL.
- Then deploy `tdhLoop`, `delegationsLoop`, `populateHistoricConsolidatedTdh`, and `api` so all drop-deletion/write paths share the updated entity shape.
- Phase 2 will backfill historic events and switch deletion to the indexed field.

## Validation
- `npm run lint`
- `npm run format`
- `npm run build`
- `npm run build` in `src/api-serverless`