### PR TITLE
Add desktop wallet auth session type

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -219,8 +219,9 @@ Important API responsibilities:
   `/auth/session-login`, `/auth/session-refresh`, and `/auth/session-logout`.
   Web session v2 challenges derive their domain and client origin from the
   request `Origin` header and refresh/logout checks are bound to the stored
-  origin. Native session v2 challenges are explicitly requested with
-  `client_type=native` and do not receive first-party web semantics. The full
+  origin. Native and desktop session v2 challenges are explicitly requested with
+  `client_type=native` or `client_type=desktop` and do not receive first-party
+  web semantics. The full
   auth contract is documented in
   [Wallet Authentication](auth/wallet-auth.md).
 - Public read APIs for NFTs, TDH, waves, drops, profiles, community metrics, subscriptions, and notifications.

--- a/docs/auth/session-v2-migration-plan.md
+++ b/docs/auth/session-v2-migration-plan.md
@@ -107,8 +107,10 @@ Backend checks after deploy:
 - `/api/settings` returns `auth.session_v2_migration_deadline=null`.
 - `POST /api/auth/redeem-refresh-token` still works for valid legacy refresh
   tokens.
-- `POST /api/auth/connection-share/legacy-desktop` works only from an
-  authenticated session-v2 web session and returns a legacy desktop
+- `POST /api/auth/connection-share/legacy-desktop` works from an authenticated
+  session-v2 source session. Web callers prove that with the web session cookie;
+  native and desktop callers provide their active refresh-token source-session
+  proof. The route returns a legacy desktop
   `/accept-connection-sharing?token=...&address=...` path.
 - V2 web auth routes return exact credentialed CORS for the real web origin and
   reject unrelated browser origins.
@@ -140,9 +142,9 @@ Frontend targets:
 - Staging web: `https://staging.6529.io` EC2/pm2 app.
 - Native app clients: iOS and Android builds that include session-v2 native
   refresh storage and connection-share redemption.
-- 6529 Desktop app: unchanged legacy build. It must continue to receive
-  connection-share links with `token`, `address`, and optional `role` query
-  parameters.
+- 6529 Desktop app: current builds should use `client_type=desktop` for
+  session-v2 auth and connection-share redemption while retaining the legacy
+  desktop bridge for backward compatibility.
 
 Checks after deploy:
 
@@ -156,9 +158,9 @@ Checks after deploy:
 - Connection sharing create/redeem works from an active session-v2 web session.
   Legacy-authenticated web users should be prompted to update authentication
   before they can create a share.
-- Desktop connection sharing from a v2 web session creates a legacy desktop
-  link and the current Desktop app can accept it through legacy refresh-token
-  redemption.
+- Desktop connection sharing from a v2 web or desktop source session creates a
+  desktop v2 share for current Desktop builds. The legacy desktop bridge still
+  creates a legacy refresh-token link for old Desktop builds.
 - A connection-share QR is an end-to-end test only when the receiver is a native
   client or native release candidate with the session-v2 accept flow. A staging
   web build without the frontend session-v2 changes is not a valid receiver
@@ -238,12 +240,14 @@ through one of these paths:
 
 This keeps the v2 session model clean: every v2 session is created by a v2
 signature or by a v2-authenticated connection-sharing flow.
-Mobile/native connection-share URLs carry the one-time code and address only;
-the server stores and returns the role associated with the share.
+Mobile/native/desktop connection-share URLs carry the one-time code and address
+only; the server stores and returns the role associated with the share. Redeem
+responses include the created `client_type` so clients persist refresh tokens
+under the correct session type.
 
-Desktop connection-share URLs are the temporary exception while Desktop remains
-legacy: they carry a legacy refresh `token`, `address`, and optional `role`, and
-are redeemed by the existing Desktop legacy auth flow.
+Legacy Desktop connection-share URLs are the temporary exception for older
+Desktop builds: they carry a legacy refresh `token`, `address`, and optional
+`role`, and are redeemed by the existing Desktop legacy auth flow.
 
 ## Rollback
 

--- a/docs/auth/wallet-auth.md
+++ b/docs/auth/wallet-auth.md
@@ -58,6 +58,13 @@ For native clients:
 - The structured message uses `Session Type: native`.
 - No browser client origin is included.
 
+For 6529 Desktop clients:
+
+- The client must request `client_type=desktop`.
+- The structured message uses the normalized localhost host as `Domain`.
+- The structured message includes `Client Origin` for that localhost app origin.
+- The structured message uses `Session Type: desktop`.
+
 `chain_id` is accepted for backward-compatible request shape, but wallet auth challenges are issued for the backend-configured auth chain. `AUTH_WALLET_CHAIN_ID` defaults to Ethereum mainnet.
 
 ## Session V2 Login
@@ -79,12 +86,14 @@ For web sessions:
   the scoped cookie lets multi-account web sessions refresh, logout, and create
   connection shares for the intended active wallet.
 
-For native sessions:
+For native and desktop sessions:
 
-- The signed message must have `Session Type: native`.
-- The server creates a row in `wallet_auth_sessions` with `client_type=native`.
-- The native refresh token is returned in the JSON response.
-- The native refresh token is stored only as a server-side hash.
+- The signed message must have `Session Type: native` or `Session Type:
+  desktop`, matching the requested `client_type`.
+- The server creates a row in `wallet_auth_sessions` with `client_type=native`
+  or `client_type=desktop`.
+- The refresh token is returned in the JSON response.
+- The refresh token is stored only as a server-side hash.
 
 Both web and native session login return a JWT access token and access-token expiry.
 
@@ -106,10 +115,11 @@ For web sessions:
   scoped cookie for the requested address without clearing another account's
   compatibility cookie.
 
-For native sessions:
+For native and desktop sessions:
 
 - The request supplies `client_address` and `native_refresh_token`.
-- The native refresh token is rotated on every successful refresh.
+- The request supplies `client_type=native` or `client_type=desktop`.
+- The refresh token is rotated on every successful refresh.
 
 `POST /api/auth/session-logout` revokes the current session by default. Current
 web clients send `client_address` so logout targets the matching address-scoped
@@ -122,24 +132,37 @@ stored session origin before revoking an existing session.
 
 Connection sharing is not a replacement for refresh-token redemption. It creates an additional authenticated session from an already authenticated session.
 
-The session-v2 mobile/native flow is:
+The session-v2 mobile/native/desktop flow is:
 
 1. An authenticated client calls `POST /api/auth/connection-share`.
 2. The server creates a short-lived one-time `connection_share_code`.
 3. The response includes `connection_share_code` and a `deep_link_path`.
-4. A native client calls `POST /api/auth/connection-share/redeem`.
-5. The server consumes the share code once and creates a native wallet auth session.
+4. A native or desktop client calls `POST /api/auth/connection-share/redeem`.
+5. The server consumes the share code once and creates the requested native or
+   desktop wallet auth session.
 
 The original client remains connected. This is connection sharing, not moving or revoking the original connection.
 
-Connection share state is stored in `wallet_connection_shares`. Share codes are stored only as server-side hashes and expire after a short TTL.
+Connection share creation requires bearer JWT auth plus proof that the caller has
+an active matching source session for the authenticated wallet and role:
 
-The desktop compatibility flow intentionally remains on the legacy refresh-token
-handoff while 6529 Desktop is still a legacy client:
+- Web callers prove the source session with the active session-v2 web cookie.
+- Native and desktop callers can instead include `client_type`,
+  `client_address`, and `native_refresh_token`; the backend checks that refresh
+  token against the active source session before issuing a share.
 
-1. A session-v2 web client calls `POST /api/auth/connection-share/legacy-desktop`.
-2. The server requires bearer JWT auth plus an active matching session-v2 web
-   cookie for the authenticated wallet and role.
+Connection share state is stored in `wallet_connection_shares`. Share codes are
+stored only as server-side hashes and expire after a short TTL. Redeeming a
+share returns `client_type` so callers can persist the refresh token under the
+actual session type created by the backend.
+
+The desktop compatibility flow remains available for legacy Desktop builds that
+still need the legacy refresh-token handoff:
+
+1. A session-v2 client calls `POST /api/auth/connection-share/legacy-desktop`.
+2. The server requires bearer JWT auth plus either an active matching
+   session-v2 web cookie or the native/desktop source-session proof described
+   above.
 3. The server returns a legacy refresh token and an
    `/accept-connection-sharing?token=...&address=...` deep-link path.
 4. 6529 Desktop redeems that token through `POST /api/auth/redeem-refresh-token`

--- a/src/api-serverless/openapi.yaml
+++ b/src/api-serverless/openapi.yaml
@@ -235,8 +235,9 @@ paths:
       description: >
         V2 wallet session nonce endpoint. Web session challenges derive their
         domain and client origin from the request Origin header and require a
-        configured first-party origin. Native and desktop challenges are
-        selected explicitly and never receive first-party web semantics.
+        configured first-party origin. Native challenges are selected explicitly.
+        Desktop challenges are selected explicitly and require a loopback
+        localhost Origin, which is signed into the challenge.
       operationId: getWalletAuthSessionNonce
       security: []
       parameters:
@@ -257,8 +258,9 @@ paths:
               - desktop
             default: web
           description: >
-            Web challenges require an allowed Origin header. Native and desktop
-            challenges are explicitly requested by refresh-token clients.
+            Web challenges require an allowed Origin header. Desktop challenges
+            require a localhost Origin. Native challenges are explicitly
+            requested by refresh-token clients.
         - name: chain_id
           in: query
           required: false
@@ -289,7 +291,9 @@ paths:
         V2 wallet sessions require structured authentication signatures. Web
         cookie sessions require Session Type first_party_web; native and
         desktop refresh-token sessions require matching Session Type values.
-        External clients should use the non-cookie bearer-token login flow.
+        Desktop sessions also require the signed Client Origin to be a
+        localhost loopback origin. External clients should use the non-cookie
+        bearer-token login flow.
       operationId: createWalletAuthSession
       security: []
       requestBody:

--- a/src/api-serverless/openapi.yaml
+++ b/src/api-serverless/openapi.yaml
@@ -235,9 +235,9 @@ paths:
       description: >
         V2 wallet session nonce endpoint. Web session challenges derive their
         domain and client origin from the request Origin header and require a
-        configured first-party origin. Native challenges are selected explicitly.
-        Desktop challenges are selected explicitly and require a loopback
-        localhost Origin, which is signed into the challenge.
+        configured first-party origin. Native challenges are selected
+        explicitly. Desktop challenges are selected explicitly and require a
+        loopback localhost Origin, which is signed into the challenge.
       operationId: getWalletAuthSessionNonce
       security: []
       parameters:
