### PR TITLE
Make wave score refresh async

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -79,6 +79,7 @@ flowchart TD
     NftLinkRefresherLoop --> NftLinkPreviewQueue["SQS: nft-link-media-previews"] --> NftLinkMediaPreviewLoop["nftLinkMediaPreviewLoop"]
     SeizeAPI --> PushQueue["SQS: firebase-push-notifications"] --> PushNotificationsHandler["pushNotificationsHandler"]
     SeizeAPI --> HelpBotQueue["SQS: help-bot-replies"] --> HelpBotReplyLoop["helpBotReplyLoop"]
+    SeizeAPI --> WaveScoreDirtyQueue["SQS: wave-score-refresh-dirty.fifo"] --> WaveScoreRefreshLoop
     TdhLoop --> TdhDoneTopic["SNS: tdh-calculation-done.fifo"]
     TdhDoneTopic --> XTdhQueue["SQS: xtdh-start.fifo"] --> XTdhLoop["xTdhLoop"]
     TdhDoneTopic --> OverRatesQueue["SQS: over-rates-revocation-start.fifo"] --> OverRatesRevocationLoop["overRatesRevocationLoop"]
@@ -117,71 +118,72 @@ flowchart TD
 
 ### Scheduled Lambdas (EventBridge)
 
-| Lambda | Purpose |
-|---|---|
-| `nftsLoop` | Discover, refresh, and audit NFTs. |
-| `transactionsLoop` | Index MEMES, Gradients, and Meme Lab transfers. |
-| `nftOwnersLoop` | Maintain current owner balance snapshots. |
-| `nftHistoryLoop` | Maintain ownership history. |
-| `delegationsLoop` | Sync delegation.cash and consolidation data. |
-| `nextgenContractLoop` | Index NextGen contract events. |
-| `nextgenMetadataLoop` | Refresh NextGen metadata. |
-| `externalCollectionSnapshottingLoop` | Snapshot external collection ownership. |
-| `externalCollectionLiveTailingLoop` | Live-tail external collection transfers. |
-| `transactionsProcessingLoop` | Normalize raw transactions into processed state. |
-| `tdhLoop` | Calculate TDH and publish TDH completion. |
-| `tdhHistoryLoop` | Write historical TDH snapshots. |
-| `ownersBalancesLoop` | Project owner balance aggregates. |
-| `aggregatedActivityLoop` | Calculate activity aggregates. |
-| `marketStatsLoop` | Aggregate market stats for MEMES, Lab, Gradients, and NextGen. |
-| `rateEventProcessingLoop` | Process DB-backed rating events. |
-| `waveDecisionExecutionLoop` | Execute wave decisions and enqueue claim builds. |
-| `waveLeaderboardSnapshotterLoop` | Snapshot wave leaderboards. |
-| `xTdhGrantsReviewerLoop` | Review xTDH grants. |
-| `subscriptionsDaily` | Process daily subscription work. |
-| `subscriptionsTopUpLoop` | Process subscription top-ups. |
-| `discoverEnsLoop` | Discover ENS names. |
-| `refreshEnsLoop` | Refresh known ENS names. |
-| `ethPriceLoop` | Snapshot ETH price. |
-| `mintAnnouncementsLoop` | Publish mint announcements. |
-| `artCurationNftWatchLoop` | Watch curated NFT state. |
-| `rememesLoop` | Refresh rememes S3 files and metadata. |
-| `royaltiesLoop` | Refresh royalty state. |
-| `dbDumpsDaily` | Create daily database dumps. |
-| `nextgenMediaUploader` | Upload NextGen media. |
-| `nextgenMediaImageResolutions` | Generate NextGen image resolutions. |
+| Lambda                               | Purpose                                                           |
+| ------------------------------------ | ----------------------------------------------------------------- |
+| `nftsLoop`                           | Discover, refresh, and audit NFTs.                                |
+| `transactionsLoop`                   | Index MEMES, Gradients, and Meme Lab transfers.                   |
+| `nftOwnersLoop`                      | Maintain current owner balance snapshots.                         |
+| `nftHistoryLoop`                     | Maintain ownership history.                                       |
+| `delegationsLoop`                    | Sync delegation.cash and consolidation data.                      |
+| `nextgenContractLoop`                | Index NextGen contract events.                                    |
+| `nextgenMetadataLoop`                | Refresh NextGen metadata.                                         |
+| `externalCollectionSnapshottingLoop` | Snapshot external collection ownership.                           |
+| `externalCollectionLiveTailingLoop`  | Live-tail external collection transfers.                          |
+| `transactionsProcessingLoop`         | Normalize raw transactions into processed state.                  |
+| `tdhLoop`                            | Calculate TDH and publish TDH completion.                         |
+| `tdhHistoryLoop`                     | Write historical TDH snapshots.                                   |
+| `ownersBalancesLoop`                 | Project owner balance aggregates.                                 |
+| `aggregatedActivityLoop`             | Calculate activity aggregates.                                    |
+| `marketStatsLoop`                    | Aggregate market stats for MEMES, Lab, Gradients, and NextGen.    |
+| `rateEventProcessingLoop`            | Process DB-backed rating events.                                  |
+| `waveDecisionExecutionLoop`          | Execute wave decisions and enqueue claim builds.                  |
+| `waveLeaderboardSnapshotterLoop`     | Snapshot wave leaderboards.                                       |
+| `waveScoreRefreshLoop`               | Scheduled fallback that drains dirty Wave Score refresh requests. |
+| `xTdhGrantsReviewerLoop`             | Review xTDH grants.                                               |
+| `subscriptionsDaily`                 | Process daily subscription work.                                  |
+| `subscriptionsTopUpLoop`             | Process subscription top-ups.                                     |
+| `discoverEnsLoop`                    | Discover ENS names.                                               |
+| `refreshEnsLoop`                     | Refresh known ENS names.                                          |
+| `ethPriceLoop`                       | Snapshot ETH price.                                               |
+| `mintAnnouncementsLoop`              | Publish mint announcements.                                       |
+| `artCurationNftWatchLoop`            | Watch curated NFT state.                                          |
+| `rememesLoop`                        | Refresh rememes S3 files and metadata.                            |
+| `royaltiesLoop`                      | Refresh royalty state.                                            |
+| `dbDumpsDaily`                       | Create daily database dumps.                                      |
+| `nextgenMediaUploader`               | Upload NextGen media.                                             |
+| `nextgenMediaImageResolutions`       | Generate NextGen image resolutions.                               |
 
 ### Triggered Lambdas
 
-| Lambda | Trigger | Purpose |
-|---|---|---|
-| `api` / `seizeAPI` | API Gateway HTTP/WebSocket | Public REST API and WebSocket boundary. |
-| `claimsBuilder` | SQS `claims-builder` | Build minting claims from winning drops. |
-| `claimsMediaArweaveUploader` | SQS `claims-media-arweave-upload` | Upload claim media and metadata to Arweave. |
-| `s3Uploader` | SQS `s3-uploader-jobs` | Mirror, compress, and upload NFT media. |
-| `attachmentsOrchestrator` | SQS `attachments-orchestration` and S3 object-created event | Find uploaded attachment objects, retry, and enqueue processing. |
-| `attachmentsProcessor` | SQS `attachments-processing` | Scan/process attachments. |
-| `dropMediaSanitizer` | SQS `drop-media-sanitizer` | Strip metadata from private-ingest drop/wave image uploads and publish sanitized originals. |
-| `nftLinkRefresherLoop` | SQS `nft-link-refreshes` | Resolve external NFT links. |
-| `nftLinkMediaPreviewLoop` | SQS `nft-link-media-previews` | Generate media previews for NFT links. |
-| `pushNotificationsHandler` | SQS `firebase-push-notifications` | Deliver Firebase push notifications. |
-| `helpBotReplyLoop` | SQS `help-bot-replies` | Answer `@help6529` mentions and direct follow-ups to bot replies. |
-| `xTdhLoop` | SNS `tdh-calculation-done.fifo` via SQS `xtdh-start.fifo` | Recalculate xTDH after TDH finishes. |
-| `overRatesRevocationLoop` | SNS `tdh-calculation-done.fifo` via SQS `over-rates-revocation-start.fifo` | Revoke over-rates after TDH changes. |
-| `waveScoreRefreshLoop` | SNS `tdh-calculation-done.fifo` via SQS `wave-score-refresh-start.fifo` | Refresh materialized wave REP and Wave Score discovery fields after TDH changes. |
-| `mediaResizerLoop` | CloudFront/request path | Resize images on demand. |
-| `nextgenMediaProxyInterceptor` | Lambda@Edge / CloudFront request | Provide NextGen metadata fallback. |
-| `dropVideoConversionInvokerLoop` | S3 object-created event for `drops/` | Invoke MediaConvert for uploaded drop videos. |
-| `cloudwatchAlarmsToDiscordLoop` | SNS `cloudwatch-alarms` | Post CloudWatch alarms to Discord. |
+| Lambda                           | Trigger                                                                                                                            | Purpose                                                                                                                     |
+| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `api` / `seizeAPI`               | API Gateway HTTP/WebSocket                                                                                                         | Public REST API and WebSocket boundary.                                                                                     |
+| `claimsBuilder`                  | SQS `claims-builder`                                                                                                               | Build minting claims from winning drops.                                                                                    |
+| `claimsMediaArweaveUploader`     | SQS `claims-media-arweave-upload`                                                                                                  | Upload claim media and metadata to Arweave.                                                                                 |
+| `s3Uploader`                     | SQS `s3-uploader-jobs`                                                                                                             | Mirror, compress, and upload NFT media.                                                                                     |
+| `attachmentsOrchestrator`        | SQS `attachments-orchestration` and S3 object-created event                                                                        | Find uploaded attachment objects, retry, and enqueue processing.                                                            |
+| `attachmentsProcessor`           | SQS `attachments-processing`                                                                                                       | Scan/process attachments.                                                                                                   |
+| `dropMediaSanitizer`             | SQS `drop-media-sanitizer`                                                                                                         | Strip metadata from private-ingest drop/wave image uploads and publish sanitized originals.                                 |
+| `nftLinkRefresherLoop`           | SQS `nft-link-refreshes`                                                                                                           | Resolve external NFT links.                                                                                                 |
+| `nftLinkMediaPreviewLoop`        | SQS `nft-link-media-previews`                                                                                                      | Generate media previews for NFT links.                                                                                      |
+| `pushNotificationsHandler`       | SQS `firebase-push-notifications`                                                                                                  | Deliver Firebase push notifications.                                                                                        |
+| `helpBotReplyLoop`               | SQS `help-bot-replies`                                                                                                             | Answer `@help6529` mentions and direct follow-ups to bot replies.                                                           |
+| `xTdhLoop`                       | SNS `tdh-calculation-done.fifo` via SQS `xtdh-start.fifo`                                                                          | Recalculate xTDH after TDH finishes.                                                                                        |
+| `overRatesRevocationLoop`        | SNS `tdh-calculation-done.fifo` via SQS `over-rates-revocation-start.fifo`                                                         | Revoke over-rates after TDH changes.                                                                                        |
+| `waveScoreRefreshLoop`           | SNS `tdh-calculation-done.fifo` via SQS `wave-score-refresh-start.fifo`; SQS `wave-score-refresh-dirty.fifo`; EventBridge fallback | Refresh materialized wave REP and Wave Score discovery fields after TDH changes or wave/drop/rating/subscription mutations. |
+| `mediaResizerLoop`               | CloudFront/request path                                                                                                            | Resize images on demand.                                                                                                    |
+| `nextgenMediaProxyInterceptor`   | Lambda@Edge / CloudFront request                                                                                                   | Provide NextGen metadata fallback.                                                                                          |
+| `dropVideoConversionInvokerLoop` | S3 object-created event for `drops/`                                                                                               | Invoke MediaConvert for uploaded drop videos.                                                                               |
+| `cloudwatchAlarmsToDiscordLoop`  | SNS `cloudwatch-alarms`                                                                                                            | Post CloudWatch alarms to Discord.                                                                                          |
 
 ### Manual Or One-Off Lambdas
 
