### PR TITLE
Backfill activity event drop ids

### DIFF
--- a/migrations/20260629122000-backfill-activity-event-drop-id.js
+++ b/migrations/20260629122000-backfill-activity-event-drop-id.js
@@ -1,0 +1,98 @@
+'use strict';
+
+var BATCH_SIZE = 5000;
+var BATCH_SIZE_BIGINT = BigInt(BATCH_SIZE);
+
+function getId(value) {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  return BigInt(value);
+}
+
+async function backfillAction(db, action, dataPath) {
+  var bounds = await db.runSql(
+    'select min(id) as min_id, max(id) as max_id from activity_events where drop_id is null and action = ?',
+    [action]
+  );
+  var firstRow = bounds && bounds[0] ? bounds[0] : {};
+  var minId = getId(firstRow.min_id);
+  var maxId = getId(firstRow.max_id);
+
+  if (minId === null || maxId === null) {
+    return;
+  }
+
+  console.log(
+    '[activity_event_drop_id_backfill] starting ' +
+      action +
+      ' id range [' +
+      minId.toString() +
+      ', ' +
+      maxId.toString() +
+      ']'
+  );
+
+  for (var startId = minId; startId <= maxId; startId += BATCH_SIZE_BIGINT) {
+    var endId = startId + BATCH_SIZE_BIGINT;
+    console.log(
+      '[activity_event_drop_id_backfill] processing ' +
+        action +
+        ' id range [' +
+        startId.toString() +
+        ', ' +
+        endId.toString() +
+        ')'
+    );
+    await db.runSql(
+      `update activity_events
+set drop_id = json_unquote(json_extract(data, ?))
+where id >= ?
+  and id < ?
+  and drop_id is null
+  and action = ?
+  and json_type(json_extract(data, ?)) = 'STRING'
+  and char_length(json_unquote(json_extract(data, ?))) <= 100`,
+      [
+        dataPath,
+        startId.toString(),
+        endId.toString(),
+        action,
+        dataPath,
+        dataPath
+      ]
+    );
+  }
+}
+
+exports.up = async function(db) {
+  // db-migrate wraps migrations in one transaction; commit before the backfill
+  // so each bounded update releases locks before the next batch starts.
+  //
+  // If a later batch fails, db-migrate does not record this migration because
+  // the error still propagates. Already committed batches are intentional
+  // partial progress, and the next run resumes via the drop_id is null filter.
+  await db.runSql('COMMIT');
+  await db.runSql('SET AUTOCOMMIT=1');
+
+  try {
+    // Current activity event actions are DROP_CREATED, DROP_REPLIED, and
+    // WAVE_CREATED. Created-drop events store their own drop id in data.drop_id;
+    // reply events store their own drop id in data.reply_id. Parent-drop reply
+    // cleanup stays covered by target_type = DROP and target_id in the delete.
+    await backfillAction(db, 'DROP_CREATED', '$.drop_id');
+    await backfillAction(db, 'DROP_REPLIED', '$.reply_id');
+  } finally {
+    await db.runSql('SET AUTOCOMMIT=0');
+    await db.runSql('START TRANSACTION');
+  }
+};
+
+exports.down = function(db) {
+  // Intentionally irreversible. Nulling drop_id here would also remove values
+  // written by phase 1 writers after this migration started.
+};
+
+exports._meta = {
+  version: 1
+};

--- a/src/drops/drops-db.test.ts
+++ b/src/drops/drops-db.test.ts
@@ -1,4 +1,5 @@
 import {
+  ACTIVITY_EVENTS_TABLE,
   DROP_VOTER_STATE_TABLE,
   DROPS_TABLE,
   IDENTITIES_TABLE,
@@ -10,6 +11,31 @@ import { PageSortDirection } from '@/api/page-request';
 import { DropsDb, LeaderboardSort } from './drops.db';
 
 describe('DropsDb', () => {
+  it('deletes activity feed items by indexed drop columns', async () => {
+    const connection = {};
+    const execute = jest.fn().mockResolvedValue([]);
+    const repo = new DropsDb(
+      () =>
+        ({
+          execute
+        }) as any
+    );
+
+    await repo.deleteDropFeedItems('drop-1', {
+      connection: { connection } as any,
+      timer: undefined
+    });
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    const [sql, params, options] = execute.mock.calls[0];
+    expect(sql).toBe(
+      `delete from ${ACTIVITY_EVENTS_TABLE} where drop_id = :dropId or (target_type = 'DROP' and target_id = :dropId)`
+    );
+    expect(sql.toLowerCase()).not.toContain('like');
+    expect(params).toEqual({ dropId: 'drop-1' });
+    expect(options).toEqual({ wrappedConnection: { connection } });
+  });
+
   it('uses wave voting credit nft rows when finding CARD_SET_TDH overvoters', async () => {
     const execute = jest.fn().mockResolvedValue([]);
     const repo = new DropsDb(

--- a/src/drops/drops.db.ts
+++ b/src/drops/drops.db.ts
@@ -1736,8 +1736,8 @@ export class DropsDb extends LazyDbAccessCompatibleService {
   public async deleteDropFeedItems(dropId: string, ctx: RequestContext) {
     ctx.timer?.start('dropsDb->deleteDropFeedItems');
     await this.db.execute(
-      `delete from ${ACTIVITY_EVENTS_TABLE} where target_id = :dropId or data like :likeDropId`,
-      { dropId, likeDropId: `%"${dropId}"%` },
+      `delete from ${ACTIVITY_EVENTS_TABLE} where drop_id = :dropId or (target_type = 'DROP' and target_id = :dropId)`,
+      { dropId },
       { wrappedConnection: ctx.connection }
     );
     ctx.timer?.stop('dropsDb->deleteDropFeedItems');


### PR DESCRIPTION
## Summary
- Backfill historic `activity_events.drop_id` values for `DROP_CREATED` and `DROP_REPLIED` events from their JSON payloads.
- Run the historic backfill in bounded primary-key batches so each update commits separately instead of holding locks for the entire migration.
- Replace drop-feed activity deletion for drops with indexed predicates on `drop_id` and `target_id`, removing the `activity_events.data LIKE` scan.

## Deployment
- Deploy `dbMigrationsLoop` first so historic rows are backfilled before the API starts relying on `drop_id` for deletion.
- Then deploy `tdhLoop`, `delegationsLoop`, `populateHistoricConsolidatedTdh`, and API from the same branch/environment.

## Validation
- `npm run format`
- `npm run lint`
- `npm test -- src/drops/drops-db.test.ts --runInBand`
- `npm run build`
- `cd src/api-serverless && npm run build`