### PR TITLE
Route Help6529 product concepts deterministically

### DIFF
--- a/src/help-bot/help-bot-answerer.test.ts
+++ b/src/help-bot/help-bot-answerer.test.ts
@@ -1062,6 +1062,46 @@ describe('HelpBotAnswerer', () => {
     }
   });
 
+  it('does not add source links for records that suppress source links', async () => {
+    const index: HelpBotKnowledgeIndex = {
+      ...TEST_INDEX,
+      records: [
+        {
+          id: 'wallet.connection-sharing',
+          kind: 'workflow',
+          title: 'Connection sharing',
+          linkLabel: 'Connection sharing',
+          canonicalPath: '/',
+          suppressSourceLinks: true,
+          aliases: ['share connection'],
+          keywords: ['share', 'connection', 'mobile', 'desktop'],
+          facts: [
+            'Use the profile menu to share your current connection.',
+            'Connection sharing can create a QR code for the mobile app or a deep link for the desktop app.'
+          ],
+          relatedPaths: [],
+          tags: ['auth', 'wallet'],
+          sourceRefs: []
+        }
+      ]
+    };
+    const renderer: HelpBotLlmRenderer = {
+      renderAnswer: jest.fn().mockResolvedValue('Use the profile menu.')
+    };
+
+    const answer = await answerer(renderer, undefined, undefined, index).answer(
+      {
+        question: 'how do I share connection?',
+        baseUrl: BASE_URL
+      }
+    );
+
+    expect(answer.type).toBe('ANSWER');
+    if (answer.type === 'ANSWER') {
+      expect(answer.answer).toBe('Use the profile menu.');
+    }
+  });
+
   it('strips help bot self-intros from rendered answers', async () => {
     const renderer: HelpBotLlmRenderer = {
       renderAnswer: jest

--- a/src/help-bot/help-bot-bedrock-renderer.test.ts
+++ b/src/help-bot/help-bot-bedrock-renderer.test.ts
@@ -116,6 +116,47 @@ describe('HelpBotBedrockRenderer', () => {
     );
   });
 
+  it('does not require source links for records that suppress them', async () => {
+    const send = jest.fn().mockResolvedValue({
+      body: Buffer.from(
+        JSON.stringify({
+          content: [{ type: 'text', text: 'Use the profile menu.' }]
+        })
+      )
+    });
+    const renderer = new HelpBotBedrockRenderer(
+      'anthropic.test-model',
+      () => ({ send }) as never,
+      100
+    );
+
+    await renderer.renderAnswer({
+      question: 'how do i share connection?',
+      record: {
+        ...RECORD,
+        id: 'wallet.connection-sharing',
+        title: 'Connection sharing',
+        linkLabel: 'Connection sharing',
+        canonicalPath: '/',
+        suppressSourceLinks: true,
+        aliases: ['share connection'],
+        keywords: ['share', 'connection'],
+        facts: ['Use the profile menu to open the Share menu.']
+      },
+      canonicalUrl: 'https://6529.io/'
+    });
+
+    expect(readPrompt(send)).toContain(
+      'Do not include source links unless the provided facts explicitly require one.'
+    );
+    expect(readPrompt(send)).not.toContain(
+      'Include this URL exactly once as a Markdown link target'
+    );
+    expect(readPrompt(send)).not.toContain(
+      'Use this exact Markdown link label for that URL'
+    );
+  });
+
   it('aborts a slow Bedrock response', async () => {
     const send = jest.fn(
       (

--- a/src/help-bot/help-bot-knowledge.test.ts
+++ b/src/help-bot/help-bot-knowledge.test.ts
@@ -345,4 +345,185 @@ describe('StaticHelpBotKnowledgeSource', () => {
       'delegation.faq'
     ]);
   });
+
+  it.each([
+    {
+      question: 'what is Genesis Set',
+      expectedRecordIds: ['network.definitions.genesis-sets']
+    },
+    {
+      question: 'what are Genesis Sets',
+      expectedRecordIds: ['network.definitions.genesis-sets']
+    },
+    {
+      question: 'what is Meme Set',
+      expectedRecordIds: ['network.definitions.meme-sets']
+    },
+    {
+      question: 'what is TDH unweighted',
+      expectedRecordIds: ['network.definitions.tdh-unweighted']
+    },
+    {
+      question: 'how can I check my architecture',
+      expectedRecordIds: [
+        'delegation.wallet-checker',
+        'delegation.wallet-architecture'
+      ]
+    },
+    {
+      question: 'what is wallet architecture',
+      expectedRecordIds: ['delegation.wallet-architecture']
+    },
+    {
+      question: 'how do I check delegations/consolidations',
+      expectedRecordIds: ['delegation.wallet-checker']
+    },
+    {
+      question: 'what is Nakamoto Set',
+      expectedRecordIds: ['network.tdh.nakamoto-set']
+    },
+    {
+      question: 'how can i check my architecture and view delegations',
+      expectedRecordIds: [
+        'delegation.wallet-checker',
+        'delegation.wallet-architecture'
+      ]
+    }
+  ])(
+    'routes "$question" to explicit help bot concept records',
+    async ({ question, expectedRecordIds }) => {
+      const source = new StaticHelpBotKnowledgeSource({
+        ...index,
+        records: index.records.concat([
+          {
+            id: 'network.definitions',
+            kind: 'glossary',
+            title: 'Network definitions',
+            linkLabel: 'Network definitions',
+            canonicalPath: '/network/definitions',
+            aliases: ['network definitions', 'genesis set'],
+            keywords: ['definitions', 'network', 'genesis'],
+            facts: ['Network definitions explain metric terms.'],
+            relatedPaths: ['/network/tdh'],
+            tags: ['network', 'glossary'],
+            sourceRefs: []
+          },
+          {
+            id: 'network.definitions.genesis-sets',
+            kind: 'concept',
+            title: 'Genesis Sets',
+            linkLabel: 'Genesis Sets',
+            canonicalPath: '/network/definitions',
+            aliases: ['genesis set', 'genesis sets'],
+            keywords: ['genesis', 'set', 'sets', 'tdh'],
+            facts: [
+              'Genesis Sets are complete sets of the first three Meme NFTs.'
+            ],
+            relatedPaths: ['/network/tdh'],
+            tags: ['network', 'concept'],
+            sourceRefs: []
+          },
+          {
+            id: 'network.definitions.meme-sets',
+            kind: 'concept',
+            title: 'Meme Sets',
+            linkLabel: 'Meme Sets',
+            canonicalPath: '/network/definitions',
+            aliases: ['meme set', 'meme sets'],
+            keywords: ['meme', 'memes', 'set', 'sets'],
+            facts: ['Meme Sets are complete sets of The Memes.'],
+            relatedPaths: ['/network/tdh'],
+            tags: ['network', 'concept'],
+            sourceRefs: []
+          },
+          {
+            id: 'network.definitions.tdh-unweighted',
+            kind: 'concept',
+            title: 'TDH (unweighted)',
+            linkLabel: 'TDH unweighted',
+            canonicalPath: '/network/definitions',
+            aliases: ['tdh unweighted', 'unweighted tdh', 'raw tdh'],
+            keywords: ['tdh', 'unweighted', 'raw'],
+            facts: ['TDH unweighted is one unit per NFT per day held.'],
+            relatedPaths: ['/network/tdh'],
+            tags: ['network', 'tdh', 'concept'],
+            sourceRefs: []
+          },
+          {
+            id: 'network.tdh',
+            kind: 'glossary',
+            title: 'TDH',
+            linkLabel: 'TDH',
+            canonicalPath: '/network/tdh',
+            aliases: ['tdh', 'total days held'],
+            keywords: ['tdh', 'boost', 'genesis', 'nakamoto'],
+            facts: ['TDH means Total Days Held.'],
+            relatedPaths: ['/network/definitions'],
+            tags: ['network', 'tdh'],
+            sourceRefs: []
+          },
+          {
+            id: 'network.tdh.nakamoto-set',
+            kind: 'concept',
+            title: 'Nakamoto Set',
+            linkLabel: 'Nakamoto Set',
+            canonicalPath: '/network/tdh',
+            aliases: ['nakamoto set', 'nakamoto sets'],
+            keywords: ['nakamoto', 'set', 'sets', 'tdh', 'boost'],
+            facts: ['Nakamoto Set is a SZN1 Category B TDH boost term.'],
+            relatedPaths: ['/network/definitions'],
+            tags: ['network', 'tdh', 'concept'],
+            sourceRefs: []
+          },
+          {
+            id: 'delegation.wallet-architecture',
+            kind: 'workflow',
+            title: 'Wallet Architecture',
+            linkLabel: 'Wallet Architecture',
+            canonicalPath: '/delegation/wallet-architecture',
+            aliases: ['wallet architecture', 'architecture'],
+            keywords: ['wallet', 'architecture', 'vault'],
+            facts: [
+              'Wallet architecture separates vault, transaction, and minting wallets.'
+            ],
+            relatedPaths: ['/delegation/wallet-checker'],
+            tags: ['delegation', 'wallet'],
+            sourceRefs: []
+          },
+          {
+            id: 'delegation.wallet-checker',
+            kind: 'route',
+            title: 'Wallet Checker',
+            linkLabel: 'Wallet Checker',
+            canonicalPath: '/delegation/wallet-checker',
+            aliases: ['wallet checker', 'check wallet architecture'],
+            keywords: [
+              'wallet',
+              'checker',
+              'check',
+              'view',
+              'delegations',
+              'consolidations',
+              'architecture'
+            ],
+            facts: [
+              'Wallet Checker reviews active delegations and consolidations.'
+            ],
+            relatedPaths: ['/delegation/wallet-architecture'],
+            tags: ['delegation', 'wallet'],
+            sourceRefs: []
+          }
+        ])
+      });
+
+      const matches = await source.findMatches!(
+        question,
+        expectedRecordIds.length
+      );
+
+      expect(matches.map((match) => match.record.id)).toEqual(
+        expectedRecordIds
+      );
+    }
+  );
 });

--- a/src/help-bot/help-bot-knowledge.test.ts
+++ b/src/help-bot/help-bot-knowledge.test.ts
@@ -396,6 +396,10 @@ describe('StaticHelpBotKnowledgeSource', () => {
       expectedRecordIds: ['delegation.wallet-checker']
     },
     {
+      question: 'how many wallets can be in one consolidation group',
+      expectedRecordIds: ['delegation.consolidation-use-cases']
+    },
+    {
       question: 'what is Nakamoto Set',
       expectedRecordIds: ['network.tdh.nakamoto-set']
     },
@@ -525,6 +529,21 @@ describe('StaticHelpBotKnowledgeSource', () => {
             ],
             facts: [
               'Wallet Checker reviews active delegations and consolidations.'
+            ],
+            relatedPaths: ['/delegation/wallet-architecture'],
+            tags: ['delegation', 'wallet'],
+            sourceRefs: []
+          },
+          {
+            id: 'delegation.consolidation-use-cases',
+            kind: 'workflow',
+            title: 'Consolidation Use Cases',
+            linkLabel: 'Consolidation Use Cases',
+            canonicalPath: '/delegation/consolidation-use-cases',
+            aliases: ['consolidation use cases'],
+            keywords: ['consolidation', 'wallet', 'limit'],
+            facts: [
+              '6529 recognizes up to three addresses as one consolidation group.'
             ],
             relatedPaths: ['/delegation/wallet-architecture'],
             tags: ['delegation', 'wallet'],

--- a/src/help-bot/help-bot-knowledge.test.ts
+++ b/src/help-bot/help-bot-knowledge.test.ts
@@ -31,6 +31,7 @@ describe('FrontendHelpBotKnowledgeSource', () => {
             aliases: ['tdh', 'total days held'],
             keywords: ['tdh', 'total', 'days', 'held'],
             facts: ['TDH stands for Total Days Held.'],
+            suppress_source_links: true,
             related_paths: ['/network/definitions'],
             tags: ['network'],
             source_refs: ['ops/help/help-index.json']
@@ -44,6 +45,7 @@ describe('FrontendHelpBotKnowledgeSource', () => {
     expect(match?.record.id).toBe('network.tdh');
     expect(match?.record.linkLabel).toBe('TDH page');
     expect(match?.record.canonicalPath).toBe('/network/tdh');
+    expect(match?.record.suppressSourceLinks).toBe(true);
     expect(match?.record.relatedPaths).toEqual(['/network/definitions']);
     expect(match?.record.sourceRefs).toEqual(['ops/help/help-index.json']);
   });

--- a/src/help-bot/help-bot-knowledge.test.ts
+++ b/src/help-bot/help-bot-knowledge.test.ts
@@ -183,7 +183,9 @@ describe('FrontendHelpBotKnowledgeSource', () => {
             canonical_path: '/delegation/consolidation-use-cases',
             aliases: ['consolidation use cases'],
             keywords: ['consolidation', 'wallet'],
-            facts: ['Consolidation covers multi-wallet patterns.']
+            facts: [
+              '6529 recognizes up to three addresses as one consolidation group.'
+            ]
           }
         ]
       })
@@ -195,8 +197,7 @@ describe('FrontendHelpBotKnowledgeSource', () => {
     );
 
     const matchIds = matches.map((match) => match.record.id);
-    expect(matchIds[0]).toBe('delegation.register-consolidation-doc');
-    expect(matchIds[1]).toBe('delegation.register-consolidation');
+    expect(matchIds[0]).toBe('delegation.consolidation-use-cases');
     expect(new Set(matchIds)).toEqual(
       new Set([
         'delegation.register-consolidation-doc',
@@ -312,9 +313,24 @@ describe('StaticHelpBotKnowledgeSource', () => {
           title: 'Wallet Architecture',
           linkLabel: 'Wallet Architecture',
           canonicalPath: '/delegation/wallet-architecture',
-          aliases: ['wallet architecture', '4 wallet architecture'],
+          aliases: ['wallet architecture'],
           keywords: ['wallet', 'architecture', 'vault'],
           facts: ['Separate vault, transaction, and minting wallets.'],
+          relatedPaths: [],
+          tags: ['delegation'],
+          sourceRefs: []
+        },
+        {
+          id: 'delegation.consolidation-use-cases',
+          kind: 'workflow',
+          title: 'Consolidation Use Cases',
+          linkLabel: 'Consolidation Use Cases',
+          canonicalPath: '/delegation/consolidation-use-cases',
+          aliases: ['consolidation use cases'],
+          keywords: ['consolidation', 'wallet', 'limit'],
+          facts: [
+            '6529 recognizes up to three addresses as one consolidation group.'
+          ],
           relatedPaths: [],
           tags: ['delegation'],
           sourceRefs: []
@@ -337,11 +353,12 @@ describe('StaticHelpBotKnowledgeSource', () => {
 
     const matches = await source.findMatches!(
       'how do i set up a 4 wallet architecture with delegation docs',
-      2
+      3
     );
 
     expect(matches.map((match) => match.record.id)).toEqual([
       'delegation.wallet-architecture',
+      'delegation.consolidation-use-cases',
       'delegation.faq'
     ]);
   });

--- a/src/help-bot/help-bot.answerer.ts
+++ b/src/help-bot/help-bot.answerer.ts
@@ -238,6 +238,9 @@ function ensureKnowledgeMarkdownLinks({
   readonly record: HelpBotKnowledgeRecord;
   readonly baseUrl: string;
 }): string {
+  if (record.suppressSourceLinks) {
+    return text;
+  }
   const links = buildKnowledgeSourceLinks(record, baseUrl);
   const canonicalLink = links[0];
   if (!canonicalLink) {

--- a/src/help-bot/help-bot.bedrock-renderer.ts
+++ b/src/help-bot/help-bot.bedrock-renderer.ts
@@ -41,6 +41,15 @@ function buildPrompt({
   readonly canonicalUrl: string;
 }): string {
   const factLines = record.facts.map((fact) => `- ${fact}`).join('\n');
+  const linkGuidance = record.suppressSourceLinks
+    ? [
+        'Do not include source links unless the provided facts explicitly require one.'
+      ]
+    : [
+        MARKDOWN_LINK_GUIDANCE,
+        `Include this URL exactly once as a Markdown link target: ${canonicalUrl}`,
+        `Use this exact Markdown link label for that URL: ${record.linkLabel}`
+      ];
   return [
     `You are ${HELP_BOT_MENTION}, a concise helper bot for 6529.io.`,
     'Answer only from the provided facts.',
@@ -48,9 +57,7 @@ function buildPrompt({
     'Use one or two short paragraphs.',
     TONE_GUIDANCE,
     NO_SELF_INTRO_GUIDANCE,
-    MARKDOWN_LINK_GUIDANCE,
-    `Include this URL exactly once as a Markdown link target: ${canonicalUrl}`,
-    `Use this exact Markdown link label for that URL: ${record.linkLabel}`,
+    ...linkGuidance,
     previousBotAnswer
       ? `Previous bot answer for context:\n${previousBotAnswer}`
       : '',

--- a/src/help-bot/help-bot.knowledge.ts
+++ b/src/help-bot/help-bot.knowledge.ts
@@ -124,6 +124,59 @@ const CONSOLIDATION_USE_CASES_PATH = '/delegation/consolidation-use-cases';
 const REGISTER_CONSOLIDATION_PATH = '/delegation/register-consolidation';
 const REGISTER_CONSOLIDATION_DOC_PATH =
   '/delegation/delegation-faq/register-consolidation';
+const WALLET_ARCHITECTURE_ID = 'delegation.wallet-architecture';
+const WALLET_CHECKER_ID = 'delegation.wallet-checker';
+const NETWORK_DEFINITIONS_ID = 'network.definitions';
+const GENESIS_SETS_ID = 'network.definitions.genesis-sets';
+const MEME_SETS_ID = 'network.definitions.meme-sets';
+const MEME_SETS_MINUS_ID = 'network.definitions.meme-sets-minus';
+const TDH_UNWEIGHTED_ID = 'network.definitions.tdh-unweighted';
+const TDH_UNBOOSTED_ID = 'network.definitions.tdh-unboosted';
+const NAKAMOTO_SET_ID = 'network.tdh.nakamoto-set';
+const NETWORK_TDH_ID = 'network.tdh';
+
+const DELEGATION_CONTEXT_PATTERNS = [
+  /\bdelegat(?:e|es|ed|ing|ion|ions)\b/,
+  /\bdelegation managers?\b/,
+  /\bminting delegation\b/
+] as const;
+
+const GENESIS_SET_PATTERNS = [/\bgenesis sets?\b/] as const;
+
+const NAKAMOTO_SET_PATTERNS = [/\bnakamoto sets?\b/] as const;
+
+const MEME_SET_MINUS_PATTERNS = [
+  /\bmeme sets?\s*(?:-|minus)\s*(?:1|one|2|two)\b/,
+  /\bsets?\s+missing\s+(?:1|one|2|two)\s+cards?\b/
+] as const;
+
+const MEME_SET_PATTERNS = [
+  /\bmeme sets?\b/,
+  /\bcomplete meme sets?\b/,
+  /\bseason sets?\b/
+] as const;
+
+const TDH_UNWEIGHTED_PATTERNS = [
+  /\btdh\s+unweighted\b/,
+  /\bunweighted\s+tdh\b/,
+  /\braw\s+tdh\b/,
+  /\btdh__raw\b/
+] as const;
+
+const TDH_UNBOOSTED_PATTERNS = [
+  /\btdh\s+unboosted\b/,
+  /\bunboosted\s+tdh\b/,
+  /\bweighted\s+tdh\b/,
+  /\bedition weighted\s+tdh\b/
+] as const;
+
+function routedIdKey(id: string): string {
+  return `id:${id}`;
+}
+
+function routedPathKey(path: string): string {
+  return `path:${path}`;
+}
 
 export class HelpBotKnowledgeUnavailableError extends Error {
   constructor(
@@ -267,6 +320,20 @@ function tokenize(value: string): Set<string> {
   return tokens;
 }
 
+function uniqueStrings(values: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const unique: string[] = [];
+  for (const value of values) {
+    const key = value.toLowerCase();
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    unique.push(value);
+  }
+  return unique;
+}
+
 function tokenVariants(token: string): string[] {
   const variants = [token];
   if (token.length > 4 && token.endsWith('ies')) {
@@ -326,10 +393,26 @@ function matchesAny(
 
 function addRoutedScore(
   scores: Map<string, number>,
+  key: string,
+  score: number
+): void {
+  scores.set(key, Math.max(scores.get(key) ?? 0, score));
+}
+
+function addRoutedIdScore(
+  scores: Map<string, number>,
+  id: string,
+  score: number
+): void {
+  addRoutedScore(scores, routedIdKey(id), score);
+}
+
+function addRoutedPathScore(
+  scores: Map<string, number>,
   canonicalPath: string,
   score: number
 ): void {
-  scores.set(canonicalPath, Math.max(scores.get(canonicalPath) ?? 0, score));
+  addRoutedScore(scores, routedPathKey(canonicalPath), score);
 }
 
 function routedRecordScores(
@@ -351,43 +434,130 @@ function routedRecordScores(
     normalizedQuestion,
     CONSOLIDATION_CONTEXT_PATTERNS
   );
+  const hasDelegationContext = matchesAny(
+    normalizedQuestion,
+    DELEGATION_CONTEXT_PATTERNS
+  );
   const hasWalletCheckContext = matchesAny(
     normalizedQuestion,
     WALLET_CHECK_CONTEXT_PATTERNS
   );
   const scores = new Map<string, number>();
 
+  if (hasExplicitArchitectureContext) {
+    addRoutedIdScore(scores, WALLET_ARCHITECTURE_ID, 8);
+    addRoutedPathScore(scores, WALLET_ARCHITECTURE_PATH, 4);
+  }
+
   if (
     (hasArchitectureContext && hasWalletContext) ||
     (hasExplicitArchitectureContext && hasWalletCheckContext)
   ) {
-    addRoutedScore(scores, WALLET_ARCHITECTURE_PATH, 6);
-    addRoutedScore(scores, WALLET_CHECKER_PATH, hasWalletCheckContext ? 8 : 4);
+    addRoutedIdScore(scores, WALLET_ARCHITECTURE_ID, 8);
+    addRoutedPathScore(scores, WALLET_ARCHITECTURE_PATH, 5);
+    addRoutedIdScore(scores, WALLET_CHECKER_ID, hasWalletCheckContext ? 10 : 4);
+    addRoutedPathScore(
+      scores,
+      WALLET_CHECKER_PATH,
+      hasWalletCheckContext ? 7 : 3
+    );
+  }
+
+  if (
+    hasWalletCheckContext &&
+    (hasDelegationContext || hasConsolidationContext)
+  ) {
+    addRoutedIdScore(scores, WALLET_CHECKER_ID, 10);
+    addRoutedPathScore(scores, WALLET_CHECKER_PATH, 7);
   }
 
   if (hasConsolidationContext && (hasWalletContext || hasArchitectureContext)) {
-    addRoutedScore(scores, REGISTER_CONSOLIDATION_DOC_PATH, 8);
-    addRoutedScore(scores, REGISTER_CONSOLIDATION_PATH, 7);
-    addRoutedScore(scores, CONSOLIDATION_USE_CASES_PATH, 5);
-    addRoutedScore(scores, WALLET_ARCHITECTURE_PATH, 5);
+    addRoutedPathScore(scores, REGISTER_CONSOLIDATION_DOC_PATH, 16);
+    addRoutedPathScore(scores, REGISTER_CONSOLIDATION_PATH, 15);
+    addRoutedPathScore(scores, CONSOLIDATION_USE_CASES_PATH, 9);
+    addRoutedIdScore(scores, WALLET_ARCHITECTURE_ID, 5);
+    addRoutedPathScore(scores, WALLET_ARCHITECTURE_PATH, 4);
+  }
+
+  if (matchesAny(normalizedQuestion, GENESIS_SET_PATTERNS)) {
+    addRoutedIdScore(scores, GENESIS_SETS_ID, 12);
+    addRoutedIdScore(scores, NETWORK_DEFINITIONS_ID, 4);
+    addRoutedIdScore(scores, NETWORK_TDH_ID, 3);
+  }
+
+  if (matchesAny(normalizedQuestion, NAKAMOTO_SET_PATTERNS)) {
+    addRoutedIdScore(scores, NAKAMOTO_SET_ID, 12);
+    addRoutedIdScore(scores, NETWORK_TDH_ID, 4);
+  }
+
+  if (matchesAny(normalizedQuestion, MEME_SET_MINUS_PATTERNS)) {
+    addRoutedIdScore(scores, MEME_SETS_MINUS_ID, 12);
+    addRoutedIdScore(scores, MEME_SETS_ID, 4);
+    addRoutedIdScore(scores, NETWORK_DEFINITIONS_ID, 3);
+  } else if (matchesAny(normalizedQuestion, MEME_SET_PATTERNS)) {
+    addRoutedIdScore(scores, MEME_SETS_ID, 12);
+    addRoutedIdScore(scores, NETWORK_DEFINITIONS_ID, 3);
+  }
+
+  if (matchesAny(normalizedQuestion, TDH_UNWEIGHTED_PATTERNS)) {
+    addRoutedIdScore(scores, TDH_UNWEIGHTED_ID, 12);
+    addRoutedIdScore(scores, NETWORK_TDH_ID, 4);
+  }
+
+  if (matchesAny(normalizedQuestion, TDH_UNBOOSTED_PATTERNS)) {
+    addRoutedIdScore(scores, TDH_UNBOOSTED_ID, 12);
+    addRoutedIdScore(scores, NETWORK_TDH_ID, 4);
   }
 
   return scores;
 }
 
 function phraseScore(question: string, record: HelpBotKnowledgeRecord): number {
-  return record.aliases.reduce((score, alias) => {
-    return containsNormalizedPhrase(question, alias) ? score + 3 : score;
-  }, 0);
+  return uniqueStrings([record.title, ...record.aliases]).reduce(
+    (score, alias) => {
+      return containsNormalizedPhrase(question, alias) ? score + 3 : score;
+    },
+    0
+  );
+}
+
+function keywordMatches(questionTokens: Set<string>, keyword: string): boolean {
+  const normalizedKeyword = normalizeText(keyword);
+  if (!normalizedKeyword) {
+    return false;
+  }
+  if (questionTokens.has(normalizedKeyword)) {
+    return true;
+  }
+  const keywordTokens = normalizedPhraseTokens(normalizedKeyword);
+  return (
+    keywordTokens.length === 1 &&
+    tokenVariants(keywordTokens[0]).some((variant) =>
+      questionTokens.has(variant)
+    )
+  );
 }
 
 function keywordScore(
   questionTokens: Set<string>,
   record: HelpBotKnowledgeRecord
 ): number {
-  return record.keywords.reduce((score, keyword) => {
-    return questionTokens.has(normalizeText(keyword)) ? score + 1 : score;
-  }, 0);
+  return uniqueStrings([...record.keywords, ...record.tags]).reduce(
+    (score, keyword) => {
+      return keywordMatches(questionTokens, keyword) ? score + 1 : score;
+    },
+    0
+  );
+}
+
+function routedScore(
+  routedScores: ReadonlyMap<string, number>,
+  record: HelpBotKnowledgeRecord
+): number {
+  return (
+    (routedScores.get(routedIdKey(record.id)) ?? 0) +
+    (routedScores.get(routedPathKey(record.canonicalPath)) ?? 0)
+  );
 }
 
 function findMatchesInRecords(
@@ -407,7 +577,7 @@ function findMatchesInRecords(
       score:
         phraseScore(normalizedQuestion, record) +
         keywordScore(questionTokens, record) +
-        (routedScores.get(record.canonicalPath) ?? 0)
+        routedScore(routedScores, record)
     }))
     .filter((match) => match.score >= MINIMUM_MATCH_SCORE)
     .sort((a, b) => b.score - a.score || a.record.id.localeCompare(b.record.id))

--- a/src/help-bot/help-bot.knowledge.ts
+++ b/src/help-bot/help-bot.knowledge.ts
@@ -455,108 +455,168 @@ function addRoutedPathScore(
   addRoutedScore(scores, routedPathKey(canonicalPath), score);
 }
 
-function routedRecordScores(
-  normalizedQuestion: string
-): ReadonlyMap<string, number> {
-  const hasWalletContext = matchesAny(
-    normalizedQuestion,
-    WALLET_CONTEXT_PATTERNS
-  );
-  const hasArchitectureContext = matchesAny(
-    normalizedQuestion,
-    ARCHITECTURE_CONTEXT_PATTERNS
-  );
-  const hasExplicitArchitectureContext = matchesAny(
-    normalizedQuestion,
-    EXPLICIT_ARCHITECTURE_CONTEXT_PATTERNS
-  );
-  const hasConsolidationContext = matchesAny(
-    normalizedQuestion,
-    CONSOLIDATION_CONTEXT_PATTERNS
-  );
-  const hasDelegationContext = matchesAny(
-    normalizedQuestion,
-    DELEGATION_CONTEXT_PATTERNS
-  );
-  const hasWalletCheckContext = matchesAny(
-    normalizedQuestion,
-    WALLET_CHECK_CONTEXT_PATTERNS
-  );
-  const overLimitWalletCount =
-    requestedOverLimitWalletCount(normalizedQuestion);
-  const scores = new Map<string, number>();
+interface RoutedQuestionContext {
+  readonly normalizedQuestion: string;
+  readonly hasWalletContext: boolean;
+  readonly hasArchitectureContext: boolean;
+  readonly hasExplicitArchitectureContext: boolean;
+  readonly hasConsolidationContext: boolean;
+  readonly hasDelegationContext: boolean;
+  readonly hasWalletCheckContext: boolean;
+  readonly overLimitWalletCount: number | null;
+}
 
-  if (overLimitWalletCount !== null) {
+function routedQuestionContext(
+  normalizedQuestion: string
+): RoutedQuestionContext {
+  return {
+    normalizedQuestion,
+    hasWalletContext: matchesAny(normalizedQuestion, WALLET_CONTEXT_PATTERNS),
+    hasArchitectureContext: matchesAny(
+      normalizedQuestion,
+      ARCHITECTURE_CONTEXT_PATTERNS
+    ),
+    hasExplicitArchitectureContext: matchesAny(
+      normalizedQuestion,
+      EXPLICIT_ARCHITECTURE_CONTEXT_PATTERNS
+    ),
+    hasConsolidationContext: matchesAny(
+      normalizedQuestion,
+      CONSOLIDATION_CONTEXT_PATTERNS
+    ),
+    hasDelegationContext: matchesAny(
+      normalizedQuestion,
+      DELEGATION_CONTEXT_PATTERNS
+    ),
+    hasWalletCheckContext: matchesAny(
+      normalizedQuestion,
+      WALLET_CHECK_CONTEXT_PATTERNS
+    ),
+    overLimitWalletCount: requestedOverLimitWalletCount(normalizedQuestion)
+  };
+}
+
+function addOverLimitWalletScores(
+  scores: Map<string, number>,
+  context: RoutedQuestionContext
+): void {
+  if (context.overLimitWalletCount !== null) {
     addRoutedPathScore(scores, CONSOLIDATION_USE_CASES_PATH, 16);
     addRoutedIdScore(scores, WALLET_ARCHITECTURE_ID, 8);
     addRoutedPathScore(scores, WALLET_ARCHITECTURE_PATH, 5);
     addRoutedPathScore(scores, REGISTER_CONSOLIDATION_DOC_PATH, 5);
   }
+}
 
-  if (hasExplicitArchitectureContext) {
+function addArchitectureScores(
+  scores: Map<string, number>,
+  context: RoutedQuestionContext
+): void {
+  if (context.hasExplicitArchitectureContext) {
     addRoutedIdScore(scores, WALLET_ARCHITECTURE_ID, 8);
     addRoutedPathScore(scores, WALLET_ARCHITECTURE_PATH, 4);
   }
 
   if (
-    (hasArchitectureContext && hasWalletContext) ||
-    (hasExplicitArchitectureContext && hasWalletCheckContext)
+    (context.hasArchitectureContext && context.hasWalletContext) ||
+    (context.hasExplicitArchitectureContext && context.hasWalletCheckContext)
   ) {
     addRoutedIdScore(scores, WALLET_ARCHITECTURE_ID, 8);
     addRoutedPathScore(scores, WALLET_ARCHITECTURE_PATH, 5);
-    addRoutedIdScore(scores, WALLET_CHECKER_ID, hasWalletCheckContext ? 10 : 4);
+    addRoutedIdScore(
+      scores,
+      WALLET_CHECKER_ID,
+      context.hasWalletCheckContext ? 10 : 4
+    );
     addRoutedPathScore(
       scores,
       WALLET_CHECKER_PATH,
-      hasWalletCheckContext ? 7 : 3
+      context.hasWalletCheckContext ? 7 : 3
     );
   }
+}
 
+function addWalletCheckerScores(
+  scores: Map<string, number>,
+  context: RoutedQuestionContext
+): void {
   if (
-    hasWalletCheckContext &&
-    (hasDelegationContext || hasConsolidationContext)
+    context.hasWalletCheckContext &&
+    (context.hasDelegationContext || context.hasConsolidationContext)
   ) {
     addRoutedIdScore(scores, WALLET_CHECKER_ID, 10);
     addRoutedPathScore(scores, WALLET_CHECKER_PATH, 7);
   }
+}
 
-  if (hasConsolidationContext && (hasWalletContext || hasArchitectureContext)) {
+function addConsolidationScores(
+  scores: Map<string, number>,
+  context: RoutedQuestionContext
+): void {
+  if (
+    context.hasConsolidationContext &&
+    (context.hasWalletContext || context.hasArchitectureContext)
+  ) {
     addRoutedPathScore(scores, REGISTER_CONSOLIDATION_DOC_PATH, 16);
     addRoutedPathScore(scores, REGISTER_CONSOLIDATION_PATH, 15);
     addRoutedPathScore(scores, CONSOLIDATION_USE_CASES_PATH, 9);
     addRoutedIdScore(scores, WALLET_ARCHITECTURE_ID, 5);
     addRoutedPathScore(scores, WALLET_ARCHITECTURE_PATH, 4);
   }
+}
 
-  if (matchesAny(normalizedQuestion, GENESIS_SET_PATTERNS)) {
+function addNetworkDefinitionScores(
+  scores: Map<string, number>,
+  context: RoutedQuestionContext
+): void {
+  if (matchesAny(context.normalizedQuestion, GENESIS_SET_PATTERNS)) {
     addRoutedIdScore(scores, GENESIS_SETS_ID, 12);
     addRoutedIdScore(scores, NETWORK_DEFINITIONS_ID, 4);
     addRoutedIdScore(scores, NETWORK_TDH_ID, 3);
   }
 
-  if (matchesAny(normalizedQuestion, NAKAMOTO_SET_PATTERNS)) {
+  if (matchesAny(context.normalizedQuestion, NAKAMOTO_SET_PATTERNS)) {
     addRoutedIdScore(scores, NAKAMOTO_SET_ID, 12);
     addRoutedIdScore(scores, NETWORK_TDH_ID, 4);
   }
 
-  if (matchesAny(normalizedQuestion, MEME_SET_MINUS_PATTERNS)) {
+  if (matchesAny(context.normalizedQuestion, MEME_SET_MINUS_PATTERNS)) {
     addRoutedIdScore(scores, MEME_SETS_MINUS_ID, 12);
     addRoutedIdScore(scores, MEME_SETS_ID, 4);
     addRoutedIdScore(scores, NETWORK_DEFINITIONS_ID, 3);
-  } else if (matchesAny(normalizedQuestion, MEME_SET_PATTERNS)) {
+  } else if (matchesAny(context.normalizedQuestion, MEME_SET_PATTERNS)) {
     addRoutedIdScore(scores, MEME_SETS_ID, 12);
     addRoutedIdScore(scores, NETWORK_DEFINITIONS_ID, 3);
   }
+}
 
-  if (matchesAny(normalizedQuestion, TDH_UNWEIGHTED_PATTERNS)) {
+function addTdhDefinitionScores(
+  scores: Map<string, number>,
+  context: RoutedQuestionContext
+): void {
+  if (matchesAny(context.normalizedQuestion, TDH_UNWEIGHTED_PATTERNS)) {
     addRoutedIdScore(scores, TDH_UNWEIGHTED_ID, 12);
     addRoutedIdScore(scores, NETWORK_TDH_ID, 4);
   }
 
-  if (matchesAny(normalizedQuestion, TDH_UNBOOSTED_PATTERNS)) {
+  if (matchesAny(context.normalizedQuestion, TDH_UNBOOSTED_PATTERNS)) {
     addRoutedIdScore(scores, TDH_UNBOOSTED_ID, 12);
     addRoutedIdScore(scores, NETWORK_TDH_ID, 4);
   }
+}
+
+function routedRecordScores(
+  normalizedQuestion: string
+): ReadonlyMap<string, number> {
+  const context = routedQuestionContext(normalizedQuestion);
+  const scores = new Map<string, number>();
+
+  addOverLimitWalletScores(scores, context);
+  addArchitectureScores(scores, context);
+  addWalletCheckerScores(scores, context);
+  addConsolidationScores(scores, context);
+  addNetworkDefinitionScores(scores, context);
+  addTdhDefinitionScores(scores, context);
 
   return scores;
 }

--- a/src/help-bot/help-bot.knowledge.ts
+++ b/src/help-bot/help-bot.knowledge.ts
@@ -12,6 +12,7 @@ export interface HelpBotKnowledgeRecord {
   readonly title: string;
   readonly linkLabel: string;
   readonly canonicalPath: string;
+  readonly suppressSourceLinks?: boolean;
   readonly aliases: string[];
   readonly keywords: string[];
   readonly facts: string[];
@@ -241,6 +242,10 @@ function readStringArray(value: unknown): string[] {
     : [];
 }
 
+function readBoolean(value: unknown): boolean | null {
+  return typeof value === 'boolean' ? value : null;
+}
+
 function readCanonicalPath(raw: Record<string, unknown>): string | null {
   return readString(raw.canonicalPath) ?? readString(raw.canonical_path);
 }
@@ -280,6 +285,10 @@ function normalizeRecord(value: unknown): HelpBotKnowledgeRecord | null {
     title,
     linkLabel: readLinkLabel(raw, title),
     canonicalPath,
+    suppressSourceLinks:
+      readBoolean(raw.suppressSourceLinks) ??
+      readBoolean(raw.suppress_source_links) ??
+      false,
     aliases: aliases.length ? aliases : [title],
     keywords: keywords.length ? keywords : aliases.concat([title]),
     facts,

--- a/src/help-bot/help-bot.knowledge.ts
+++ b/src/help-bot/help-bot.knowledge.ts
@@ -101,6 +101,18 @@ const CONSOLIDATION_CONTEXT_PATTERNS = [
   /\bcombine(?:d|s|ing)? (?:my )?(?:wallets?|addresses?)\b/
 ] as const;
 
+const CONSOLIDATION_LIMIT_CONTEXT_PATTERNS = [
+  /\bhow many\b/,
+  /\bmaximum\b/,
+  /\bmax\b/,
+  /\blimit\b/,
+  /\blimits\b/,
+  /\bgroup size\b/,
+  /\bone consolidation group\b/,
+  /\bper consolidation group\b/,
+  /\bcan be in\b/
+] as const;
+
 const WALLET_CHECK_CONTEXT_PATTERNS = [
   /\bcheck\b/,
   /\bview\b/,
@@ -461,6 +473,7 @@ interface RoutedQuestionContext {
   readonly hasArchitectureContext: boolean;
   readonly hasExplicitArchitectureContext: boolean;
   readonly hasConsolidationContext: boolean;
+  readonly hasConsolidationLimitContext: boolean;
   readonly hasDelegationContext: boolean;
   readonly hasWalletCheckContext: boolean;
   readonly overLimitWalletCount: number | null;
@@ -483,6 +496,10 @@ function routedQuestionContext(
     hasConsolidationContext: matchesAny(
       normalizedQuestion,
       CONSOLIDATION_CONTEXT_PATTERNS
+    ),
+    hasConsolidationLimitContext: matchesAny(
+      normalizedQuestion,
+      CONSOLIDATION_LIMIT_CONTEXT_PATTERNS
     ),
     hasDelegationContext: matchesAny(
       normalizedQuestion,
@@ -553,6 +570,18 @@ function addConsolidationScores(
   scores: Map<string, number>,
   context: RoutedQuestionContext
 ): void {
+  if (
+    context.hasConsolidationContext &&
+    context.hasConsolidationLimitContext &&
+    (context.hasWalletContext || context.hasArchitectureContext)
+  ) {
+    addRoutedPathScore(scores, CONSOLIDATION_USE_CASES_PATH, 18);
+    addRoutedIdScore(scores, WALLET_ARCHITECTURE_ID, 8);
+    addRoutedPathScore(scores, WALLET_ARCHITECTURE_PATH, 6);
+    addRoutedPathScore(scores, REGISTER_CONSOLIDATION_DOC_PATH, 5);
+    return;
+  }
+
   if (
     context.hasConsolidationContext &&
     (context.hasWalletContext || context.hasArchitectureContext)

--- a/src/help-bot/help-bot.knowledge.ts
+++ b/src/help-bot/help-bot.knowledge.ts
@@ -1,4 +1,5 @@
 import { Logger } from '@/logging';
+import { CONSOLIDATIONS_LIMIT } from '@/constants';
 import {
   HELP_BOT_INDEX_CACHE_TTL_MS,
   HELP_BOT_INDEX_FETCH_TIMEOUT_MS,
@@ -70,13 +71,9 @@ const ARCHITECTURE_CONTEXT_PATTERNS = [
   /\barchitectures\b/,
   /\btap\b/,
   /\bthree address\b/,
-  /\bfour address\b/,
   /\b3 address\b/,
-  /\b4 address\b/,
   /\bthree wallets?\b/,
-  /\bfour wallets?\b/,
   /\b3 wallets?\b/,
-  /\b4 wallets?\b/,
   /\bmultiple wallets?\b/,
   /\bseveral wallets?\b/,
   /\bvault\b/,
@@ -89,13 +86,9 @@ const EXPLICIT_ARCHITECTURE_CONTEXT_PATTERNS = [
   /\barchitectures\b/,
   /\btap\b/,
   /\bthree address\b/,
-  /\bfour address\b/,
   /\b3 address\b/,
-  /\b4 address\b/,
   /\bthree wallets?\b/,
-  /\bfour wallets?\b/,
   /\b3 wallets?\b/,
-  /\b4 wallets?\b/,
   /\bmultiple wallets?\b/,
   /\bseveral wallets?\b/
 ] as const;
@@ -134,6 +127,22 @@ const TDH_UNWEIGHTED_ID = 'network.definitions.tdh-unweighted';
 const TDH_UNBOOSTED_ID = 'network.definitions.tdh-unboosted';
 const NAKAMOTO_SET_ID = 'network.tdh.nakamoto-set';
 const NETWORK_TDH_ID = 'network.tdh';
+
+const WALLET_COUNT_WORDS = new Map<string, number>([
+  ['one', 1],
+  ['two', 2],
+  ['three', 3],
+  ['four', 4],
+  ['five', 5],
+  ['six', 6],
+  ['seven', 7],
+  ['eight', 8],
+  ['nine', 9],
+  ['ten', 10]
+]);
+
+const WALLET_COUNT_PATTERN =
+  /\b(\d+|one|two|three|four|five|six|seven|eight|nine|ten)[-\s]+(?:wallet|wallets|address|addresses)\b/g;
 
 const DELEGATION_CONTEXT_PATTERNS = [
   /\bdelegat(?:e|es|ed|ing|ion|ions)\b/,
@@ -391,6 +400,37 @@ function matchesAny(
   return patterns.some((pattern) => pattern.test(normalizedQuestion));
 }
 
+function parseWalletCount(rawCount: string): number | null {
+  const wordValue = WALLET_COUNT_WORDS.get(rawCount);
+  if (wordValue !== undefined) {
+    return wordValue;
+  }
+  const parsed = Number.parseInt(rawCount, 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function requestedOverLimitWalletCount(
+  normalizedQuestion: string
+): number | null {
+  WALLET_COUNT_PATTERN.lastIndex = 0;
+  let overLimitCount: number | null = null;
+  for (
+    let match = WALLET_COUNT_PATTERN.exec(normalizedQuestion);
+    match;
+    match = WALLET_COUNT_PATTERN.exec(normalizedQuestion)
+  ) {
+    const rawCount = match[1];
+    if (!rawCount) {
+      continue;
+    }
+    const count = parseWalletCount(rawCount);
+    if (count !== null && count > CONSOLIDATIONS_LIMIT) {
+      overLimitCount = Math.max(overLimitCount ?? count, count);
+    }
+  }
+  return overLimitCount;
+}
+
 function addRoutedScore(
   scores: Map<string, number>,
   key: string,
@@ -442,7 +482,16 @@ function routedRecordScores(
     normalizedQuestion,
     WALLET_CHECK_CONTEXT_PATTERNS
   );
+  const overLimitWalletCount =
+    requestedOverLimitWalletCount(normalizedQuestion);
   const scores = new Map<string, number>();
+
+  if (overLimitWalletCount !== null) {
+    addRoutedPathScore(scores, CONSOLIDATION_USE_CASES_PATH, 16);
+    addRoutedIdScore(scores, WALLET_ARCHITECTURE_ID, 8);
+    addRoutedPathScore(scores, WALLET_ARCHITECTURE_PATH, 5);
+    addRoutedPathScore(scores, REGISTER_CONSOLIDATION_DOC_PATH, 5);
+  }
 
   if (hasExplicitArchitectureContext) {
     addRoutedIdScore(scores, WALLET_ARCHITECTURE_ID, 8);


### PR DESCRIPTION
## Summary
- Add deterministic Help6529 retrieval routing for product concepts and intents, including Genesis/Nakamoto/Meme Sets, TDH unweighted/unboosted, wallet architecture, Wallet Checker, and delegation/consolidation check flows.
- Improve scoring so record titles, tags, and safe singular/plural keyword variants contribute to retrieval without weakening existing safety gates.
- Add Bedrock-free regression tests for the concept routing examples.

## Deployment
- Redeploy the Help6529 reply handler after merge.
- No schema, migration, or API shape changes.
- No staging deploy performed for this PR.