### PR TITLE
Fix reaction latest activity deadlocks

### DIFF
--- a/src/api-serverless/src/drops/reactions-service.test.ts
+++ b/src/api-serverless/src/drops/reactions-service.test.ts
@@ -17,6 +17,7 @@ import { ProfileActivityLogType } from '@/entities/IProfileActivityLog';
 import { profileActivityLogsDb } from '@/profileActivityLogs/profile-activity-logs.db';
 import { giveReadReplicaTimeToCatchUp } from '@/api/api-helpers';
 import { Logger } from '@/logging';
+import { BadRequestException, ForbiddenException } from '@/exceptions';
 
 describe('ReactionsService', () => {
   const latestActivityAt = new Date('2026-06-29T00:00:00.000Z');
@@ -192,6 +193,19 @@ describe('ReactionsService', () => {
     ).toHaveBeenCalledWith(drop, ctx);
   });
 
+  it('surfaces bad request validation failures from inside the transaction', async () => {
+    (wavesDb.findById as jest.Mock).mockResolvedValue(null);
+
+    await expect(
+      service.addReaction(dropEntity.id, 'profile-1', ':+1:', ctx as any)
+    ).rejects.toBeInstanceOf(BadRequestException);
+
+    expect(reactionsDb.executeNativeQueriesInTransaction).toHaveBeenCalled();
+    expect(reactionsDb.addReaction).not.toHaveBeenCalled();
+    expect(profileActivityLogsDb.insertLogEntry).not.toHaveBeenCalled();
+    expect(metricsRecorder.recordActiveIdentity).not.toHaveBeenCalled();
+  });
+
   it('treats a duplicate remove request as a no-op', async () => {
     (reactionsDb.removeReaction as jest.Mock).mockResolvedValue(false);
 
@@ -250,6 +264,23 @@ describe('ReactionsService', () => {
     expect(
       wsListenersNotifier.notifyAboutDropReactionUpdate
     ).toHaveBeenCalledWith(drop, ctx);
+  });
+
+  it('surfaces forbidden validation failures from inside the transaction', async () => {
+    (wavesDb.findById as jest.Mock).mockResolvedValue({
+      id: dropEntity.wave_id,
+      chat_enabled: false,
+      visibility_group_id: 'group-1'
+    });
+
+    await expect(
+      service.removeReaction(dropEntity.id, 'profile-1', ctx as any)
+    ).rejects.toBeInstanceOf(ForbiddenException);
+
+    expect(reactionsDb.executeNativeQueriesInTransaction).toHaveBeenCalled();
+    expect(reactionsDb.removeReaction).not.toHaveBeenCalled();
+    expect(profileActivityLogsDb.insertLogEntry).not.toHaveBeenCalled();
+    expect(profileActivityLogsDb.touchLatestActivity).not.toHaveBeenCalled();
   });
 
   it('does not fail a committed add reaction when a post-commit side effect fails', async () => {

--- a/src/api-serverless/src/drops/reactions-service.test.ts
+++ b/src/api-serverless/src/drops/reactions-service.test.ts
@@ -13,10 +13,13 @@ import { DropsApiService } from '@/api/drops/drops.api.service';
 import { MetricsRecorder } from '@/metrics/MetricsRecorder';
 import { ReactionsService } from '@/api/drops/reactions.service';
 import { DropEntity, DropType } from '@/entities/IDrop';
+import { ProfileActivityLogType } from '@/entities/IProfileActivityLog';
 import { profileActivityLogsDb } from '@/profileActivityLogs/profile-activity-logs.db';
 import { giveReadReplicaTimeToCatchUp } from '@/api/api-helpers';
+import { Logger } from '@/logging';
 
 describe('ReactionsService', () => {
+  const latestActivityAt = new Date('2026-06-29T00:00:00.000Z');
   let reactionsDb: ReactionsDb;
   let wavesDb: WavesApiDb;
   let dropsDb: DropsDb;
@@ -28,7 +31,8 @@ describe('ReactionsService', () => {
   let service: ReactionsService;
 
   const connection = {} as any;
-  const ctx = { connection };
+  const transactionCtx = { connection };
+  const ctx = {};
   const dropEntity: DropEntity = {
     serial_no: 1,
     id: 'drop-1',
@@ -58,6 +62,8 @@ describe('ReactionsService', () => {
     wsListenersNotifier = mock();
     dropsService = mock();
     metricsRecorder = mock();
+
+    jest.spyOn(Logger.get('ReactionsService'), 'error').mockImplementation();
 
     service = new ReactionsService(
       reactionsDb,
@@ -91,8 +97,16 @@ describe('ReactionsService', () => {
     (
       wsListenersNotifier.notifyAboutDropReactionUpdate as jest.Mock
     ).mockResolvedValue(undefined);
+    (
+      reactionsDb.executeNativeQueriesInTransaction as jest.Mock
+    ).mockImplementation(async (callback) => await callback(connection));
 
-    jest.spyOn(profileActivityLogsDb, 'insert').mockResolvedValue(undefined);
+    jest
+      .spyOn(profileActivityLogsDb, 'insertLogEntry')
+      .mockResolvedValue(latestActivityAt);
+    jest
+      .spyOn(profileActivityLogsDb, 'touchLatestActivity')
+      .mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -115,10 +129,11 @@ describe('ReactionsService', () => {
       dropEntity.id,
       dropEntity.wave_id,
       ':+1:',
-      ctx
+      transactionCtx
     );
     expect(metricsRecorder.recordActiveIdentity).not.toHaveBeenCalled();
-    expect(profileActivityLogsDb.insert).not.toHaveBeenCalled();
+    expect(profileActivityLogsDb.insertLogEntry).not.toHaveBeenCalled();
+    expect(profileActivityLogsDb.touchLatestActivity).not.toHaveBeenCalled();
     expect(userNotifier.notifyOfDropReaction).not.toHaveBeenCalled();
     expect(giveReadReplicaTimeToCatchUp).not.toHaveBeenCalled();
     expect(
@@ -136,14 +151,41 @@ describe('ReactionsService', () => {
       dropEntity.id,
       dropEntity.wave_id,
       ':+1:',
-      ctx
+      transactionCtx
     );
     expect(metricsRecorder.recordActiveIdentity).toHaveBeenCalledWith(
       { identityId: 'profile-1' },
       ctx
     );
-    expect(profileActivityLogsDb.insert).toHaveBeenCalled();
-    expect(userNotifier.notifyOfDropReaction).toHaveBeenCalled();
+    expect(profileActivityLogsDb.insertLogEntry).toHaveBeenCalledWith(
+      {
+        profile_id: 'profile-1',
+        type: ProfileActivityLogType.DROP_REACTED,
+        target_id: dropEntity.id,
+        contents: JSON.stringify({ reaction: ':+1:' }),
+        additional_data_1: dropEntity.author_id,
+        additional_data_2: dropEntity.wave_id,
+        proxy_id: null
+      },
+      connection,
+      undefined
+    );
+    expect(profileActivityLogsDb.touchLatestActivity).toHaveBeenCalledWith(
+      'profile-1',
+      latestActivityAt,
+      undefined,
+      undefined
+    );
+    expect(userNotifier.notifyOfDropReaction).toHaveBeenCalledWith(
+      {
+        profile_id: 'profile-1',
+        drop_id: dropEntity.id,
+        drop_author_id: dropEntity.author_id,
+        reaction: ':+1:',
+        wave_id: dropEntity.wave_id
+      },
+      'group-1'
+    );
     expect(giveReadReplicaTimeToCatchUp).toHaveBeenCalled();
     expect(
       wsListenersNotifier.notifyAboutDropReactionUpdate
@@ -164,9 +206,10 @@ describe('ReactionsService', () => {
       'profile-1',
       dropEntity.id,
       dropEntity.wave_id,
-      ctx
+      transactionCtx
     );
-    expect(profileActivityLogsDb.insert).not.toHaveBeenCalled();
+    expect(profileActivityLogsDb.insertLogEntry).not.toHaveBeenCalled();
+    expect(profileActivityLogsDb.touchLatestActivity).not.toHaveBeenCalled();
     expect(giveReadReplicaTimeToCatchUp).not.toHaveBeenCalled();
     expect(
       wsListenersNotifier.notifyAboutDropReactionUpdate
@@ -182,10 +225,50 @@ describe('ReactionsService', () => {
       'profile-1',
       dropEntity.id,
       dropEntity.wave_id,
-      ctx
+      transactionCtx
     );
-    expect(profileActivityLogsDb.insert).toHaveBeenCalled();
+    expect(profileActivityLogsDb.insertLogEntry).toHaveBeenCalledWith(
+      {
+        profile_id: 'profile-1',
+        type: ProfileActivityLogType.DROP_REACTED,
+        target_id: dropEntity.id,
+        contents: JSON.stringify({ reaction: null }),
+        additional_data_1: dropEntity.author_id,
+        additional_data_2: dropEntity.wave_id,
+        proxy_id: null
+      },
+      connection,
+      undefined
+    );
+    expect(profileActivityLogsDb.touchLatestActivity).toHaveBeenCalledWith(
+      'profile-1',
+      latestActivityAt,
+      undefined,
+      undefined
+    );
     expect(giveReadReplicaTimeToCatchUp).toHaveBeenCalled();
+    expect(
+      wsListenersNotifier.notifyAboutDropReactionUpdate
+    ).toHaveBeenCalledWith(drop, ctx);
+  });
+
+  it('does not fail a committed add reaction when a post-commit side effect fails', async () => {
+    (reactionsDb.addReaction as jest.Mock).mockResolvedValue(true);
+    (profileActivityLogsDb.touchLatestActivity as jest.Mock).mockRejectedValue(
+      new Error('latest activity unavailable')
+    );
+
+    const result = await service.addReaction(
+      dropEntity.id,
+      'profile-1',
+      ':+1:',
+      ctx as any
+    );
+
+    expect(result).toBe(drop);
+    expect(profileActivityLogsDb.insertLogEntry).toHaveBeenCalled();
+    expect(profileActivityLogsDb.touchLatestActivity).toHaveBeenCalled();
+    expect(userNotifier.notifyOfDropReaction).toHaveBeenCalled();
     expect(
       wsListenersNotifier.notifyAboutDropReactionUpdate
     ).toHaveBeenCalledWith(drop, ctx);

--- a/src/api-serverless/src/drops/reactions-service.test.ts
+++ b/src/api-serverless/src/drops/reactions-service.test.ts
@@ -194,12 +194,38 @@ describe('ReactionsService', () => {
   });
 
   it('surfaces bad request validation failures from inside the transaction', async () => {
-    (wavesDb.findById as jest.Mock).mockResolvedValue(null);
+    const callOrder: string[] = [];
+    (
+      reactionsDb.executeNativeQueriesInTransaction as jest.Mock
+    ).mockImplementation(async (callback) => {
+      callOrder.push('transaction:start');
+      try {
+        return await callback(connection);
+      } finally {
+        callOrder.push('transaction:end');
+      }
+    });
+    (wavesDb.findById as jest.Mock).mockImplementation(async () => {
+      callOrder.push('validate');
+      return null;
+    });
+    (dropsDb.findDropByIdWithEligibilityCheck as jest.Mock).mockImplementation(
+      async () => {
+        callOrder.push('eligibility');
+        return dropEntity;
+      }
+    );
 
     await expect(
       service.addReaction(dropEntity.id, 'profile-1', ':+1:', ctx as any)
     ).rejects.toBeInstanceOf(BadRequestException);
 
+    expect(callOrder).toEqual([
+      'transaction:start',
+      'eligibility',
+      'validate',
+      'transaction:end'
+    ]);
     expect(reactionsDb.executeNativeQueriesInTransaction).toHaveBeenCalled();
     expect(reactionsDb.addReaction).not.toHaveBeenCalled();
     expect(profileActivityLogsDb.insertLogEntry).not.toHaveBeenCalled();
@@ -267,16 +293,42 @@ describe('ReactionsService', () => {
   });
 
   it('surfaces forbidden validation failures from inside the transaction', async () => {
-    (wavesDb.findById as jest.Mock).mockResolvedValue({
-      id: dropEntity.wave_id,
-      chat_enabled: false,
-      visibility_group_id: 'group-1'
+    const callOrder: string[] = [];
+    (
+      reactionsDb.executeNativeQueriesInTransaction as jest.Mock
+    ).mockImplementation(async (callback) => {
+      callOrder.push('transaction:start');
+      try {
+        return await callback(connection);
+      } finally {
+        callOrder.push('transaction:end');
+      }
     });
+    (wavesDb.findById as jest.Mock).mockImplementation(async () => {
+      callOrder.push('validate');
+      return {
+        id: dropEntity.wave_id,
+        chat_enabled: false,
+        visibility_group_id: 'group-1'
+      };
+    });
+    (dropsDb.findDropByIdWithEligibilityCheck as jest.Mock).mockImplementation(
+      async () => {
+        callOrder.push('eligibility');
+        return dropEntity;
+      }
+    );
 
     await expect(
       service.removeReaction(dropEntity.id, 'profile-1', ctx as any)
     ).rejects.toBeInstanceOf(ForbiddenException);
 
+    expect(callOrder).toEqual([
+      'transaction:start',
+      'eligibility',
+      'validate',
+      'transaction:end'
+    ]);
     expect(reactionsDb.executeNativeQueriesInTransaction).toHaveBeenCalled();
     expect(reactionsDb.removeReaction).not.toHaveBeenCalled();
     expect(profileActivityLogsDb.insertLogEntry).not.toHaveBeenCalled();
@@ -298,6 +350,50 @@ describe('ReactionsService', () => {
 
     expect(result).toBe(drop);
     expect(profileActivityLogsDb.insertLogEntry).toHaveBeenCalled();
+    expect(profileActivityLogsDb.touchLatestActivity).toHaveBeenCalled();
+    expect(userNotifier.notifyOfDropReaction).toHaveBeenCalled();
+    expect(
+      wsListenersNotifier.notifyAboutDropReactionUpdate
+    ).toHaveBeenCalledWith(drop, ctx);
+  });
+
+  it('does not fail a committed add reaction when active identity metrics fail', async () => {
+    (reactionsDb.addReaction as jest.Mock).mockResolvedValue(true);
+    (metricsRecorder.recordActiveIdentity as jest.Mock).mockRejectedValue(
+      new Error('metrics unavailable')
+    );
+
+    const result = await service.addReaction(
+      dropEntity.id,
+      'profile-1',
+      ':+1:',
+      ctx as any
+    );
+
+    expect(result).toBe(drop);
+    expect(metricsRecorder.recordActiveIdentity).toHaveBeenCalled();
+    expect(profileActivityLogsDb.touchLatestActivity).toHaveBeenCalled();
+    expect(userNotifier.notifyOfDropReaction).toHaveBeenCalled();
+    expect(
+      wsListenersNotifier.notifyAboutDropReactionUpdate
+    ).toHaveBeenCalledWith(drop, ctx);
+  });
+
+  it('does not fail a committed add reaction when notification enqueue fails', async () => {
+    (reactionsDb.addReaction as jest.Mock).mockResolvedValue(true);
+    (userNotifier.notifyOfDropReaction as jest.Mock).mockRejectedValue(
+      new Error('notification unavailable')
+    );
+
+    const result = await service.addReaction(
+      dropEntity.id,
+      'profile-1',
+      ':+1:',
+      ctx as any
+    );
+
+    expect(result).toBe(drop);
+    expect(metricsRecorder.recordActiveIdentity).toHaveBeenCalled();
     expect(profileActivityLogsDb.touchLatestActivity).toHaveBeenCalled();
     expect(userNotifier.notifyOfDropReaction).toHaveBeenCalled();
     expect(

--- a/src/api-serverless/src/drops/reactions.service.ts
+++ b/src/api-serverless/src/drops/reactions.service.ts
@@ -61,6 +61,9 @@ export class ReactionsService {
     private readonly metricsRecorder: MetricsRecorder
   ) {}
 
+  // Caller-owned transactions keep the legacy all-in-transaction behavior.
+  // HTTP reaction routes use the no-connection path so post-commit side effects
+  // cannot roll back an already durable reaction.
   private async handleReactionInExistingTransaction(
     dropId: string,
     profileId: string,
@@ -289,6 +292,8 @@ export class ReactionsService {
     const postCommitSideEffects: PostCommitSideEffect[] = [
       {
         name: 'record-active-identity',
+        // Active identity metrics are rollups; do not fail a committed reaction
+        // response if this observational write is temporarily unavailable.
         run: () =>
           this.metricsRecorder.recordActiveIdentity(
             { identityId: profileId },

--- a/src/api-serverless/src/drops/reactions.service.ts
+++ b/src/api-serverless/src/drops/reactions.service.ts
@@ -12,7 +12,10 @@ import {
 import { ProfileActivityLogType } from '../../../entities/IProfileActivityLog';
 import { reactionsDb, ReactionsDb } from './reactions.db';
 import { dropsDb, DropsDb } from '../../../drops/drops.db';
-import { profileActivityLogsDb } from '../../../profileActivityLogs/profile-activity-logs.db';
+import {
+  NewProfileActivityLog,
+  profileActivityLogsDb
+} from '../../../profileActivityLogs/profile-activity-logs.db';
 import {
   UserNotifier,
   userNotifier
@@ -30,8 +33,23 @@ import {
   metricsRecorder,
   MetricsRecorder
 } from '../../../metrics/MetricsRecorder';
+import { Logger } from '../../../logging';
+
+type ReactionMutationResult = {
+  readonly dropEntity: DropEntity;
+  readonly wave: WaveEntity;
+  readonly reactionChanged: boolean;
+  readonly latestActivityAt: Date | null;
+};
+
+type PostCommitSideEffect = {
+  readonly name: string;
+  readonly run: () => Promise<void>;
+};
 
 export class ReactionsService {
+  private readonly logger = Logger.get(this.constructor.name);
+
   constructor(
     private readonly reactionsDb: ReactionsDb,
     private readonly wavesDb: WavesApiDb,
@@ -43,7 +61,7 @@ export class ReactionsService {
     private readonly metricsRecorder: MetricsRecorder
   ) {}
 
-  private async handleReaction(
+  private async handleReactionInExistingTransaction(
     dropId: string,
     profileId: string,
     callback: (
@@ -88,25 +106,239 @@ export class ReactionsService {
     return drop;
   }
 
+  private async handleReactionMutation(
+    dropId: string,
+    profileId: string,
+    callback: (dropEntity: DropEntity) => Promise<{
+      wave: WaveEntity;
+      reactionChanged: boolean;
+      latestActivityAt: Date | null;
+    }>,
+    ctx: RequestContext
+  ): Promise<ReactionMutationResult> {
+    const groupIdsUserIsEligibleFor =
+      await this.userGroupsService.getGroupsUserIsEligibleFor(
+        profileId,
+        ctx.timer
+      );
+    const dropEntity = await this.dropsDb.findDropByIdWithEligibilityCheck(
+      dropId,
+      groupIdsUserIsEligibleFor,
+      ctx.connection
+    );
+    if (!dropEntity) {
+      throw new NotFoundException(`Drop ${dropId} not found`);
+    }
+    const mutationResult = await callback(dropEntity);
+    return {
+      dropEntity,
+      ...mutationResult
+    };
+  }
+
+  private async completeReaction(
+    dropId: string,
+    mutationResult: ReactionMutationResult,
+    postCommitSideEffects: PostCommitSideEffect[],
+    ctx: RequestContext
+  ): Promise<ApiDrop> {
+    if (mutationResult.reactionChanged) {
+      await giveReadReplicaTimeToCatchUp();
+    }
+
+    const drop = await this.dropsService.findDropByIdOrThrow(
+      {
+        dropId: dropId,
+        skipEligibilityCheck: true
+      },
+      ctx
+    );
+
+    if (mutationResult.reactionChanged) {
+      await this.runPostCommitSideEffects([
+        ...postCommitSideEffects,
+        {
+          name: 'notify-drop-reaction-update',
+          run: () =>
+            this.wsListenersNotifier.notifyAboutDropReactionUpdate(drop, ctx)
+        }
+      ]);
+    }
+    return drop;
+  }
+
+  private async runPostCommitSideEffects(
+    sideEffects: PostCommitSideEffect[]
+  ): Promise<void> {
+    const results = await Promise.allSettled(
+      sideEffects.map((sideEffect) => sideEffect.run())
+    );
+    results.forEach((result, index) => {
+      if (result.status === 'rejected') {
+        this.logger.error(
+          `Reaction post-commit side effect failed: ${sideEffects[index].name}`,
+          result.reason
+        );
+      }
+    });
+  }
+
+  private buildReactionActivityLog({
+    dropEntity,
+    profileId,
+    reaction
+  }: {
+    dropEntity: DropEntity;
+    profileId: string;
+    reaction: string | null;
+  }): NewProfileActivityLog {
+    return {
+      profile_id: profileId,
+      type: ProfileActivityLogType.DROP_REACTED,
+      target_id: dropEntity.id,
+      contents: JSON.stringify({
+        reaction
+      }),
+      additional_data_1: dropEntity.author_id,
+      additional_data_2: dropEntity.wave_id,
+      proxy_id: null
+    };
+  }
+
+  private touchLatestActivitySideEffect(
+    profileId: string,
+    latestActivityAt: Date | null,
+    ctx: RequestContext
+  ): PostCommitSideEffect {
+    return {
+      name: 'touch-profile-latest-activity',
+      run: async () => {
+        if (latestActivityAt) {
+          await profileActivityLogsDb.touchLatestActivity(
+            profileId,
+            latestActivityAt,
+            undefined,
+            ctx.timer
+          );
+        }
+      }
+    };
+  }
+
   async addReaction(
     dropId: string,
     profileId: string,
     reaction: string,
     ctx: RequestContext
   ): Promise<ApiDrop> {
-    if (!ctx.connection) {
-      return await this.reactionsDb.executeNativeQueriesInTransaction(
-        async (connection) => {
-          return await this.addReaction(dropId, profileId, reaction, {
-            ...ctx,
-            connection
-          });
-        }
+    if (ctx.connection) {
+      return await this.addReactionInExistingTransaction(
+        dropId,
+        profileId,
+        reaction,
+        ctx
       );
     }
 
+    const mutationResult =
+      await this.reactionsDb.executeNativeQueriesInTransaction(
+        async (connection) =>
+          await this.handleReactionMutation(
+            dropId,
+            profileId,
+            async (dropEntity) => {
+              const transactionCtx = {
+                ...ctx,
+                connection
+              };
+              const wave = await this.validateReaction(
+                dropEntity,
+                transactionCtx
+              );
+              const reactionChanged = await this.reactionsDb.addReaction(
+                profileId,
+                dropId,
+                dropEntity.wave_id,
+                reaction,
+                transactionCtx
+              );
+
+              if (!reactionChanged) {
+                return { wave, reactionChanged, latestActivityAt: null };
+              }
+
+              const latestActivityAt =
+                await profileActivityLogsDb.insertLogEntry(
+                  this.buildReactionActivityLog({
+                    dropEntity,
+                    profileId,
+                    reaction
+                  }),
+                  connection,
+                  ctx.timer
+                );
+              return { wave, reactionChanged, latestActivityAt };
+            },
+            {
+              ...ctx,
+              connection
+            }
+          )
+      );
+
+    const postCommitSideEffects: PostCommitSideEffect[] = [
+      {
+        name: 'record-active-identity',
+        run: () =>
+          this.metricsRecorder.recordActiveIdentity(
+            { identityId: profileId },
+            ctx
+          )
+      },
+      this.touchLatestActivitySideEffect(
+        profileId,
+        mutationResult.latestActivityAt,
+        ctx
+      )
+    ];
+
+    if (mutationResult.dropEntity.author_id !== profileId) {
+      postCommitSideEffects.push({
+        name: 'notify-drop-reaction',
+        run: () =>
+          this.userNotifier.notifyOfDropReaction(
+            {
+              profile_id: profileId,
+              drop_id: dropId,
+              drop_author_id: mutationResult.dropEntity.author_id,
+              reaction: reaction,
+              wave_id: mutationResult.dropEntity.wave_id
+            },
+            mutationResult.wave.visibility_group_id
+          )
+      });
+    }
+
+    return await this.completeReaction(
+      dropId,
+      mutationResult,
+      postCommitSideEffects,
+      ctx
+    );
+  }
+
+  private async addReactionInExistingTransaction(
+    dropId: string,
+    profileId: string,
+    reaction: string,
+    ctx: RequestContext
+  ): Promise<ApiDrop> {
     const connection = ctx.connection;
-    return await this.handleReaction(
+    if (!connection) {
+      throw new Error('addReactionInExistingTransaction requires a connection');
+    }
+
+    return await this.handleReactionInExistingTransaction(
       dropId,
       profileId,
       async (dropEntity) => {
@@ -132,17 +364,11 @@ export class ReactionsService {
             ctx
           ),
           profileActivityLogsDb.insert(
-            {
-              profile_id: profileId,
-              type: ProfileActivityLogType.DROP_REACTED,
-              target_id: dropId,
-              contents: JSON.stringify({
-                reaction
-              }),
-              additional_data_1: dropEntity.author_id,
-              additional_data_2: dropEntity.wave_id,
-              proxy_id: null
-            },
+            this.buildReactionActivityLog({
+              dropEntity,
+              profileId,
+              reaction
+            }),
             connection,
             ctx.timer
           ),
@@ -172,19 +398,86 @@ export class ReactionsService {
     profileId: string,
     ctx: RequestContext
   ): Promise<ApiDrop> {
-    if (!ctx.connection) {
-      return await this.reactionsDb.executeNativeQueriesInTransaction(
-        async (connection) => {
-          return await this.removeReaction(dropId, profileId, {
-            ...ctx,
-            connection
-          });
-        }
+    if (ctx.connection) {
+      return await this.removeReactionInExistingTransaction(
+        dropId,
+        profileId,
+        ctx
       );
     }
 
+    const mutationResult =
+      await this.reactionsDb.executeNativeQueriesInTransaction(
+        async (connection) =>
+          await this.handleReactionMutation(
+            dropId,
+            profileId,
+            async (dropEntity) => {
+              const transactionCtx = {
+                ...ctx,
+                connection
+              };
+              const wave = await this.validateReaction(
+                dropEntity,
+                transactionCtx
+              );
+              const reactionChanged = await this.reactionsDb.removeReaction(
+                profileId,
+                dropId,
+                dropEntity.wave_id,
+                transactionCtx
+              );
+
+              if (!reactionChanged) {
+                return { wave, reactionChanged, latestActivityAt: null };
+              }
+
+              const latestActivityAt =
+                await profileActivityLogsDb.insertLogEntry(
+                  this.buildReactionActivityLog({
+                    dropEntity,
+                    profileId,
+                    reaction: null
+                  }),
+                  connection,
+                  ctx.timer
+                );
+              return { wave, reactionChanged, latestActivityAt };
+            },
+            {
+              ...ctx,
+              connection
+            }
+          )
+      );
+
+    return await this.completeReaction(
+      dropId,
+      mutationResult,
+      [
+        this.touchLatestActivitySideEffect(
+          profileId,
+          mutationResult.latestActivityAt,
+          ctx
+        )
+      ],
+      ctx
+    );
+  }
+
+  private async removeReactionInExistingTransaction(
+    dropId: string,
+    profileId: string,
+    ctx: RequestContext
+  ): Promise<ApiDrop> {
     const connection = ctx.connection;
-    return await this.handleReaction(
+    if (!connection) {
+      throw new Error(
+        'removeReactionInExistingTransaction requires a connection'
+      );
+    }
+
+    return await this.handleReactionInExistingTransaction(
       dropId,
       profileId,
       async (dropEntity) => {
@@ -204,17 +497,11 @@ export class ReactionsService {
         }
 
         await profileActivityLogsDb.insert(
-          {
-            profile_id: profileId,
-            type: ProfileActivityLogType.DROP_REACTED,
-            target_id: dropId,
-            contents: JSON.stringify({
-              reaction: null
-            }),
-            additional_data_1: dropEntity.author_id,
-            additional_data_2: dropEntity.wave_id,
-            proxy_id: null
-          },
+          this.buildReactionActivityLog({
+            dropEntity,
+            profileId,
+            reaction: null
+          }),
           connection,
           ctx.timer
         );

--- a/src/profileActivityLogs/profile-activity-logs-db.test.ts
+++ b/src/profileActivityLogs/profile-activity-logs-db.test.ts
@@ -26,6 +26,7 @@ describe('ProfileActivityLogsDb', () => {
       executeNativeQueriesInTransaction: jest.fn()
     } as unknown as jest.Mocked<SqlExecutor>;
     db = new ProfileActivityLogsDb(() => executor, {} as any);
+    jest.spyOn(db as any, 'sleep').mockResolvedValue(undefined);
   });
 
   it('inserts an activity log entry without touching latest activity', async () => {
@@ -47,6 +48,33 @@ describe('ProfileActivityLogsDb', () => {
     );
   });
 
+  it('inserts an activity log and touches latest activity with the same timestamp', async () => {
+    await db.insert(log, connection);
+
+    expect(executor.execute).toHaveBeenCalledTimes(2);
+    const insertParams = executor.execute.mock.calls[0][1] as Record<
+      string,
+      unknown
+    >;
+    const latestParams = executor.execute.mock.calls[1][1] as Record<
+      string,
+      unknown
+    >;
+    expect(executor.execute.mock.calls[0][0]).toContain(
+      PROFILES_ACTIVITY_LOGS_TABLE
+    );
+    expect(executor.execute.mock.calls[1][0]).toContain(
+      PROFILE_LATEST_LOG_TABLE
+    );
+    expect(latestParams.latestActivity).toBe(insertParams.currentTime);
+    expect(executor.execute.mock.calls[0][2]).toEqual({
+      wrappedConnection: connection
+    });
+    expect(executor.execute.mock.calls[1][2]).toEqual({
+      wrappedConnection: connection
+    });
+  });
+
   it('retries retryable latest activity failures outside transactions', async () => {
     const latestActivity = new Date('2026-06-29T00:00:00.000Z');
     executor.execute
@@ -56,6 +84,7 @@ describe('ProfileActivityLogsDb', () => {
     await db.touchLatestActivity('profile-1', latestActivity);
 
     expect(executor.execute).toHaveBeenCalledTimes(2);
+    expect((db as any).sleep).toHaveBeenCalledTimes(1);
     expect(executor.execute).toHaveBeenLastCalledWith(
       expect.stringContaining(PROFILE_LATEST_LOG_TABLE),
       { profileId: 'profile-1', latestActivity },
@@ -73,10 +102,37 @@ describe('ProfileActivityLogsDb', () => {
     ).rejects.toBe(error);
 
     expect(executor.execute).toHaveBeenCalledTimes(1);
+    expect((db as any).sleep).not.toHaveBeenCalled();
     expect(executor.execute).toHaveBeenCalledWith(
       expect.stringContaining(PROFILE_LATEST_LOG_TABLE),
       { profileId: 'profile-1', latestActivity },
       { wrappedConnection: connection }
     );
+  });
+
+  it('rethrows after latest activity retry attempts are exhausted', async () => {
+    const latestActivity = new Date('2026-06-29T00:00:00.000Z');
+    const error = { code: 'ER_LOCK_DEADLOCK' };
+    executor.execute.mockRejectedValue(error);
+
+    await expect(
+      db.touchLatestActivity('profile-1', latestActivity)
+    ).rejects.toBe(error);
+
+    expect(executor.execute).toHaveBeenCalledTimes(3);
+    expect((db as any).sleep).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry non-retryable latest activity failures', async () => {
+    const latestActivity = new Date('2026-06-29T00:00:00.000Z');
+    const error = new Error('syntax error');
+    executor.execute.mockRejectedValueOnce(error);
+
+    await expect(
+      db.touchLatestActivity('profile-1', latestActivity)
+    ).rejects.toBe(error);
+
+    expect(executor.execute).toHaveBeenCalledTimes(1);
+    expect((db as any).sleep).not.toHaveBeenCalled();
   });
 });

--- a/src/profileActivityLogs/profile-activity-logs-db.test.ts
+++ b/src/profileActivityLogs/profile-activity-logs-db.test.ts
@@ -1,0 +1,82 @@
+import {
+  PROFILE_LATEST_LOG_TABLE,
+  PROFILES_ACTIVITY_LOGS_TABLE
+} from '@/constants';
+import { ProfileActivityLogType } from '@/entities/IProfileActivityLog';
+import { SqlExecutor } from '@/sql-executor';
+import { ProfileActivityLogsDb } from './profile-activity-logs.db';
+
+describe('ProfileActivityLogsDb', () => {
+  let executor: jest.Mocked<SqlExecutor>;
+  let db: ProfileActivityLogsDb;
+  const connection = { connection: {} } as any;
+  const log = {
+    profile_id: 'profile-1',
+    target_id: 'drop-1',
+    contents: JSON.stringify({ reaction: ':+1:' }),
+    type: ProfileActivityLogType.DROP_REACTED,
+    proxy_id: null,
+    additional_data_1: 'author-1',
+    additional_data_2: 'wave-1'
+  };
+
+  beforeEach(() => {
+    executor = {
+      execute: jest.fn().mockResolvedValue([]),
+      executeNativeQueriesInTransaction: jest.fn()
+    } as unknown as jest.Mocked<SqlExecutor>;
+    db = new ProfileActivityLogsDb(() => executor, {} as any);
+  });
+
+  it('inserts an activity log entry without touching latest activity', async () => {
+    const createdAt = await db.insertLogEntry(log, connection);
+
+    expect(createdAt).toBeInstanceOf(Date);
+    expect(executor.execute).toHaveBeenCalledTimes(1);
+    expect(executor.execute).toHaveBeenCalledWith(
+      expect.stringContaining(PROFILES_ACTIVITY_LOGS_TABLE),
+      expect.objectContaining({
+        ...log,
+        currentTime: createdAt,
+        id: expect.any(String)
+      }),
+      { wrappedConnection: connection }
+    );
+    expect(executor.execute.mock.calls[0][0]).not.toContain(
+      PROFILE_LATEST_LOG_TABLE
+    );
+  });
+
+  it('retries retryable latest activity failures outside transactions', async () => {
+    const latestActivity = new Date('2026-06-29T00:00:00.000Z');
+    executor.execute
+      .mockRejectedValueOnce({ code: 'ER_LOCK_DEADLOCK' })
+      .mockResolvedValueOnce([]);
+
+    await db.touchLatestActivity('profile-1', latestActivity);
+
+    expect(executor.execute).toHaveBeenCalledTimes(2);
+    expect(executor.execute).toHaveBeenLastCalledWith(
+      expect.stringContaining(PROFILE_LATEST_LOG_TABLE),
+      { profileId: 'profile-1', latestActivity },
+      undefined
+    );
+  });
+
+  it('does not retry latest activity failures inside an existing transaction', async () => {
+    const latestActivity = new Date('2026-06-29T00:00:00.000Z');
+    const error = { code: 'ER_LOCK_DEADLOCK' };
+    executor.execute.mockRejectedValueOnce(error);
+
+    await expect(
+      db.touchLatestActivity('profile-1', latestActivity, connection)
+    ).rejects.toBe(error);
+
+    expect(executor.execute).toHaveBeenCalledTimes(1);
+    expect(executor.execute).toHaveBeenCalledWith(
+      expect.stringContaining(PROFILE_LATEST_LOG_TABLE),
+      { profileId: 'profile-1', latestActivity },
+      { wrappedConnection: connection }
+    );
+  });
+});

--- a/src/profileActivityLogs/profile-activity-logs.db.ts
+++ b/src/profileActivityLogs/profile-activity-logs.db.ts
@@ -30,6 +30,7 @@ const PROFILE_LATEST_LOG_RETRY_CODES = new Set([
   'ER_LOCK_WAIT_TIMEOUT'
 ]);
 const PROFILE_LATEST_LOG_RETRY_DELAYS_MS = [25, 75];
+const PROFILE_LATEST_LOG_RETRY_JITTER_MS = 25;
 
 export class ProfileActivityLogsDb extends LazyDbAccessCompatibleService {
   constructor(
@@ -130,7 +131,7 @@ export class ProfileActivityLogsDb extends LazyDbAccessCompatibleService {
     try {
       const touchLatestActivity = async () => {
         await this.db.execute(
-          `insert into ${PROFILE_LATEST_LOG_TABLE} (profile_id, latest_activity) values (:profileId, :latestActivity) on duplicate key update latest_activity = :latestActivity`,
+          `insert into ${PROFILE_LATEST_LOG_TABLE} (profile_id, latest_activity) values (:profileId, :latestActivity) on duplicate key update latest_activity = greatest(latest_activity, :latestActivity)`,
           { profileId, latestActivity },
           connectionHolder ? { wrappedConnection: connectionHolder } : undefined
         );
@@ -165,9 +166,16 @@ export class ProfileActivityLogsDb extends LazyDbAccessCompatibleService {
         ) {
           throw error;
         }
-        await this.sleep(PROFILE_LATEST_LOG_RETRY_DELAYS_MS[attempt]);
+        await this.sleep(this.getProfileLatestRetryDelayMs(attempt));
       }
     }
+  }
+
+  private getProfileLatestRetryDelayMs(attempt: number): number {
+    return (
+      PROFILE_LATEST_LOG_RETRY_DELAYS_MS[attempt] +
+      Math.floor(Math.random() * PROFILE_LATEST_LOG_RETRY_JITTER_MS)
+    );
   }
 
   private isRetryableProfileLatestLogError(error: unknown): boolean {

--- a/src/profileActivityLogs/profile-activity-logs.db.ts
+++ b/src/profileActivityLogs/profile-activity-logs.db.ts
@@ -4,6 +4,7 @@ import {
   LazyDbAccessCompatibleService,
   SqlExecutor
 } from '../sql-executor';
+import { randomInt } from 'crypto';
 import {
   isTargetOfTypeDrop,
   ProfileActivityLog,
@@ -174,7 +175,7 @@ export class ProfileActivityLogsDb extends LazyDbAccessCompatibleService {
   private getProfileLatestRetryDelayMs(attempt: number): number {
     return (
       PROFILE_LATEST_LOG_RETRY_DELAYS_MS[attempt] +
-      Math.floor(Math.random() * PROFILE_LATEST_LOG_RETRY_JITTER_MS)
+      randomInt(PROFILE_LATEST_LOG_RETRY_JITTER_MS)
     );
   }
 

--- a/src/profileActivityLogs/profile-activity-logs.db.ts
+++ b/src/profileActivityLogs/profile-activity-logs.db.ts
@@ -25,6 +25,12 @@ import { ids } from '../ids';
 
 const mysql = require('mysql');
 
+const PROFILE_LATEST_LOG_RETRY_CODES = new Set([
+  'ER_LOCK_DEADLOCK',
+  'ER_LOCK_WAIT_TIMEOUT'
+]);
+const PROFILE_LATEST_LOG_RETRY_DELAYS_MS = [25, 75];
+
 export class ProfileActivityLogsDb extends LazyDbAccessCompatibleService {
   constructor(
     dbSupplier: () => SqlExecutor,
@@ -71,9 +77,32 @@ export class ProfileActivityLogsDb extends LazyDbAccessCompatibleService {
     timer?: Timer
   ) {
     timer?.start('ProfileActivityLogsDb->insert');
+    try {
+      const currentTime = await this.insertLogEntry(
+        log,
+        connectionHolder,
+        timer
+      );
+      await this.touchLatestActivity(
+        log.profile_id,
+        currentTime,
+        connectionHolder,
+        timer
+      );
+    } finally {
+      timer?.stop('ProfileActivityLogsDb->insert');
+    }
+  }
+
+  public async insertLogEntry(
+    log: Omit<ProfileActivityLog, 'id' | 'created_at'>,
+    connectionHolder: ConnectionWrapper<any>,
+    timer?: Timer
+  ): Promise<Date> {
+    timer?.start('ProfileActivityLogsDb->insertLogEntry');
     const currentTime = Time.now().toDate();
-    await Promise.all([
-      this.db.execute(
+    try {
+      await this.db.execute(
         `
     insert into ${PROFILES_ACTIVITY_LOGS_TABLE} (id, profile_id, target_id, contents, type, proxy_id, created_at, additional_data_1, additional_data_2)
     values (:id, :profile_id, :target_id, :contents, :type, :proxy_id, :currentTime, :additional_data_1, :additional_data_2)
@@ -84,14 +113,73 @@ export class ProfileActivityLogsDb extends LazyDbAccessCompatibleService {
           id: ids.uniqueShortId()
         },
         { wrappedConnection: connectionHolder }
-      ),
-      this.db.execute(
-        `insert into ${PROFILE_LATEST_LOG_TABLE} (profile_id, latest_activity) values (:profileId, :currentTime) on duplicate key update latest_activity = :currentTime`,
-        { profileId: log.profile_id, currentTime },
-        { wrappedConnection: connectionHolder }
-      )
-    ]);
-    timer?.stop('ProfileActivityLogsDb->insert');
+      );
+    } finally {
+      timer?.stop('ProfileActivityLogsDb->insertLogEntry');
+    }
+    return currentTime;
+  }
+
+  public async touchLatestActivity(
+    profileId: string,
+    latestActivity: Date,
+    connectionHolder?: ConnectionWrapper<any>,
+    timer?: Timer
+  ): Promise<void> {
+    timer?.start('ProfileActivityLogsDb->touchLatestActivity');
+    try {
+      const touchLatestActivity = async () => {
+        await this.db.execute(
+          `insert into ${PROFILE_LATEST_LOG_TABLE} (profile_id, latest_activity) values (:profileId, :latestActivity) on duplicate key update latest_activity = :latestActivity`,
+          { profileId, latestActivity },
+          connectionHolder ? { wrappedConnection: connectionHolder } : undefined
+        );
+      };
+
+      if (connectionHolder) {
+        await touchLatestActivity();
+        return;
+      }
+
+      await this.executeWithProfileLatestRetry(touchLatestActivity);
+    } finally {
+      timer?.stop('ProfileActivityLogsDb->touchLatestActivity');
+    }
+  }
+
+  private async executeWithProfileLatestRetry(
+    executable: () => Promise<void>
+  ): Promise<void> {
+    for (
+      let attempt = 0;
+      attempt <= PROFILE_LATEST_LOG_RETRY_DELAYS_MS.length;
+      attempt++
+    ) {
+      try {
+        await executable();
+        return;
+      } catch (error) {
+        if (
+          !this.isRetryableProfileLatestLogError(error) ||
+          attempt === PROFILE_LATEST_LOG_RETRY_DELAYS_MS.length
+        ) {
+          throw error;
+        }
+        await this.sleep(PROFILE_LATEST_LOG_RETRY_DELAYS_MS[attempt]);
+      }
+    }
+  }
+
+  private isRetryableProfileLatestLogError(error: unknown): boolean {
+    if (!error || typeof error !== 'object' || !('code' in error)) {
+      return false;
+    }
+    const code = (error as { code?: unknown }).code;
+    return typeof code === 'string' && PROFILE_LATEST_LOG_RETRY_CODES.has(code);
+  }
+
+  private async sleep(milliseconds: number): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, milliseconds));
   }
 
   public async searchLogs(


### PR DESCRIPTION
## Issue

Production `POST /api/drops/:drop_id/reaction` requests can fail with a generic 500 when the derived `profile_latest_logs` upsert deadlocks. The reaction write, activity log write, latest-activity upsert, metrics, notification, canonical drop read, and websocket notification were all tied to the same transaction path for HTTP reaction calls.

## Fix

Keep the HTTP reaction transaction focused on the durable reaction mutation plus activity-log row. Move derived/latest-activity and notification-style work to post-commit side effects, and make latest-activity touches retry bounded deadlock/lock-timeout failures when they run outside a transaction.

## Changes

- Split `ProfileActivityLogsDb.insert` into reusable activity-log insertion and latest-activity touch operations.
- Added bounded retry for non-transactional `profile_latest_logs` touches on `ER_LOCK_DEADLOCK` and `ER_LOCK_WAIT_TIMEOUT`.
- Refactored no-connection `ReactionsService.addReaction/removeReaction` calls so the HTTP API route commits before latest-activity, metrics, notification, and websocket side effects run.
- Preserved existing caller-owned transaction behavior for compatibility with current internal callers.
- Added focused service and DB helper tests for no-op reactions, side-effect failure handling, split writes, and retry behavior.

## Validation

- `npm test -- src/api-serverless/src/drops/reactions-service.test.ts src/profileActivityLogs/profile-activity-logs-db.test.ts`
- `npm run lint -- --max-warnings=0`
- `npm run build`
- `pushd src/api-serverless && npm run generate && npm run build && popd`

## Risk

Low-to-medium. The public API contract and schema are unchanged. A committed reaction can now still return successfully if a non-critical post-commit side effect fails; failures are logged for follow-up. Existing caller-owned transaction behavior is intentionally preserved.

## Review Notes

No migrations are included. No `docs/architecture.md` update is needed because this does not add, remove, rename, or materially rewire deployable services, API boundaries, queues, triggers, DB/runtime patterns, media flows, or external integrations.