@@ -289,11 +289,11 @@ paths:
       summary: Authenticate and create a wallet auth session
       description: >
         V2 wallet sessions require structured authentication signatures. Web
-        cookie sessions require Session Type first_party_web; native and
-        desktop refresh-token sessions require matching Session Type values.
-        Desktop sessions also require the signed Client Origin to be a
-        localhost loopback origin. External clients should use the non-cookie
-        bearer-token login flow.
+        cookie sessions require Session Type first_party_web; native and desktop
+        refresh-token sessions require matching Session Type values. Desktop
+        sessions also require the signed Client Origin to be a localhost
+        loopback origin. External clients should use the non-cookie bearer-token
+        login flow.
       operationId: createWalletAuthSession
       security: []
       requestBody:
@@ -400,14 +400,16 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ApiCreateLegacyDesktopConnectionShareRequest"
+              $ref: >-
+                #/components/schemas/ApiCreateLegacyDesktopConnectionShareRequest
       responses:
         "201":
           description: successful operation
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ApiCreateLegacyDesktopConnectionShareResponse"
+                $ref: >-
+                  #/components/schemas/ApiCreateLegacyDesktopConnectionShareResponse
         "400":
           description: Invalid request
   /auth/connection-share/redeem:
@@ -11786,6 +11788,18 @@ components:
         role:
           type: string
           nullable: true
+        client_type:
+          type: string
+          description: Optional source session type for native or desktop callers.
+          enum:
+            - native
+            - desktop
+        client_address:
+          type: string
+          description: Wallet address bound to the source native or desktop session.
+        native_refresh_token:
+          type: string
+          description: Refresh token for the source native or desktop session.
     ApiCreateConnectionShareResponse:
       type: object
       required:
@@ -11810,28 +11824,6 @@ components:
           enum:
             - native
             - desktop
-        deep_link_path:
-          type: string
-    ApiCreateLegacyDesktopConnectionShareRequest:
-      type: object
-      properties:
-        role:
-          type: string
-          nullable: true
-    ApiCreateLegacyDesktopConnectionShareResponse:
-      type: object
-      required:
-        - refresh_token
-        - address
-        - deep_link_path
-      properties:
-        refresh_token:
-          type: string
-        address:
-          type: string
-        role:
-          type: string
-          nullable: true
         deep_link_path:
           type: string
     ApiCreateDropMedia:
@@ -11975,6 +11967,40 @@ components:
         is_beneficiary_of_grant_id:
           type: string
           nullable: true
+    ApiCreateLegacyDesktopConnectionShareRequest:
+      type: object
+      properties:
+        role:
+          type: string
+          nullable: true
+        client_type:
+          type: string
+          description: Optional source session type for native or desktop callers.
+          enum:
+            - native
+            - desktop
+        client_address:
+          type: string
+          description: Wallet address bound to the source native or desktop session.
+        native_refresh_token:
+          type: string
+          description: Refresh token for the source native or desktop session.
+    ApiCreateLegacyDesktopConnectionShareResponse:
+      type: object
+      required:
+        - refresh_token
+        - address
+        - deep_link_path
+      properties:
+        refresh_token:
+          type: string
+        address:
+          type: string
+        role:
+          type: string
+          nullable: true
+        deep_link_path:
+          type: string
     ApiCreateMediaUploadUrlRequest:
       required:
         - content_type
@@ -17042,6 +17068,7 @@ components:
         - address
         - access_token
         - access_token_expires_at
+        - client_type
         - native_refresh_token
         - refresh_token_expires_at
       properties:
@@ -17055,6 +17082,11 @@ components:
         access_token_expires_at:
           type: string
           format: date-time
+        client_type:
+          type: string
+          enum:
+            - native
+            - desktop
         native_refresh_token:
           type: string
         refresh_token_expires_at:

--- a/src/api-serverless/openapi.yaml
+++ b/src/api-serverless/openapi.yaml
@@ -235,8 +235,8 @@ paths:
       description: >
         V2 wallet session nonce endpoint. Web session challenges derive their
         domain and client origin from the request Origin header and require a
-        configured first-party origin. Native challenges are selected with
-        client_type=native and never receive first-party web semantics.
+        configured first-party origin. Native and desktop challenges are
+        selected explicitly and never receive first-party web semantics.
       operationId: getWalletAuthSessionNonce
       security: []
       parameters:
@@ -254,10 +254,11 @@ paths:
             enum:
               - web
               - native
+              - desktop
             default: web
           description: >
-            Web challenges require an allowed Origin header. Native challenges
-            are explicitly requested by native clients.
+            Web challenges require an allowed Origin header. Native and desktop
+            challenges are explicitly requested by refresh-token clients.
         - name: chain_id
           in: query
           required: false
@@ -286,9 +287,9 @@ paths:
       summary: Authenticate and create a wallet auth session
       description: >
         V2 wallet sessions require structured authentication signatures. Web
-        cookie sessions require Session Type first_party_web; native refresh
-        token sessions require Session Type native. External clients should use
-        the non-cookie bearer-token login flow.
+        cookie sessions require Session Type first_party_web; native and
+        desktop refresh-token sessions require matching Session Type values.
+        External clients should use the non-cookie bearer-token login flow.
       operationId: createWalletAuthSession
       security: []
       requestBody:
@@ -11777,6 +11778,7 @@ components:
           type: string
           enum:
             - native
+            - desktop
         role:
           type: string
           nullable: true
@@ -11803,6 +11805,7 @@ components:
           type: string
           enum:
             - native
+            - desktop
         deep_link_path:
           type: string
     ApiCreateLegacyDesktopConnectionShareRequest:
@@ -17028,6 +17031,7 @@ components:
           type: string
           enum:
             - native
+            - desktop
     ApiRedeemConnectionShareResponse:
       type: object
       required:
@@ -17307,6 +17311,7 @@ components:
           enum:
             - web
             - native
+            - desktop
         client_address:
           type: string
         client_signature:
@@ -17316,8 +17321,9 @@ components:
           description: >-
             Server-signed structured challenge token. /auth/session-login only
             accepts first_party_web challenges for web cookie sessions and
-            native challenges for native refresh-token sessions; external_client
-            challenges use /auth/login bearer-token auth instead.
+            matching native or desktop challenges for refresh-token sessions;
+            external_client challenges use /auth/login bearer-token auth
+            instead.
         role:
           type: string
           nullable: true
@@ -17345,6 +17351,7 @@ components:
           type: string
           enum:
             - native
+            - desktop
         client_address:
           type: string
         native_refresh_token:
@@ -17394,6 +17401,7 @@ components:
           type: string
           enum:
             - native
+            - desktop
         native_refresh_token:
           type: string
         refresh_token_expires_at:
@@ -17413,6 +17421,7 @@ components:
           enum:
             - web
             - native
+            - desktop
           default: web
         chain_id:
           type: integer
@@ -17442,6 +17451,7 @@ components:
           type: string
           enum:
             - native
+            - desktop
         client_address:
           type: string
         native_refresh_token:

--- a/src/api-serverless/src/auth/auth-db.test.ts
+++ b/src/api-serverless/src/auth/auth-db.test.ts
@@ -168,6 +168,60 @@ describe('AuthDb', () => {
     );
   });
 
