### PR TITLE
Improve Help6529 wallet consolidation routing

### DIFF
--- a/src/help-bot/help-bot-answerer.test.ts
+++ b/src/help-bot/help-bot-answerer.test.ts
@@ -219,7 +219,7 @@ describe('HelpBotAnswerer', () => {
   it('includes related help-index matches in deterministic knowledge answers', async () => {
     const index: HelpBotKnowledgeIndex = {
       ...TEST_INDEX,
-      records: [
+      records: TEST_INDEX.records.concat([
         {
           id: 'delegation.wallet-architecture',
           kind: 'workflow',
@@ -257,7 +257,7 @@ describe('HelpBotAnswerer', () => {
           tags: ['delegation'],
           sourceRefs: []
         }
-      ]
+      ])
     };
 
     const answer = await answerer(
@@ -360,6 +360,7 @@ describe('HelpBotAnswerer', () => {
     expect(answer.type).toBe('ANSWER');
     if (answer.type === 'ANSWER') {
       expect(answer.record.id).toBe('delegation.register-consolidation-doc');
+      expect(answer.record.kind).toBe('workflow');
       expect(answer.answer).toContain(
         'Register Consolidation connects wallets you control.'
       );

--- a/src/help-bot/help-bot-answerer.test.ts
+++ b/src/help-bot/help-bot-answerer.test.ts
@@ -300,6 +300,84 @@ describe('HelpBotAnswerer', () => {
     }
   });
 
+  it('answers wallet consolidation setup questions through routed knowledge', async () => {
+    const index: HelpBotKnowledgeIndex = {
+      ...TEST_INDEX,
+      records: [
+        {
+          id: 'delegation.wallet-architecture',
+          kind: 'workflow',
+          title: 'Wallet Architecture',
+          linkLabel: 'Wallet Architecture',
+          canonicalPath: '/delegation/wallet-architecture',
+          aliases: ['wallet architecture'],
+          keywords: ['wallet', 'architecture', 'vault'],
+          facts: ['Separate vault, transaction, and minting wallets.'],
+          relatedPaths: ['/delegation/wallet-checker'],
+          tags: ['delegation'],
+          sourceRefs: []
+        },
+        {
+          id: 'delegation.register-consolidation-doc',
+          kind: 'workflow',
+          title: 'Register Consolidation Guide',
+          linkLabel: 'Register Consolidation Guide',
+          canonicalPath: '/delegation/delegation-faq/register-consolidation',
+          aliases: ['register consolidation guide'],
+          keywords: ['register', 'consolidation'],
+          facts: ['Register Consolidation connects wallets you control.'],
+          relatedPaths: ['/delegation/register-consolidation'],
+          tags: ['delegation'],
+          sourceRefs: []
+        },
+        {
+          id: 'delegation.register-consolidation',
+          kind: 'route',
+          title: 'Register Consolidation',
+          linkLabel: 'Register Consolidation',
+          canonicalPath: '/delegation/register-consolidation',
+          aliases: ['register consolidation'],
+          keywords: ['register', 'consolidation'],
+          facts: ['Use the Register Consolidation form.'],
+          relatedPaths: [],
+          tags: ['delegation'],
+          sourceRefs: []
+        }
+      ]
+    };
+
+    const answer = await answerer(
+      undefined,
+      undefined,
+      undefined,
+      index
+    ).answer({
+      question:
+        "i have four wallets i'd like to consolidate. how do i do that?",
+      baseUrl: BASE_URL
+    });
+
+    expect(answer.type).toBe('ANSWER');
+    if (answer.type === 'ANSWER') {
+      expect(answer.record.id).toBe('delegation.register-consolidation-doc');
+      expect(answer.answer).toContain(
+        'Register Consolidation connects wallets you control.'
+      );
+      expect(answer.answer).toContain(
+        'Wallet Architecture: Separate vault, transaction, and minting wallets.'
+      );
+      expect(answer.answer).toContain(
+        '[Register Consolidation Guide](https://6529.io/delegation/delegation-faq/register-consolidation)'
+      );
+      expect(answer.answer).toContain(
+        '[Register Consolidation](https://6529.io/delegation/register-consolidation)'
+      );
+      expect(answer.answer).toContain(
+        '[Wallet Architecture](https://6529.io/delegation/wallet-architecture)'
+      );
+    }
+  });
+
   it('adds a weak-match caveat and review flag when the match score is uncertain', async () => {
     const answer = await answerer(undefined, undefined, undefined).answer({
       question: 'weakbot card',

--- a/src/help-bot/help-bot-knowledge.test.ts
+++ b/src/help-bot/help-bot-knowledge.test.ts
@@ -120,6 +120,31 @@ describe('FrontendHelpBotKnowledgeSource', () => {
     expect(match?.record.id).toBe('network.definitions');
   });
 
+  it('does not generate unsafe trailing-s singular variants', async () => {
+    const source = new FrontendHelpBotKnowledgeSource(async () =>
+      response({
+        schema_version: 1,
+        generated_at: '2026-06-19T00:00:00.000Z',
+        commit_sha: 'test',
+        base_url: 'https://6529.io',
+        records: [
+          {
+            id: 'debug.bad-stem',
+            title: 'Bad Stem',
+            canonical_path: '/debug/bad-stem',
+            aliases: ['statu'],
+            keywords: ['statu'],
+            facts: ['This record should not match status.']
+          }
+        ]
+      })
+    );
+
+    const match = await source.findMatch('what is status?');
+
+    expect(match).toBeNull();
+  });
+
   it('routes wallet consolidation questions to consolidation records', async () => {
     const source = new FrontendHelpBotKnowledgeSource(async () =>
       response({
@@ -169,12 +194,50 @@ describe('FrontendHelpBotKnowledgeSource', () => {
       4
     );
 
-    expect(matches.map((match) => match.record.id)).toEqual([
-      'delegation.register-consolidation-doc',
-      'delegation.register-consolidation',
-      'delegation.wallet-architecture',
-      'delegation.consolidation-use-cases'
-    ]);
+    const matchIds = matches.map((match) => match.record.id);
+    expect(matchIds[0]).toBe('delegation.register-consolidation-doc');
+    expect(matchIds[1]).toBe('delegation.register-consolidation');
+    expect(new Set(matchIds)).toEqual(
+      new Set([
+        'delegation.register-consolidation-doc',
+        'delegation.register-consolidation',
+        'delegation.wallet-architecture',
+        'delegation.consolidation-use-cases'
+      ])
+    );
+  });
+
+  it('does not route generic transaction display questions as wallet architecture', async () => {
+    const source = new FrontendHelpBotKnowledgeSource(async () =>
+      response({
+        schema_version: 1,
+        generated_at: '2026-06-19T00:00:00.000Z',
+        commit_sha: 'test',
+        base_url: 'https://6529.io',
+        records: [
+          {
+            id: 'delegation.wallet-architecture',
+            title: 'Wallet Architecture',
+            canonical_path: '/delegation/wallet-architecture',
+            aliases: ['wallet architecture'],
+            keywords: ['transaction'],
+            facts: ['Separate vault, transaction, and minting wallets.']
+          },
+          {
+            id: 'delegation.wallet-checker',
+            title: 'Wallet Checker',
+            canonical_path: '/delegation/wallet-checker',
+            aliases: ['wallet checker'],
+            keywords: ['wallet'],
+            facts: ['Wallet Checker reviews wallet setup.']
+          }
+        ]
+      })
+    );
+
+    const match = await source.findMatch('show me my transaction history');
+
+    expect(match).toBeNull();
   });
 
   it('throws and negative-caches when the frontend help index cannot be loaded', async () => {

--- a/src/help-bot/help-bot-knowledge.test.ts
+++ b/src/help-bot/help-bot-knowledge.test.ts
@@ -95,6 +95,88 @@ describe('FrontendHelpBotKnowledgeSource', () => {
     ]);
   });
 
+  it('matches pluralized product terms against singular aliases', async () => {
+    const source = new FrontendHelpBotKnowledgeSource(async () =>
+      response({
+        schema_version: 1,
+        generated_at: '2026-06-19T00:00:00.000Z',
+        commit_sha: 'test',
+        base_url: 'https://6529.io',
+        records: [
+          {
+            id: 'network.definitions',
+            title: 'Network Definitions',
+            canonical_path: '/network/definitions',
+            aliases: ['genesis set'],
+            keywords: ['genesis', 'set'],
+            facts: ['Genesis Set is a TDH boost definition.']
+          }
+        ]
+      })
+    );
+
+    const match = await source.findMatch('what are Genesis Sets?');
+
+    expect(match?.record.id).toBe('network.definitions');
+  });
+
+  it('routes wallet consolidation questions to consolidation records', async () => {
+    const source = new FrontendHelpBotKnowledgeSource(async () =>
+      response({
+        schema_version: 1,
+        generated_at: '2026-06-19T00:00:00.000Z',
+        commit_sha: 'test',
+        base_url: 'https://6529.io',
+        records: [
+          {
+            id: 'delegation.wallet-architecture',
+            title: 'Wallet Architecture',
+            canonical_path: '/delegation/wallet-architecture',
+            aliases: ['wallet architecture'],
+            keywords: ['wallet', 'architecture', 'vault'],
+            facts: ['Separate vault, transaction, and minting wallets.']
+          },
+          {
+            id: 'delegation.register-consolidation-doc',
+            title: 'Register Consolidation Guide',
+            canonical_path: '/delegation/delegation-faq/register-consolidation',
+            aliases: ['register consolidation guide'],
+            keywords: ['register', 'consolidation'],
+            facts: ['Register Consolidation connects wallets you control.']
+          },
+          {
+            id: 'delegation.register-consolidation',
+            title: 'Register Consolidation',
+            canonical_path: '/delegation/register-consolidation',
+            aliases: ['register consolidation'],
+            keywords: ['register', 'consolidation'],
+            facts: ['Use the Register Consolidation form.']
+          },
+          {
+            id: 'delegation.consolidation-use-cases',
+            title: 'Consolidation Use Cases',
+            canonical_path: '/delegation/consolidation-use-cases',
+            aliases: ['consolidation use cases'],
+            keywords: ['consolidation', 'wallet'],
+            facts: ['Consolidation covers multi-wallet patterns.']
+          }
+        ]
+      })
+    );
+
+    const matches = await source.findMatches(
+      "i have four wallets i'd like to consolidate. how do i do that?",
+      4
+    );
+
+    expect(matches.map((match) => match.record.id)).toEqual([
+      'delegation.register-consolidation-doc',
+      'delegation.register-consolidation',
+      'delegation.wallet-architecture',
+      'delegation.consolidation-use-cases'
+    ]);
+  });
+
   it('throws and negative-caches when the frontend help index cannot be loaded', async () => {
     const fetcher = jest
       .fn()

--- a/src/help-bot/help-bot.knowledge.ts
+++ b/src/help-bot/help-bot.knowledge.ts
@@ -55,6 +55,60 @@ const MINIMUM_MATCH_SCORE = 3;
 const DEFAULT_COMMIT_SHA = 'unknown';
 const logger = Logger.get('HelpBotKnowledge');
 
+const WALLET_CONTEXT_PATTERNS = [
+  /\bwallets?\b/,
+  /\baddresses?\b/,
+  /\bvault\b/,
+  /\bhot wallet\b/,
+  /\bcold wallet\b/,
+  /\bminting wallet\b/,
+  /\btransaction wallet\b/
+] as const;
+
+const ARCHITECTURE_CONTEXT_PATTERNS = [
+  /\barchitecture\b/,
+  /\barchitectures\b/,
+  /\btap\b/,
+  /\bthree address\b/,
+  /\bfour address\b/,
+  /\b3 address\b/,
+  /\b4 address\b/,
+  /\bthree wallets?\b/,
+  /\bfour wallets?\b/,
+  /\b3 wallets?\b/,
+  /\b4 wallets?\b/,
+  /\bmultiple wallets?\b/,
+  /\bseveral wallets?\b/,
+  /\bvault\b/,
+  /\bminting\b/,
+  /\btransaction\b/
+] as const;
+
+const CONSOLIDATION_CONTEXT_PATTERNS = [
+  /\bconsolidat(?:e|es|ed|ing|ion|ions)\b/,
+  /\bcount(?:ed)? together\b/,
+  /\btreat(?:ed)? together\b/,
+  /\bconnect(?:ed|ing)? (?:my )?(?:wallets?|addresses?)\b/,
+  /\bcombine(?:d|s|ing)? (?:my )?(?:wallets?|addresses?)\b/
+] as const;
+
+const WALLET_CHECK_CONTEXT_PATTERNS = [
+  /\bcheck\b/,
+  /\bview\b/,
+  /\breview\b/,
+  /\bverify\b/,
+  /\binspect\b/,
+  /\bsee\b/,
+  /\bshow\b/
+] as const;
+
+const WALLET_ARCHITECTURE_RECORD_ID = 'delegation.wallet-architecture';
+const WALLET_CHECKER_RECORD_ID = 'delegation.wallet-checker';
+const CONSOLIDATION_USE_CASES_RECORD_ID = 'delegation.consolidation-use-cases';
+const REGISTER_CONSOLIDATION_RECORD_ID = 'delegation.register-consolidation';
+const REGISTER_CONSOLIDATION_DOC_RECORD_ID =
+  'delegation.register-consolidation-doc';
+
 export class HelpBotKnowledgeUnavailableError extends Error {
   constructor(
     message: string,
@@ -187,11 +241,31 @@ function normalizeText(value: string): string {
 }
 
 function tokenize(value: string): Set<string> {
-  return new Set(
-    normalizeText(value)
-      .split(' ')
-      .filter((token) => token.length > 1 || token === '+')
-  );
+  const tokens = new Set<string>();
+  normalizeText(value)
+    .split(' ')
+    .filter((token) => token.length > 1 || token === '+')
+    .forEach((token) => {
+      tokenVariants(token).forEach((variant) => tokens.add(variant));
+    });
+  return tokens;
+}
+
+function tokenVariants(token: string): string[] {
+  const variants = [token];
+  if (token.length > 4 && token.endsWith('ies')) {
+    variants.push(`${token.slice(0, -3)}y`);
+  }
+  if (token.length > 3 && token.endsWith('s') && !token.endsWith('ss')) {
+    variants.push(token.slice(0, -1));
+  }
+  return variants;
+}
+
+function normalizedPhraseTokens(value: string): string[] {
+  return normalizeText(value)
+    .split(' ')
+    .filter((token) => token.length > 0);
 }
 
 function containsNormalizedPhrase(
@@ -202,7 +276,78 @@ function containsNormalizedPhrase(
   if (!normalizedPhrase) {
     return false;
   }
-  return ` ${normalizedQuestion} `.includes(` ${normalizedPhrase} `);
+  if (` ${normalizedQuestion} `.includes(` ${normalizedPhrase} `)) {
+    return true;
+  }
+  const questionTokens = normalizedPhraseTokens(normalizedQuestion);
+  const phraseTokens = normalizedPhraseTokens(phrase);
+  if (!phraseTokens.length || phraseTokens.length > questionTokens.length) {
+    return false;
+  }
+  return questionTokens.some((_token, index) => {
+    const candidate = questionTokens.slice(index, index + phraseTokens.length);
+    return (
+      candidate.length === phraseTokens.length &&
+      phraseTokens.every((phraseToken, phraseIndex) =>
+        tokenVariants(candidate[phraseIndex]).includes(phraseToken)
+      )
+    );
+  });
+}
+
+function matchesAny(
+  normalizedQuestion: string,
+  patterns: readonly RegExp[]
+): boolean {
+  return patterns.some((pattern) => pattern.test(normalizedQuestion));
+}
+
+function addRoutedScore(
+  scores: Map<string, number>,
+  recordId: string,
+  score: number
+): void {
+  scores.set(recordId, Math.max(scores.get(recordId) ?? 0, score));
+}
+
+function routedRecordScores(
+  normalizedQuestion: string
+): ReadonlyMap<string, number> {
+  const hasWalletContext = matchesAny(
+    normalizedQuestion,
+    WALLET_CONTEXT_PATTERNS
+  );
+  const hasArchitectureContext = matchesAny(
+    normalizedQuestion,
+    ARCHITECTURE_CONTEXT_PATTERNS
+  );
+  const hasConsolidationContext = matchesAny(
+    normalizedQuestion,
+    CONSOLIDATION_CONTEXT_PATTERNS
+  );
+  const hasWalletCheckContext = matchesAny(
+    normalizedQuestion,
+    WALLET_CHECK_CONTEXT_PATTERNS
+  );
+  const scores = new Map<string, number>();
+
+  if (hasArchitectureContext && (hasWalletContext || hasWalletCheckContext)) {
+    addRoutedScore(scores, WALLET_ARCHITECTURE_RECORD_ID, 6);
+    addRoutedScore(
+      scores,
+      WALLET_CHECKER_RECORD_ID,
+      hasWalletCheckContext ? 8 : 4
+    );
+  }
+
+  if (hasConsolidationContext && (hasWalletContext || hasArchitectureContext)) {
+    addRoutedScore(scores, REGISTER_CONSOLIDATION_DOC_RECORD_ID, 8);
+    addRoutedScore(scores, REGISTER_CONSOLIDATION_RECORD_ID, 7);
+    addRoutedScore(scores, CONSOLIDATION_USE_CASES_RECORD_ID, 5);
+    addRoutedScore(scores, WALLET_ARCHITECTURE_RECORD_ID, 5);
+  }
+
+  return scores;
 }
 
 function phraseScore(question: string, record: HelpBotKnowledgeRecord): number {
@@ -230,12 +375,14 @@ function findMatchesInRecords(
     return [];
   }
   const questionTokens = tokenize(question);
+  const routedScores = routedRecordScores(normalizedQuestion);
   return records
     .map((record) => ({
       record,
       score:
         phraseScore(normalizedQuestion, record) +
-        keywordScore(questionTokens, record)
+        keywordScore(questionTokens, record) +
+        (routedScores.get(record.id) ?? 0)
     }))
     .filter((match) => match.score >= MINIMUM_MATCH_SCORE)
     .sort((a, b) => b.score - a.score || a.record.id.localeCompare(b.record.id))

--- a/src/help-bot/help-bot.knowledge.ts
+++ b/src/help-bot/help-bot.knowledge.ts
@@ -84,6 +84,22 @@ const ARCHITECTURE_CONTEXT_PATTERNS = [
   /\btransaction\b/
 ] as const;
 
+const EXPLICIT_ARCHITECTURE_CONTEXT_PATTERNS = [
+  /\barchitecture\b/,
+  /\barchitectures\b/,
+  /\btap\b/,
+  /\bthree address\b/,
+  /\bfour address\b/,
+  /\b3 address\b/,
+  /\b4 address\b/,
+  /\bthree wallets?\b/,
+  /\bfour wallets?\b/,
+  /\b3 wallets?\b/,
+  /\b4 wallets?\b/,
+  /\bmultiple wallets?\b/,
+  /\bseveral wallets?\b/
+] as const;
+
 const CONSOLIDATION_CONTEXT_PATTERNS = [
   /\bconsolidat(?:e|es|ed|ing|ion|ions)\b/,
   /\bcount(?:ed)? together\b/,
@@ -102,12 +118,12 @@ const WALLET_CHECK_CONTEXT_PATTERNS = [
   /\bshow\b/
 ] as const;
 
-const WALLET_ARCHITECTURE_RECORD_ID = 'delegation.wallet-architecture';
-const WALLET_CHECKER_RECORD_ID = 'delegation.wallet-checker';
-const CONSOLIDATION_USE_CASES_RECORD_ID = 'delegation.consolidation-use-cases';
-const REGISTER_CONSOLIDATION_RECORD_ID = 'delegation.register-consolidation';
-const REGISTER_CONSOLIDATION_DOC_RECORD_ID =
-  'delegation.register-consolidation-doc';
+const WALLET_ARCHITECTURE_PATH = '/delegation/wallet-architecture';
+const WALLET_CHECKER_PATH = '/delegation/wallet-checker';
+const CONSOLIDATION_USE_CASES_PATH = '/delegation/consolidation-use-cases';
+const REGISTER_CONSOLIDATION_PATH = '/delegation/register-consolidation';
+const REGISTER_CONSOLIDATION_DOC_PATH =
+  '/delegation/delegation-faq/register-consolidation';
 
 export class HelpBotKnowledgeUnavailableError extends Error {
   constructor(
@@ -256,10 +272,16 @@ function tokenVariants(token: string): string[] {
   if (token.length > 4 && token.endsWith('ies')) {
     variants.push(`${token.slice(0, -3)}y`);
   }
-  if (token.length > 3 && token.endsWith('s') && !token.endsWith('ss')) {
+  if (isSafeTrailingPlural(token)) {
     variants.push(token.slice(0, -1));
   }
   return variants;
+}
+
+function isSafeTrailingPlural(token: string): boolean {
+  return (
+    token.length > 3 && token.endsWith('s') && !/(ss|us|is|ias)$/.test(token)
+  );
 }
 
 function normalizedPhraseTokens(value: string): string[] {
@@ -280,7 +302,7 @@ function containsNormalizedPhrase(
     return true;
   }
   const questionTokens = normalizedPhraseTokens(normalizedQuestion);
-  const phraseTokens = normalizedPhraseTokens(phrase);
+  const phraseTokens = normalizedPhraseTokens(normalizedPhrase);
   if (!phraseTokens.length || phraseTokens.length > questionTokens.length) {
     return false;
   }
@@ -304,10 +326,10 @@ function matchesAny(
 
 function addRoutedScore(
   scores: Map<string, number>,
-  recordId: string,
+  canonicalPath: string,
   score: number
 ): void {
-  scores.set(recordId, Math.max(scores.get(recordId) ?? 0, score));
+  scores.set(canonicalPath, Math.max(scores.get(canonicalPath) ?? 0, score));
 }
 
 function routedRecordScores(
@@ -321,6 +343,10 @@ function routedRecordScores(
     normalizedQuestion,
     ARCHITECTURE_CONTEXT_PATTERNS
   );
+  const hasExplicitArchitectureContext = matchesAny(
+    normalizedQuestion,
+    EXPLICIT_ARCHITECTURE_CONTEXT_PATTERNS
+  );
   const hasConsolidationContext = matchesAny(
     normalizedQuestion,
     CONSOLIDATION_CONTEXT_PATTERNS
@@ -331,20 +357,19 @@ function routedRecordScores(
   );
   const scores = new Map<string, number>();
 
-  if (hasArchitectureContext && (hasWalletContext || hasWalletCheckContext)) {
-    addRoutedScore(scores, WALLET_ARCHITECTURE_RECORD_ID, 6);
-    addRoutedScore(
-      scores,
-      WALLET_CHECKER_RECORD_ID,
-      hasWalletCheckContext ? 8 : 4
-    );
+  if (
+    (hasArchitectureContext && hasWalletContext) ||
+    (hasExplicitArchitectureContext && hasWalletCheckContext)
+  ) {
+    addRoutedScore(scores, WALLET_ARCHITECTURE_PATH, 6);
+    addRoutedScore(scores, WALLET_CHECKER_PATH, hasWalletCheckContext ? 8 : 4);
   }
 
   if (hasConsolidationContext && (hasWalletContext || hasArchitectureContext)) {
-    addRoutedScore(scores, REGISTER_CONSOLIDATION_DOC_RECORD_ID, 8);
-    addRoutedScore(scores, REGISTER_CONSOLIDATION_RECORD_ID, 7);
-    addRoutedScore(scores, CONSOLIDATION_USE_CASES_RECORD_ID, 5);
-    addRoutedScore(scores, WALLET_ARCHITECTURE_RECORD_ID, 5);
+    addRoutedScore(scores, REGISTER_CONSOLIDATION_DOC_PATH, 8);
+    addRoutedScore(scores, REGISTER_CONSOLIDATION_PATH, 7);
+    addRoutedScore(scores, CONSOLIDATION_USE_CASES_PATH, 5);
+    addRoutedScore(scores, WALLET_ARCHITECTURE_PATH, 5);
   }
 
   return scores;
@@ -382,7 +407,7 @@ function findMatchesInRecords(
       score:
         phraseScore(normalizedQuestion, record) +
         keywordScore(questionTokens, record) +
-        (routedScores.get(record.id) ?? 0)
+        (routedScores.get(record.canonicalPath) ?? 0)
     }))
     .filter((match) => match.score >= MINIMUM_MATCH_SCORE)
     .sort((a, b) => b.score - a.score || a.record.id.localeCompare(b.record.id))


### PR DESCRIPTION
## Summary
- Add narrow backend retrieval routing for wallet architecture and consolidation setup questions.
- Match simple plural product terms against singular aliases.
- Cover the routing behavior with knowledge-source and answerer tests.

## Validation
- `npm test -- --runInBand src/help-bot/help-bot-knowledge.test.ts src/help-bot/help-bot-answerer.test.ts`
- `npm run lint`