-| Lambda | Purpose |
-|---|---|
-| `dbMigrationsLoop` | TypeORM entity synchronization, usually run from deploy workflow. |
-| `customReplayLoop` | Controlled replay job. |
-| `populateHistoricConsolidatedTdh` | Historic consolidated TDH backfill. |
-| `teamLoop` | Team CSV and Arweave upload. |
+| Lambda                            | Purpose                                                           |
+| --------------------------------- | ----------------------------------------------------------------- |
+| `dbMigrationsLoop`                | TypeORM entity synchronization, usually run from deploy workflow. |
+| `customReplayLoop`                | Controlled replay job.                                            |
+| `populateHistoricConsolidatedTdh` | Historic consolidated TDH backfill.                               |
+| `teamLoop`                        | Team CSV and Arweave upload.                                      |
 
 ## Runtime Shape
 
@@ -197,7 +199,7 @@ MySQL is the integration contract between nearly all modules. API routes, schedu
 2. The API validates input, authenticates JWT or anonymous context, reads/writes MySQL, uses Redis for cache/rate limiting, and sometimes publishes SQS work.
 3. Scheduled ingestion Lambdas poll Ethereum/RPC/Alchemy/Etherscan, normalize chain state, and write canonical rows into MySQL.
 4. Derived-data Lambdas read canonical tables and write projections such as TDH, owner balances, aggregated activity, wave decisions, leaderboards, metrics, and reputation aggregates.
-5. SQS workers handle slow or retryable side effects through named queues: claim building, claim media Arweave uploads, S3 media mirroring, attachment orchestration/processing, NFT link resolution/previews, xTDH recalculation, and Firebase push notifications.
+5. SQS workers handle slow or retryable side effects through named queues: claim building, claim media Arweave uploads, S3 media mirroring, attachment orchestration/processing, NFT link resolution/previews, xTDH recalculation, Wave Score dirty refreshes, and Firebase push notifications.
 6. S3 and CloudFront serve media. Drop and wave image uploads can first land in a private ingest bucket, then `dropMediaSanitizer` strips metadata and publishes the sanitized full-size original to the public bucket before CloudFront/resizer paths serve it. Other specialized media paths include on-demand resizing, video conversion, and NextGen metadata placeholder interception.
 7. Operational signals flow to Sentry, CloudWatch alarms, Discord, and SNS.
 
@@ -312,6 +314,8 @@ There are three async patterns:
 - DB-backed event processing: the `events` table stores processable events, and `rateEventProcessingLoop` locks and dispatches them to listener implementations.
 
 Most long-running scheduled jobs have reserved concurrency set low, usually `1`, which protects shared tables from concurrent writer races. SQS workers use queue visibility timeouts, DLQs, and batch failure reporting where configured.
+
+Wave Score refreshes use a hybrid DB-backed/SQS pattern. Request-path mutations write `wave_score_refresh_requests` rows inside the same primary-DB transaction as the drop, rating, or subscription change, then publish a small wakeup message to `wave-score-refresh-dirty.fifo` after commit. `waveScoreRefreshLoop` drains dirty rows from the write pool, recalculates scores, and deletes a row only if its selected `(wave_id, dirty_at)` version still matches, so a wave dirtied again during processing remains queued. A one-minute EventBridge fallback invokes the same dirty drain in case enqueueing fails after the transaction commits.
 
 ## 6529 Help Bot Flow
 

--- a/src/api-serverless/src/drops/drop-creation.api.service.ts
+++ b/src/api-serverless/src/drops/drop-creation.api.service.ts
@@ -41,7 +41,10 @@ import {
 } from '@/api/drops/drop-polls.api.service';
 import { ApiCreateDropPollRequest } from '@/api/generated/models/ApiCreateDropPollRequest';
 import { invalidateWaveUnreadCacheForWave } from '@/api/waves/wave-unread-cache';
-import { waveScoreService } from '@/api/waves/wave-score.service';
+import {
+  waveScoreService,
+  WaveScoreDirtyRefreshReason
+} from '@/api/waves/wave-score.service';
 
 function normalizeCreateDropPollRequest(
   poll: ApiCreateDropPollRequest | null | undefined
@@ -103,7 +106,11 @@ export class DropCreationApiService {
           );
         }
       );