+  it('filters refresh-token wallet auth sessions by the requested client type', async () => {
+    const { authDb, execute, oneOrNull } = createExecutor();
+    const now = new Date();
+    oneOrNull.mockResolvedValueOnce(null).mockResolvedValueOnce({
+      id: 'session-1',
+      address: '0xabc',
+      role: null,
+      client_type: 'desktop',
+      secret_hash: null,
+      refresh_token_hash: 'new-hash',
+      user_agent_hash: null,
+      signature_domain: null,
+      client_origin: null,
+      created_at: new Date(),
+      last_used_at: now,
+      expires_at: now,
+      revoked_at: null
+    });
+
+    await authDb.getActiveNativeSessionByRefreshHash(
+      '0xabc',
+      'refresh-hash',
+      now,
+      'desktop'
+    );
+
+    expect(oneOrNull).toHaveBeenCalledWith(
+      expect.stringContaining('client_type = :clientType'),
+      {
+        address: '0xabc',
+        refreshTokenHash: 'refresh-hash',
+        now,
+        clientType: 'desktop'
+      }
+    );
+
+    await authDb.rotateNativeSessionRefreshToken({
+      sessionId: 'session-1',
+      previousRefreshTokenHash: 'old-hash',
+      nextRefreshTokenHash: 'new-hash',
+      expiresAt: now,
+      now,
+      clientType: 'desktop'
+    });
+
+    expect(execute).toHaveBeenCalledWith(
+      expect.stringContaining('client_type = :clientType'),
+      expect.objectContaining({
+        sessionId: 'session-1',
+        clientType: 'desktop'
+      })
+    );
+  });
+
   it('reads newly written connection shares from the write pool', async () => {
     const { authDb, oneOrNull } = createExecutor();
     oneOrNull.mockResolvedValueOnce({

--- a/src/api-serverless/src/auth/auth-routes-desktop-origin.test.ts
+++ b/src/api-serverless/src/auth/auth-routes-desktop-origin.test.ts
@@ -1,0 +1,24 @@
+import { isDesktopSessionOriginAllowed } from './auth.routes';
+
+describe('desktop auth origin validation', () => {
+  it.each([
+    'http://localhost:6529',
+    'http://127.0.0.1:6529',
+    'http://[::1]:6529'
+  ])('allows loopback HTTP origins with a port: %s', (origin) => {
+    expect(isDesktopSessionOriginAllowed(origin)).toBe(true);
+  });
+
+  it.each([
+    null,
+    '',
+    'http://localhost',
+    'https://localhost:6529',
+    'http://localhost.evil.example:6529',
+    'http://192.168.0.10:6529',
+    'https://6529.io',
+    'not-a-url'
+  ])('rejects non-desktop origins: %s', (origin) => {
+    expect(isDesktopSessionOriginAllowed(origin)).toBe(false);
+  });
+});

--- a/src/api-serverless/src/auth/auth-routes-desktop-origin.test.ts
+++ b/src/api-serverless/src/auth/auth-routes-desktop-origin.test.ts
@@ -1,3 +1,9 @@
+jest.mock('passport', () => ({
+  authenticate: jest.fn(
+    () => (_req: unknown, _res: unknown, next: () => void) => next()
+  )
+}));
+
 import { isDesktopSessionOriginAllowed } from './auth.routes';
 
 describe('desktop auth origin validation', () => {

--- a/src/api-serverless/src/auth/auth-session-v2.test.ts
+++ b/src/api-serverless/src/auth/auth-session-v2.test.ts
@@ -8,6 +8,7 @@ import {
   createWebSession,
   getActiveWebSession,
   getWalletSessionCookieNameForAddress,
+  hasActiveNativeSessionForAddressAndRole,
   hasActiveWebSessionForAddressAndRole,
   isAuthConnectionSharingEnabled,
   logoutNativeSession,
@@ -422,6 +423,67 @@ describe('auth-session-v2', () => {
         address: '0xaaa',
         role: 'profile-b',
         requestOrigin: 'https://6529.io'
+      })
+    ).resolves.toBe(false);
+  });
+
+  it('accepts active native sessions for matching source wallet, role, and client type', async () => {
+    authDbMock.getActiveNativeSessionByRefreshHash.mockResolvedValue({
+      id: 'session-a',
+      address: '0xaaa',
+      role: 'profile-a',
+      client_type: 'desktop',
+      secret_hash: null,
+      refresh_token_hash: 'stored-refresh-hash',
+      user_agent_hash: null,
+      signature_domain: 'localhost:6529',
+      client_origin: 'http://localhost:6529',
+      created_at: new Date(),
+      last_used_at: new Date(),
+      expires_at: new Date(Date.now() + 60_000),
+      revoked_at: null
+    });
+
+    await expect(
+      hasActiveNativeSessionForAddressAndRole({
+        address: '0xAAA',
+        role: 'profile-a',
+        nativeRefreshToken: 'refresh-secret',
+        clientType: 'desktop'
+      })
+    ).resolves.toBe(true);
+
+    expect(authDbMock.getActiveNativeSessionByRefreshHash).toHaveBeenCalledWith(
+      '0xaaa',
+      expect.stringMatching(/^[a-f0-9]{64}$/),
+      expect.any(Date),
+      'desktop'
+    );
+  });
+
+  it('rejects native source sessions with the wrong role', async () => {
+    authDbMock.getActiveNativeSessionByRefreshHash.mockResolvedValue({
+      id: 'session-a',
+      address: '0xaaa',
+      role: 'profile-a',
+      client_type: 'desktop',
+      secret_hash: null,
+      refresh_token_hash: 'stored-refresh-hash',
+      user_agent_hash: null,
+      signature_domain: 'localhost:6529',
+      client_origin: 'http://localhost:6529',
+      created_at: new Date(),
+      last_used_at: new Date(),
+      expires_at: new Date(Date.now() + 60_000),
+      revoked_at: null
+    });
+
+    await expect(
+      hasActiveNativeSessionForAddressAndRole({
+        address: '0xAAA',
+        role: 'profile-b',
+        nativeRefreshToken: 'refresh-secret',
+        clientType: 'desktop'
       })
     ).resolves.toBe(false);
   });
@@ -926,10 +988,10 @@ describe('auth-session-v2', () => {
 
     expect(redeemed?.response).toMatchObject({
       address: '0xabc',
-      role: 'profile-1'
+      role: 'profile-1',
+      client_type: 'native'
     });
     expect(redeemed?.response.native_refresh_token).toEqual(expect.any(String));
-    expect(redeemed?.response).not.toHaveProperty('client_type');
 
     const [consumeParams] =
       authDbMock.consumeWalletConnectionShare.mock.calls[0];
@@ -1006,6 +1068,7 @@ describe('auth-session-v2', () => {
       target_client_type: 'desktop'
     });
     expect(redeemed?.response.native_refresh_token).toEqual(expect.any(String));
+    expect(redeemed?.response.client_type).toBe('desktop');
 
     const [storedSession] = authDbMock.createWalletAuthSession.mock.calls[0];
     expect(storedSession.clientType).toBe('desktop');

--- a/src/api-serverless/src/auth/auth-session-v2.test.ts
+++ b/src/api-serverless/src/auth/auth-session-v2.test.ts
@@ -4,6 +4,7 @@ import {
   clearWalletSessionCookieForAddressAndOrigin,
   clearWalletSessionCookieForOrigin,
   createConnectionShare,
+  createNativeSession,
   createWebSession,
   getActiveWebSession,
   getWalletSessionCookieNameForAddress,
@@ -252,6 +253,46 @@ describe('auth-session-v2', () => {
     const setCookieHeader = result.setCookie.join('\n');
     expect(setCookieHeader).toContain('SameSite=Lax');
     expect(setCookieHeader).not.toContain('SameSite=None');
+  });
+
+  it('creates desktop refresh-token sessions with a desktop client type', async () => {
+    authDbMock.createWalletAuthSession.mockImplementation(async (params) => ({
+      id: params.id,
+      address: params.address,
+      role: params.role,
+      client_type: params.clientType,
+      secret_hash: params.secretHash,
+      refresh_token_hash: params.refreshTokenHash,
+      user_agent_hash: params.userAgentHash,
+      signature_domain: params.signatureDomain,
+      client_origin: params.clientOrigin,
+      created_at: new Date(),
+      last_used_at: new Date(),
+      expires_at: params.expiresAt,
+      revoked_at: null
+    }));
+
+    const result = await createNativeSession({
+      address: '0xABCDEF',
+      role: 'profile-1',
+      userAgent: '6529 Desktop',
+      clientType: 'desktop'
+    });
+
+    expect(result.response).toMatchObject({
+      address: '0xabcdef',
+      role: 'profile-1',
+      client_type: 'desktop'
+    });
+    expect(result.response.native_refresh_token).toEqual(expect.any(String));
+
+    const [storedSession] = authDbMock.createWalletAuthSession.mock.calls[0];
+    expect(storedSession.clientType).toBe('desktop');
+    expect(storedSession.secretHash).toBeNull();
+    expect(storedSession.refreshTokenHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(storedSession.userAgentHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(storedSession.signatureDomain).toBeNull();
+    expect(storedSession.clientOrigin).toBeNull();
   });
 
   it('loads active web sessions from the session-v2 cookie without trusting URL role metadata', async () => {
@@ -567,7 +608,8 @@ describe('auth-session-v2', () => {
     expect(authDbMock.getActiveNativeSessionByRefreshHash).toHaveBeenCalledWith(
       '0xabc',
       expect.stringMatching(/^[a-f0-9]{64}$/),
-      expect.any(Date)
+      expect.any(Date),
+      'native'
     );
     expect(authDbMock.revokeWalletAuthSessionsForAddress).toHaveBeenCalledWith(
       '0xabc',
@@ -753,6 +795,63 @@ describe('auth-session-v2', () => {
     expect(rotateParams.nextRefreshTokenHash).not.toBe(
       result?.response.native_refresh_token
     );
+    expect(rotateParams.clientType).toBe('native');
+  });
+
+  it('rotates desktop refresh tokens separately from native sessions', async () => {
+    authDbMock.getActiveNativeSessionByRefreshHash.mockResolvedValue({
+      id: 'session-1',
+      address: '0xabc',
+      role: 'profile-1',
+      client_type: 'desktop',
+      secret_hash: null,
+      refresh_token_hash: 'old-hash',
+      user_agent_hash: null,
+      signature_domain: null,
+      client_origin: null,
+      created_at: new Date(),
+      last_used_at: new Date(),
+      expires_at: new Date(Date.now() + 60_000),
+      revoked_at: null
+    });
+    authDbMock.rotateNativeSessionRefreshToken.mockImplementation(
+      async (params) => ({
+        id: params.sessionId,
+        address: '0xabc',
+        role: 'profile-1',
+        client_type: 'desktop',
+        secret_hash: null,
+        refresh_token_hash: params.nextRefreshTokenHash,
+        user_agent_hash: null,
+        signature_domain: null,
+        client_origin: null,
+        created_at: new Date(),
+        last_used_at: params.now,
+        expires_at: params.expiresAt,
+        revoked_at: null
+      })
+    );
+
+    const result = await refreshNativeSession({
+      address: '0xABC',
+      nativeRefreshToken: 'raw-desktop-refresh-token',
+      clientType: 'desktop'
+    });
+
+    expect(result?.response).toMatchObject({
+      address: '0xabc',
+      role: 'profile-1',
+      client_type: 'desktop'
+    });
+    expect(authDbMock.getActiveNativeSessionByRefreshHash).toHaveBeenCalledWith(
+      '0xabc',
+      expect.stringMatching(/^[a-f0-9]{64}$/),
+      expect.any(Date),
+      'desktop'
+    );
+    const [rotateParams] =
+      authDbMock.rotateNativeSessionRefreshToken.mock.calls[0];
+    expect(rotateParams.clientType).toBe('desktop');
   });
 
   it('creates one-time connection share codes as hashes and redeems them into native sessions', async () => {
@@ -849,6 +948,72 @@ describe('auth-session-v2', () => {
     );
   });
 
+  it('creates one-time connection share codes for desktop sessions', async () => {
+    authDbMock.createWalletConnectionShare.mockImplementation(
+      async (params) => ({
+        id: params.id,
+        connection_share_code_hash: params.connectionShareCodeHash,
+        address: params.address,
+        role: params.role,
+        target_client_type: params.targetClientType,
+        created_at: new Date(),
+        expires_at: params.expiresAt,
+        consumed_at: null,
+        consumed_session_id: null
+      })
+    );
+    authDbMock.consumeWalletConnectionShare.mockResolvedValue({
+      id: 'share-1',
+      connection_share_code_hash: 'hashed-share',
+      address: '0xabc',
+      role: 'profile-1',
+      target_client_type: 'desktop',
+      created_at: new Date(),
+      expires_at: new Date(Date.now() + 60_000),
+      consumed_at: new Date(),
+      consumed_session_id: null
+    });
+    authDbMock.createWalletAuthSession.mockImplementation(async (params) => ({
+      id: params.id,
+      address: params.address,
+      role: params.role,
+      client_type: params.clientType,
+      secret_hash: params.secretHash,
+      refresh_token_hash: params.refreshTokenHash,
+      user_agent_hash: params.userAgentHash,
+      signature_domain: params.signatureDomain,
+      client_origin: params.clientOrigin,
+      created_at: new Date(),
+      last_used_at: new Date(),
+      expires_at: params.expiresAt,
+      revoked_at: null
+    }));
+
+    const created = await createConnectionShare({
+      address: '0xABC',
+      role: 'profile-1',
+      targetClientType: 'desktop'
+    });
+    const redeemed = await redeemConnectionShare({
+      connectionShareCode: created.connection_share_code,
+      targetClientType: 'desktop',
+      userAgent: '6529 Desktop'
+    });
+
+    expect(created).toMatchObject({
+      address: '0xabc',
+      role: 'profile-1',
+      target_client_type: 'desktop'
+    });
+    expect(redeemed?.response.native_refresh_token).toEqual(expect.any(String));
+
+    const [storedSession] = authDbMock.createWalletAuthSession.mock.calls[0];
+    expect(storedSession.clientType).toBe('desktop');
+    const [consumeParams] =
+      authDbMock.consumeWalletConnectionShare.mock.calls[0];
+    expect(consumeParams.targetClientType).toBe('desktop');
+  });
+
   it('rejects web connection-share targets at the service boundary', async () => {
     await expect(
       createConnectionShare({
@@ -856,7 +1021,7 @@ describe('auth-session-v2', () => {
         role: null,
         targetClientType: 'web'
       })
-    ).rejects.toThrow('native clients only');
+    ).rejects.toThrow('refresh-token clients only');
 
     await expect(
       redeemConnectionShare({
@@ -864,6 +1029,6 @@ describe('auth-session-v2', () => {
         targetClientType: 'web',
         userAgent: 'Mozilla/5.0'
       })
-    ).rejects.toThrow('native clients only');
+    ).rejects.toThrow('refresh-token clients only');
   });
 });

--- a/src/api-serverless/src/auth/auth-session-v2.ts
+++ b/src/api-serverless/src/auth/auth-session-v2.ts
@@ -13,19 +13,19 @@ import { authDb } from './auth.db';
 import {
   ApiCreateConnectionShareResponse,
   ApiCreateConnectionShareResponseTargetClientTypeEnum
-} from '../generated/models/ApiCreateConnectionShareResponse';
+} from '@/api/generated/models/ApiCreateConnectionShareResponse';
 import {
   ApiRedeemConnectionShareResponse,
   ApiRedeemConnectionShareResponseClientTypeEnum
-} from '../generated/models/ApiRedeemConnectionShareResponse';
+} from '@/api/generated/models/ApiRedeemConnectionShareResponse';
 import {
   ApiSessionNativeResponse,
   ApiSessionNativeResponseClientTypeEnum
-} from '../generated/models/ApiSessionNativeResponse';
+} from '@/api/generated/models/ApiSessionNativeResponse';
 import {
   ApiSessionWebResponse,
   ApiSessionWebResponseClientTypeEnum
-} from '../generated/models/ApiSessionWebResponse';
+} from '@/api/generated/models/ApiSessionWebResponse';
 
 export const WALLET_SESSION_COOKIE_NAME = '6529_session';
 const WALLET_SESSION_ADDRESS_COOKIE_PREFIX = `${WALLET_SESSION_COOKIE_NAME}_`;

--- a/src/api-serverless/src/auth/auth-session-v2.ts
+++ b/src/api-serverless/src/auth/auth-session-v2.ts
@@ -14,7 +14,10 @@ import {
   ApiCreateConnectionShareResponse,
   ApiCreateConnectionShareResponseTargetClientTypeEnum
 } from '../generated/models/ApiCreateConnectionShareResponse';
-import { ApiRedeemConnectionShareResponse } from '../generated/models/ApiRedeemConnectionShareResponse';
+import {
+  ApiRedeemConnectionShareResponse,
+  ApiRedeemConnectionShareResponseClientTypeEnum
+} from '../generated/models/ApiRedeemConnectionShareResponse';
 import {
   ApiSessionNativeResponse,
   ApiSessionNativeResponseClientTypeEnum
@@ -388,6 +391,31 @@ export async function hasActiveWebSessionForAddressAndRole({
   return false;
 }
 
+export async function hasActiveNativeSessionForAddressAndRole({
+  address,
+  role,
+  nativeRefreshToken,
+  clientType
+}: {
+  readonly address: string;
+  readonly role: string | null;
+  readonly nativeRefreshToken: string;
+  readonly clientType: RefreshTokenSessionClientType;
+}): Promise<boolean> {
+  const normalizedAddress = address.toLowerCase();
+  const existing = await authDb.getActiveNativeSessionByRefreshHash(
+    normalizedAddress,
+    hashSecret(nativeRefreshToken),
+    new Date(),
+    clientType
+  );
+  return (
+    existing?.address === normalizedAddress &&
+    existing.role === role &&
+    existing.client_type === clientType
+  );
+}
+
 export async function refreshWebSessionForAddress({
   cookieHeader,
   address,
@@ -723,6 +751,10 @@ export async function redeemConnectionShare({
       role: session.response.role,
       access_token: session.response.access_token,
       access_token_expires_at: session.response.access_token_expires_at,
+      client_type:
+        session.response.client_type === 'desktop'
+          ? ApiRedeemConnectionShareResponseClientTypeEnum.Desktop
+          : ApiRedeemConnectionShareResponseClientTypeEnum.Native,
       native_refresh_token: session.response.native_refresh_token,
       refresh_token_expires_at: session.response.refresh_token_expires_at
     }

--- a/src/api-serverless/src/auth/auth-session-v2.ts
+++ b/src/api-serverless/src/auth/auth-session-v2.ts
@@ -39,6 +39,8 @@ export type SessionV2WebResponse = ApiSessionWebResponse;
 
 export type SessionV2NativeResponse = ApiSessionNativeResponse;
 
+type RefreshTokenSessionClientType = Exclude<WalletAuthClientType, 'web'>;
+
 export interface CreatedWebSession {
   readonly response: SessionV2WebResponse;
   readonly setCookie: string[];
@@ -267,16 +269,19 @@ export async function createWebSession({
 export async function createNativeSession({
   address,
   role,
-  userAgent
+  userAgent,
+  clientType = 'native'
 }: {
   readonly address: string;
   readonly role: string | null;
   readonly userAgent: string | null;
+  readonly clientType?: RefreshTokenSessionClientType;
 }): Promise<CreatedNativeSession> {
   const session = await createNativeSessionRecord({
     address,
     role,
-    userAgent
+    userAgent,
+    clientType
   });
   return { response: session.response };
 }
@@ -518,16 +523,19 @@ function getWebSessionClearCookieHeader({
 
 export async function refreshNativeSession({
   address,
-  nativeRefreshToken
+  nativeRefreshToken,
+  clientType = 'native'
 }: {
   readonly address: string;
   readonly nativeRefreshToken: string;
+  readonly clientType?: RefreshTokenSessionClientType;
 }): Promise<CreatedNativeSession | null> {
   const now = new Date();
   const existing = await authDb.getActiveNativeSessionByRefreshHash(
     address.toLowerCase(),
     hashSecret(nativeRefreshToken),
-    now
+    now,
+    clientType
   );
   if (!existing) {
     return null;
@@ -539,7 +547,8 @@ export async function refreshNativeSession({
     previousRefreshTokenHash: hashSecret(nativeRefreshToken),
     nextRefreshTokenHash: hashSecret(nextRefreshToken),
     expiresAt,
-    now
+    now,
+    clientType
   });
   if (!rotated) {
     return null;
@@ -551,7 +560,7 @@ export async function refreshNativeSession({
       role: rotated.role,
       access_token: accessToken.token,
       access_token_expires_at: accessToken.expiresAt,
-      client_type: ApiSessionNativeResponseClientTypeEnum.Native,
+      client_type: toNativeSessionResponseClientType(clientType),
       native_refresh_token: nextRefreshToken,
       refresh_token_expires_at: expiresAt
     }
@@ -606,11 +615,13 @@ export async function logoutWebSession({
 export async function logoutNativeSession({
   address,
   nativeRefreshToken,
-  allSessions
+  allSessions,
+  clientType = 'native'
 }: {
   readonly address: string;
   readonly nativeRefreshToken: string;
   readonly allSessions: boolean;
+  readonly clientType?: RefreshTokenSessionClientType;
 }): Promise<void> {
   const now = new Date();
   const refreshTokenHash = hashSecret(nativeRefreshToken);
@@ -618,7 +629,8 @@ export async function logoutNativeSession({
     const existing = await authDb.getActiveNativeSessionByRefreshHash(
       address.toLowerCase(),
       refreshTokenHash,
-      now
+      now,
+      clientType
     );
     if (existing) {
       await authDb.revokeWalletAuthSessionsForAddress(existing.address, now);
@@ -637,7 +649,7 @@ export async function createConnectionShare({
   readonly role: string | null;
   readonly targetClientType: WalletAuthClientType;
 }): Promise<CreatedConnectionShare> {
-  assertNativeConnectionShareTarget(targetClientType);
+  assertRefreshTokenConnectionShareTarget(targetClientType);
   const connectionShareCode = createOpaqueSecret();
   const expiresAt = getConnectionShareExpiresAt();
   const share = await authDb.createWalletConnectionShare({
@@ -657,7 +669,7 @@ export async function createConnectionShare({
     address: share.address,
     role: share.role,
     target_client_type:
-      ApiCreateConnectionShareResponseTargetClientTypeEnum.Native,
+      toConnectionShareResponseTargetClientType(targetClientType),
     deep_link_path: `/accept-connection-sharing?${queryParams.toString()}`
   };
 }
@@ -671,7 +683,7 @@ export async function redeemConnectionShare({
   readonly targetClientType: WalletAuthClientType;
   readonly userAgent: string | null;
 }): Promise<RedeemedConnectionShare | null> {
-  assertNativeConnectionShareTarget(targetClientType);
+  assertRefreshTokenConnectionShareTarget(targetClientType);
   const session = await authDb.executeNativeQueriesInTransaction(
     async (connection) => {
       const share = await authDb.consumeWalletConnectionShare(
@@ -689,7 +701,8 @@ export async function redeemConnectionShare({
         {
           address: share.address,
           role: share.role,
-          userAgent
+          userAgent,
+          clientType: targetClientType
         },
         connection
       );
@@ -716,14 +729,32 @@ export async function redeemConnectionShare({
   };
 }
 
-function assertNativeConnectionShareTarget(
+function assertRefreshTokenConnectionShareTarget(
   targetClientType: WalletAuthClientType
-): void {
-  if (targetClientType !== 'native') {
+): asserts targetClientType is RefreshTokenSessionClientType {
+  if (targetClientType !== 'native' && targetClientType !== 'desktop') {
     throw new BadRequestException(
-      'Connection share codes currently support native clients only'
+      'Connection share codes currently support refresh-token clients only'
     );
   }
+}
+
+function toNativeSessionResponseClientType(
+  clientType: RefreshTokenSessionClientType
+): ApiSessionNativeResponseClientTypeEnum {
+  if (clientType === 'desktop') {
+    return ApiSessionNativeResponseClientTypeEnum.Desktop;
+  }
+  return ApiSessionNativeResponseClientTypeEnum.Native;
+}
+
+function toConnectionShareResponseTargetClientType(
+  clientType: RefreshTokenSessionClientType
+): ApiCreateConnectionShareResponseTargetClientTypeEnum {
+  if (clientType === 'desktop') {
+    return ApiCreateConnectionShareResponseTargetClientTypeEnum.Desktop;
+  }
+  return ApiCreateConnectionShareResponseTargetClientTypeEnum.Native;
 }
 
 function toWebSessionResponse(
@@ -744,11 +775,13 @@ async function createNativeSessionRecord(
   {
     address,
     role,
-    userAgent
+    userAgent,
+    clientType = 'native'
   }: {
     readonly address: string;
     readonly role: string | null;
     readonly userAgent: string | null;
+    readonly clientType?: RefreshTokenSessionClientType;
   },
   connection?: AuthDbConnection
 ): Promise<CreatedNativeSession & { readonly sessionId: string }> {
@@ -760,7 +793,7 @@ async function createNativeSessionRecord(
       id: sessionId,
       address: address.toLowerCase(),
       role,
-      clientType: 'native',
+      clientType,
       secretHash: null,
       refreshTokenHash: hashSecret(nativeRefreshToken),
       userAgentHash: userAgent ? hashPublicValue(userAgent) : null,
@@ -778,7 +811,7 @@ async function createNativeSessionRecord(
       role: session.role,
       access_token: accessToken.token,
       access_token_expires_at: accessToken.expiresAt,
-      client_type: ApiSessionNativeResponseClientTypeEnum.Native,
+      client_type: toNativeSessionResponseClientType(clientType),
       native_refresh_token: nativeRefreshToken,
       refresh_token_expires_at: expiresAt
     }

--- a/src/api-serverless/src/auth/auth.db.ts
+++ b/src/api-serverless/src/auth/auth.db.ts
@@ -18,8 +18,10 @@ import {
 } from '../../../entities/IWalletAuthSession';
 import { WalletConnectionShareEntity } from '../../../entities/IWalletConnectionShare';
 
+type RefreshTokenWalletAuthClientType = Exclude<WalletAuthClientType, 'web'>;
+
 const CLIENT_TYPE_WEB: WalletAuthClientType = 'web';
-const CLIENT_TYPE_NATIVE: WalletAuthClientType = 'native';
+const CLIENT_TYPE_NATIVE: RefreshTokenWalletAuthClientType = 'native';
 
 type AuthDbConnection = ConnectionWrapper<any>;
 
@@ -165,7 +167,8 @@ export class AuthDb extends LazyDbAccessCompatibleService {
   async getActiveNativeSessionByRefreshHash(
     address: string,
     refreshTokenHash: string,
-    now: Date
+    now: Date,
+    clientType: RefreshTokenWalletAuthClientType = CLIENT_TYPE_NATIVE
   ): Promise<WalletAuthSessionEntity | null> {
     return this.db.oneOrNull<WalletAuthSessionEntity>(
       `select * from ${WALLET_AUTH_SESSIONS_TABLE}
@@ -174,7 +177,7 @@ export class AuthDb extends LazyDbAccessCompatibleService {
          and refresh_token_hash = :refreshTokenHash
          and revoked_at is null
          and expires_at > :now`,
-      { address, refreshTokenHash, now, clientType: CLIENT_TYPE_NATIVE }
+      { address, refreshTokenHash, now, clientType }
     );
   }
 
@@ -209,7 +212,9 @@ export class AuthDb extends LazyDbAccessCompatibleService {
     readonly nextRefreshTokenHash: string;
     readonly expiresAt: Date;
     readonly now: Date;
+    readonly clientType?: RefreshTokenWalletAuthClientType;
   }): Promise<WalletAuthSessionEntity | null> {
+    const clientType = params.clientType ?? CLIENT_TYPE_NATIVE;
     const result = await this.db.execute(
       `update ${WALLET_AUTH_SESSIONS_TABLE}
        set refresh_token_hash = :nextRefreshTokenHash,
@@ -220,7 +225,7 @@ export class AuthDb extends LazyDbAccessCompatibleService {
          and refresh_token_hash = :previousRefreshTokenHash
          and revoked_at is null
          and expires_at > :now`,
-      { ...params, clientType: CLIENT_TYPE_NATIVE }
+      { ...params, clientType }
     );
     if (this.db.getAffectedRows(result) !== 1) {
       return null;

--- a/src/api-serverless/src/auth/auth.routes.ts
+++ b/src/api-serverless/src/auth/auth.routes.ts
@@ -238,7 +238,13 @@ router.post(
         timer
       );
       if (isRefreshTokenSessionClientType(loginRequest.client_type)) {
-        assertSessionLoginSignatureType(nonce, loginRequest.client_type);
+        const parsedMessage = assertSessionLoginSignatureType(
+          nonce,
+          loginRequest.client_type
+        );
+        if (loginRequest.client_type === 'desktop') {
+          assertDesktopSessionOriginAllowed(req, parsedMessage);
+        }
         const created = await createNativeSession({
           address: signingAddress,
           role: chosenRole,
@@ -780,17 +786,60 @@ function normalizeDomain(value: string | null | undefined): string | null {
   }
 }
 
+export function isDesktopSessionOriginAllowed(
+  origin: string | null | undefined
+): boolean {
+  const normalizedOrigin = normalizeOrigin(origin);
+  if (!normalizedOrigin) {
+    return false;
+  }
+
+  try {
+    const url = new URL(normalizedOrigin);
+    return (
+      url.protocol === 'http:' &&
+      !!url.port &&
+      (url.hostname === 'localhost' ||
+        url.hostname === '127.0.0.1' ||
+        url.hostname === '::1' ||
+        url.hostname === '[::1]')
+    );
+  } catch {
+    return false;
+  }
+}
+
 function resolveSessionNonceContext(
   req: Request<any, any, any, any, any>,
   nonceRequest: SessionNonceQueryRequest
 ): ResolvedSessionNonceContext {
-  if (isRefreshTokenSessionClientType(nonceRequest.client_type)) {
+  if (nonceRequest.client_type === 'native') {
     return {
       domain: nonceRequest.client_type,
       clientOrigin: null,
       sessionType: nonceRequest.client_type
     };
   }
+  if (nonceRequest.client_type === 'desktop') {
+    const requestOrigin = getNormalizedRequestOrigin(req);
+    if (!isDesktopSessionOriginAllowed(requestOrigin)) {
+      throw new BadRequestException(
+        'Wallet auth desktop sessions require a localhost Origin'
+      );
+    }
+    const domain = normalizeDomain(requestOrigin);
+    if (!domain) {
+      throw new BadRequestException(
+        'Wallet auth desktop sessions require a valid localhost Origin'
+      );
+    }
+    return {
+      domain,
+      clientOrigin: requestOrigin,
+      sessionType: 'desktop'
+    };
+  }
+
   const requestOrigin = getNormalizedRequestOrigin(req);
   if (!requestOrigin) {
     throw new BadRequestException(
@@ -814,6 +863,35 @@ function resolveSessionNonceContext(
     clientOrigin: requestOrigin,
     sessionType: 'first_party_web'
   };
+}
+
+function assertDesktopSessionOriginAllowed(
+  req: Request<any, any, any, any, any>,
+  parsedMessage: ParsedStructuredWalletSignatureMessage
+): void {
+  const signedClientOrigin = parsedMessage.clientOrigin;
+  if (
+    !signedClientOrigin ||
+    !isDesktopSessionOriginAllowed(signedClientOrigin)
+  ) {
+    throw new BadRequestException(
+      'Wallet auth desktop sessions require a localhost Origin'
+    );
+  }
+
+  const expectedDomain = normalizeDomain(signedClientOrigin);
+  if (!expectedDomain || parsedMessage.domain !== expectedDomain) {
+    throw new BadRequestException(
+      'Wallet auth desktop session domain does not match the signed Origin'
+    );
+  }
+
+  const requestOrigin = getNormalizedRequestOrigin(req);
+  if (requestOrigin && requestOrigin !== signedClientOrigin) {
+    throw new BadRequestException(
+      'Wallet auth desktop session Origin does not match the signed challenge'
+    );
+  }
 }
 
 function assertSessionOriginMatchesRequest(

--- a/src/api-serverless/src/auth/auth.routes.ts
+++ b/src/api-serverless/src/auth/auth.routes.ts
@@ -970,7 +970,7 @@ async function getAuthenticatedConnectionShareContext(
       });
     if (!hasActiveMatchingNativeSession) {
       throw new UnauthorisedException(
-        'Connection sharing requires an active session-v2 native session'
+        'Connection sharing requires an active session-v2 refresh-token session'
       );
     }
     return { authenticatedWallet, authRole };

--- a/src/api-serverless/src/auth/auth.routes.ts
+++ b/src/api-serverless/src/auth/auth.routes.ts
@@ -72,8 +72,11 @@ import type {
   ParsedStructuredWalletSignatureMessage,
   StructuredWalletSignatureSessionType
 } from '../wallet-signatures/structured-wallet-signatures';
+import type { WalletAuthClientType } from '@/entities/IWalletAuthSession';
 
 const router = asyncRouter();
+
+type RefreshTokenSessionClientType = Exclude<WalletAuthClientType, 'web'>;
 
 interface NonceQueryRequest {
   signer_address: string;
@@ -82,7 +85,7 @@ interface NonceQueryRequest {
 
 interface SessionNonceQueryRequest {
   signer_address: string;
-  client_type: 'web' | 'native';
+  client_type: WalletAuthClientType;
   chain_id: number;
 }
 
@@ -234,12 +237,13 @@ router.post(
         loginRequest.role ?? null,
         timer
       );
-      if (loginRequest.client_type === 'native') {
-        assertSessionLoginSignatureType(nonce, 'native');
+      if (isRefreshTokenSessionClientType(loginRequest.client_type)) {
+        assertSessionLoginSignatureType(nonce, loginRequest.client_type);
         const created = await createNativeSession({
           address: signingAddress,
           role: chosenRole,
-          userAgent: getUserAgent(req)
+          userAgent: getUserAgent(req),
+          clientType: loginRequest.client_type
         });
         res.status(201).send(created.response);
         return;
@@ -285,14 +289,15 @@ router.post(
   ) {
     const body = req.body ?? {};
     const clientType = getSessionClientType(body);
-    if (clientType === 'native') {
+    if (isRefreshTokenSessionClientType(clientType)) {
       const refreshRequest = getValidatedByJoiOrThrow(
         body,
         SessionRefreshNativeRequestSchema
       );
       const refreshed = await refreshNativeSession({
         address: refreshRequest.client_address,
-        nativeRefreshToken: refreshRequest.native_refresh_token
+        nativeRefreshToken: refreshRequest.native_refresh_token,
+        clientType
       });
       if (!refreshed) {
         throw new UnauthorisedException('Invalid session');
@@ -348,7 +353,7 @@ router.post(
   ) {
     const body = req.body ?? {};
     const clientType = getSessionClientType(body);
-    if (clientType === 'native') {
+    if (isRefreshTokenSessionClientType(clientType)) {
       const logoutRequest = getValidatedByJoiOrThrow(
         body,
         SessionLogoutNativeRequestSchema
@@ -356,7 +361,8 @@ router.post(
       await logoutNativeSession({
         address: logoutRequest.client_address,
         nativeRefreshToken: logoutRequest.native_refresh_token,
-        allSessions: logoutRequest.all_sessions ?? false
+        allSessions: logoutRequest.all_sessions ?? false,
+        clientType
       });
       res.status(204).send();
       return;
@@ -514,14 +520,24 @@ function assertConnectionSharingEnabled(): void {
 
 function getSessionClientType(body: {
   readonly client_type?: unknown;
-}): 'web' | 'native' {
+}): WalletAuthClientType {
   if (body.client_type == null) {
     return 'web';
   }
-  if (body.client_type === 'web' || body.client_type === 'native') {
+  if (
+    body.client_type === 'web' ||
+    body.client_type === 'native' ||
+    body.client_type === 'desktop'
+  ) {
     return body.client_type;
   }
-  throw new BadRequestException('client_type must be either web or native');
+  throw new BadRequestException('client_type must be web, native, or desktop');
+}
+
+function isRefreshTokenSessionClientType(
+  clientType: WalletAuthClientType
+): clientType is RefreshTokenSessionClientType {
+  return clientType === 'native' || clientType === 'desktop';
 }
 
 async function resolveAuthenticatedRole(
@@ -685,10 +701,9 @@ function getAuthWalletChainId(): number {
 
 function assertSessionLoginSignatureType(
   nonce: string,
-  clientType: 'web' | 'native'
+  clientType: WalletAuthClientType
 ): ParsedStructuredWalletSignatureMessage {
-  const expectedSessionType =
-    clientType === 'web' ? 'first_party_web' : 'native';
+  const expectedSessionType = getStructuredSessionTypeForClientType(clientType);
   if (!isStructuredWalletSignatureMessage(nonce)) {
     throw new BadRequestException(
       'Wallet auth sessions require a structured signature'
@@ -701,6 +716,15 @@ function assertSessionLoginSignatureType(
     );
   }
   return parsedMessage;
+}
+
+function getStructuredSessionTypeForClientType(
+  clientType: WalletAuthClientType
+): StructuredWalletSignatureSessionType {
+  if (clientType === 'web') {
+    return 'first_party_web';
+  }
+  return clientType;
 }
 
 function getUserAgent(req: Request<any, any, any, any, any>): string | null {
@@ -760,11 +784,11 @@ function resolveSessionNonceContext(
   req: Request<any, any, any, any, any>,
   nonceRequest: SessionNonceQueryRequest
 ): ResolvedSessionNonceContext {
-  if (nonceRequest.client_type === 'native') {
+  if (isRefreshTokenSessionClientType(nonceRequest.client_type)) {
     return {
-      domain: 'native',
+      domain: nonceRequest.client_type,
       clientOrigin: null,
-      sessionType: 'native'
+      sessionType: nonceRequest.client_type
     };
   }
   const requestOrigin = getNormalizedRequestOrigin(req);
@@ -879,11 +903,14 @@ const NonceQueryRequestSchema: Joi.ObjectSchema<NonceQueryRequest> =
 const SessionNonceQueryRequestSchema: Joi.ObjectSchema<SessionNonceQueryRequest> =
   Joi.object<SessionNonceQueryRequest>({
     signer_address: Joi.string().required(),
-    client_type: Joi.string().valid('web', 'native').optional().default('web'),
+    client_type: Joi.string()
+      .valid('web', 'native', 'desktop')
+      .optional()
+      .default('web'),
     chain_id: Joi.number().integer().min(1).optional().default(1)
   }).unknown(false);
 
-const ClientTypeSchema = Joi.string().valid('web', 'native');
+const ClientTypeSchema = Joi.string().valid('web', 'native', 'desktop');
 
 const SessionLoginRequestSchema: Joi.ObjectSchema<ApiSessionLoginRequest> =
   Joi.object<ApiSessionLoginRequest>({
@@ -907,7 +934,7 @@ const SessionRefreshWebRequestSchema: Joi.ObjectSchema<ApiSessionRefreshWebReque
 
 const SessionRefreshNativeRequestSchema: Joi.ObjectSchema<ApiSessionRefreshNativeRequest> =
   Joi.object<ApiSessionRefreshNativeRequest>({
-    client_type: Joi.string().valid('native').required(),
+    client_type: Joi.string().valid('native', 'desktop').required(),
     client_address: Joi.string().required(),
     native_refresh_token: Joi.string().hex().length(128).required()
   }).unknown(false);
@@ -921,7 +948,7 @@ const SessionLogoutWebRequestSchema: Joi.ObjectSchema<ApiSessionLogoutWebRequest
 
 const SessionLogoutNativeRequestSchema: Joi.ObjectSchema<ApiSessionLogoutNativeRequest> =
   Joi.object<ApiSessionLogoutNativeRequest>({
-    client_type: Joi.string().valid('native').required(),
+    client_type: Joi.string().valid('native', 'desktop').required(),
     client_address: Joi.string().required(),
     native_refresh_token: Joi.string().hex().length(128).required(),
     all_sessions: Joi.boolean().optional().default(false)
@@ -929,7 +956,7 @@ const SessionLogoutNativeRequestSchema: Joi.ObjectSchema<ApiSessionLogoutNativeR
 
 const CreateConnectionShareRequestSchema: Joi.ObjectSchema<ApiCreateConnectionShareRequest> =
   Joi.object<ApiCreateConnectionShareRequest>({
-    target_client_type: Joi.string().valid('native').required(),
+    target_client_type: Joi.string().valid('native', 'desktop').required(),
     role: Joi.string().optional().allow(null)
   }).unknown(false);
 
@@ -941,7 +968,7 @@ const CreateLegacyDesktopConnectionShareRequestSchema: Joi.ObjectSchema<ApiCreat
 const RedeemConnectionShareRequestSchema: Joi.ObjectSchema<ApiRedeemConnectionShareRequest> =
   Joi.object<ApiRedeemConnectionShareRequest>({
     connection_share_code: Joi.string().hex().length(64).required(),
-    target_client_type: Joi.string().valid('native').required()
+    target_client_type: Joi.string().valid('native', 'desktop').required()
   }).unknown(false);
 
 interface ApiLoginResponse {

--- a/src/api-serverless/src/auth/auth.routes.ts
+++ b/src/api-serverless/src/auth/auth.routes.ts
@@ -47,6 +47,7 @@ import {
   createConnectionShare,
   createNativeSession,
   createWebSession,
+  hasActiveNativeSessionForAddressAndRole,
   hasActiveWebSessionForAddressAndRole,
   isAuthConnectionSharingEnabled,
   issueAccessToken,
@@ -93,6 +94,13 @@ interface ResolvedSessionNonceContext {
   readonly domain: string;
   readonly clientOrigin: string | null;
   readonly sessionType: StructuredWalletSignatureSessionType;
+}
+
+interface ConnectionShareAuthProof {
+  readonly role?: string | null;
+  readonly client_type?: RefreshTokenSessionClientType;
+  readonly client_address?: string;
+  readonly native_refresh_token?: string;
 }
 
 router.get(
@@ -403,7 +411,7 @@ router.post(
       CreateConnectionShareRequestSchema
     );
     const { authenticatedWallet, authRole } =
-      await getAuthenticatedConnectionShareContext(req, shareRequest.role);
+      await getAuthenticatedConnectionShareContext(req, shareRequest);
     const created = await createConnectionShare({
       address: authenticatedWallet,
       role: authRole,
@@ -433,10 +441,7 @@ router.post(
       CreateLegacyDesktopConnectionShareRequestSchema
     );
     const { authenticatedWallet, authRole } =
-      await getAuthenticatedConnectionShareContext(
-        req,
-        legacyShareRequest.role
-      );
+      await getAuthenticatedConnectionShareContext(req, legacyShareRequest);
     const refreshToken = await authDb.retrieveOrGenerateRefreshToken(
       authenticatedWallet,
       authRole
@@ -929,7 +934,7 @@ function assertWebAuthCredentialOriginAllowed(
 
 async function getAuthenticatedConnectionShareContext(
   req: Request<any, any, any, any, any>,
-  requestedRole: string | null | undefined
+  shareRequest: ConnectionShareAuthProof
 ): Promise<{
   readonly authenticatedWallet: string;
   readonly authRole: string | null;
@@ -939,11 +944,38 @@ async function getAuthenticatedConnectionShareContext(
     throw new UnauthorisedException('Authentication required');
   }
   const authRole = ((req.user as any)?.role ?? null) as string | null;
-  if (requestedRole && requestedRole !== authRole) {
+  if (shareRequest.role !== undefined && shareRequest.role !== authRole) {
     throw new BadRequestException(
       'Share role must match authenticated session role'
     );
   }
+
+  if (shareRequest.client_type) {
+    if (
+      !shareRequest.client_address ||
+      !shareRequest.native_refresh_token ||
+      shareRequest.client_address.toLowerCase() !== authenticatedWallet
+    ) {
+      throw new BadRequestException(
+        'Share source session must match authenticated wallet'
+      );
+    }
+
+    const hasActiveMatchingNativeSession =
+      await hasActiveNativeSessionForAddressAndRole({
+        address: authenticatedWallet,
+        role: authRole,
+        nativeRefreshToken: shareRequest.native_refresh_token,
+        clientType: shareRequest.client_type
+      });
+    if (!hasActiveMatchingNativeSession) {
+      throw new UnauthorisedException(
+        'Connection sharing requires an active session-v2 native session'
+      );
+    }
+    return { authenticatedWallet, authRole };
+  }
+
   const hasActiveMatchingWebSession =
     await hasActiveWebSessionForAddressAndRole({
       cookieHeader: req.headers.cookie,
@@ -1030,18 +1062,28 @@ const SessionLogoutNativeRequestSchema: Joi.ObjectSchema<ApiSessionLogoutNativeR
     client_address: Joi.string().required(),
     native_refresh_token: Joi.string().hex().length(128).required(),
     all_sessions: Joi.boolean().optional().default(false)
-  });
+  }).unknown(false);
 
 const CreateConnectionShareRequestSchema: Joi.ObjectSchema<ApiCreateConnectionShareRequest> =
   Joi.object<ApiCreateConnectionShareRequest>({
     target_client_type: Joi.string().valid('native', 'desktop').required(),
-    role: Joi.string().optional().allow(null)
-  }).unknown(false);
+    role: Joi.string().optional().allow(null),
+    client_type: Joi.string().valid('native', 'desktop').optional(),
+    client_address: Joi.string().optional(),
+    native_refresh_token: Joi.string().hex().length(128).optional()
+  })
+    .and('client_type', 'client_address', 'native_refresh_token')
+    .unknown(false);
 
 const CreateLegacyDesktopConnectionShareRequestSchema: Joi.ObjectSchema<ApiCreateLegacyDesktopConnectionShareRequest> =
   Joi.object<ApiCreateLegacyDesktopConnectionShareRequest>({
-    role: Joi.string().optional().allow(null).default(null)
-  }).unknown(false);
+    role: Joi.string().optional().allow(null),
+    client_type: Joi.string().valid('native', 'desktop').optional(),
+    client_address: Joi.string().optional(),
+    native_refresh_token: Joi.string().hex().length(128).optional()
+  })
+    .and('client_type', 'client_address', 'native_refresh_token')
+    .unknown(false);
 
 const RedeemConnectionShareRequestSchema: Joi.ObjectSchema<ApiRedeemConnectionShareRequest> =
   Joi.object<ApiRedeemConnectionShareRequest>({

--- a/src/api-serverless/src/generated/models/ApiCreateConnectionShareRequest.ts
+++ b/src/api-serverless/src/generated/models/ApiCreateConnectionShareRequest.ts
@@ -43,6 +43,7 @@ export class ApiCreateConnectionShareRequest {
 }
 
 export enum ApiCreateConnectionShareRequestTargetClientTypeEnum {
-    Native = 'native'
+    Native = 'native',
+    Desktop = 'desktop'
 }
 

--- a/src/api-serverless/src/generated/models/ApiCreateConnectionShareRequest.ts
+++ b/src/api-serverless/src/generated/models/ApiCreateConnectionShareRequest.ts
@@ -15,6 +15,18 @@ import { HttpFile } from '../http/http';
 export class ApiCreateConnectionShareRequest {
     'target_client_type': ApiCreateConnectionShareRequestTargetClientTypeEnum;
     'role'?: string | null;
+    /**
+    * Optional source session type for native or desktop callers.
+    */
+    'client_type'?: ApiCreateConnectionShareRequestClientTypeEnum;
+    /**
+    * Wallet address bound to the source native or desktop session.
+    */
+    'client_address'?: string;
+    /**
+    * Refresh token for the source native or desktop session.
+    */
+    'native_refresh_token'?: string;
 
     static readonly discriminator: string | undefined = undefined;
 
@@ -32,6 +44,24 @@ export class ApiCreateConnectionShareRequest {
             "baseName": "role",
             "type": "string",
             "format": ""
+        },
+        {
+            "name": "client_type",
+            "baseName": "client_type",
+            "type": "ApiCreateConnectionShareRequestClientTypeEnum",
+            "format": ""
+        },
+        {
+            "name": "client_address",
+            "baseName": "client_address",
+            "type": "string",
+            "format": ""
+        },
+        {
+            "name": "native_refresh_token",
+            "baseName": "native_refresh_token",
+            "type": "string",
+            "format": ""
         }    ];
 
     static getAttributeTypeMap() {
@@ -43,6 +73,10 @@ export class ApiCreateConnectionShareRequest {
 }
 
 export enum ApiCreateConnectionShareRequestTargetClientTypeEnum {
+    Native = 'native',
+    Desktop = 'desktop'
+}
+export enum ApiCreateConnectionShareRequestClientTypeEnum {
     Native = 'native',
     Desktop = 'desktop'
 }

--- a/src/api-serverless/src/generated/models/ApiCreateConnectionShareResponse.ts
+++ b/src/api-serverless/src/generated/models/ApiCreateConnectionShareResponse.ts
@@ -71,6 +71,7 @@ export class ApiCreateConnectionShareResponse {
 }
 
 export enum ApiCreateConnectionShareResponseTargetClientTypeEnum {
-    Native = 'native'
+    Native = 'native',
+    Desktop = 'desktop'
 }
 

--- a/src/api-serverless/src/generated/models/ApiCreateLegacyDesktopConnectionShareRequest.ts
+++ b/src/api-serverless/src/generated/models/ApiCreateLegacyDesktopConnectionShareRequest.ts
@@ -69,3 +69,4 @@ export enum ApiCreateLegacyDesktopConnectionShareRequestClientTypeEnum {
     Native = 'native',
     Desktop = 'desktop'
 }
+

--- a/src/api-serverless/src/generated/models/ApiCreateLegacyDesktopConnectionShareRequest.ts
+++ b/src/api-serverless/src/generated/models/ApiCreateLegacyDesktopConnectionShareRequest.ts
@@ -14,6 +14,18 @@ import { HttpFile } from '../http/http';
 
 export class ApiCreateLegacyDesktopConnectionShareRequest {
     'role'?: string | null;
+    /**
+    * Optional source session type for native or desktop callers.
+    */
+    'client_type'?: ApiCreateLegacyDesktopConnectionShareRequestClientTypeEnum;
+    /**
+    * Wallet address bound to the source native or desktop session.
+    */
+    'client_address'?: string;
+    /**
+    * Refresh token for the source native or desktop session.
+    */
+    'native_refresh_token'?: string;
 
     static readonly discriminator: string | undefined = undefined;
 
@@ -25,6 +37,24 @@ export class ApiCreateLegacyDesktopConnectionShareRequest {
             "baseName": "role",
             "type": "string",
             "format": ""
+        },
+        {
+            "name": "client_type",
+            "baseName": "client_type",
+            "type": "ApiCreateLegacyDesktopConnectionShareRequestClientTypeEnum",
+            "format": ""
+        },
+        {
+            "name": "client_address",
+            "baseName": "client_address",
+            "type": "string",
+            "format": ""
+        },
+        {
+            "name": "native_refresh_token",
+            "baseName": "native_refresh_token",
+            "type": "string",
+            "format": ""
         }    ];
 
     static getAttributeTypeMap() {
@@ -33,4 +63,9 @@ export class ApiCreateLegacyDesktopConnectionShareRequest {
 
     public constructor() {
     }
+}
+
+export enum ApiCreateLegacyDesktopConnectionShareRequestClientTypeEnum {
+    Native = 'native',
+    Desktop = 'desktop'
 }

--- a/src/api-serverless/src/generated/models/ApiRedeemConnectionShareRequest.ts
+++ b/src/api-serverless/src/generated/models/ApiRedeemConnectionShareRequest.ts
@@ -43,6 +43,7 @@ export class ApiRedeemConnectionShareRequest {
 }
 
 export enum ApiRedeemConnectionShareRequestTargetClientTypeEnum {
-    Native = 'native'
+    Native = 'native',
+    Desktop = 'desktop'
 }
 

--- a/src/api-serverless/src/generated/models/ApiRedeemConnectionShareResponse.ts
+++ b/src/api-serverless/src/generated/models/ApiRedeemConnectionShareResponse.ts
@@ -17,6 +17,7 @@ export class ApiRedeemConnectionShareResponse {
     'role'?: string | null;
     'access_token': string;
     'access_token_expires_at': Date;
+    'client_type': ApiRedeemConnectionShareResponseClientTypeEnum;
     'native_refresh_token': string;
     'refresh_token_expires_at': Date;
 
@@ -50,6 +51,12 @@ export class ApiRedeemConnectionShareResponse {
             "format": "date-time"
         },
         {
+            "name": "client_type",
+            "baseName": "client_type",
+            "type": "ApiRedeemConnectionShareResponseClientTypeEnum",
+            "format": ""
+        },
+        {
             "name": "native_refresh_token",
             "baseName": "native_refresh_token",
             "type": "string",
@@ -68,4 +75,9 @@ export class ApiRedeemConnectionShareResponse {
 
     public constructor() {
     }
+}
+
+export enum ApiRedeemConnectionShareResponseClientTypeEnum {
+    Native = 'native',
+    Desktop = 'desktop'
 }

--- a/src/api-serverless/src/generated/models/ApiRedeemConnectionShareResponse.ts
+++ b/src/api-serverless/src/generated/models/ApiRedeemConnectionShareResponse.ts
@@ -81,3 +81,4 @@ export enum ApiRedeemConnectionShareResponseClientTypeEnum {
     Native = 'native',
     Desktop = 'desktop'
 }
+

--- a/src/api-serverless/src/generated/models/ApiSessionLoginRequest.ts
+++ b/src/api-serverless/src/generated/models/ApiSessionLoginRequest.ts
@@ -17,7 +17,7 @@ export class ApiSessionLoginRequest {
     'client_address': string;
     'client_signature': string;
     /**
-    * Server-signed structured challenge token. /auth/session-login only accepts first_party_web challenges for web cookie sessions and native challenges for native refresh-token sessions; external_client challenges use /auth/login bearer-token auth instead.
+    * Server-signed structured challenge token. /auth/session-login only accepts first_party_web challenges for web cookie sessions and matching native or desktop challenges for refresh-token sessions; external_client challenges use /auth/login bearer-token auth instead.
     */
     'server_signature': string;
     'role'?: string | null;
@@ -82,7 +82,8 @@ export class ApiSessionLoginRequest {
 
 export enum ApiSessionLoginRequestClientTypeEnum {
     Web = 'web',
-    Native = 'native'
+    Native = 'native',
+    Desktop = 'desktop'
 }
 export enum ApiSessionLoginRequestWalletKindHintEnum {
     Eoa = 'eoa',

--- a/src/api-serverless/src/generated/models/ApiSessionLogoutNativeRequest.ts
+++ b/src/api-serverless/src/generated/models/ApiSessionLogoutNativeRequest.ts
@@ -57,6 +57,7 @@ export class ApiSessionLogoutNativeRequest {
 }
 
 export enum ApiSessionLogoutNativeRequestClientTypeEnum {
-    Native = 'native'
+    Native = 'native',
+    Desktop = 'desktop'
 }
 

--- a/src/api-serverless/src/generated/models/ApiSessionNativeResponse.ts
+++ b/src/api-serverless/src/generated/models/ApiSessionNativeResponse.ts
@@ -78,6 +78,7 @@ export class ApiSessionNativeResponse {
 }
 
 export enum ApiSessionNativeResponseClientTypeEnum {
-    Native = 'native'
+    Native = 'native',
+    Desktop = 'desktop'
 }
 

--- a/src/api-serverless/src/generated/models/ApiSessionNonceQuery.ts
+++ b/src/api-serverless/src/generated/models/ApiSessionNonceQuery.ts
@@ -57,6 +57,7 @@ export class ApiSessionNonceQuery {
 
 export enum ApiSessionNonceQueryClientTypeEnum {
     Web = 'web',
-    Native = 'native'
+    Native = 'native',
+    Desktop = 'desktop'
 }
 

--- a/src/api-serverless/src/generated/models/ApiSessionRefreshNativeRequest.ts
+++ b/src/api-serverless/src/generated/models/ApiSessionRefreshNativeRequest.ts
@@ -50,6 +50,7 @@ export class ApiSessionRefreshNativeRequest {
 }
 
 export enum ApiSessionRefreshNativeRequestClientTypeEnum {
-    Native = 'native'
+    Native = 'native',
+    Desktop = 'desktop'
 }
 

--- a/src/api-serverless/src/generated/models/ObjectSerializer.ts
+++ b/src/api-serverless/src/generated/models/ObjectSerializer.ts
@@ -573,7 +573,7 @@ import { ApiConsolidatedTdhMetricsSort } from '../models/ApiConsolidatedTdhMetri
 import { ApiConsolidatedTdhView } from '../models/ApiConsolidatedTdhView';
 import { ApiCreateAttachmentMultipartUploadRequest   } from '../models/ApiCreateAttachmentMultipartUploadRequest';
 import { ApiCreateAttachmentMultipartUploadResponse     } from '../models/ApiCreateAttachmentMultipartUploadResponse';
-import { ApiCreateConnectionShareRequest, ApiCreateConnectionShareRequestTargetClientTypeEnum    } from '../models/ApiCreateConnectionShareRequest';
+import { ApiCreateConnectionShareRequest, ApiCreateConnectionShareRequestTargetClientTypeEnum   , ApiCreateConnectionShareRequestClientTypeEnum     } from '../models/ApiCreateConnectionShareRequest';
 import { ApiCreateConnectionShareResponse    , ApiCreateConnectionShareResponseTargetClientTypeEnum    } from '../models/ApiCreateConnectionShareResponse';
 import { ApiCreateDropMedia } from '../models/ApiCreateDropMedia';
 import { ApiCreateDropPart } from '../models/ApiCreateDropPart';
@@ -581,7 +581,7 @@ import { ApiCreateDropPollRequest } from '../models/ApiCreateDropPollRequest';
 import { ApiCreateDropRequest                 } from '../models/ApiCreateDropRequest';
 import { ApiCreateGroup } from '../models/ApiCreateGroup';
 import { ApiCreateGroupDescription } from '../models/ApiCreateGroupDescription';
-import { ApiCreateLegacyDesktopConnectionShareRequest } from '../models/ApiCreateLegacyDesktopConnectionShareRequest';
+import { ApiCreateLegacyDesktopConnectionShareRequest , ApiCreateLegacyDesktopConnectionShareRequestClientTypeEnum     } from '../models/ApiCreateLegacyDesktopConnectionShareRequest';
 import { ApiCreateLegacyDesktopConnectionShareResponse } from '../models/ApiCreateLegacyDesktopConnectionShareResponse';
 import { ApiCreateMediaUploadUrlRequest   } from '../models/ApiCreateMediaUploadUrlRequest';
 import { ApiCreateMediaUrlResponse } from '../models/ApiCreateMediaUrlResponse';
@@ -807,7 +807,7 @@ import { ApiRateMatter } from '../models/ApiRateMatter';
 import { ApiRatingWithProfileInfoAndLevel } from '../models/ApiRatingWithProfileInfoAndLevel';
 import { ApiRatingWithProfileInfoAndLevelPage } from '../models/ApiRatingWithProfileInfoAndLevelPage';
 import { ApiRedeemConnectionShareRequest , ApiRedeemConnectionShareRequestTargetClientTypeEnum   } from '../models/ApiRedeemConnectionShareRequest';
-import { ApiRedeemConnectionShareResponse } from '../models/ApiRedeemConnectionShareResponse';
+import { ApiRedeemConnectionShareResponse    , ApiRedeemConnectionShareResponseClientTypeEnum     } from '../models/ApiRedeemConnectionShareResponse';
 import { ApiRedeemRefreshTokenRequest } from '../models/ApiRedeemRefreshTokenRequest';
 import { ApiRedeemRefreshTokenResponse } from '../models/ApiRedeemRefreshTokenResponse';
 import { ApiRegisterPushNotificationTokenRequest } from '../models/ApiRegisterPushNotificationTokenRequest';
@@ -1039,7 +1039,9 @@ let enumsMap: Set<string> = new Set<string>([
     "ApiConsolidatedTdhMetricsSort",
     "ApiConsolidatedTdhView",
     "ApiCreateConnectionShareRequestTargetClientTypeEnum",
+    "ApiCreateConnectionShareRequestClientTypeEnum",
     "ApiCreateConnectionShareResponseTargetClientTypeEnum",
+    "ApiCreateLegacyDesktopConnectionShareRequestClientTypeEnum",
     "ApiDecentralizedMediaProtocol",
     "ApiDropGroupMention",
     "ApiDropMainType",
@@ -1083,6 +1085,7 @@ let enumsMap: Set<string> = new Set<string>([
     "ApiProfileProxyActionType",
     "ApiRateMatter",
     "ApiRedeemConnectionShareRequestTargetClientTypeEnum",
+    "ApiRedeemConnectionShareResponseClientTypeEnum",
     "ApiRepDirection",
     "ApiSessionLoginRequestClientTypeEnum",
     "ApiSessionLoginRequestWalletKindHintEnum",

--- a/src/api-serverless/src/wallet-signatures/structured-wallet-signatures.test.ts
+++ b/src/api-serverless/src/wallet-signatures/structured-wallet-signatures.test.ts
@@ -121,6 +121,25 @@ describe('structured wallet signatures', () => {
       clientOrigin: 'https://example.com',
       sessionType: 'first_party_web'
     });
+
+    const desktopMessage = buildStructuredWalletSignatureMessage({
+      kind: 'authentication',
+      domain: 'desktop',
+      sessionType: 'desktop',
+      wallet: wallet.address,
+      issuedAt,
+      expirationTime: getExpirationTime(),
+      nonce: 'login-nonce-desktop-session',
+      action: 'login',
+      purpose: 'Sign this message to authenticate with 6529.'
+    });
+
+    expect(parseStructuredWalletSignatureMessage(desktopMessage)).toMatchObject(
+      {
+        domain: 'desktop',
+        sessionType: 'desktop'
+      }
+    );
   });
 
   it('parses field values that contain additional colons', () => {

--- a/src/api-serverless/src/wallet-signatures/structured-wallet-signatures.ts
+++ b/src/api-serverless/src/wallet-signatures/structured-wallet-signatures.ts
@@ -55,7 +55,8 @@ export type StructuredWalletSignatureAction =
 export type StructuredWalletSignatureSessionType =
   | 'first_party_web'
   | 'external_client'
-  | 'native';
+  | 'native'
+  | 'desktop';
 
 export interface ParsedStructuredWalletSignatureMessage {
   kind: StructuredWalletSignatureKind;
@@ -409,7 +410,8 @@ function parseSessionType(
   if (
     value === 'first_party_web' ||
     value === 'external_client' ||
-    value === 'native'
+    value === 'native' ||
+    value === 'desktop'
   ) {
     return value;
   }

--- a/src/entities/IWalletAuthSession.ts
+++ b/src/entities/IWalletAuthSession.ts
@@ -1,7 +1,7 @@
 import { Column, Entity, Index, PrimaryColumn } from 'typeorm';
 import { WALLET_AUTH_SESSIONS_TABLE } from '@/constants';
 
-export type WalletAuthClientType = 'web' | 'native';
+export type WalletAuthClientType = 'web' | 'native' | 'desktop';
 
 @Entity(WALLET_AUTH_SESSIONS_TABLE)
 export class WalletAuthSessionEntity {


### PR DESCRIPTION
## Issue
- Desktop needs its own wallet auth session-v2 client type instead of sharing the native client type.
- Browser-to-desktop auth should be able to request desktop-specific challenges, refresh tokens, and connection-share targets while keeping native clients compatible.

## Fix
- Add `desktop` to wallet auth session client types and structured session signature parsing.
- Route `desktop` through the same refresh-token session flow as native, but preserve the requested client type on session records, refresh rotation, logout, nonce challenge domain/session type, and connection sharing.

## Changes
- Extends session nonce/login/refresh/logout validation and OpenAPI/generated models to accept `web`, `native`, and `desktop` where appropriate.
- Stores and filters refresh-token sessions by `native` or `desktop` client type.
- Allows one-time connection-share creation/redeem for `native` and `desktop` targets while still rejecting web targets.
- Adds auth DB, session flow, and structured signature tests for desktop behavior.

## Validation
- `npm run tsc -- --noEmit`
- `npx eslint <touched auth files> --max-warnings=0`
- `git diff --check`
- Attempted focused Jest: `npm test -- src/api-serverless/src/auth/auth-session-v2.test.ts src/api-serverless/src/auth/auth-db.test.ts src/api-serverless/src/wallet-signatures/structured-wallet-signatures.test.ts --runInBand`. It could not run because the repo global Jest setup requires Testcontainers and this environment has no working container runtime.

## Risk
- Level: Medium
- Why: Auth contract and refresh-token session handling are deployment-sensitive, but the change is scoped to a new client type and preserves existing web/native behavior.
- Rollback: Revert this PR and redeploy the API service.

## Review Notes
- Deploy impact: API serverless auth endpoints need redeploy after merge. No backend loop redeploy order is required.
- Please review client type filtering on refresh-token sessions and the structured signature challenge type mapping.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a **desktop** wallet client option across session nonce/login/refresh/logout and connection-share creation/redemption, including desktop-targeted share handling and redemption responses.
* **Bug Fixes**
  * Strengthened desktop security by enforcing localhost loopback signed-origin/domain rules and applying session/refresh behavior per **client type**.
* **Tests**
  * Added/updated coverage for desktop session flows, connection-share desktop redemption, structured signature parsing, refresh-token rotation filtering, and desktop origin validation.
* **Documentation**
  * Updated wallet-auth docs, architecture notes, migration plan, and the OpenAPI contract to reflect **desktop** semantics and schemas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->