-    await waveScoreService.enqueueDirtyWaveScoreRefreshBestEffort(ctx);
+    await waveScoreService.requestWaveScoreRefreshBestEffort(
+      [model.wave_id],
+      WaveScoreDirtyRefreshReason.DROP_CHANGED,
+      ctx
+    );
     await invalidateWaveUnreadCacheForWave(model.wave_id);
     void this.sendPendingPushNotifications({
       dropId: drop.id,
@@ -192,10 +199,14 @@ export class DropCreationApiService {
       }
     );
     if (deleteResponse) {
-      await waveScoreService.enqueueDirtyWaveScoreRefreshBestEffort({
-        timer,
-        authenticationContext
-      });
+      await waveScoreService.requestWaveScoreRefreshBestEffort(
+        [deleteResponse.wave_id],
+        WaveScoreDirtyRefreshReason.DROP_DELETED,
+        {
+          timer,
+          authenticationContext
+        }
+      );
       await invalidateWaveUnreadCacheForWave(deleteResponse.wave_id);
       await this.wsListenersNotifier.notifyAboutDropDelete(
         {
@@ -322,7 +333,11 @@ export class DropCreationApiService {
           };
         }
       );
-    await waveScoreService.enqueueDirtyWaveScoreRefreshBestEffort(ctx);
+    await waveScoreService.requestWaveScoreRefreshBestEffort(
+      [model.wave_id],
+      WaveScoreDirtyRefreshReason.DROP_CHANGED,
+      ctx
+    );
     await invalidateWaveUnreadCacheForWave(model.wave_id);
     void this.sendPendingPushNotifications({
       dropId: apiDrop.id,

--- a/src/api-serverless/src/drops/drop-creation.api.service.ts
+++ b/src/api-serverless/src/drops/drop-creation.api.service.ts
@@ -41,6 +41,7 @@ import {
 } from '@/api/drops/drop-polls.api.service';
 import { ApiCreateDropPollRequest } from '@/api/generated/models/ApiCreateDropPollRequest';
 import { invalidateWaveUnreadCacheForWave } from '@/api/waves/wave-unread-cache';
+import { waveScoreService } from '@/api/waves/wave-score.service';
 
 function normalizeCreateDropPollRequest(
   poll: ApiCreateDropPollRequest | null | undefined
@@ -102,6 +103,7 @@ export class DropCreationApiService {
           );
         }
       );
+    await waveScoreService.enqueueDirtyWaveScoreRefreshBestEffort(ctx);
     await invalidateWaveUnreadCacheForWave(model.wave_id);
     void this.sendPendingPushNotifications({
       dropId: drop.id,
@@ -190,6 +192,10 @@ export class DropCreationApiService {
       }
     );
     if (deleteResponse) {
+      await waveScoreService.enqueueDirtyWaveScoreRefreshBestEffort({
+        timer,
+        authenticationContext
+      });
       await invalidateWaveUnreadCacheForWave(deleteResponse.wave_id);
       await this.wsListenersNotifier.notifyAboutDropDelete(
         {
@@ -316,6 +322,7 @@ export class DropCreationApiService {
           };
         }
       );
+    await waveScoreService.enqueueDirtyWaveScoreRefreshBestEffort(ctx);
     await invalidateWaveUnreadCacheForWave(model.wave_id);
     void this.sendPendingPushNotifications({
       dropId: apiDrop.id,

--- a/src/api-serverless/src/waves/wave-rep.routes.ts
+++ b/src/api-serverless/src/waves/wave-rep.routes.ts
@@ -29,7 +29,10 @@ import { identityFetcher } from '@/api/identities/identity.fetcher';
 import { getValidatedByJoiOrThrow } from '@/api/validation';
 import { assertWaveAndParentVisibleOrThrow } from '@/api/waves/wave-access.helpers';
 import { waveRepOverviewApiService } from '@/api/waves/wave-rep-overview.api.service';
-import { waveScoreService } from '@/api/waves/wave-score.service';
+import {
+  waveScoreService,
+  WaveScoreDirtyRefreshReason
+} from '@/api/waves/wave-score.service';
 import { wavesApiDb } from '@/api/waves/waves.api.db';
 import { userGroupsService } from '@/api/community-members/user-groups.service';
 import { ApiRatingWithProfileInfoAndLevelPage } from '@/api/generated/models/ApiRatingWithProfileInfoAndLevelPage';
@@ -199,8 +202,9 @@ router.post(
       },
       ctx
     );
-    await waveScoreService.refreshWaveScoresForWaveIdsBestEffort(
+    await waveScoreService.requestWaveScoreRefreshBestEffort(
       [req.params.id],
+      WaveScoreDirtyRefreshReason.WAVE_REP_CHANGED,
       ctx
     );
     await giveReadReplicaTimeToCatchUp();

--- a/src/api-serverless/src/waves/wave-score-service.test.ts
+++ b/src/api-serverless/src/waves/wave-score-service.test.ts
@@ -1,7 +1,14 @@
 import { ApiWaveVisibilityTier } from '@/api/generated/models/ApiWaveVisibilityTier';
+import { DbPoolName } from '@/db-query.options';
+import { sqs } from '@/sqs';
 import { Time } from '@/time';
 import { mapWaveScore } from './wave-score.api-mapper';
-import { WaveScoreService } from './wave-score.service';
+import {
+  WAVE_SCORE_DIRTY_REFRESH_MESSAGE_GROUP_ID,
+  WAVE_SCORE_DIRTY_REFRESH_QUEUE_NAME,
+  WaveScoreDirtyRefreshReason,
+  WaveScoreService
+} from './wave-score.service';
 
 function makeInput(overrides: Record<string, unknown> = {}) {
   return {
@@ -235,5 +242,114 @@ describe('WaveScoreService', () => {
     expect(
       getScoreInputRows.mock.calls.map(([ids]) => (ids as string[]).length)
     ).toEqual([100, 100, 5]);
+  });
+
+  it('marks distinct waves dirty with a monotonic dirty timestamp inside the caller connection', async () => {
+    jest.spyOn(Time, 'currentMillis').mockReturnValue(12_345);
+    const execute = jest.fn().mockResolvedValue([]);
+    const service = new WaveScoreService(() => ({ execute }) as any);
+    const connection = {} as any;
+
+    await service.markWaveScoresDirty(
+      ['wave-1', 'wave-1', ''],
+      WaveScoreDirtyRefreshReason.DROP_CHANGED,
+      { connection }
+    );
+
+    expect(execute).toHaveBeenCalledWith(
+      expect.stringContaining('insert into wave_score_refresh_requests'),
+      expect.objectContaining({
+        waveId0: 'wave-1',
+        reason0: WaveScoreDirtyRefreshReason.DROP_CHANGED,
+        dirtyAt0: 12_345,
+        createdAt0: 12_345,
+        updatedAt0: 12_345
+      }),
+      { wrappedConnection: connection }
+    );
+    expect(execute.mock.calls[0]?.[0]).toContain('greatest(');
+  });
+
+  it('drains dirty wave refresh rows from the write pool and deletes only the captured dirty timestamp', async () => {
+    const execute = jest.fn(async (sql: string) => {
+      if (sql.includes('select wave_id, dirty_at')) {
+        return [{ wave_id: 'wave-1', dirty_at: '1000' }];
+      }
+      return [];
+    });
+    const service = new WaveScoreService(() => ({ execute }) as any);
+    jest
+      .spyOn(service, 'refreshWaveScoresForWaveIds')
+      .mockResolvedValue(undefined);
+
+    await expect(
+      service.refreshDirtyWaveScores({ batchSize: 10, maxBatches: 1 })
+    ).resolves.toEqual({
+      batches: 1,
+      waves: 1,
+      hasMore: false
+    });
+
+    expect(execute).toHaveBeenCalledWith(
+      expect.stringContaining('select wave_id, dirty_at'),
+      { batchSize: 10 },
+      expect.objectContaining({ forcePool: DbPoolName.WRITE })
+    );
+    expect(service.refreshWaveScoresForWaveIds).toHaveBeenCalledWith(
+      ['wave-1'],
+      {}
+    );
+    expect(execute).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'where (wave_id, dirty_at) in ((:dirtyWaveId0, :dirtyAt0))'
+      ),
+      {
+        dirtyWaveId0: 'wave-1',
+        dirtyAt0: 1000
+      },
+      expect.objectContaining({ forcePool: DbPoolName.WRITE })
+    );
+  });
+
+  it('persists and enqueues async dirty refresh requests', async () => {
+    const service = new WaveScoreService(() => ({}) as any);
+    const markWaveScoresDirty = jest
+      .spyOn(service, 'markWaveScoresDirty')
+      .mockResolvedValue(undefined);
+    const enqueueDirtyWaveScoreRefresh = jest
+      .spyOn(service, 'enqueueDirtyWaveScoreRefreshBestEffort')
+      .mockResolvedValue(undefined);
+
+    await service.requestWaveScoreRefreshBestEffort(
+      ['wave-1'],
+      WaveScoreDirtyRefreshReason.WAVE_REP_CHANGED
+    );
+
+    expect(markWaveScoresDirty).toHaveBeenCalledWith(
+      ['wave-1'],
+      WaveScoreDirtyRefreshReason.WAVE_REP_CHANGED,
+      {}
+    );
+    expect(enqueueDirtyWaveScoreRefresh).toHaveBeenCalledWith({});
+  });
+
+  it('sends unique dirty refresh wakeups to the dirty FIFO queue', async () => {
+    jest.spyOn(Time, 'currentMillis').mockReturnValue(12_345);
+    const sendToQueueName = jest
+      .spyOn(sqs, 'sendToQueueName')
+      .mockResolvedValue(undefined);
+    const service = new WaveScoreService(() => ({}) as any);
+
+    await service.enqueueDirtyWaveScoreRefresh();
+
+    expect(sendToQueueName).toHaveBeenCalledWith({
+      queueName: WAVE_SCORE_DIRTY_REFRESH_QUEUE_NAME,
+      messageGroupId: WAVE_SCORE_DIRTY_REFRESH_MESSAGE_GROUP_ID,
+      message: {
+        mode: 'DIRTY',
+        requestedAt: 12_345,
+        nonce: expect.any(String)
+      }
+    });
   });
 });

--- a/src/api-serverless/src/waves/wave-score-service.test.ts
+++ b/src/api-serverless/src/waves/wave-score-service.test.ts
@@ -344,8 +344,8 @@ describe('WaveScoreService', () => {
 
     expect(dirtySelectParams).toEqual([
       { batchSize: 1 },
-      { batchSize: 1, excludedWaveIds: ['wave-1'] },
-      { batchSize: 1, excludedWaveIds: ['wave-1', 'wave-2'] }
+      { batchSize: 1, excludedWaveId0: 'wave-1' },
+      { batchSize: 1, excludedWaveId0: 'wave-1', excludedWaveId1: 'wave-2' }
     ]);
     expect(service.refreshWaveScoresForWaveIds).toHaveBeenNthCalledWith(
       1,

--- a/src/api-serverless/src/waves/wave-score-service.test.ts
+++ b/src/api-serverless/src/waves/wave-score-service.test.ts
@@ -311,6 +311,74 @@ describe('WaveScoreService', () => {
     );
   });
 
+  it('does not reselect already processed dirty waves in the same drain', async () => {
+    const dirtySelectParams: Array<Record<string, unknown>> = [];
+    const execute = jest.fn(async (sql: string, params?: any) => {
+      if (sql.includes('select wave_id, dirty_at')) {
+        dirtySelectParams.push(params);
+        if (dirtySelectParams.length === 1) {
+          return [{ wave_id: 'wave-1', dirty_at: '1000' }];
+        }
+        if (dirtySelectParams.length === 2) {
+          return [{ wave_id: 'wave-2', dirty_at: '1001' }];
+        }
+        return [];
+      }
+      if (sql.includes('select wave_id')) {
+        return [{ wave_id: 'wave-1' }];
+      }
+      return [];
+    });
+    const service = new WaveScoreService(() => ({ execute }) as any);
+    jest
+      .spyOn(service, 'refreshWaveScoresForWaveIds')
+      .mockResolvedValue(undefined);
+
+    await expect(
+      service.refreshDirtyWaveScores({ batchSize: 1, maxBatches: 3 })
+    ).resolves.toEqual({
+      batches: 2,
+      waves: 2,
+      hasMore: true
+    });
+
+    expect(dirtySelectParams).toEqual([
+      { batchSize: 1 },
+      { batchSize: 1, excludedWaveIds: ['wave-1'] },
+      { batchSize: 1, excludedWaveIds: ['wave-1', 'wave-2'] }
+    ]);
+    expect(service.refreshWaveScoresForWaveIds).toHaveBeenNthCalledWith(
+      1,
+      ['wave-1'],
+      {}
+    );
+    expect(service.refreshWaveScoresForWaveIds).toHaveBeenNthCalledWith(
+      2,
+      ['wave-2'],
+      {}
+    );
+  });
+
+  it('does not run synchronous fallback inside a dirty mark transaction', async () => {
+    const service = new WaveScoreService(
+      () =>
+        ({
+          execute: jest.fn().mockRejectedValue(new Error('missing table'))
+        }) as any
+    );
+    const refreshWaveScoresForWaveIdsBestEffort = jest
+      .spyOn(service, 'refreshWaveScoresForWaveIdsBestEffort')
+      .mockResolvedValue(undefined);
+
+    await service.markWaveScoresDirtyBestEffort(
+      ['wave-1'],
+      WaveScoreDirtyRefreshReason.DROP_CHANGED,
+      { connection: {} as any }
+    );
+
+    expect(refreshWaveScoresForWaveIdsBestEffort).not.toHaveBeenCalled();
+  });
+
   it('persists and enqueues async dirty refresh requests', async () => {
     const service = new WaveScoreService(() => ({}) as any);
     const markWaveScoresDirty = jest

--- a/src/api-serverless/src/waves/wave-score-service.test.ts
+++ b/src/api-serverless/src/waves/wave-score-service.test.ts
@@ -359,6 +359,61 @@ describe('WaveScoreService', () => {
     );
   });
 
+  it('records a dirty wave refresh failure and continues through the batch', async () => {
+    const execute = jest.fn(async (sql: string) => {
+      if (sql.includes('select wave_id, dirty_at')) {
+        return [
+          { wave_id: 'wave-1', dirty_at: '1000' },
+          { wave_id: 'wave-2', dirty_at: '1001' }
+        ];
+      }
+      return [];
+    });
+    const service = new WaveScoreService(() => ({ execute }) as any);
+    jest
+      .spyOn(service, 'refreshWaveScoresForWaveIds')
+      .mockRejectedValueOnce(new Error('score refresh failed'))
+      .mockResolvedValueOnce(undefined);
+
+    await expect(
+      service.refreshDirtyWaveScores({ batchSize: 10, maxBatches: 1 })
+    ).resolves.toEqual({
+      batches: 1,
+      waves: 2,
+      hasMore: false
+    });
+
+    expect(service.refreshWaveScoresForWaveIds).toHaveBeenNthCalledWith(
+      1,
+      ['wave-1'],
+      {}
+    );
+    expect(service.refreshWaveScoresForWaveIds).toHaveBeenNthCalledWith(
+      2,
+      ['wave-2'],
+      {}
+    );
+    expect(execute).toHaveBeenCalledWith(
+      expect.stringContaining('attempts = attempts + 1'),
+      expect.objectContaining({
+        dirtyWaveId0: 'wave-1',
+        dirtyAt0: 1000,
+        lastError: 'score refresh failed'
+      }),
+      expect.objectContaining({ forcePool: DbPoolName.WRITE })
+    );
+    expect(execute).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'where (wave_id, dirty_at) in ((:dirtyWaveId0, :dirtyAt0))'
+      ),
+      {
+        dirtyWaveId0: 'wave-2',
+        dirtyAt0: 1001
+      },
+      expect.objectContaining({ forcePool: DbPoolName.WRITE })
+    );
+  });
+
   it('does not run synchronous fallback inside a dirty mark transaction', async () => {
     const service = new WaveScoreService(
       () =>

--- a/src/api-serverless/src/waves/wave-score.service.ts
+++ b/src/api-serverless/src/waves/wave-score.service.ts
@@ -5,6 +5,7 @@ import {
   IDENTITY_SUBSCRIPTIONS_TABLE,
   RATINGS_TABLE,
   WAVE_METRICS_TABLE,
+  WAVE_SCORE_REFRESH_REQUESTS_TABLE,
   WAVES_TABLE
 } from '@/constants';
 import { assertUnreachable } from '@/assertions';
@@ -14,6 +15,9 @@ import { Logger } from '@/logging';
 import { RequestContext } from '@/request.context';
 import { dbSupplier, LazyDbAccessCompatibleService } from '@/sql-executor';
 import { Time } from '@/time';
+import { DbPoolName } from '@/db-query.options';
+import { sqs } from '@/sqs';
+import { randomUUID } from 'crypto';
 import {
   DEMOTED_MIN_VISIBILITY_SCORE,
   EXPLORATION_NEUTRAL_MIN_VISIBILITY_SCORE,
@@ -37,6 +41,22 @@ import {
   WAVE_SCORE_VISIBILITY_COMPONENT_WEIGHTS
 } from './wave-score.constants';
 
+export const WAVE_SCORE_DIRTY_REFRESH_QUEUE_NAME =
+  'wave-score-refresh-dirty.fifo';
+export const WAVE_SCORE_DIRTY_REFRESH_MESSAGE_GROUP_ID =
+  'wave-score-refresh-dirty';
+
+export const WaveScoreDirtyRefreshReason = {
+  DROP_CHANGED: 'DROP_CHANGED',
+  DROP_DELETED: 'DROP_DELETED',
+  WAVE_REP_CHANGED: 'WAVE_REP_CHANGED',
+  WAVE_SUBSCRIPTION_CHANGED: 'WAVE_SUBSCRIPTION_CHANGED',
+  IDENTITY_CONSOLIDATION: 'IDENTITY_CONSOLIDATION'
+} as const;
+
+export type WaveScoreDirtyRefreshReason =
+  (typeof WaveScoreDirtyRefreshReason)[keyof typeof WaveScoreDirtyRefreshReason];
+
 export interface RefreshAllWaveScoresOptions {
   readonly batchSize?: number | undefined;
   readonly maxBatches?: number | undefined;
@@ -49,6 +69,17 @@ export interface RefreshAllWaveScoresResult {
   readonly hasMore: boolean;
   readonly startedAfterWaveId: string | null;
   readonly lastWaveId: string | null;
+}
+
+export interface RefreshDirtyWaveScoresOptions {
+  readonly batchSize?: number | undefined;
+  readonly maxBatches?: number | undefined;
+}
+
+export interface RefreshDirtyWaveScoresResult {
+  readonly batches: number;
+  readonly waves: number;
+  readonly hasMore: boolean;
 }
 
 interface WaveScoreInputRow {
@@ -72,6 +103,11 @@ interface WaveScoreInputRow {
   readonly trusted_subscriber_count: number | string | null;
   readonly trusted_subscription_weight: number | string | null;
   readonly cross_mentions: number | string | null;
+}
+
+interface DirtyWaveScoreRefreshRequestRow {
+  readonly wave_id: string;
+  readonly dirty_at: number | string;
 }
 
 interface WaveScoreCalculation {
@@ -154,6 +190,185 @@ export class WaveScoreService extends LazyDbAccessCompatibleService {
     }
   }
 
+  public async markWaveScoresDirty(
+    waveIds: string[],
+    reason: WaveScoreDirtyRefreshReason,
+    ctx: RequestContext = {}
+  ): Promise<void> {
+    const distinctWaveIds = this.distinctWaveIds(waveIds);
+    if (!distinctWaveIds.length) {
+      return;
+    }
+    ctx.timer?.start(`${this.constructor.name}->markWaveScoresDirty`);
+    try {
+      const now = Time.currentMillis();
+      const params = distinctWaveIds.reduce<Record<string, string | number>>(
+        (acc, waveId, i) => {
+          acc[`waveId${i}`] = waveId;
+          acc[`reason${i}`] = reason;
+          acc[`dirtyAt${i}`] = now;
+          acc[`createdAt${i}`] = now;
+          acc[`updatedAt${i}`] = now;
+          return acc;
+        },
+        {}
+      );
+      await this.db.execute(
+        `
+        insert into ${WAVE_SCORE_REFRESH_REQUESTS_TABLE}
+          (wave_id, reason, dirty_at, attempts, last_error, created_at, updated_at)
+        values ${distinctWaveIds
+          .map(
+            (_, i) =>
+              `(:waveId${i}, :reason${i}, :dirtyAt${i}, 0, null, :createdAt${i}, :updatedAt${i})`
+          )
+          .join(', ')}
+        as new
+        on duplicate key update
+          reason = new.reason,
+          dirty_at = greatest(
+            new.dirty_at,
+            ${WAVE_SCORE_REFRESH_REQUESTS_TABLE}.dirty_at + 1
+          ),
+          attempts = 0,
+          last_error = null,
+          updated_at = new.updated_at
+        `,
+        params,
+        { wrappedConnection: ctx.connection }
+      );
+    } finally {
+      ctx.timer?.stop(`${this.constructor.name}->markWaveScoresDirty`);
+    }
+  }
+
+  public async markWaveScoresDirtyBestEffort(
+    waveIds: string[],
+    reason: WaveScoreDirtyRefreshReason,
+    ctx: RequestContext = {}
+  ): Promise<void> {
+    try {
+      await this.markWaveScoresDirty(waveIds, reason, ctx);
+    } catch (error) {
+      this.logger.error(
+        `Failed to mark wave scores dirty for ${waveIds.length}`,
+        {
+          waveIds,
+          reason,
+          error
+        }
+      );
+      await this.refreshWaveScoresForWaveIdsBestEffort(waveIds, ctx);
+    }
+  }
+
+  public async requestWaveScoreRefreshBestEffort(
+    waveIds: string[],
+    reason: WaveScoreDirtyRefreshReason,
+    ctx: RequestContext = {}
+  ): Promise<void> {
+    try {
+      await this.markWaveScoresDirty(waveIds, reason, ctx);
+    } catch (error) {
+      this.logger.error(
+        `Failed to persist dirty wave score refresh request for ${waveIds.length}`,
+        {
+          waveIds,
+          reason,
+          error
+        }
+      );
+      await this.refreshWaveScoresForWaveIdsBestEffort(waveIds, ctx);
+      return;
+    }
+    await this.enqueueDirtyWaveScoreRefreshBestEffort(ctx);
+  }
+
+  public async enqueueDirtyWaveScoreRefresh(
+    ctx: RequestContext = {}
+  ): Promise<void> {
+    ctx.timer?.start(`${this.constructor.name}->enqueueDirtyWaveScoreRefresh`);
+    try {
+      await sqs.sendToQueueName({
+        queueName: WAVE_SCORE_DIRTY_REFRESH_QUEUE_NAME,
+        messageGroupId: WAVE_SCORE_DIRTY_REFRESH_MESSAGE_GROUP_ID,
+        message: {
+          mode: 'DIRTY',
+          requestedAt: Time.currentMillis(),
+          nonce: randomUUID()
+        }
+      });
+    } finally {
+      ctx.timer?.stop(`${this.constructor.name}->enqueueDirtyWaveScoreRefresh`);
+    }
+  }
+
+  public async enqueueDirtyWaveScoreRefreshBestEffort(
+    ctx: RequestContext = {}
+  ): Promise<void> {
+    try {
+      await this.enqueueDirtyWaveScoreRefresh(ctx);
+    } catch (error) {
+      this.logger.error(`Failed to enqueue dirty wave score refresh`, {
+        error
+      });
+    }
+  }
+
+  public async refreshDirtyWaveScores(
+    options: RefreshDirtyWaveScoresOptions = {},
+    ctx: RequestContext = {}
+  ): Promise<RefreshDirtyWaveScoresResult> {
+    const batchSize = Math.max(
+      1,
+      Math.min(
+        WAVE_SCORE_MAX_BACKFILL_BATCH_SIZE,
+        options.batchSize ?? WAVE_SCORE_DEFAULT_BACKFILL_BATCH_SIZE
+      )
+    );
+    const maxBatches = Math.max(
+      1,
+      options.maxBatches ?? Number.MAX_SAFE_INTEGER
+    );
+    let batches = 0;
+    let waves = 0;
+    let hasMore = false;
+
+    for (;;) {
+      if (batches >= maxBatches) {
+        hasMore = true;
+        break;
+      }
+      const rows = await this.getDirtyWaveScoreRefreshRequests(batchSize, ctx);
+      if (!rows.length) {
+        hasMore = false;
+        break;
+      }
+      try {
+        await this.refreshWaveScoresForWaveIds(
+          rows.map((row) => row.wave_id),
+          ctx
+        );
+        await this.deleteDirtyWaveScoreRefreshRequests(rows, ctx);
+      } catch (error) {
+        await this.recordDirtyWaveScoreRefreshFailure(rows, error, ctx);
+        throw error;
+      }
+      batches += 1;
+      waves += rows.length;
+      hasMore = rows.length === batchSize;
+      if (!hasMore) {
+        break;
+      }
+    }
+
+    return {
+      batches,
+      waves,
+      hasMore
+    };
+  }
+
   public async refreshAllWaveScores(
     options: RefreshAllWaveScoresOptions = {},
     ctx: RequestContext = {}
@@ -202,6 +417,94 @@ export class WaveScoreService extends LazyDbAccessCompatibleService {
       startedAfterWaveId,
       lastWaveId
     };
+  }
+
+  private async getDirtyWaveScoreRefreshRequests(
+    batchSize: number,
+    ctx: RequestContext
+  ): Promise<DirtyWaveScoreRefreshRequestRow[]> {
+    return this.db.execute<DirtyWaveScoreRefreshRequestRow>(
+      `
+      select wave_id, dirty_at
+      from ${WAVE_SCORE_REFRESH_REQUESTS_TABLE}
+      order by dirty_at asc, wave_id asc
+      limit :batchSize
+      `,
+      { batchSize },
+      {
+        wrappedConnection: ctx.connection,
+        // Dirty rows are inserted on the primary inside the write transaction.
+        // The refresher must read primary too, or replica lag can delay/skip work.
+        forcePool: DbPoolName.WRITE
+      }
+    );
+  }
+
+  private async deleteDirtyWaveScoreRefreshRequests(
+    rows: DirtyWaveScoreRefreshRequestRow[],
+    ctx: RequestContext
+  ): Promise<void> {
+    if (!rows.length) {
+      return;
+    }
+    await this.db.execute(
+      `
+      delete from ${WAVE_SCORE_REFRESH_REQUESTS_TABLE}
+      where ${this.capturedDirtyRowsWhere(rows)}
+      `,
+      this.capturedDirtyRowsParams(rows),
+      {
+        wrappedConnection: ctx.connection,
+        forcePool: DbPoolName.WRITE
+      }
+    );
+  }
+
+  private async recordDirtyWaveScoreRefreshFailure(
+    rows: DirtyWaveScoreRefreshRequestRow[],
+    error: unknown,
+    ctx: RequestContext
+  ): Promise<void> {
+    if (!rows.length) {
+      return;
+    }
+    await this.db.execute(
+      `
+      update ${WAVE_SCORE_REFRESH_REQUESTS_TABLE}
+      set
+        attempts = attempts + 1,
+        last_error = :lastError,
+        updated_at = :updatedAt
+      where ${this.capturedDirtyRowsWhere(rows)}
+      `,
+      {
+        ...this.capturedDirtyRowsParams(rows),
+        lastError: this.errorToString(error).slice(0, 2000),
+        updatedAt: Time.currentMillis()
+      },
+      {
+        wrappedConnection: ctx.connection,
+        forcePool: DbPoolName.WRITE
+      }
+    );
+  }
+
+  private capturedDirtyRowsWhere(
+    rows: DirtyWaveScoreRefreshRequestRow[]
+  ): string {
+    return `(wave_id, dirty_at) in (${rows
+      .map((_, i) => `(:dirtyWaveId${i}, :dirtyAt${i})`)
+      .join(', ')})`;
+  }
+
+  private capturedDirtyRowsParams(
+    rows: DirtyWaveScoreRefreshRequestRow[]
+  ): Record<string, string | number> {
+    return rows.reduce<Record<string, string | number>>((acc, row, i) => {
+      acc[`dirtyWaveId${i}`] = row.wave_id;
+      acc[`dirtyAt${i}`] = this.toNumber(row.dirty_at);
+      return acc;
+    }, {});
   }
 
   private async getWaveIdsPage(
@@ -610,6 +913,17 @@ export class WaveScoreService extends LazyDbAccessCompatibleService {
 
   private roundScore(value: number): number {
     return Math.round(value * 100) / 100;
+  }
+
+  private distinctWaveIds(waveIds: string[]): string[] {
+    return Array.from(new Set(waveIds)).filter(Boolean);
+  }
+
+  private errorToString(error: unknown): string {
+    if (error instanceof Error) {
+      return error.message;
+    }
+    return String(error);
   }
 
   private clamp(value: number, min: number, max: number): number {

--- a/src/api-serverless/src/waves/wave-score.service.ts
+++ b/src/api-serverless/src/waves/wave-score.service.ts
@@ -261,6 +261,8 @@ export class WaveScoreService extends LazyDbAccessCompatibleService {
         }
       );
       if (ctx.connection) {
+        // Keep write transactions short; post-commit callers issue a second
+        // best-effort dirty mark and wakeup when the transaction succeeds.
         return;
       }
       await this.refreshWaveScoresForWaveIdsBestEffort(waveIds, ctx);

--- a/src/api-serverless/src/waves/wave-score.service.ts
+++ b/src/api-serverless/src/waves/wave-score.service.ts
@@ -258,6 +258,9 @@ export class WaveScoreService extends LazyDbAccessCompatibleService {
           error
         }
       );
+      if (ctx.connection) {
+        return;
+      }
       await this.refreshWaveScoresForWaveIdsBestEffort(waveIds, ctx);
     }
   }
@@ -333,17 +336,25 @@ export class WaveScoreService extends LazyDbAccessCompatibleService {
     let batches = 0;
     let waves = 0;
     let hasMore = false;
+    const processedWaveIds = new Set<string>();
 
     for (;;) {
       if (batches >= maxBatches) {
         hasMore = true;
         break;
       }
-      const rows = await this.getDirtyWaveScoreRefreshRequests(batchSize, ctx);
+      const rows = await this.getDirtyWaveScoreRefreshRequests(
+        batchSize,
+        Array.from(processedWaveIds),
+        ctx
+      );
       if (!rows.length) {
-        hasMore = false;
+        hasMore = processedWaveIds.size
+          ? await this.hasDirtyWaveScoreRefreshRequests(ctx)
+          : false;
         break;
       }
+      rows.forEach((row) => processedWaveIds.add(row.wave_id));
       try {
         await this.refreshWaveScoresForWaveIds(
           rows.map((row) => row.wave_id),
@@ -358,6 +369,7 @@ export class WaveScoreService extends LazyDbAccessCompatibleService {
       waves += rows.length;
       hasMore = rows.length === batchSize;
       if (!hasMore) {
+        hasMore = await this.hasDirtyWaveScoreRefreshRequests(ctx);
         break;
       }
     }
@@ -421,16 +433,25 @@ export class WaveScoreService extends LazyDbAccessCompatibleService {
 
   private async getDirtyWaveScoreRefreshRequests(
     batchSize: number,
+    excludedWaveIds: string[],
     ctx: RequestContext
   ): Promise<DirtyWaveScoreRefreshRequestRow[]> {
+    const params: Record<string, string[] | number> = { batchSize };
+    const excludedWaveIdsClause = excludedWaveIds.length
+      ? `where wave_id not in (:excludedWaveIds)`
+      : '';
+    if (excludedWaveIds.length) {
+      params.excludedWaveIds = excludedWaveIds;
+    }
     return this.db.execute<DirtyWaveScoreRefreshRequestRow>(
       `
       select wave_id, dirty_at
       from ${WAVE_SCORE_REFRESH_REQUESTS_TABLE}
+      ${excludedWaveIdsClause}
       order by dirty_at asc, wave_id asc
       limit :batchSize
       `,
-      { batchSize },
+      params,
       {
         wrappedConnection: ctx.connection,
         // Dirty rows are inserted on the primary inside the write transaction.
@@ -438,6 +459,24 @@ export class WaveScoreService extends LazyDbAccessCompatibleService {
         forcePool: DbPoolName.WRITE
       }
     );
+  }
+
+  private async hasDirtyWaveScoreRefreshRequests(
+    ctx: RequestContext
+  ): Promise<boolean> {
+    const rows = await this.db.execute<{ readonly wave_id: string }>(
+      `
+      select wave_id
+      from ${WAVE_SCORE_REFRESH_REQUESTS_TABLE}
+      limit 1
+      `,
+      undefined,
+      {
+        wrappedConnection: ctx.connection,
+        forcePool: DbPoolName.WRITE
+      }
+    );
+    return rows.length > 0;
   }
 
   private async deleteDirtyWaveScoreRefreshRequests(

--- a/src/api-serverless/src/waves/wave-score.service.ts
+++ b/src/api-serverless/src/waves/wave-score.service.ts
@@ -226,6 +226,8 @@ export class WaveScoreService extends LazyDbAccessCompatibleService {
         as new
         on duplicate key update
           reason = new.reason,
+          -- Re-dirties during a drain must survive the captured-version delete.
+          -- A continuously written hot wave remains queued until writes pause.
           dirty_at = greatest(
             new.dirty_at,
             ${WAVE_SCORE_REFRESH_REQUESTS_TABLE}.dirty_at + 1
@@ -355,15 +357,8 @@ export class WaveScoreService extends LazyDbAccessCompatibleService {
         break;
       }
       rows.forEach((row) => processedWaveIds.add(row.wave_id));
-      try {
-        await this.refreshWaveScoresForWaveIds(
-          rows.map((row) => row.wave_id),
-          ctx
-        );
-        await this.deleteDirtyWaveScoreRefreshRequests(rows, ctx);
-      } catch (error) {
-        await this.recordDirtyWaveScoreRefreshFailure(rows, error, ctx);
-        throw error;
+      for (const row of rows) {
+        await this.processDirtyWaveScoreRefreshRequest(row, ctx);
       }
       batches += 1;
       waves += rows.length;
@@ -379,6 +374,23 @@ export class WaveScoreService extends LazyDbAccessCompatibleService {
       waves,
       hasMore
     };
+  }
+
+  private async processDirtyWaveScoreRefreshRequest(
+    row: DirtyWaveScoreRefreshRequestRow,
+    ctx: RequestContext
+  ): Promise<void> {
+    try {
+      await this.refreshWaveScoresForWaveIds([row.wave_id], ctx);
+      await this.deleteDirtyWaveScoreRefreshRequests([row], ctx);
+    } catch (error) {
+      await this.recordDirtyWaveScoreRefreshFailure([row], error, ctx);
+      this.logger.error(`Failed to refresh dirty wave score`, {
+        waveId: row.wave_id,
+        dirtyAt: row.dirty_at,
+        error
+      });
+    }
   }
 
   public async refreshAllWaveScores(

--- a/src/api-serverless/src/waves/wave-score.service.ts
+++ b/src/api-serverless/src/waves/wave-score.service.ts
@@ -448,13 +448,22 @@ export class WaveScoreService extends LazyDbAccessCompatibleService {
     excludedWaveIds: string[],
     ctx: RequestContext
   ): Promise<DirtyWaveScoreRefreshRequestRow[]> {
-    const params: Record<string, string[] | number> = { batchSize };
+    const excludedWaveIdParams = excludedWaveIds.reduce<Record<string, string>>(
+      (acc, waveId, i) => {
+        acc[`excludedWaveId${i}`] = waveId;
+        return acc;
+      },
+      {}
+    );
+    const params: Record<string, string | number> = {
+      batchSize,
+      ...excludedWaveIdParams
+    };
     const excludedWaveIdsClause = excludedWaveIds.length
-      ? `where wave_id not in (:excludedWaveIds)`
+      ? `where wave_id not in (${excludedWaveIds
+          .map((_, i) => `:excludedWaveId${i}`)
+          .join(', ')})`
       : '';
-    if (excludedWaveIds.length) {
-      params.excludedWaveIds = excludedWaveIds;
-    }
     return this.db.execute<DirtyWaveScoreRefreshRequestRow>(
       `
       select wave_id, dirty_at

--- a/src/api-serverless/src/waves/wave.api.service.ts
+++ b/src/api-serverless/src/waves/wave.api.service.ts
@@ -108,7 +108,10 @@ import {
   invalidateWaveUnreadCacheForReaderWave,
   invalidateWaveUnreadCacheForWave
 } from '@/api/waves/wave-unread-cache';
-import { waveScoreService } from '@/api/waves/wave-score.service';
+import {
+  waveScoreService,
+  WaveScoreDirtyRefreshReason
+} from '@/api/waves/wave-score.service';
 
 const CARD_SET_TDH_SUPPORTED_CONTRACTS = new Set(
   [MEMES_CONTRACT, GRADIENT_CONTRACT].map((contract) => contract.toLowerCase())
@@ -569,7 +572,11 @@ export class WaveApiService {
           };
         }
       );
-    await waveScoreService.enqueueDirtyWaveScoreRefreshBestEffort(ctx);
+    await waveScoreService.requestWaveScoreRefreshBestEffort(
+      [createdWave.id],
+      WaveScoreDirtyRefreshReason.DROP_CHANGED,
+      ctx
+    );
     await invalidateWaveUnreadCacheForWave(createdWave.id);
     await giveReadReplicaTimeToCatchUp();
     await clearWaveGroupsCache();

--- a/src/api-serverless/src/waves/wave.api.service.ts
+++ b/src/api-serverless/src/waves/wave.api.service.ts
@@ -108,6 +108,7 @@ import {
   invalidateWaveUnreadCacheForReaderWave,
   invalidateWaveUnreadCacheForWave
 } from '@/api/waves/wave-unread-cache';
+import { waveScoreService } from '@/api/waves/wave-score.service';
 
 const CARD_SET_TDH_SUPPORTED_CONTRACTS = new Set(
   [MEMES_CONTRACT, GRADIENT_CONTRACT].map((contract) => contract.toLowerCase())
@@ -568,6 +569,7 @@ export class WaveApiService {
           };
         }
       );
+    await waveScoreService.enqueueDirtyWaveScoreRefreshBestEffort(ctx);
     await invalidateWaveUnreadCacheForWave(createdWave.id);
     await giveReadReplicaTimeToCatchUp();
     await clearWaveGroupsCache();

--- a/src/api-serverless/src/waves/waves.routes.ts
+++ b/src/api-serverless/src/waves/waves.routes.ts
@@ -92,7 +92,10 @@ import { ApiWaveParticipationSubmissionStrategyType } from '@/api/generated/mode
 import { curationsApiService } from '@/api/curations/curations.api.service';
 import { ApiCurationDropsPage } from '@/api/generated/models/ApiCurationDropsPage';
 import waveRepRoutes from './wave-rep.routes';
-import { waveScoreService } from './wave-score.service';
+import {
+  waveScoreService,
+  WaveScoreDirtyRefreshReason
+} from './wave-score.service';
 
 const router = asyncRouter();
 
@@ -374,8 +377,9 @@ router.post(
       subscriber: authenticatedProfileId,
       actions: request.actions
     });
-    await waveScoreService.refreshWaveScoresForWaveIdsBestEffort(
+    await waveScoreService.requestWaveScoreRefreshBestEffort(
       [req.params.id],
+      WaveScoreDirtyRefreshReason.WAVE_SUBSCRIPTION_CHANGED,
       { authenticationContext, timer }
     );
     res.send({
@@ -471,8 +475,9 @@ router.delete(
       subscriber: authenticatedProfileId,
       actions: request.actions
     });
-    await waveScoreService.refreshWaveScoresForWaveIdsBestEffort(
+    await waveScoreService.requestWaveScoreRefreshBestEffort(
       [req.params.id],
+      WaveScoreDirtyRefreshReason.WAVE_SUBSCRIPTION_CHANGED,
       { authenticationContext, timer }
     );
     res.send({

--- a/src/constants/db-tables.ts
+++ b/src/constants/db-tables.ts
@@ -146,6 +146,7 @@ export const WAVES_DECISION_WINNER_DROPS_TABLE = 'wave_decision_winner_drops';
 export const MINTING_CLAIMS_TABLE = 'minting_claims';
 export const MINTING_CLAIM_ACTIONS_TABLE = 'minting_claim_actions';
 export const WAVE_METRICS_TABLE = 'wave_metrics';
+export const WAVE_SCORE_REFRESH_REQUESTS_TABLE = 'wave_score_refresh_requests';
 export const WAVE_DROPPER_METRICS_TABLE = 'wave_dropper_metrics';
 export const WAVE_CHAT_DROP_COOLDOWNS_TABLE = 'wave_chat_drop_cooldowns';
 export const WAVE_READER_METRICS_TABLE = 'wave_reader_metrics';

--- a/src/db.ts
+++ b/src/db.ts
@@ -105,6 +105,7 @@ import {
   invalidateWaveUnreadCache,
   type WaveUnreadCacheInvalidations
 } from '@/api/waves/wave-unread-cache';
+import { waveScoreService } from '@/api/waves/wave-score.service';
 
 const mysql = require('mysql');
 
@@ -1069,6 +1070,9 @@ export async function persistConsolidatedTDH(
   });
 
   await invalidateWaveUnreadCache(unreadCacheInvalidations);
+  if (unreadCacheInvalidations.waveIds.length) {
+    await waveScoreService.enqueueDirtyWaveScoreRefreshBestEffort();
+  }
   await recalculateXTdhUseCase.activateLoop({});
   logger.info(`[CONSOLIDATED TDH] PERSISTED ALL WALLETS TDH [${tdh.length}]`);
 }

--- a/src/db.ts
+++ b/src/db.ts
@@ -105,7 +105,10 @@ import {
   invalidateWaveUnreadCache,
   type WaveUnreadCacheInvalidations
 } from '@/api/waves/wave-unread-cache';
-import { waveScoreService } from '@/api/waves/wave-score.service';
+import {
+  waveScoreService,
+  WaveScoreDirtyRefreshReason
+} from '@/api/waves/wave-score.service';
 
 const mysql = require('mysql');
 
@@ -1071,7 +1074,10 @@ export async function persistConsolidatedTDH(
 
   await invalidateWaveUnreadCache(unreadCacheInvalidations);
   if (unreadCacheInvalidations.waveIds.length) {
-    await waveScoreService.enqueueDirtyWaveScoreRefreshBestEffort();
+    await waveScoreService.requestWaveScoreRefreshBestEffort(
+      unreadCacheInvalidations.waveIds,
+      WaveScoreDirtyRefreshReason.IDENTITY_CONSOLIDATION
+    );
   }
   await recalculateXTdhUseCase.activateLoop({});
   logger.info(`[CONSOLIDATED TDH] PERSISTED ALL WALLETS TDH [${tdh.length}]`);

--- a/src/deployer-dropper.ts
+++ b/src/deployer-dropper.ts
@@ -8,6 +8,7 @@ import { CreateOrUpdateDropModel } from '@/drops/create-or-update-drop.model';
 import { MEMES_DEPLOYER } from '@/constants';
 import { DropType } from '@/entities/IDrop';
 import { sendIdentityPushNotifications } from '@/api/push-notifications/push-notifications.service';
+import { waveScoreService } from '@/api/waves/wave-score.service';
 
 export class DeployerDropper {
   constructor(private readonly createDrop: CreateOrUpdateDropUseCase) {}
@@ -27,6 +28,9 @@ export class DeployerDropper {
             return await this._drop(params, { ...ctx, connection });
           }
         );
+      if (params.waves.length) {
+        await waveScoreService.enqueueDirtyWaveScoreRefreshBestEffort(ctx);
+      }
       await sendIdentityPushNotifications(pendingPushNotificationIds);
       return pendingPushNotificationIds;
     } else {

--- a/src/deployer-dropper.ts
+++ b/src/deployer-dropper.ts
@@ -8,7 +8,10 @@ import { CreateOrUpdateDropModel } from '@/drops/create-or-update-drop.model';
 import { MEMES_DEPLOYER } from '@/constants';
 import { DropType } from '@/entities/IDrop';
 import { sendIdentityPushNotifications } from '@/api/push-notifications/push-notifications.service';
-import { waveScoreService } from '@/api/waves/wave-score.service';
+import {
+  waveScoreService,
+  WaveScoreDirtyRefreshReason
+} from '@/api/waves/wave-score.service';
 
 export class DeployerDropper {
   constructor(private readonly createDrop: CreateOrUpdateDropUseCase) {}
@@ -29,7 +32,11 @@ export class DeployerDropper {
           }
         );
       if (params.waves.length) {
-        await waveScoreService.enqueueDirtyWaveScoreRefreshBestEffort(ctx);
+        await waveScoreService.requestWaveScoreRefreshBestEffort(
+          params.waves,
+          WaveScoreDirtyRefreshReason.DROP_CHANGED,
+          ctx
+        );
       }
       await sendIdentityPushNotifications(pendingPushNotificationIds);
       return pendingPushNotificationIds;

--- a/src/drops/create-or-update-drop.use-case.ts
+++ b/src/drops/create-or-update-drop.use-case.ts
@@ -75,7 +75,10 @@ import {
   artCurationTokenWatchService,
   ArtCurationTokenWatchService
 } from '@/art-curation/art-curation-token-watch.service';
-import { waveScoreService } from '@/api/waves/wave-score.service';
+import {
+  waveScoreService,
+  WaveScoreDirtyRefreshReason
+} from '@/api/waves/wave-score.service';
 import { extractUrlCandidatesFromText } from '@/nft-links/nft-link-candidates';
 import { validateLinkUrl } from '@/nft-links/nft-link-resolver.validator';
 import { env } from '@/env';
@@ -1627,10 +1630,14 @@ export class CreateOrUpdateDropUseCase {
       connection,
       timer
     });
-    await waveScoreService.refreshWaveScoresForWaveIdsBestEffort([wave.id], {
-      timer,
-      connection
-    });
+    await waveScoreService.markWaveScoresDirtyBestEffort(
+      [wave.id],
+      WaveScoreDirtyRefreshReason.DROP_CHANGED,
+      {
+        timer,
+        connection
+      }
+    );
     await this.recordQuoteNotifications({ model, wave }, { timer, connection });
     const pendingPushNotificationIds = await this.notifyWaveDropRecipients(
       {

--- a/src/drops/delete-drop-use-case.test.ts
+++ b/src/drops/delete-drop-use-case.test.ts
@@ -101,8 +101,8 @@ describe('DeleteDropUseCase', () => {
       identityFetcher,
       'getProfileIdByIdentityKey'
     );
-    const refreshWaveScoresSpy = jest
-      .spyOn(waveScoreService, 'refreshWaveScoresForWaveIdsBestEffort')
+    const markWaveScoresDirtySpy = jest
+      .spyOn(waveScoreService, 'markWaveScoresDirtyBestEffort')
       .mockResolvedValue(undefined);
 
     await expect(
@@ -137,10 +137,14 @@ describe('DeleteDropUseCase', () => {
       timer: undefined,
       connection
     });
-    expect(refreshWaveScoresSpy).toHaveBeenCalledWith(['wave-1'], {
-      timer: undefined,
-      connection
-    });
+    expect(markWaveScoresDirtySpy).toHaveBeenCalledWith(
+      ['wave-1'],
+      'DROP_DELETED',
+      {
+        timer: undefined,
+        connection
+      }
+    );
     expect(dropsDb.insertDeletedDrop).toHaveBeenCalledWith(
       expect.objectContaining({
         id: 'drop-1',

--- a/src/drops/delete-drop.use-case.ts
+++ b/src/drops/delete-drop.use-case.ts
@@ -36,7 +36,10 @@ import {
   dropPollsDb,
   DropPollsDb
 } from '@/api-serverless/src/drops/drop-polls.db';
-import { waveScoreService } from '@/api/waves/wave-score.service';
+import {
+  waveScoreService,
+  WaveScoreDirtyRefreshReason
+} from '@/api/waves/wave-score.service';
 
 export class DeleteDropUseCase {
   public constructor(
@@ -159,8 +162,9 @@ export class DeleteDropUseCase {
           timer,
           connection
         });
-        await waveScoreService.refreshWaveScoresForWaveIdsBestEffort(
+        await waveScoreService.markWaveScoresDirtyBestEffort(
           [drop.wave_id],
+          WaveScoreDirtyRefreshReason.DROP_DELETED,
           { timer, connection }
         );
         await this.dropsDb.insertDeletedDrop(

--- a/src/entities/IWaveScoreRefreshRequest.ts
+++ b/src/entities/IWaveScoreRefreshRequest.ts
@@ -1,0 +1,27 @@
+import { WAVE_SCORE_REFRESH_REQUESTS_TABLE } from '@/constants';
+import { Column, Entity, Index, PrimaryColumn } from 'typeorm';
+
+@Entity(WAVE_SCORE_REFRESH_REQUESTS_TABLE)
+@Index('idx_wsrr_dirty_wave', ['dirty_at', 'wave_id'])
+export class WaveScoreRefreshRequestEntity {
+  @PrimaryColumn({ type: 'varchar', length: 100, nullable: false })
+  readonly wave_id!: string;
+
+  @Column({ type: 'varchar', length: 64, nullable: false })
+  readonly reason!: string;
+
+  @Column({ type: 'bigint', nullable: false })
+  readonly dirty_at!: number;
+
+  @Column({ type: 'int', nullable: false, default: 0 })
+  readonly attempts!: number;
+
+  @Column({ type: 'text', nullable: true, default: null })
+  readonly last_error!: string | null;
+
+  @Column({ type: 'bigint', nullable: false })
+  readonly created_at!: number;
+
+  @Column({ type: 'bigint', nullable: false })
+  readonly updated_at!: number;
+}

--- a/src/entities/entities.ts
+++ b/src/entities/entities.ts
@@ -197,6 +197,7 @@ export { WaveDropperMetricEntity } from './IWaveDropperMetric';
 export { WaveLeaderboardEntryEntity } from './IWaveLeaderboardEntry';
 export { WaveMetadataEntity } from './IWaveMetadata';
 export { WaveMetricEntity } from './IWaveMetric';
+export { WaveScoreRefreshRequestEntity } from './IWaveScoreRefreshRequest';
 export { WaveReaderMetricEntity } from './IWaveReaderMetric';
 export { WaveCurationEntity } from './IWaveCuration';
 export { WaveGroupNotificationSubscriptionEntity } from './IWaveGroupNotificationSubscription';

--- a/src/help-bot/help-bot-drop-writer-service.test.ts
+++ b/src/help-bot/help-bot-drop-writer-service.test.ts
@@ -1,4 +1,5 @@
 import { DropType } from '@/entities/IDrop';
+import { waveScoreService } from '@/api/waves/wave-score.service';
 import { HelpBotDropWriterService } from './help-bot-drop-writer.service';
 
 describe('HelpBotDropWriterService', () => {
@@ -23,6 +24,9 @@ describe('HelpBotDropWriterService', () => {
     const wsListenersNotifier = {
       notifyAboutDropUpdate: jest.fn().mockResolvedValue(undefined)
     };
+    const enqueueDirtyWaveScoreRefreshSpy = jest
+      .spyOn(waveScoreService, 'enqueueDirtyWaveScoreRefreshBestEffort')
+      .mockResolvedValue(undefined);
     const service = new HelpBotDropWriterService(
       createOrUpdateDrop as never,
       dropsDb as never,
@@ -104,5 +108,6 @@ describe('HelpBotDropWriterService', () => {
     ).toBeLessThan(
       wsListenersNotifier.notifyAboutDropUpdate.mock.invocationCallOrder[0]
     );
+    expect(enqueueDirtyWaveScoreRefreshSpy).toHaveBeenCalledWith({});
   });
 });

--- a/src/help-bot/help-bot-drop-writer-service.test.ts
+++ b/src/help-bot/help-bot-drop-writer-service.test.ts
@@ -8,6 +8,7 @@ describe('HelpBotDropWriterService', () => {
     const createOrUpdateDrop = {
       execute: jest.fn().mockResolvedValue({
         drop_id: 'reply-drop',
+        wave_id: 'wave-1',
         pending_push_notification_ids: []
       })
     };
@@ -25,7 +26,7 @@ describe('HelpBotDropWriterService', () => {
       notifyAboutDropUpdate: jest.fn().mockResolvedValue(undefined)
     };
     const enqueueDirtyWaveScoreRefreshSpy = jest
-      .spyOn(waveScoreService, 'enqueueDirtyWaveScoreRefreshBestEffort')
+      .spyOn(waveScoreService, 'requestWaveScoreRefreshBestEffort')
       .mockResolvedValue(undefined);
     const service = new HelpBotDropWriterService(
       createOrUpdateDrop as never,
@@ -108,6 +109,10 @@ describe('HelpBotDropWriterService', () => {
     ).toBeLessThan(
       wsListenersNotifier.notifyAboutDropUpdate.mock.invocationCallOrder[0]
     );
-    expect(enqueueDirtyWaveScoreRefreshSpy).toHaveBeenCalledWith({});
+    expect(enqueueDirtyWaveScoreRefreshSpy).toHaveBeenCalledWith(
+      ['wave-1'],
+      'DROP_CHANGED',
+      {}
+    );
   });
 });

--- a/src/help-bot/help-bot-drop-writer.service.ts
+++ b/src/help-bot/help-bot-drop-writer.service.ts
@@ -16,6 +16,7 @@ import { dropsService, DropsApiService } from '@/api/drops/drops.api.service';
 import { HELP_BOT_HANDLE } from './help-bot.config';
 import { Logger } from '@/logging';
 import { withHelpBotAuthentication } from './help-bot.auth';
+import { waveScoreService } from '@/api/waves/wave-score.service';
 
 export class HelpBotDropWriterService {
   private readonly logger = Logger.get(this.constructor.name);
@@ -111,6 +112,7 @@ export class HelpBotDropWriterService {
         }
       );
 
+    await waveScoreService.enqueueDirtyWaveScoreRefreshBestEffort(ctx);
     void this.sendPendingPushNotifications({
       dropId: drop.id,
       pendingPushNotificationIds

--- a/src/help-bot/help-bot-drop-writer.service.ts
+++ b/src/help-bot/help-bot-drop-writer.service.ts
@@ -16,7 +16,10 @@ import { dropsService, DropsApiService } from '@/api/drops/drops.api.service';
 import { HELP_BOT_HANDLE } from './help-bot.config';
 import { Logger } from '@/logging';
 import { withHelpBotAuthentication } from './help-bot.auth';
-import { waveScoreService } from '@/api/waves/wave-score.service';
+import {
+  waveScoreService,
+  WaveScoreDirtyRefreshReason
+} from '@/api/waves/wave-score.service';
 
 export class HelpBotDropWriterService {
   private readonly logger = Logger.get(this.constructor.name);
@@ -112,7 +115,11 @@ export class HelpBotDropWriterService {
         }
       );
 
-    await waveScoreService.enqueueDirtyWaveScoreRefreshBestEffort(ctx);
+    await waveScoreService.requestWaveScoreRefreshBestEffort(
+      [waveId],
+      WaveScoreDirtyRefreshReason.DROP_CHANGED,
+      ctx
+    );
     void this.sendPendingPushNotifications({
       dropId: drop.id,
       pendingPushNotificationIds

--- a/src/mintAnnouncementsLoop/announce-mint-state-change.use-case.ts
+++ b/src/mintAnnouncementsLoop/announce-mint-state-change.use-case.ts
@@ -15,7 +15,10 @@ import {
   PUBLIC_PHASE_ENDING_SOON_ANNOUNCEMENTS_DONE_MEME_TOKENS_TABLE
 } from '@/constants';
 import { sendIdentityPushNotifications } from '@/api/push-notifications/push-notifications.service';
-import { waveScoreService } from '@/api/waves/wave-score.service';
+import {
+  waveScoreService,
+  WaveScoreDirtyRefreshReason
+} from '@/api/waves/wave-score.service';
 
 interface PhaseConfig {
   readonly name: string;
@@ -233,7 +236,11 @@ export class AnnounceMintStateChangeUseCase {
             return pendingPushNotificationIds;
           }
         );
-      await waveScoreService.enqueueDirtyWaveScoreRefreshBestEffort(ctx);
+      await waveScoreService.requestWaveScoreRefreshBestEffort(
+        waves,
+        WaveScoreDirtyRefreshReason.DROP_CHANGED,
+        ctx
+      );
       await sendIdentityPushNotifications(pendingPushNotificationIds);
     } finally {
       ctx.timer?.stop(`${this.constructor.name}->handle`);

--- a/src/mintAnnouncementsLoop/announce-mint-state-change.use-case.ts
+++ b/src/mintAnnouncementsLoop/announce-mint-state-change.use-case.ts
@@ -15,6 +15,7 @@ import {
   PUBLIC_PHASE_ENDING_SOON_ANNOUNCEMENTS_DONE_MEME_TOKENS_TABLE
 } from '@/constants';
 import { sendIdentityPushNotifications } from '@/api/push-notifications/push-notifications.service';
+import { waveScoreService } from '@/api/waves/wave-score.service';
 
 interface PhaseConfig {
   readonly name: string;
@@ -232,6 +233,7 @@ export class AnnounceMintStateChangeUseCase {
             return pendingPushNotificationIds;
           }
         );
+      await waveScoreService.enqueueDirtyWaveScoreRefreshBestEffort(ctx);
       await sendIdentityPushNotifications(pendingPushNotificationIds);
     } finally {
       ctx.timer?.stop(`${this.constructor.name}->handle`);

--- a/src/rates/ratings.service.ts
+++ b/src/rates/ratings.service.ts
@@ -5,7 +5,10 @@ import { ApiBulkRateRequest } from '../api-serverless/src/generated/models/ApiBu
 import { ApiBulkRepRequest } from '../api-serverless/src/generated/models/ApiBulkRepRequest';
 import { ApiRatingWithProfileInfoAndLevel } from '../api-serverless/src/generated/models/ApiRatingWithProfileInfoAndLevel';
 import { ApiRatingWithProfileInfoAndLevelPage } from '../api-serverless/src/generated/models/ApiRatingWithProfileInfoAndLevelPage';
-import { waveScoreService } from '../api-serverless/src/waves/wave-score.service';
+import {
+  waveScoreService,
+  WaveScoreDirtyRefreshReason
+} from '../api-serverless/src/waves/wave-score.service';
 import { identityFetcher } from '../api-serverless/src/identities/identity.fetcher';
 import { FullPageRequest, Page } from '../api-serverless/src/page-request';
 import {
@@ -665,8 +668,9 @@ export class RatingsService {
       });
     }
     if (waveRepTargetsToRefresh.size > 0) {
-      await waveScoreService.refreshWaveScoresForWaveIdsBestEffort(
-        Array.from(waveRepTargetsToRefresh)
+      await waveScoreService.requestWaveScoreRefreshBestEffort(
+        Array.from(waveRepTargetsToRefresh),
+        WaveScoreDirtyRefreshReason.WAVE_REP_CHANGED
       );
     }
     this.logger.info(`Reduced rates for profile ${raterProfileId}`);

--- a/src/waveScoreRefreshLoop/index.ts
+++ b/src/waveScoreRefreshLoop/index.ts
@@ -6,17 +6,25 @@ import { IdentitySubscriptionEntity } from '../entities/IIdentitySubscription';
 import { Rating } from '../entities/IRating';
 import { WaveEntity } from '../entities/IWave';
 import { WaveMetricEntity } from '../entities/IWaveMetric';
+import { WaveScoreRefreshRequestEntity } from '../entities/IWaveScoreRefreshRequest';
 import { Logger } from '../logging';
 import { doInDbContext } from '../secrets';
 import { sqs } from '../sqs';
 import { Timer } from '../time';
-import { waveScoreService } from '../api-serverless/src/waves/wave-score.service';
+import {
+  WAVE_SCORE_DIRTY_REFRESH_MESSAGE_GROUP_ID,
+  WAVE_SCORE_DIRTY_REFRESH_QUEUE_NAME,
+  waveScoreService
+} from '../api-serverless/src/waves/wave-score.service';
+import { randomUUID } from 'crypto';
 
 const logger = Logger.get('WAVE_SCORE_REFRESH_LOOP');
-const QUEUE_NAME = 'wave-score-refresh-start.fifo';
+const FULL_REFRESH_QUEUE_NAME = 'wave-score-refresh-start.fifo';
 const DEFAULT_MAX_BATCHES_PER_INVOCATION = 10;
+type WaveScoreRefreshMode = 'FULL' | 'DIRTY';
 
 interface WaveScoreRefreshMessage {
+  readonly mode?: WaveScoreRefreshMode;
   readonly batchSize?: number;
   readonly maxBatches?: number;
   readonly startAfterWaveId?: string;
@@ -57,6 +65,14 @@ function parseStringValue(value: unknown): string | undefined {
   return typeof value === 'string' ? value.trim() || undefined : undefined;
 }
 
+function parseModeValue(value: unknown): WaveScoreRefreshMode | undefined {
+  const parsed = parseStringValue(value)?.toUpperCase();
+  if (parsed === 'FULL' || parsed === 'DIRTY') {
+    return parsed;
+  }
+  return undefined;
+}
+
 function parseJsonObject(value: string): Record<string, unknown> {
   const parsed = JSON.parse(value) as unknown;
   if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
@@ -73,6 +89,7 @@ function parseMessageBody(body: string): WaveScoreRefreshMessage {
         ? parseJsonObject(parsed.Message)
         : parsed;
     return {
+      mode: parseModeValue(snsMessage.mode),
       batchSize: parsePositiveIntValue(snsMessage.batchSize, 'batchSize'),
       maxBatches: parsePositiveIntValue(snsMessage.maxBatches, 'maxBatches'),
       startAfterWaveId: parseStringValue(snsMessage.startAfterWaveId)
@@ -99,6 +116,7 @@ function getMessages(event: unknown): WaveScoreRefreshMessage[] {
   }
   return [
     {
+      mode: parseModeValue((event as Record<string, unknown>).mode),
       batchSize: parsePositiveIntValue(
         (event as Record<string, unknown>).batchSize,
         'batchSize'
@@ -128,7 +146,7 @@ function resolveRefreshOptions(message: WaveScoreRefreshMessage) {
   };
 }
 
-async function enqueueContinuation({
+async function enqueueFullRefreshContinuation({
   batchSize,
   maxBatches,
   startAfterWaveId
@@ -138,12 +156,33 @@ async function enqueueContinuation({
   startAfterWaveId: string;
 }) {
   await sqs.sendToQueueName({
-    queueName: QUEUE_NAME,
+    queueName: FULL_REFRESH_QUEUE_NAME,
     messageGroupId: 'wave-score-refresh',
     message: {
+      mode: 'FULL',
       ...(batchSize ? { batchSize } : {}),
       maxBatches,
       startAfterWaveId
+    }
+  });
+}
+
+async function enqueueDirtyRefreshContinuation({
+  batchSize,
+  maxBatches
+}: {
+  batchSize?: number;
+  maxBatches: number;
+}) {
+  await sqs.sendToQueueName({
+    queueName: WAVE_SCORE_DIRTY_REFRESH_QUEUE_NAME,
+    messageGroupId: WAVE_SCORE_DIRTY_REFRESH_MESSAGE_GROUP_ID,
+    message: {
+      mode: 'DIRTY',
+      ...(batchSize ? { batchSize } : {}),
+      maxBatches,
+      requestedAt: Date.now(),
+      nonce: randomUUID()
     }
   });
 }
@@ -155,19 +194,41 @@ const waveScoreRefreshHandler: Handler = async (event) => {
         const timer = new Timer('WAVE_SCORE_REFRESH_LOOP');
         try {
           const options = resolveRefreshOptions(message);
-          const result = await waveScoreService.refreshAllWaveScores(options, {
-            timer
-          });
-          logger.info(`Refreshed wave scores ${JSON.stringify(result)}`);
-          if (result.hasMore && result.lastWaveId) {
-            await enqueueContinuation({
-              batchSize: options.batchSize,
-              maxBatches: options.maxBatches,
-              startAfterWaveId: result.lastWaveId
-            });
-            logger.info(
-              `Queued wave score refresh continuation after ${result.lastWaveId}`
+          if (message.mode === 'DIRTY') {
+            const result = await waveScoreService.refreshDirtyWaveScores(
+              options,
+              {
+                timer
+              }
             );
+            logger.info(
+              `Refreshed dirty wave scores ${JSON.stringify(result)}`
+            );
+            if (result.hasMore) {
+              await enqueueDirtyRefreshContinuation({
+                batchSize: options.batchSize,
+                maxBatches: options.maxBatches
+              });
+              logger.info(`Queued dirty wave score refresh continuation`);
+            }
+          } else {
+            const result = await waveScoreService.refreshAllWaveScores(
+              options,
+              {
+                timer
+              }
+            );
+            logger.info(`Refreshed wave scores ${JSON.stringify(result)}`);
+            if (result.hasMore && result.lastWaveId) {
+              await enqueueFullRefreshContinuation({
+                batchSize: options.batchSize,
+                maxBatches: options.maxBatches,
+                startAfterWaveId: result.lastWaveId
+              });
+              logger.info(
+                `Queued wave score refresh continuation after ${result.lastWaveId}`
+              );
+            }
           }
         } finally {
           logger.info(`Finished executing ${timer.getReport()}`);
@@ -183,7 +244,8 @@ const waveScoreRefreshHandler: Handler = async (event) => {
         IdentitySubscriptionEntity,
         Rating,
         WaveEntity,
-        WaveMetricEntity
+        WaveMetricEntity,
+        WaveScoreRefreshRequestEntity
       ]
     }
   );

--- a/src/waveScoreRefreshLoop/serverless.yaml
+++ b/src/waveScoreRefreshLoop/serverless.yaml
@@ -27,6 +27,16 @@ functions:
             Fn::GetAtt:
               - WaveScoreRefreshStartQueue
               - Arn
+      - sqs:
+          batchSize: 1
+          arn:
+            Fn::GetAtt:
+              - WaveScoreDirtyRefreshQueue
+              - Arn
+      - schedule:
+          rate: rate(1 minute)
+          input:
+            mode: 'DIRTY'
     role: arn:aws:iam::987989283142:role/lambda-vpc-role
     vpc:
       securityGroupIds: ${file(../../serverless-config/${opt:stage, self:provider.stage}/vpc.js):security}
@@ -49,6 +59,23 @@ resources:
         QueueName: 'wave-score-refresh-start.fifo'
         FifoQueue: true
         VisibilityTimeout: 1000
+        ContentBasedDeduplication: true
+    WaveScoreDirtyRefreshQueue:
+      Type: 'AWS::SQS::Queue'
+      Properties:
+        QueueName: 'wave-score-refresh-dirty.fifo'
+        FifoQueue: true
+        VisibilityTimeout: 1000
+        ContentBasedDeduplication: true
+        RedrivePolicy:
+          deadLetterTargetArn:
+            Fn::GetAtt: [WaveScoreDirtyRefreshDLQ, Arn]
+          maxReceiveCount: 5
+    WaveScoreDirtyRefreshDLQ:
+      Type: 'AWS::SQS::Queue'
+      Properties:
+        QueueName: 'wave-score-refresh-dirty-dlq.fifo'
+        FifoQueue: true
         ContentBasedDeduplication: true
     WaveScoreRefreshTDHCalculatedSubscription:
       Type: AWS::SNS::Subscription
@@ -79,6 +106,21 @@ resources:
                 - sqs:ChangeMessageVisibility
               Resource:
                 - !GetAtt WaveScoreRefreshStartQueue.Arn
+    WaveScoreDirtyRefreshQueuePolicy:
+      Type: 'AWS::SQS::QueuePolicy'
+      Properties:
+        Queues:
+          - Ref: 'WaveScoreDirtyRefreshQueue'
+        PolicyDocument:
+          Statement:
+            - Effect: 'Allow'
+              Principal:
+                AWS: arn:aws:iam::987989283142:role/lambda-vpc-role
+              Action:
+                - sqs:GetQueueUrl
+                - sqs:SendMessage
+              Resource:
+                - !GetAtt WaveScoreDirtyRefreshQueue.Arn
     WaveScoreRefreshLoopOOMFilter:
       Type: AWS::Logs::MetricFilter
       DependsOn:

--- a/src/waveScoreRefreshLoop/serverless.yaml
+++ b/src/waveScoreRefreshLoop/serverless.yaml
@@ -119,8 +119,26 @@ resources:
               Action:
                 - sqs:GetQueueUrl
                 - sqs:SendMessage
+                - sqs:ReceiveMessage
+                - sqs:DeleteMessage
+                - sqs:GetQueueAttributes
+                - sqs:ChangeMessageVisibility
               Resource:
                 - !GetAtt WaveScoreDirtyRefreshQueue.Arn
+    WaveScoreDirtyRefreshDLQPolicy:
+      Type: 'AWS::SQS::QueuePolicy'
+      Properties:
+        Queues:
+          - Ref: 'WaveScoreDirtyRefreshDLQ'
+        PolicyDocument:
+          Statement:
+            - Effect: 'Allow'
+              Principal:
+                AWS: arn:aws:iam::987989283142:role/lambda-vpc-role
+              Action:
+                - sqs:SendMessage
+              Resource:
+                - !GetAtt WaveScoreDirtyRefreshDLQ.Arn
     WaveScoreRefreshLoopOOMFilter:
       Type: AWS::Logs::MetricFilter
       DependsOn:

--- a/src/waves/wave-decisions.service.test.ts
+++ b/src/waves/wave-decisions.service.test.ts
@@ -9,6 +9,7 @@ import { WaveDecisionsDb } from '@/waves/wave-decisions.db';
 import { WaveDecisionsService } from '@/waves/wave-decisions.service';
 import { WaveLeaderboardCalculationService } from '@/waves/wave-leaderboard-calculation.service';
 import * as pushNotificationsService from '@/api/push-notifications/push-notifications.service';
+import { waveScoreService } from '@/api/waves/wave-score.service';
 
 describe('WaveDecisionsService', () => {
   let service: WaveDecisionsService;
@@ -26,6 +27,9 @@ describe('WaveDecisionsService', () => {
     deployerDropper = mock();
     jest
       .spyOn(pushNotificationsService, 'sendIdentityPushNotifications')
+      .mockResolvedValue(undefined);
+    jest
+      .spyOn(waveScoreService, 'enqueueDirtyWaveScoreRefreshBestEffort')
       .mockResolvedValue(undefined);
     jest.spyOn(wavesApiDb, 'getWavesOutcomes').mockResolvedValue({});
     jest

--- a/src/waves/wave-decisions.service.test.ts
+++ b/src/waves/wave-decisions.service.test.ts
@@ -29,7 +29,7 @@ describe('WaveDecisionsService', () => {
       .spyOn(pushNotificationsService, 'sendIdentityPushNotifications')
       .mockResolvedValue(undefined);
     jest
-      .spyOn(waveScoreService, 'enqueueDirtyWaveScoreRefreshBestEffort')
+      .spyOn(waveScoreService, 'requestWaveScoreRefreshBestEffort')
       .mockResolvedValue(undefined);
     jest.spyOn(wavesApiDb, 'getWavesOutcomes').mockResolvedValue({});
     jest

--- a/src/waves/wave-decisions.service.ts
+++ b/src/waves/wave-decisions.service.ts
@@ -614,7 +614,10 @@ export class WaveDecisionsService {
       claimBuildDropId,
       pendingPushNotificationIds:
         announcementDropResult.pendingPushNotificationIds,
-      dirtyWaveIds: announcementDropResult.waveIds
+      dirtyWaveIds: collections.distinct([
+        waveId,
+        ...announcementDropResult.waveIds
+      ])
     };
   }
 

--- a/src/waves/wave-decisions.service.ts
+++ b/src/waves/wave-decisions.service.ts
@@ -31,6 +31,7 @@ import {
 } from './wave-leaderboard-calculation.service';
 import * as priorityAlertsContext from '../priority-alerts.context';
 import { sendIdentityPushNotifications } from '@/api/push-notifications/push-notifications.service';
+import { waveScoreService } from '@/api/waves/wave-score.service';
 
 interface WaveOutcome {
   type: WaveOutcomeType;
@@ -185,6 +186,9 @@ export class WaveDecisionsService {
             );
           }
         );
+        await waveScoreService.enqueueDirtyWaveScoreRefreshBestEffort({
+          timer
+        });
         if (claimBuildDropId) {
           await this.enqueueClaimBuild(claimBuildDropId, waveId);
         }
@@ -314,6 +318,9 @@ export class WaveDecisionsService {
               decisionResult.pendingPushNotificationIds;
           }
         );
+        await waveScoreService.enqueueDirtyWaveScoreRefreshBestEffort({
+          timer
+        });
         if (claimBuildDropId) {
           await this.enqueueClaimBuild(claimBuildDropId, waveId);
         }

--- a/src/waves/wave-decisions.service.ts
+++ b/src/waves/wave-decisions.service.ts
@@ -31,7 +31,10 @@ import {
 } from './wave-leaderboard-calculation.service';
 import * as priorityAlertsContext from '../priority-alerts.context';
 import { sendIdentityPushNotifications } from '@/api/push-notifications/push-notifications.service';
-import { waveScoreService } from '@/api/waves/wave-score.service';
+import {
+  waveScoreService,
+  WaveScoreDirtyRefreshReason
+} from '@/api/waves/wave-score.service';
 
 interface WaveOutcome {
   type: WaveOutcomeType;
@@ -142,6 +145,7 @@ export class WaveDecisionsService {
       if (latestDecisionTime < decisionTime) {
         let claimBuildDropId: string | null = null;
         let pendingPushNotificationIds: number[] = [];
+        let dirtyWaveIds: string[] = [];
         await this.waveDecisionsDb.executeNativeQueriesInTransaction(
           async (connection) => {
             this.logger.info(
@@ -159,6 +163,7 @@ export class WaveDecisionsService {
                 claimBuildDropId = decisionResult.claimBuildDropId;
                 pendingPushNotificationIds =
                   decisionResult.pendingPushNotificationIds;
+                dirtyWaveIds = decisionResult.dirtyWaveIds ?? [];
                 decisionsExecuted++;
               } else {
                 this.logger.info(
@@ -186,9 +191,13 @@ export class WaveDecisionsService {
             );
           }
         );
-        await waveScoreService.enqueueDirtyWaveScoreRefreshBestEffort({
-          timer
-        });
+        if (dirtyWaveIds.length) {
+          await waveScoreService.requestWaveScoreRefreshBestEffort(
+            dirtyWaveIds,
+            WaveScoreDirtyRefreshReason.DROP_CHANGED,
+            { timer }
+          );
+        }
         if (claimBuildDropId) {
           await this.enqueueClaimBuild(claimBuildDropId, waveId);
         }
@@ -292,6 +301,7 @@ export class WaveDecisionsService {
         );
         let claimBuildDropId: string | null = null;
         let pendingPushNotificationIds: number[] = [];
+        let dirtyWaveIds: string[] = [];
         await this.waveDecisionsDb.executeNativeQueriesInTransaction(
           async (connection) => {
             this.logger.info(
@@ -316,11 +326,16 @@ export class WaveDecisionsService {
             claimBuildDropId = decisionResult.claimBuildDropId;
             pendingPushNotificationIds =
               decisionResult.pendingPushNotificationIds;
+            dirtyWaveIds = decisionResult.dirtyWaveIds ?? [];
           }
         );
-        await waveScoreService.enqueueDirtyWaveScoreRefreshBestEffort({
-          timer
-        });
+        if (dirtyWaveIds.length) {
+          await waveScoreService.requestWaveScoreRefreshBestEffort(
+            dirtyWaveIds,
+            WaveScoreDirtyRefreshReason.DROP_CHANGED,
+            { timer }
+          );
+        }
         if (claimBuildDropId) {
           await this.enqueueClaimBuild(claimBuildDropId, waveId);
         }
@@ -466,6 +481,7 @@ export class WaveDecisionsService {
   ): Promise<{
     claimBuildDropId: string | null;
     pendingPushNotificationIds: number[];
+    dirtyWaveIds: string[];
   }> {
     ctx?.timer?.start(`${this.constructor.name}->createDecision`);
     const n = outcomes
@@ -507,6 +523,7 @@ export class WaveDecisionsService {
   ): Promise<{
     claimBuildDropId: string | null;
     pendingPushNotificationIds: number[];
+    dirtyWaveIds: string[];
   }> {
     await this.waveDecisionsDb.insertDecision(
       {
@@ -588,12 +605,17 @@ export class WaveDecisionsService {
     await this.waveDecisionsDb.deleteDropsRanks(winnerDropIds, ctx);
     await this.dropsDb.resyncParticipatoryDropCountsForWaves([waveId], ctx);
     await this.dropVotingDb.deleteStaleLeaderboardEntries(ctx);
-    const pendingPushNotificationIds = await this.createAnnouncementDrop(
+    const announcementDropResult = await this.createAnnouncementDrop(
       waveId,
       winnerDropIds,
       ctx
     );
-    return { claimBuildDropId, pendingPushNotificationIds };
+    return {
+      claimBuildDropId,
+      pendingPushNotificationIds:
+        announcementDropResult.pendingPushNotificationIds,
+      dirtyWaveIds: announcementDropResult.waveIds
+    };
   }
 
   private async enqueueClaimBuild(
@@ -724,12 +746,13 @@ export class WaveDecisionsService {
     waveId: string,
     winnerDropIds: string[],
     ctx: RequestContext
-  ): Promise<number[]> {
+  ): Promise<{ pendingPushNotificationIds: number[]; waveIds: string[] }> {
     const mainStageWaveId = env.getStringOrNull('MAIN_STAGE_WAVE_ID');
     const wavesToDropWinnerAnnouncementsTo = env.getStringArray(
       'DEPLOYER_ANNOUNCEMENTS_WAVE_IDS'
     );
     const pendingPushNotificationIds: number[] = [];
+    let createdAnnouncementDrop = false;
     if (wavesToDropWinnerAnnouncementsTo.length && waveId === mainStageWaveId) {
       for (const dropId of winnerDropIds) {
         const winnerHandle = await this.dropsDb.getDropAuthorHandle(
@@ -751,12 +774,18 @@ export class WaveDecisionsService {
           },
           ctx
         );
+        createdAnnouncementDrop = true;
         for (const id of newIds) {
           pendingPushNotificationIds.push(id);
         }
       }
     }
-    return pendingPushNotificationIds;
+    return {
+      pendingPushNotificationIds,
+      waveIds: createdAnnouncementDrop
+        ? collections.distinct(wavesToDropWinnerAnnouncementsTo)
+        : []
+    };
   }
 }
 


### PR DESCRIPTION
## Summary
- Add a DB-backed dirty wave score refresh queue table and enqueue async refresh work instead of refreshing scores inline on drop/write paths.
- Drain dirty refresh requests in `waveScoreRefreshLoop` via a new FIFO SQS queue plus scheduled fallback.
- Read dirty requests from the write pool and delete only the exact `(wave_id, dirty_at)` version refreshed so concurrent writes are not missed.
- Update docs and targeted tests for the async dirty refresh flow.

## Rollout
Zero-downtime order:
1. Deploy `dbMigrationsLoop` first so TypeORM sync creates `wave_score_refresh_requests`.
2. Deploy `waveScoreRefreshLoop` so the dirty queue and scheduled drain exist.
3. Deploy producers that can mark/enqueue dirty wave scores: API, help bot drop writer runtime, rate processing runtime, and TDH/consolidation runtime.

If the dirty table is missing during a partial rollout, write paths fall back to the old synchronous best-effort refresh.

## Verification
- `npm test -- src/api-serverless/src/waves/wave-score-service.test.ts src/drops/delete-drop-use-case.test.ts src/help-bot/help-bot-drop-writer-service.test.ts --runInBand`
- `npm run lint`
- `npm run build`
- `npm run tsc`
- `cd src/waveScoreRefreshLoop && npm run build`
- `git diff --check`
