### PR TITLE
Async refresh drop metrics after deletions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,6 +71,7 @@ on:
           - transactionsProcessingLoop
           - waveDecisionExecutionLoop
           - waveLeaderboardSnapshotterLoop
+          - waveDropMetricsRefreshLoop
           - waveScoreRefreshLoop
           - xTdhLoop
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -51,7 +51,8 @@ flowchart TD
     MarketStatsLoop ~~~ RateEventProcessingLoop["rateEventProcessingLoop"]
     RateEventProcessingLoop ~~~ WaveDecisionExecutionLoop["waveDecisionExecutionLoop"]
     WaveDecisionExecutionLoop ~~~ WaveLeaderboardSnapshotterLoop["waveLeaderboardSnapshotterLoop"]
-    WaveLeaderboardSnapshotterLoop ~~~ WaveScoreRefreshLoop["waveScoreRefreshLoop"]
+    WaveLeaderboardSnapshotterLoop ~~~ WaveDropMetricsRefreshLoop["waveDropMetricsRefreshLoop"]
+    WaveDropMetricsRefreshLoop ~~~ WaveScoreRefreshLoop["waveScoreRefreshLoop"]
     WaveScoreRefreshLoop ~~~ XTdhGrantsReviewerLoop["xTdhGrantsReviewerLoop"]
     XTdhGrantsReviewerLoop ~~~ SubscriptionsDaily["subscriptionsDaily"]
     SubscriptionsDaily ~~~ SubscriptionsTopUpLoop["subscriptionsTopUpLoop"]
@@ -79,6 +80,7 @@ flowchart TD
     NftLinkRefresherLoop --> NftLinkPreviewQueue["SQS: nft-link-media-previews"] --> NftLinkMediaPreviewLoop["nftLinkMediaPreviewLoop"]
     SeizeAPI --> PushQueue["SQS: firebase-push-notifications"] --> PushNotificationsHandler["pushNotificationsHandler"]
     SeizeAPI --> HelpBotQueue["SQS: help-bot-replies"] --> HelpBotReplyLoop["helpBotReplyLoop"]
+    SeizeAPI --> WaveDropMetricsDirtyQueue["SQS: wave-drop-metrics-refresh-dirty.fifo"] --> WaveDropMetricsRefreshLoop
     SeizeAPI --> WaveScoreDirtyQueue["SQS: wave-score-refresh-dirty.fifo"] --> WaveScoreRefreshLoop
     TdhLoop --> TdhDoneTopic["SNS: tdh-calculation-done.fifo"]
     TdhDoneTopic --> XTdhQueue["SQS: xtdh-start.fifo"] --> XTdhLoop["xTdhLoop"]
@@ -138,6 +140,7 @@ flowchart TD
 | `rateEventProcessingLoop`            | Process DB-backed rating events.                                  |
 | `waveDecisionExecutionLoop`          | Execute wave decisions and enqueue claim builds.                  |
 | `waveLeaderboardSnapshotterLoop`     | Snapshot wave leaderboards.                                       |
+| `waveDropMetricsRefreshLoop`         | Scheduled fallback that drains dirty drop metric refresh requests. |
 | `waveScoreRefreshLoop`               | Scheduled fallback that drains dirty Wave Score refresh requests. |
 | `xTdhGrantsReviewerLoop`             | Review xTDH grants.                                               |
 | `subscriptionsDaily`                 | Process daily subscription work.                                  |
@@ -168,6 +171,7 @@ flowchart TD
 | `nftLinkMediaPreviewLoop`        | SQS `nft-link-media-previews`                                                                                                      | Generate media previews for NFT links.                                                                                      |
 | `pushNotificationsHandler`       | SQS `firebase-push-notifications`                                                                                                  | Deliver Firebase push notifications.                                                                                        |
 | `helpBotReplyLoop`               | SQS `help-bot-replies`                                                                                                             | Answer `@help6529` mentions and direct follow-ups to bot replies.                                                           |
+| `waveDropMetricsRefreshLoop`      | SQS `wave-drop-metrics-refresh-dirty.fifo`; EventBridge fallback                                                                   | Repair materialized wave/dropper drop counts and latest-drop timestamps after drop deletes.                                |
 | `xTdhLoop`                       | SNS `tdh-calculation-done.fifo` via SQS `xtdh-start.fifo`                                                                          | Recalculate xTDH after TDH finishes.                                                                                        |
 | `overRatesRevocationLoop`        | SNS `tdh-calculation-done.fifo` via SQS `over-rates-revocation-start.fifo`                                                         | Revoke over-rates after TDH changes.                                                                                        |
 | `waveScoreRefreshLoop`           | SNS `tdh-calculation-done.fifo` via SQS `wave-score-refresh-start.fifo`; SQS `wave-score-refresh-dirty.fifo`; EventBridge fallback | Refresh materialized wave REP and Wave Score discovery fields after TDH changes or wave/drop/rating/subscription mutations. |
@@ -316,6 +320,8 @@ There are three async patterns:
 Most long-running scheduled jobs have reserved concurrency set low, usually `1`, which protects shared tables from concurrent writer races. SQS workers use queue visibility timeouts, DLQs, and batch failure reporting where configured.
 
 Wave Score refreshes use a hybrid DB-backed/SQS pattern. Request-path mutations write `wave_score_refresh_requests` rows inside the same primary-DB transaction as the drop, rating, or subscription change, then publish a small wakeup message to `wave-score-refresh-dirty.fifo` after commit. `waveScoreRefreshLoop` drains dirty rows from the write pool, recalculates scores, and deletes a row only if its selected `(wave_id, dirty_at)` version still matches, so a wave dirtied again during processing remains queued. A one-minute EventBridge fallback invokes the same dirty drain in case enqueueing fails after the transaction commits.
+
+Wave drop metric repairs use the same DB-backed/SQS pattern. Drop deletes apply a bounded in-transaction counter decrement, write `wave_drop_metrics_refresh_requests`, and publish to `wave-drop-metrics-refresh-dirty.fifo` after commit. `waveDropMetricsRefreshLoop` drains from the write pool and runs the full wave/dropper metric reconciliation outside the API path, with an EventBridge fallback for missed wakeups.
 
 ## 6529 Help Bot Flow
 

--- a/src/api-serverless/src/drops/drop-creation-api-service.test.ts
+++ b/src/api-serverless/src/drops/drop-creation-api-service.test.ts
@@ -1,4 +1,11 @@
 import { DropCreationApiService } from '@/api/drops/drop-creation.api.service';
+import { waveScoreService } from '@/api/waves/wave-score.service';
+import { invalidateWaveUnreadCacheForWave } from '@/api/waves/wave-unread-cache';
+import { waveDropMetricsRefreshService } from '@/drops/wave-drop-metrics-refresh.service';
+
+jest.mock('@/api/waves/wave-unread-cache', () => ({
+  invalidateWaveUnreadCacheForWave: jest.fn().mockResolvedValue(undefined)
+}));
 
 function makeService({
   currentHidden,
@@ -134,5 +141,104 @@ describe('DropCreationApiService.toggleHideLinkPreview', () => {
       ctx
     );
     expect(wsListenersNotifier.notifyAboutDropUpdate).not.toHaveBeenCalled();
+  });
+});
+
+describe('DropCreationApiService.deleteDropById', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('requests async drop metric and score refresh after the delete transaction commits', async () => {
+    const connection = {} as any;
+    const deleteResponse = {
+      id: 'drop-1',
+      serial_no: 7,
+      visibility_group_id: 'group-1',
+      wave_id: 'wave-1'
+    };
+    const dropsDb = {
+      executeNativeQueriesInTransaction: jest.fn(
+        async (callback: (connection: unknown) => Promise<unknown>) =>
+          callback(connection)
+      )
+    };
+    const deleteDrop = {
+      execute: jest.fn().mockResolvedValue(deleteResponse)
+    };
+    const wsListenersNotifier = {
+      notifyAboutDropDelete: jest.fn().mockResolvedValue(undefined)
+    };
+    const service = new DropCreationApiService(
+      {} as never,
+      dropsDb as never,
+      {} as never,
+      {} as never,
+      deleteDrop as never,
+      wsListenersNotifier as never,
+      {} as never,
+      {} as never,
+      {} as never
+    );
+    const requestWaveDropMetricsRefreshSpy = jest
+      .spyOn(
+        waveDropMetricsRefreshService,
+        'requestWaveDropMetricsRefreshBestEffort'
+      )
+      .mockResolvedValue(undefined);
+    const requestWaveScoreRefreshSpy = jest
+      .spyOn(waveScoreService, 'requestWaveScoreRefreshBestEffort')
+      .mockResolvedValue(undefined);
+    const ctx = {
+      authenticationContext: {
+        getActingAsId: jest.fn().mockReturnValue('profile-1'),
+        isAuthenticatedAsProxy: jest.fn().mockReturnValue(false)
+      },
+      timer: {
+        start: jest.fn(),
+        stop: jest.fn()
+      }
+    };
+
+    await service.deleteDropById({ id: 'drop-1' }, ctx as never);
+
+    expect(deleteDrop.execute).toHaveBeenCalledWith(
+      {
+        drop_id: 'drop-1',
+        deleter_identity: 'profile-1',
+        deleter_id: 'profile-1',
+        deletion_purpose: 'DELETE'
+      },
+      { timer: ctx.timer, connection }
+    );
+    expect(requestWaveDropMetricsRefreshSpy).toHaveBeenCalledWith(
+      ['wave-1'],
+      'DROP_DELETED',
+      {
+        timer: ctx.timer,
+        authenticationContext: ctx.authenticationContext
+      }
+    );
+    expect(requestWaveScoreRefreshSpy).toHaveBeenCalledWith(
+      ['wave-1'],
+      'DROP_DELETED',
+      {
+        timer: ctx.timer,
+        authenticationContext: ctx.authenticationContext
+      }
+    );
+    expect(invalidateWaveUnreadCacheForWave).toHaveBeenCalledWith('wave-1');
+    expect(wsListenersNotifier.notifyAboutDropDelete).toHaveBeenCalledWith(
+      {
+        drop_id: 'drop-1',
+        drop_serial: 7,
+        wave_id: 'wave-1'
+      },
+      'group-1',
+      {
+        timer: ctx.timer,
+        authenticationContext: ctx.authenticationContext
+      }
+    );
   });
 });

--- a/src/api-serverless/src/drops/drop-creation.api.service.ts
+++ b/src/api-serverless/src/drops/drop-creation.api.service.ts
@@ -45,6 +45,10 @@ import {
   waveScoreService,
   WaveScoreDirtyRefreshReason
 } from '@/api/waves/wave-score.service';
+import {
+  waveDropMetricsRefreshService,
+  WaveDropMetricsDirtyRefreshReason
+} from '@/drops/wave-drop-metrics-refresh.service';
 
 function normalizeCreateDropPollRequest(
   poll: ApiCreateDropPollRequest | null | undefined
@@ -199,6 +203,14 @@ export class DropCreationApiService {
       }
     );
     if (deleteResponse) {
+      await waveDropMetricsRefreshService.requestWaveDropMetricsRefreshBestEffort(
+        [deleteResponse.wave_id],
+        WaveDropMetricsDirtyRefreshReason.DROP_DELETED,
+        {
+          timer,
+          authenticationContext
+        }
+      );
       await waveScoreService.requestWaveScoreRefreshBestEffort(
         [deleteResponse.wave_id],
         WaveScoreDirtyRefreshReason.DROP_DELETED,

--- a/src/config/deploy-services.json
+++ b/src/config/deploy-services.json
@@ -54,6 +54,7 @@
     { "name": "transactionsProcessingLoop", "allowed_environments": ["staging", "prod"] },
     { "name": "waveDecisionExecutionLoop", "allowed_environments": ["staging", "prod"] },
     { "name": "waveLeaderboardSnapshotterLoop", "allowed_environments": ["staging", "prod"] },
+    { "name": "waveDropMetricsRefreshLoop", "allowed_environments": ["staging", "prod"] },
     { "name": "waveScoreRefreshLoop", "allowed_environments": ["staging", "prod"] },
     { "name": "xTdhLoop", "allowed_environments": ["staging", "prod"] }
   ]

--- a/src/constants/db-tables.ts
+++ b/src/constants/db-tables.ts
@@ -147,6 +147,8 @@ export const MINTING_CLAIMS_TABLE = 'minting_claims';
 export const MINTING_CLAIM_ACTIONS_TABLE = 'minting_claim_actions';
 export const WAVE_METRICS_TABLE = 'wave_metrics';
 export const WAVE_SCORE_REFRESH_REQUESTS_TABLE = 'wave_score_refresh_requests';
+export const WAVE_DROP_METRICS_REFRESH_REQUESTS_TABLE =
+  'wave_drop_metrics_refresh_requests';
 export const WAVE_DROPPER_METRICS_TABLE = 'wave_dropper_metrics';
 export const WAVE_CHAT_DROP_COOLDOWNS_TABLE = 'wave_chat_drop_cooldowns';
 export const WAVE_READER_METRICS_TABLE = 'wave_reader_metrics';

--- a/src/drops/delete-drop-use-case.test.ts
+++ b/src/drops/delete-drop-use-case.test.ts
@@ -1,6 +1,7 @@
 import { identityFetcher } from '@/api-serverless/src/identities/identity.fetcher';
 import { userGroupsService } from '@/api-serverless/src/community-members/user-groups.service';
 import { waveScoreService } from '@/api/waves/wave-score.service';
+import { waveDropMetricsRefreshService } from '@/drops/wave-drop-metrics-refresh.service';
 import { DropType } from '@/entities/IDrop';
 import { DeleteDropUseCase } from './delete-drop.use-case';
 
@@ -30,7 +31,7 @@ describe('DeleteDropUseCase', () => {
       deleteDropFeedItems: jest.fn().mockResolvedValue(undefined),
       deleteDropNotifications: jest.fn().mockResolvedValue(undefined),
       deleteDropSubscriptions: jest.fn().mockResolvedValue(undefined),
-      resyncDropCountsForWaves: jest.fn().mockResolvedValue(undefined),
+      applyDeletedDropMetricsDelta: jest.fn().mockResolvedValue(undefined),
       insertDeletedDrop: jest.fn().mockResolvedValue(undefined)
     };
     const reactionsService = {
@@ -104,6 +105,12 @@ describe('DeleteDropUseCase', () => {
     const markWaveScoresDirtySpy = jest
       .spyOn(waveScoreService, 'markWaveScoresDirtyBestEffort')
       .mockResolvedValue(undefined);
+    const markWaveDropMetricsDirtySpy = jest
+      .spyOn(
+        waveDropMetricsRefreshService,
+        'markWaveDropMetricsDirtyBestEffort'
+      )
+      .mockResolvedValue(undefined);
 
     await expect(
       useCase.execute(
@@ -133,10 +140,18 @@ describe('DeleteDropUseCase', () => {
       timer: undefined,
       connection
     });
-    expect(dropsDb.resyncDropCountsForWaves).toHaveBeenCalledWith(['wave-1'], {
+    expect(dropsDb.applyDeletedDropMetricsDelta).toHaveBeenCalledWith(drop, {
       timer: undefined,
       connection
     });
+    expect(markWaveDropMetricsDirtySpy).toHaveBeenCalledWith(
+      ['wave-1'],
+      'DROP_DELETED',
+      {
+        timer: undefined,
+        connection
+      }
+    );
     expect(markWaveScoresDirtySpy).toHaveBeenCalledWith(
       ['wave-1'],
       'DROP_DELETED',

--- a/src/drops/delete-drop.use-case.ts
+++ b/src/drops/delete-drop.use-case.ts
@@ -40,6 +40,10 @@ import {
   waveScoreService,
   WaveScoreDirtyRefreshReason
 } from '@/api/waves/wave-score.service';
+import {
+  waveDropMetricsRefreshService,
+  WaveDropMetricsDirtyRefreshReason
+} from '@/drops/wave-drop-metrics-refresh.service';
 
 export class DeleteDropUseCase {
   public constructor(
@@ -158,10 +162,15 @@ export class DeleteDropUseCase {
         this.dropBookmarksDb.deleteBookmarksByDropId(dropId, connection)
       ]);
       if (isPermanentDelete) {
-        await this.dropsDb.resyncDropCountsForWaves([drop.wave_id], {
+        await this.dropsDb.applyDeletedDropMetricsDelta(drop, {
           timer,
           connection
         });
+        await waveDropMetricsRefreshService.markWaveDropMetricsDirtyBestEffort(
+          [drop.wave_id],
+          WaveDropMetricsDirtyRefreshReason.DROP_DELETED,
+          { timer, connection }
+        );
         await waveScoreService.markWaveScoresDirtyBestEffort(
           [drop.wave_id],
           WaveScoreDirtyRefreshReason.DROP_DELETED,

--- a/src/drops/drops-db.test.ts
+++ b/src/drops/drops-db.test.ts
@@ -4,13 +4,95 @@ import {
   DROPS_TABLE,
   IDENTITIES_TABLE,
   TDH_NFT_TABLE,
+  WAVE_DROPPER_METRICS_TABLE,
+  WAVE_METRICS_TABLE,
   WAVE_VOTING_CREDIT_NFTS_TABLE,
   WAVES_TABLE
 } from '@/constants';
 import { PageSortDirection } from '@/api/page-request';
+import { DbPoolName } from '@/db-query.options';
+import { DropType } from '@/entities/IDrop';
 import { DropsDb, LeaderboardSort } from './drops.db';
 
 describe('DropsDb', () => {
+  it('applies a bounded metrics delta when a drop is deleted', async () => {
+    const connection = {};
+    const execute = jest.fn().mockResolvedValue([]);
+    const repo = new DropsDb(
+      () =>
+        ({
+          execute
+        }) as any
+    );
+
+    await repo.applyDeletedDropMetricsDelta(
+      {
+        wave_id: 'wave-1',
+        author_id: 'author-1',
+        drop_type: DropType.PARTICIPATORY
+      },
+      {
+        connection: { connection } as any,
+        timer: undefined
+      }
+    );
+
+    expect(execute).toHaveBeenCalledTimes(2);
+    expect(execute.mock.calls[0]?.[0]).toContain(
+      `update ${WAVE_METRICS_TABLE} wm`
+    );
+    expect(execute.mock.calls[0]?.[0]).toContain(
+      'wm.participatory_drops_count - :participatoryDropsDelta'
+    );
+    expect(execute.mock.calls[0]?.[0]).toContain(`from ${DROPS_TABLE} d`);
+    expect(execute.mock.calls[0]?.[1]).toEqual({
+      waveId: 'wave-1',
+      chatDropsDelta: 0,
+      participatoryDropsDelta: 1
+    });
+    expect(execute.mock.calls[0]?.[2]).toEqual({
+      wrappedConnection: { connection }
+    });
+    expect(execute.mock.calls[1]?.[0]).toContain(
+      `update ${WAVE_DROPPER_METRICS_TABLE} wdm`
+    );
+    expect(execute.mock.calls[1]?.[1]).toEqual({
+      waveId: 'wave-1',
+      dropperId: 'author-1',
+      chatDropsDelta: 0,
+      participatoryDropsDelta: 1
+    });
+    expect(execute.mock.calls[1]?.[2]).toEqual({
+      wrappedConnection: { connection }
+    });
+  });
+
+  it('can force full drop metrics resyncs onto the write pool', async () => {
+    const execute = jest.fn().mockResolvedValue([]);
+    const repo = new DropsDb(
+      () =>
+        ({
+          execute
+        }) as any
+    );
+
+    await repo.resyncDropCountsForWaves(
+      ['wave-1'],
+      { timer: undefined },
+      { forcePool: DbPoolName.WRITE }
+    );
+
+    expect(execute).toHaveBeenCalledTimes(2);
+    expect(execute.mock.calls[0]?.[2]).toEqual({
+      wrappedConnection: undefined,
+      forcePool: DbPoolName.WRITE
+    });
+    expect(execute.mock.calls[1]?.[2]).toEqual({
+      wrappedConnection: undefined,
+      forcePool: DbPoolName.WRITE
+    });
+  });
+
   it('deletes activity feed items by indexed drop columns', async () => {
     const connection = {};
     const execute = jest.fn().mockResolvedValue([]);

--- a/src/drops/drops.db.ts
+++ b/src/drops/drops.db.ts
@@ -75,6 +75,7 @@ import {
   LazyDbAccessCompatibleService
 } from '../sql-executor';
 import { Time, Timer } from '../time';
+import { DbPoolName } from '@/db-query.options';
 
 const mysql = require('mysql');
 
@@ -1797,15 +1798,23 @@ export class DropsDb extends LazyDbAccessCompatibleService {
 
   public async resyncDropCountsForWaves(
     waveIds: string[],
-    ctx: RequestContext
+    ctx: RequestContext,
+    options: { forcePool?: DbPoolName } = {}
   ) {
     if (!waveIds.length) {
       return;
     }
     ctx.timer?.start('dropsDb->resyncDropCountsForWaves');
-    await Promise.all([
-      this.db.execute(
-        `
+    try {
+      const queryOptions = options.forcePool
+        ? {
+            wrappedConnection: ctx.connection,
+            forcePool: options.forcePool
+          }
+        : { wrappedConnection: ctx.connection };
+      await Promise.all([
+        this.db.execute(
+          `
           update ${WAVE_DROPPER_METRICS_TABLE} wdm
             left join (
               select
@@ -1828,11 +1837,11 @@ export class DropsDb extends LazyDbAccessCompatibleService {
               or wdm.latest_drop_timestamp <> ifnull(actual.latest_drop_timestamp, 0)
             )
         `,
-        { waveIds },
-        { wrappedConnection: ctx.connection }
-      ),
-      this.db.execute(
-        `
+          { waveIds },
+          queryOptions
+        ),
+        this.db.execute(
+          `
           update ${WAVE_METRICS_TABLE} wm
             left join (
               select
@@ -1854,11 +1863,80 @@ export class DropsDb extends LazyDbAccessCompatibleService {
               or wm.latest_drop_timestamp <> ifnull(actual.latest_drop_timestamp, 0)
             )
         `,
-        { waveIds },
-        { wrappedConnection: ctx.connection }
-      )
-    ]);
-    ctx.timer?.stop('dropsDb->resyncDropCountsForWaves');
+          { waveIds },
+          queryOptions
+        )
+      ]);
+    } finally {
+      ctx.timer?.stop('dropsDb->resyncDropCountsForWaves');
+    }
+  }
+
+  public async applyDeletedDropMetricsDelta(
+    drop: Pick<DropEntity, 'wave_id' | 'author_id' | 'drop_type'>,
+    ctx: RequestContext
+  ) {
+    ctx.timer?.start('dropsDb->applyDeletedDropMetricsDelta');
+    try {
+      // Mirrors insertDrop: CHAT increments drops_count, PARTICIPATORY increments
+      // participatory_drops_count, and WINNER only affects latest_drop_timestamp.
+      // This keeps DELETE fast; the async full resync is the authoritative repair
+      // for stale counters, retries, and races.
+      const chatDropsDelta = drop.drop_type === DropType.CHAT ? 1 : 0;
+      const participatoryDropsDelta =
+        drop.drop_type === DropType.PARTICIPATORY ? 1 : 0;
+      await Promise.all([
+        this.db.execute(
+          `
+          update ${WAVE_METRICS_TABLE} wm
+          set wm.drops_count = greatest(wm.drops_count - :chatDropsDelta, 0),
+              wm.participatory_drops_count = greatest(
+                wm.participatory_drops_count - :participatoryDropsDelta,
+                0
+              ),
+              wm.latest_drop_timestamp = (
+                select ifnull(max(d.created_at), 0)
+                from ${DROPS_TABLE} d
+                where d.wave_id = :waveId
+              )
+          where wm.wave_id = :waveId
+        `,
+          {
+            waveId: drop.wave_id,
+            chatDropsDelta,
+            participatoryDropsDelta
+          },
+          { wrappedConnection: ctx.connection }
+        ),
+        this.db.execute(
+          `
+          update ${WAVE_DROPPER_METRICS_TABLE} wdm
+          set wdm.drops_count = greatest(wdm.drops_count - :chatDropsDelta, 0),
+              wdm.participatory_drops_count = greatest(
+                wdm.participatory_drops_count - :participatoryDropsDelta,
+                0
+              ),
+              wdm.latest_drop_timestamp = (
+                select ifnull(max(d.created_at), 0)
+                from ${DROPS_TABLE} d
+                where d.wave_id = :waveId
+                  and d.author_id = :dropperId
+              )
+          where wdm.wave_id = :waveId
+            and wdm.dropper_id = :dropperId
+        `,
+          {
+            waveId: drop.wave_id,
+            dropperId: drop.author_id,
+            chatDropsDelta,
+            participatoryDropsDelta
+          },
+          { wrappedConnection: ctx.connection }
+        )
+      ]);
+    } finally {
+      ctx.timer?.stop('dropsDb->applyDeletedDropMetricsDelta');
+    }
   }
 
   public async deleteDropSubscriptions(dropId: string, ctx: RequestContext) {

--- a/src/drops/wave-drop-metrics-refresh-service.test.ts
+++ b/src/drops/wave-drop-metrics-refresh-service.test.ts
@@ -1,0 +1,288 @@
+import { DbPoolName } from '@/db-query.options';
+import { sqs } from '@/sqs';
+import { Time } from '@/time';
+import {
+  WAVE_DROP_METRICS_DIRTY_REFRESH_MESSAGE_GROUP_ID,
+  WAVE_DROP_METRICS_DIRTY_REFRESH_QUEUE_NAME,
+  WaveDropMetricsDirtyRefreshReason,
+  WaveDropMetricsRefreshService
+} from './wave-drop-metrics-refresh.service';
+
+describe('WaveDropMetricsRefreshService', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('marks distinct waves dirty with a monotonic dirty timestamp inside the caller connection', async () => {
+    jest.spyOn(Time, 'currentMillis').mockReturnValue(12_345);
+    const execute = jest.fn().mockResolvedValue([]);
+    const service = new WaveDropMetricsRefreshService(
+      () => ({ execute }) as any,
+      {} as any
+    );
+    const connection = {} as any;
+
+    await service.markWaveDropMetricsDirty(
+      ['wave-1', 'wave-1', ''],
+      WaveDropMetricsDirtyRefreshReason.DROP_DELETED,
+      { connection }
+    );
+
+    expect(execute).toHaveBeenCalledWith(
+      expect.stringContaining('insert into wave_drop_metrics_refresh_requests'),
+      expect.objectContaining({
+        waveId0: 'wave-1',
+        reason0: WaveDropMetricsDirtyRefreshReason.DROP_DELETED,
+        dirtyAt0: 12_345,
+        createdAt0: 12_345,
+        updatedAt0: 12_345
+      }),
+      { wrappedConnection: connection }
+    );
+    expect(execute.mock.calls[0]?.[0]).toContain('greatest(');
+  });
+
+  it('drains dirty drop metrics rows from the write pool and deletes only the captured dirty timestamp', async () => {
+    const execute = jest.fn(async (sql: string) => {
+      if (sql.includes('select wave_id, dirty_at')) {
+        return [{ wave_id: 'wave-1', dirty_at: '1000' }];
+      }
+      return [];
+    });
+    const dropsDb = {
+      resyncDropCountsForWaves: jest.fn().mockResolvedValue(undefined)
+    };
+    const service = new WaveDropMetricsRefreshService(
+      () => ({ execute }) as any,
+      dropsDb as any
+    );
+
+    await expect(
+      service.refreshDirtyWaveDropMetrics({ batchSize: 10, maxBatches: 1 })
+    ).resolves.toEqual({
+      batches: 1,
+      waves: 1,
+      hasMore: false
+    });
+
+    expect(execute).toHaveBeenCalledWith(
+      expect.stringContaining('select wave_id, dirty_at'),
+      expect.objectContaining({
+        batchSize: 10,
+        maxAttempts: 5
+      }),
+      expect.objectContaining({ forcePool: DbPoolName.WRITE })
+    );
+    expect(dropsDb.resyncDropCountsForWaves).toHaveBeenCalledWith(
+      ['wave-1'],
+      {},
+      { forcePool: DbPoolName.WRITE }
+    );
+    expect(execute).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'where (wave_id, dirty_at) in ((:dirtyWaveId0, :dirtyAt0))'
+      ),
+      {
+        dirtyWaveId0: 'wave-1',
+        dirtyAt0: 1000
+      },
+      expect.objectContaining({ forcePool: DbPoolName.WRITE })
+    );
+  });
+
+  it('records a dirty drop metrics refresh failure and continues through the batch', async () => {
+    const execute = jest.fn(async (sql: string) => {
+      if (sql.includes('select wave_id, dirty_at')) {
+        return [
+          { wave_id: 'wave-1', dirty_at: '1000' },
+          { wave_id: 'wave-2', dirty_at: '1001' }
+        ];
+      }
+      return [];
+    });
+    const dropsDb = {
+      resyncDropCountsForWaves: jest
+        .fn()
+        .mockRejectedValueOnce(new Error('drop metrics refresh failed'))
+        .mockResolvedValueOnce(undefined)
+    };
+    const service = new WaveDropMetricsRefreshService(
+      () => ({ execute }) as any,
+      dropsDb as any
+    );
+
+    await expect(
+      service.refreshDirtyWaveDropMetrics({ batchSize: 10, maxBatches: 1 })
+    ).resolves.toEqual({
+      batches: 1,
+      waves: 2,
+      hasMore: false
+    });
+
+    expect(dropsDb.resyncDropCountsForWaves).toHaveBeenNthCalledWith(
+      1,
+      ['wave-1'],
+      {},
+      { forcePool: DbPoolName.WRITE }
+    );
+    expect(dropsDb.resyncDropCountsForWaves).toHaveBeenNthCalledWith(
+      2,
+      ['wave-2'],
+      {},
+      { forcePool: DbPoolName.WRITE }
+    );
+    expect(execute).toHaveBeenCalledWith(
+      expect.stringContaining('attempts = attempts + 1'),
+      expect.objectContaining({
+        dirtyWaveId0: 'wave-1',
+        dirtyAt0: 1000,
+        lastError: 'drop metrics refresh failed'
+      }),
+      expect.objectContaining({ forcePool: DbPoolName.WRITE })
+    );
+    expect(execute).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'where (wave_id, dirty_at) in ((:dirtyWaveId0, :dirtyAt0))'
+      ),
+      {
+        dirtyWaveId0: 'wave-2',
+        dirtyAt0: 1001
+      },
+      expect.objectContaining({ forcePool: DbPoolName.WRITE })
+    );
+  });
+
+  it('does not continue when the max batch only leaves failed rows behind', async () => {
+    const execute = jest.fn(async (sql: string) => {
+      if (sql.includes('select wave_id, dirty_at')) {
+        return [{ wave_id: 'wave-1', dirty_at: '1000' }];
+      }
+      if (sql.includes('select wave_id')) {
+        return [];
+      }
+      return [];
+    });
+    const dropsDb = {
+      resyncDropCountsForWaves: jest
+        .fn()
+        .mockRejectedValue(new Error('drop metrics refresh failed'))
+    };
+    const service = new WaveDropMetricsRefreshService(
+      () => ({ execute }) as any,
+      dropsDb as any
+    );
+
+    await expect(
+      service.refreshDirtyWaveDropMetrics({ batchSize: 1, maxBatches: 1 })
+    ).resolves.toEqual({
+      batches: 1,
+      waves: 1,
+      hasMore: false
+    });
+
+    expect(execute).toHaveBeenCalledWith(
+      expect.stringContaining('wave_id not in (:excludedWaveId0)'),
+      expect.objectContaining({
+        excludedWaveId0: 'wave-1',
+        maxAttempts: 5
+      }),
+      expect.objectContaining({ forcePool: DbPoolName.WRITE })
+    );
+  });
+
+  it('checks for remaining dirty rows before continuing after the max batch', async () => {
+    const execute = jest.fn(async (sql: string) => {
+      if (sql.includes('select wave_id, dirty_at')) {
+        return [{ wave_id: 'wave-1', dirty_at: '1000' }];
+      }
+      if (sql.includes('select wave_id')) {
+        return [];
+      }
+      return [];
+    });
+    const dropsDb = {
+      resyncDropCountsForWaves: jest.fn().mockResolvedValue(undefined)
+    };
+    const service = new WaveDropMetricsRefreshService(
+      () => ({ execute }) as any,
+      dropsDb as any
+    );
+
+    await expect(
+      service.refreshDirtyWaveDropMetrics({ batchSize: 1, maxBatches: 1 })
+    ).resolves.toEqual({
+      batches: 1,
+      waves: 1,
+      hasMore: false
+    });
+  });
+
+  it('does not run synchronous fallback inside a dirty mark transaction', async () => {
+    const service = new WaveDropMetricsRefreshService(
+      () =>
+        ({
+          execute: jest.fn().mockRejectedValue(new Error('missing table'))
+        }) as any,
+      {} as any
+    );
+    const refreshDropMetricsForWaveIdsBestEffort = jest
+      .spyOn(service, 'refreshDropMetricsForWaveIdsBestEffort')
+      .mockResolvedValue(undefined);
+
+    await service.markWaveDropMetricsDirtyBestEffort(
+      ['wave-1'],
+      WaveDropMetricsDirtyRefreshReason.DROP_DELETED,
+      { connection: {} as any }
+    );
+
+    expect(refreshDropMetricsForWaveIdsBestEffort).not.toHaveBeenCalled();
+  });
+
+  it('persists and enqueues async dirty refresh requests', async () => {
+    const service = new WaveDropMetricsRefreshService(
+      () => ({}) as any,
+      {} as any
+    );
+    const markWaveDropMetricsDirty = jest
+      .spyOn(service, 'markWaveDropMetricsDirty')
+      .mockResolvedValue(undefined);
+    const enqueueDirtyWaveDropMetricsRefresh = jest
+      .spyOn(service, 'enqueueDirtyWaveDropMetricsRefreshBestEffort')
+      .mockResolvedValue(undefined);
+
+    await service.requestWaveDropMetricsRefreshBestEffort(
+      ['wave-1'],
+      WaveDropMetricsDirtyRefreshReason.DROP_DELETED
+    );
+
+    expect(markWaveDropMetricsDirty).toHaveBeenCalledWith(
+      ['wave-1'],
+      WaveDropMetricsDirtyRefreshReason.DROP_DELETED,
+      {}
+    );
+    expect(enqueueDirtyWaveDropMetricsRefresh).toHaveBeenCalledWith({});
+  });
+
+  it('sends unique dirty refresh wakeups to the dirty FIFO queue', async () => {
+    jest.spyOn(Time, 'currentMillis').mockReturnValue(12_345);
+    const sendToQueueName = jest
+      .spyOn(sqs, 'sendToQueueName')
+      .mockResolvedValue(undefined);
+    const service = new WaveDropMetricsRefreshService(
+      () => ({}) as any,
+      {} as any
+    );
+
+    await service.enqueueDirtyWaveDropMetricsRefresh();
+
+    expect(sendToQueueName).toHaveBeenCalledWith({
+      queueName: WAVE_DROP_METRICS_DIRTY_REFRESH_QUEUE_NAME,
+      messageGroupId: WAVE_DROP_METRICS_DIRTY_REFRESH_MESSAGE_GROUP_ID,
+      message: {
+        mode: 'DIRTY',
+        requestedAt: 12_345,
+        nonce: expect.any(String)
+      }
+    });
+  });
+});

--- a/src/drops/wave-drop-metrics-refresh.service.ts
+++ b/src/drops/wave-drop-metrics-refresh.service.ts
@@ -1,0 +1,496 @@
+import { WAVE_DROP_METRICS_REFRESH_REQUESTS_TABLE } from '@/constants';
+import { DbPoolName } from '@/db-query.options';
+import { Logger } from '@/logging';
+import { RequestContext } from '@/request.context';
+import {
+  dbSupplier,
+  LazyDbAccessCompatibleService,
+  SqlExecutor
+} from '@/sql-executor';
+import { sqs } from '@/sqs';
+import { Time } from '@/time';
+import { randomUUID } from 'crypto';
+import { dropsDb as defaultDropsDb, DropsDb } from './drops.db';
+
+export const WAVE_DROP_METRICS_DIRTY_REFRESH_QUEUE_NAME =
+  'wave-drop-metrics-refresh-dirty.fifo';
+export const WAVE_DROP_METRICS_DIRTY_REFRESH_MESSAGE_GROUP_ID =
+  'wave-drop-metrics-refresh-dirty';
+
+const WAVE_DROP_METRICS_DEFAULT_REFRESH_BATCH_SIZE = 10;
+const WAVE_DROP_METRICS_MAX_REFRESH_BATCH_SIZE = 50;
+const WAVE_DROP_METRICS_MAX_REFRESH_ATTEMPTS = 5;
+
+export const WaveDropMetricsDirtyRefreshReason = {
+  DROP_CHANGED: 'DROP_CHANGED',
+  DROP_DELETED: 'DROP_DELETED',
+  REPAIR: 'REPAIR'
+} as const;
+
+export type WaveDropMetricsDirtyRefreshReason =
+  (typeof WaveDropMetricsDirtyRefreshReason)[keyof typeof WaveDropMetricsDirtyRefreshReason];
+
+export interface RefreshDirtyWaveDropMetricsOptions {
+  readonly batchSize?: number | undefined;
+  readonly maxBatches?: number | undefined;
+}
+
+export interface RefreshDirtyWaveDropMetricsResult {
+  readonly batches: number;
+  readonly waves: number;
+  readonly hasMore: boolean;
+}
+
+interface DirtyWaveDropMetricsRefreshRequestRow {
+  readonly wave_id: string;
+  readonly dirty_at: number | string;
+}
+
+export class WaveDropMetricsRefreshService extends LazyDbAccessCompatibleService {
+  private readonly logger = Logger.get(this.constructor.name);
+
+  public constructor(
+    sqlExecutorGetter: () => SqlExecutor = dbSupplier,
+    private readonly dropsDb: DropsDb = defaultDropsDb
+  ) {
+    super(sqlExecutorGetter);
+  }
+
+  public async refreshDropMetricsForWaveIds(
+    waveIds: string[],
+    ctx: RequestContext = {}
+  ): Promise<void> {
+    const distinctWaveIds = this.distinctWaveIds(waveIds);
+    if (!distinctWaveIds.length) {
+      return;
+    }
+    ctx.timer?.start(`${this.constructor.name}->refreshDropMetricsForWaveIds`);
+    try {
+      for (
+        let i = 0;
+        i < distinctWaveIds.length;
+        i += WAVE_DROP_METRICS_MAX_REFRESH_BATCH_SIZE
+      ) {
+        const waveIdsChunk = distinctWaveIds.slice(
+          i,
+          i + WAVE_DROP_METRICS_MAX_REFRESH_BATCH_SIZE
+        );
+        await this.dropsDb.resyncDropCountsForWaves(waveIdsChunk, ctx, {
+          forcePool: DbPoolName.WRITE
+        });
+      }
+    } finally {
+      ctx.timer?.stop(`${this.constructor.name}->refreshDropMetricsForWaveIds`);
+    }
+  }
+
+  public async refreshDropMetricsForWaveIdsBestEffort(
+    waveIds: string[],
+    ctx: RequestContext = {}
+  ): Promise<void> {
+    try {
+      await this.refreshDropMetricsForWaveIds(waveIds, ctx);
+    } catch (error) {
+      this.logger.error(
+        `Failed to refresh drop metrics for ${waveIds.length}`,
+        {
+          waveIds,
+          error
+        }
+      );
+    }
+  }
+
+  public async markWaveDropMetricsDirty(
+    waveIds: string[],
+    reason: WaveDropMetricsDirtyRefreshReason,
+    ctx: RequestContext = {}
+  ): Promise<void> {
+    const distinctWaveIds = this.distinctWaveIds(waveIds);
+    if (!distinctWaveIds.length) {
+      return;
+    }
+    ctx.timer?.start(`${this.constructor.name}->markWaveDropMetricsDirty`);
+    try {
+      const now = Time.currentMillis();
+      const params = distinctWaveIds.reduce<Record<string, string | number>>(
+        (acc, waveId, i) => {
+          acc[`waveId${i}`] = waveId;
+          acc[`reason${i}`] = reason;
+          acc[`dirtyAt${i}`] = now;
+          acc[`createdAt${i}`] = now;
+          acc[`updatedAt${i}`] = now;
+          return acc;
+        },
+        {}
+      );
+      await this.db.execute(
+        `
+        insert into ${WAVE_DROP_METRICS_REFRESH_REQUESTS_TABLE}
+          (wave_id, reason, dirty_at, attempts, last_error, created_at, updated_at)
+        values ${distinctWaveIds
+          .map(
+            (_, i) =>
+              `(:waveId${i}, :reason${i}, :dirtyAt${i}, 0, null, :createdAt${i}, :updatedAt${i})`
+          )
+          .join(', ')}
+        as new
+        on duplicate key update
+          reason = new.reason,
+          -- Re-dirties during a drain must survive the captured-version delete.
+          -- Treat dirty_at as a version; same-millisecond writes can move it ahead of wall-clock time.
+          dirty_at = greatest(
+            new.dirty_at,
+            ${WAVE_DROP_METRICS_REFRESH_REQUESTS_TABLE}.dirty_at + 1
+          ),
+          attempts = 0,
+          last_error = null,
+          updated_at = new.updated_at
+        `,
+        params,
+        { wrappedConnection: ctx.connection }
+      );
+    } finally {
+      ctx.timer?.stop(`${this.constructor.name}->markWaveDropMetricsDirty`);
+    }
+  }
+
+  public async markWaveDropMetricsDirtyBestEffort(
+    waveIds: string[],
+    reason: WaveDropMetricsDirtyRefreshReason,
+    ctx: RequestContext = {}
+  ): Promise<void> {
+    try {
+      await this.markWaveDropMetricsDirty(waveIds, reason, ctx);
+    } catch (error) {
+      this.logger.error(
+        `Failed to mark wave drop metrics dirty for ${waveIds.length}`,
+        {
+          waveIds,
+          reason,
+          error
+        }
+      );
+      if (ctx.connection) {
+        // Keep write transactions short; post-commit callers issue a second
+        // best-effort dirty mark and wakeup when the transaction succeeds.
+        return;
+      }
+      await this.refreshDropMetricsForWaveIdsBestEffort(waveIds, ctx);
+    }
+  }
+
+  public async requestWaveDropMetricsRefreshBestEffort(
+    waveIds: string[],
+    reason: WaveDropMetricsDirtyRefreshReason,
+    ctx: RequestContext = {}
+  ): Promise<void> {
+    try {
+      await this.markWaveDropMetricsDirty(waveIds, reason, ctx);
+    } catch (error) {
+      this.logger.error(
+        `Failed to persist dirty wave drop metrics refresh request for ${waveIds.length}`,
+        {
+          waveIds,
+          reason,
+          error
+        }
+      );
+      await this.refreshDropMetricsForWaveIdsBestEffort(waveIds, ctx);
+      return;
+    }
+    await this.enqueueDirtyWaveDropMetricsRefreshBestEffort(ctx);
+  }
+
+  public async enqueueDirtyWaveDropMetricsRefresh(
+    ctx: RequestContext = {}
+  ): Promise<void> {
+    ctx.timer?.start(
+      `${this.constructor.name}->enqueueDirtyWaveDropMetricsRefresh`
+    );
+    try {
+      await sqs.sendToQueueName({
+        queueName: WAVE_DROP_METRICS_DIRTY_REFRESH_QUEUE_NAME,
+        messageGroupId: WAVE_DROP_METRICS_DIRTY_REFRESH_MESSAGE_GROUP_ID,
+        message: {
+          mode: 'DIRTY',
+          requestedAt: Time.currentMillis(),
+          nonce: randomUUID()
+        }
+      });
+    } finally {
+      ctx.timer?.stop(
+        `${this.constructor.name}->enqueueDirtyWaveDropMetricsRefresh`
+      );
+    }
+  }
+
+  public async enqueueDirtyWaveDropMetricsRefreshBestEffort(
+    ctx: RequestContext = {}
+  ): Promise<void> {
+    try {
+      await this.enqueueDirtyWaveDropMetricsRefresh(ctx);
+    } catch (error) {
+      this.logger.error(`Failed to enqueue dirty wave drop metrics refresh`, {
+        error
+      });
+    }
+  }
+
+  public async refreshDirtyWaveDropMetrics(
+    options: RefreshDirtyWaveDropMetricsOptions = {},
+    ctx: RequestContext = {}
+  ): Promise<RefreshDirtyWaveDropMetricsResult> {
+    const batchSize = Math.max(
+      1,
+      Math.min(
+        WAVE_DROP_METRICS_MAX_REFRESH_BATCH_SIZE,
+        options.batchSize ?? WAVE_DROP_METRICS_DEFAULT_REFRESH_BATCH_SIZE
+      )
+    );
+    const maxBatches = Math.max(
+      1,
+      options.maxBatches ?? Number.MAX_SAFE_INTEGER
+    );
+    let batches = 0;
+    let waves = 0;
+    let hasMore = false;
+    const failedWaveIds = new Set<string>();
+
+    for (;;) {
+      // Successful rows are deleted; only failures need to be skipped for the
+      // rest of this invocation so the IN-list stays bounded by failures.
+      const rows = await this.getDirtyWaveDropMetricsRefreshRequests(
+        batchSize,
+        Array.from(failedWaveIds),
+        ctx
+      );
+      if (!rows.length) {
+        hasMore = false;
+        break;
+      }
+      for (const row of rows) {
+        const succeeded = await this.processDirtyWaveDropMetricsRefreshRequest(
+          row,
+          ctx
+        );
+        if (!succeeded) {
+          failedWaveIds.add(row.wave_id);
+        }
+      }
+      batches += 1;
+      waves += rows.length;
+      if (batches >= maxBatches) {
+        hasMore = await this.hasDirtyWaveDropMetricsRefreshRequests(
+          Array.from(failedWaveIds),
+          ctx
+        );
+        break;
+      }
+      if (rows.length < batchSize) {
+        hasMore = false;
+        break;
+      }
+    }
+
+    return {
+      batches,
+      waves,
+      hasMore
+    };
+  }
+
+  private async processDirtyWaveDropMetricsRefreshRequest(
+    row: DirtyWaveDropMetricsRefreshRequestRow,
+    ctx: RequestContext
+  ): Promise<boolean> {
+    try {
+      await this.refreshDropMetricsForWaveIds([row.wave_id], ctx);
+      await this.deleteDirtyWaveDropMetricsRefreshRequests([row], ctx);
+      return true;
+    } catch (error) {
+      await this.recordDirtyWaveDropMetricsRefreshFailure([row], error, ctx);
+      this.logger.error(`Failed to refresh dirty wave drop metrics`, {
+        waveId: row.wave_id,
+        dirtyAt: row.dirty_at,
+        error
+      });
+      return false;
+    }
+  }
+
+  private async getDirtyWaveDropMetricsRefreshRequests(
+    batchSize: number,
+    excludedWaveIds: string[],
+    ctx: RequestContext
+  ): Promise<DirtyWaveDropMetricsRefreshRequestRow[]> {
+    const excludedWaveIdParams = excludedWaveIds.reduce<Record<string, string>>(
+      (acc, waveId, i) => {
+        acc[`excludedWaveId${i}`] = waveId;
+        return acc;
+      },
+      {}
+    );
+    const params: Record<string, string | number> = {
+      batchSize,
+      maxAttempts: WAVE_DROP_METRICS_MAX_REFRESH_ATTEMPTS,
+      ...excludedWaveIdParams
+    };
+    const clauses = [
+      // Park poison rows until another write re-dirties the wave and resets attempts.
+      'attempts < :maxAttempts',
+      ...(excludedWaveIds.length
+        ? [
+            `wave_id not in (${excludedWaveIds
+              .map((_, i) => `:excludedWaveId${i}`)
+              .join(', ')})`
+          ]
+        : [])
+    ];
+    return this.db.execute<DirtyWaveDropMetricsRefreshRequestRow>(
+      `
+      select wave_id, dirty_at
+      from ${WAVE_DROP_METRICS_REFRESH_REQUESTS_TABLE}
+      where ${clauses.join(' and ')}
+      order by dirty_at asc, wave_id asc
+      limit :batchSize
+      `,
+      params,
+      {
+        wrappedConnection: ctx.connection,
+        // Dirty rows are inserted on the primary inside the write transaction.
+        // The refresher must read primary too, or replica lag can delay work.
+        forcePool: DbPoolName.WRITE
+      }
+    );
+  }
+
+  private async hasDirtyWaveDropMetricsRefreshRequests(
+    excludedWaveIds: string[],
+    ctx: RequestContext
+  ): Promise<boolean> {
+    const excludedWaveIdParams = excludedWaveIds.reduce<Record<string, string>>(
+      (acc, waveId, i) => {
+        acc[`excludedWaveId${i}`] = waveId;
+        return acc;
+      },
+      {}
+    );
+    const params: Record<string, string | number> = {
+      maxAttempts: WAVE_DROP_METRICS_MAX_REFRESH_ATTEMPTS,
+      ...excludedWaveIdParams
+    };
+    const clauses = [
+      'attempts < :maxAttempts',
+      ...(excludedWaveIds.length
+        ? [
+            `wave_id not in (${excludedWaveIds
+              .map((_, i) => `:excludedWaveId${i}`)
+              .join(', ')})`
+          ]
+        : [])
+    ];
+    const rows = await this.db.execute<{ readonly wave_id: string }>(
+      `
+      select wave_id
+      from ${WAVE_DROP_METRICS_REFRESH_REQUESTS_TABLE}
+      where ${clauses.join(' and ')}
+      limit 1
+      `,
+      params,
+      {
+        wrappedConnection: ctx.connection,
+        forcePool: DbPoolName.WRITE
+      }
+    );
+    return rows.length > 0;
+  }
+
+  private async deleteDirtyWaveDropMetricsRefreshRequests(
+    rows: DirtyWaveDropMetricsRefreshRequestRow[],
+    ctx: RequestContext
+  ): Promise<void> {
+    if (!rows.length) {
+      return;
+    }
+    await this.db.execute(
+      `
+      delete from ${WAVE_DROP_METRICS_REFRESH_REQUESTS_TABLE}
+      where ${this.capturedDirtyRowsWhere(rows)}
+      `,
+      this.capturedDirtyRowsParams(rows),
+      {
+        wrappedConnection: ctx.connection,
+        forcePool: DbPoolName.WRITE
+      }
+    );
+  }
+
+  private async recordDirtyWaveDropMetricsRefreshFailure(
+    rows: DirtyWaveDropMetricsRefreshRequestRow[],
+    error: unknown,
+    ctx: RequestContext
+  ): Promise<void> {
+    if (!rows.length) {
+      return;
+    }
+    await this.db.execute(
+      `
+      update ${WAVE_DROP_METRICS_REFRESH_REQUESTS_TABLE}
+      set
+        attempts = attempts + 1,
+        last_error = :lastError,
+        updated_at = :updatedAt
+      where ${this.capturedDirtyRowsWhere(rows)}
+      `,
+      {
+        ...this.capturedDirtyRowsParams(rows),
+        lastError: this.errorToString(error).slice(0, 2000),
+        updatedAt: Time.currentMillis()
+      },
+      {
+        wrappedConnection: ctx.connection,
+        forcePool: DbPoolName.WRITE
+      }
+    );
+  }
+
+  private capturedDirtyRowsWhere(
+    rows: DirtyWaveDropMetricsRefreshRequestRow[]
+  ): string {
+    return `(wave_id, dirty_at) in (${rows
+      .map((_, i) => `(:dirtyWaveId${i}, :dirtyAt${i})`)
+      .join(', ')})`;
+  }
+
+  private capturedDirtyRowsParams(
+    rows: DirtyWaveDropMetricsRefreshRequestRow[]
+  ): Record<string, string | number> {
+    return rows.reduce<Record<string, string | number>>((acc, row, i) => {
+      acc[`dirtyWaveId${i}`] = row.wave_id;
+      acc[`dirtyAt${i}`] = this.toNumber(row.dirty_at);
+      return acc;
+    }, {});
+  }
+
+  private distinctWaveIds(waveIds: string[]): string[] {
+    return Array.from(new Set(waveIds)).filter(Boolean);
+  }
+
+  private errorToString(error: unknown): string {
+    if (error instanceof Error) {
+      return error.message;
+    }
+    return String(error);
+  }
+
+  private toNumber(value: number | string | null | undefined): number {
+    if (value === null || value === undefined) {
+      return 0;
+    }
+    return Number(value) || 0;
+  }
+}
+
+export const waveDropMetricsRefreshService =
+  new WaveDropMetricsRefreshService();

--- a/src/entities/IWaveDropMetricsRefreshRequest.ts
+++ b/src/entities/IWaveDropMetricsRefreshRequest.ts
@@ -1,0 +1,27 @@
+import { WAVE_DROP_METRICS_REFRESH_REQUESTS_TABLE } from '@/constants';
+import { Column, Entity, Index, PrimaryColumn } from 'typeorm';
+
+@Entity(WAVE_DROP_METRICS_REFRESH_REQUESTS_TABLE)
+@Index('idx_wdmrr_dirty_wave', ['dirty_at', 'wave_id'])
+export class WaveDropMetricsRefreshRequestEntity {
+  @PrimaryColumn({ type: 'varchar', length: 100, nullable: false })
+  readonly wave_id!: string;
+
+  @Column({ type: 'varchar', length: 64, nullable: false })
+  readonly reason!: string;
+
+  @Column({ type: 'bigint', nullable: false })
+  readonly dirty_at!: number;
+
+  @Column({ type: 'int', nullable: false, default: 0 })
+  readonly attempts!: number;
+
+  @Column({ type: 'text', nullable: true, default: null })
+  readonly last_error!: string | null;
+
+  @Column({ type: 'bigint', nullable: false })
+  readonly created_at!: number;
+
+  @Column({ type: 'bigint', nullable: false })
+  readonly updated_at!: number;
+}

--- a/src/entities/entities.ts
+++ b/src/entities/entities.ts
@@ -193,6 +193,7 @@ export {
   WaveDecisionWinnerDropEntity
 } from './IWaveDecision';
 export { WaveChatDropCooldownEntity } from './IWaveChatDropCooldown';
+export { WaveDropMetricsRefreshRequestEntity } from './IWaveDropMetricsRefreshRequest';
 export { WaveDropperMetricEntity } from './IWaveDropperMetric';
 export { WaveLeaderboardEntryEntity } from './IWaveLeaderboardEntry';
 export { WaveMetadataEntity } from './IWaveMetadata';

--- a/src/waveDropMetricsRefreshLoop/index.ts
+++ b/src/waveDropMetricsRefreshLoop/index.ts
@@ -1,0 +1,194 @@
+import * as sentryContext from '@/sentry.context';
+import type { Handler } from 'aws-lambda';
+import { DropEntity } from '@/entities/IDrop';
+import { WaveDropMetricsRefreshRequestEntity } from '@/entities/IWaveDropMetricsRefreshRequest';
+import { WaveDropperMetricEntity } from '@/entities/IWaveDropperMetric';
+import { WaveMetricEntity } from '@/entities/IWaveMetric';
+import { Logger } from '@/logging';
+import { doInDbContext } from '@/secrets';
+import { sqs } from '@/sqs';
+import { Timer } from '@/time';
+import {
+  WAVE_DROP_METRICS_DIRTY_REFRESH_MESSAGE_GROUP_ID,
+  WAVE_DROP_METRICS_DIRTY_REFRESH_QUEUE_NAME,
+  waveDropMetricsRefreshService
+} from '@/drops/wave-drop-metrics-refresh.service';
+import { randomUUID } from 'crypto';
+
+const logger = Logger.get('WAVE_DROP_METRICS_REFRESH_LOOP');
+const DEFAULT_MAX_BATCHES_PER_INVOCATION = 10;
+const POSITIVE_INTEGER_PATTERN = /^[1-9]\d*$/;
+
+interface WaveDropMetricsRefreshMessage {
+  readonly batchSize?: number;
+  readonly maxBatches?: number;
+}
+
+function parsePositiveIntEnv(name: string): number | undefined {
+  const raw = process.env[name]?.trim();
+  if (!raw) {
+    return undefined;
+  }
+  return parsePositiveIntString(raw, name);
+}
+
+function parsePositiveIntString(value: string, name: string): number {
+  if (!POSITIVE_INTEGER_PATTERN.test(value)) {
+    throw new Error(`[${name}] must be a positive integer`);
+  }
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed)) {
+    throw new Error(`[${name}] must be a safe positive integer`);
+  }
+  return parsed;
+}
+
+function parsePositiveIntValue(
+  value: unknown,
+  name: string
+): number | undefined {
+  if (typeof value === 'undefined' || value === null || value === '') {
+    return undefined;
+  }
+  if (typeof value === 'number') {
+    if (!Number.isSafeInteger(value) || value <= 0) {
+      throw new Error(`[${name}] must be a positive integer`);
+    }
+    return value;
+  }
+  const raw = String(value).trim();
+  if (!raw) {
+    return undefined;
+  }
+  if (!POSITIVE_INTEGER_PATTERN.test(raw)) {
+    throw new Error(`[${name}] must be a positive integer`);
+  }
+  return parsePositiveIntString(raw, name);
+}
+
+function parseJsonObject(value: string): Record<string, unknown> {
+  const parsed = JSON.parse(value) as unknown;
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return {};
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function parseMessageBody(body: string): WaveDropMetricsRefreshMessage {
+  const parsed = parseJsonObject(body);
+  const snsMessage =
+    typeof parsed.Message === 'string'
+      ? parseJsonObject(parsed.Message)
+      : parsed;
+  return {
+    batchSize: parsePositiveIntValue(snsMessage.batchSize, 'batchSize'),
+    maxBatches: parsePositiveIntValue(snsMessage.maxBatches, 'maxBatches')
+  };
+}
+
+function getMessages(event: unknown): WaveDropMetricsRefreshMessage[] {
+  if (
+    event &&
+    typeof event === 'object' &&
+    'Records' in event &&
+    Array.isArray((event as { Records?: unknown }).Records)
+  ) {
+    return (event as { Records: { body?: unknown }[] }).Records.map((record) =>
+      parseMessageBody(String(record.body ?? '{}'))
+    );
+  }
+  if (!event || typeof event !== 'object') {
+    return [{}];
+  }
+  return [
+    {
+      batchSize: parsePositiveIntValue(
+        (event as Record<string, unknown>).batchSize,
+        'batchSize'
+      ),
+      maxBatches: parsePositiveIntValue(
+        (event as Record<string, unknown>).maxBatches,
+        'maxBatches'
+      )
+    }
+  ];
+}
+
+function resolveRefreshOptions(message: WaveDropMetricsRefreshMessage) {
+  return {
+    batchSize:
+      message.batchSize ??
+      parsePositiveIntEnv('WAVE_DROP_METRICS_REFRESH_BATCH_SIZE'),
+    maxBatches:
+      message.maxBatches ??
+      parsePositiveIntEnv('WAVE_DROP_METRICS_REFRESH_MAX_BATCHES') ??
+      DEFAULT_MAX_BATCHES_PER_INVOCATION
+  };
+}
+
+async function enqueueDirtyRefreshContinuation({
+  batchSize,
+  maxBatches
+}: {
+  batchSize?: number;
+  maxBatches: number;
+}) {
+  await sqs.sendToQueueName({
+    queueName: WAVE_DROP_METRICS_DIRTY_REFRESH_QUEUE_NAME,
+    messageGroupId: WAVE_DROP_METRICS_DIRTY_REFRESH_MESSAGE_GROUP_ID,
+    message: {
+      mode: 'DIRTY',
+      ...(batchSize ? { batchSize } : {}),
+      maxBatches,
+      requestedAt: Date.now(),
+      nonce: randomUUID()
+    }
+  });
+}
+
+const waveDropMetricsRefreshHandler: Handler = async (event) => {
+  await doInDbContext(
+    async () => {
+      for (const message of getMessages(event)) {
+        const timer = new Timer('WAVE_DROP_METRICS_REFRESH_LOOP');
+        try {
+          const options = resolveRefreshOptions(message);
+          const result =
+            await waveDropMetricsRefreshService.refreshDirtyWaveDropMetrics(
+              options,
+              {
+                timer
+              }
+            );
+          logger.info(
+            `Refreshed dirty wave drop metrics ${JSON.stringify(result)}`
+          );
+          if (result.hasMore) {
+            // Continuations reduce backlog latency; reservedConcurrency: 1 and
+            // the durable dirty table provide the backpressure boundary.
+            await enqueueDirtyRefreshContinuation({
+              batchSize: options.batchSize,
+              maxBatches: options.maxBatches
+            });
+            logger.info(`Queued dirty wave drop metrics refresh continuation`);
+          }
+        } finally {
+          logger.info(`Finished executing ${timer.getReport()}`);
+        }
+      }
+    },
+    {
+      logger,
+      entities: [
+        DropEntity,
+        WaveDropperMetricEntity,
+        WaveMetricEntity,
+        WaveDropMetricsRefreshRequestEntity
+      ]
+    }
+  );
+};
+
+export const handler = sentryContext.wrapLambdaHandler(
+  waveDropMetricsRefreshHandler
+);

--- a/src/waveDropMetricsRefreshLoop/package.json
+++ b/src/waveDropMetricsRefreshLoop/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "wavedropmetricsrefreshloop",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.ts",
+  "scripts": {
+    "prebuild": "rm -rf dist",
+    "build": "esbuild index.ts --bundle --sourcemap --platform=node --target=es2020 --outfile=dist/index.js",
+    "postbuild": "cd dist && zip -r index.zip index.js*",
+    "sls-deploy:prod": "node ../../node_modules/serverless/bin/serverless.js deploy --stage=prod --region=us-east-1",
+    "sls-deploy:staging": "node ../../node_modules/serverless/bin/serverless.js deploy --stage=staging --region=eu-west-1"
+  },
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "@types/aws-lambda": "^8.10.110",
+    "esbuild": "^0.27.2"
+  },
+  "dependencies": {}
+}

--- a/src/waveDropMetricsRefreshLoop/serverless.yaml
+++ b/src/waveDropMetricsRefreshLoop/serverless.yaml
@@ -1,0 +1,154 @@
+service: waveDropMetricsRefreshLoop
+
+package:
+  artifact: dist/index.zip
+
+plugins:
+  - serverless-offline
+
+provider:
+  name: aws
+  runtime: nodejs22.x
+  memorySize: 1024
+  timeout: 900
+  architecture: arm64
+  logRetentionInDays: 60
+
+functions:
+  waveDropMetricsRefreshLoop:
+    handler: index.handler
+    reservedConcurrency: 1
+    name: waveDropMetricsRefreshLoop
+    description: ${env:VERSION_DESCRIPTION}
+    events:
+      - sqs:
+          batchSize: 1
+          arn:
+            Fn::GetAtt:
+              - WaveDropMetricsDirtyRefreshQueue
+              - Arn
+      - schedule:
+          rate: rate(1 minute)
+          input:
+            mode: 'DIRTY'
+    role: arn:aws:iam::987989283142:role/lambda-vpc-role
+    vpc:
+      securityGroupIds: ${file(../../serverless-config/${opt:stage, self:provider.stage}/vpc.js):security}
+      subnetIds: ${file(../../serverless-config/${opt:stage, self:provider.stage}/vpc.js):subnets}
+    environment:
+      SENTRY_DSN: ${env:SENTRY_DSN}
+      SENTRY_ENVIRONMENT: 'waveDropMetricsRefreshLoop_${opt:stage, self:provider.stage}'
+
+resources:
+  Resources:
+    WaveDropMetricsRefreshLoopLogGroup:
+      Type: AWS::Logs::LogGroup
+      Properties:
+        LogGroupName: /aws/lambda/waveDropMetricsRefreshLoop
+        RetentionInDays: 60
+
+    WaveDropMetricsDirtyRefreshQueue:
+      Type: 'AWS::SQS::Queue'
+      Properties:
+        QueueName: 'wave-drop-metrics-refresh-dirty.fifo'
+        FifoQueue: true
+        VisibilityTimeout: 1200
+        ContentBasedDeduplication: true
+        RedrivePolicy:
+          deadLetterTargetArn:
+            Fn::GetAtt: [WaveDropMetricsDirtyRefreshDLQ, Arn]
+          maxReceiveCount: 5
+    WaveDropMetricsDirtyRefreshDLQ:
+      Type: 'AWS::SQS::Queue'
+      Properties:
+        QueueName: 'wave-drop-metrics-refresh-dirty-dlq.fifo'
+        FifoQueue: true
+        MessageRetentionPeriod: 1209600
+        ContentBasedDeduplication: true
+    WaveDropMetricsDirtyRefreshQueuePolicy:
+      Type: 'AWS::SQS::QueuePolicy'
+      Properties:
+        Queues:
+          - Ref: 'WaveDropMetricsDirtyRefreshQueue'
+        PolicyDocument:
+          Statement:
+            - Effect: 'Allow'
+              Principal:
+                AWS: arn:aws:iam::987989283142:role/lambda-vpc-role
+              Action:
+                - sqs:GetQueueUrl
+                - sqs:SendMessage
+                - sqs:ReceiveMessage
+                - sqs:DeleteMessage
+                - sqs:GetQueueAttributes
+                - sqs:ChangeMessageVisibility
+              Resource:
+                - !GetAtt WaveDropMetricsDirtyRefreshQueue.Arn
+    WaveDropMetricsDirtyRefreshDLQPolicy:
+      Type: 'AWS::SQS::QueuePolicy'
+      Properties:
+        Queues:
+          - Ref: 'WaveDropMetricsDirtyRefreshDLQ'
+        PolicyDocument:
+          Statement:
+            - Effect: 'Allow'
+              Principal:
+                AWS: arn:aws:iam::987989283142:role/lambda-vpc-role
+              Action:
+                - sqs:SendMessage
+              Resource:
+                - !GetAtt WaveDropMetricsDirtyRefreshDLQ.Arn
+    WaveDropMetricsRefreshLoopOOMFilter:
+      Type: AWS::Logs::MetricFilter
+      DependsOn:
+        - WaveDropMetricsRefreshLoopLogGroup
+      Properties:
+        LogGroupName:
+          Ref: WaveDropMetricsRefreshLoopLogGroup
+        FilterPattern: 'Runtime.OutOfMemory'
+        MetricTransformations:
+          - MetricNamespace: 'Lambda/OOM'
+            MetricName: 'waveDropMetricsRefreshLoop_OOMErrorCount'
+            MetricValue: '1'
+            DefaultValue: 0
+
+    WaveDropMetricsRefreshLoopOOMAlarm:
+      Type: AWS::CloudWatch::Alarm
+      DependsOn: WaveDropMetricsRefreshLoopOOMFilter
+      Properties:
+        AlarmName: !Sub '${AWS::StackName}-waveDropMetricsRefreshLoop-OOM'
+        AlarmDescription: !Sub 'Lambda waveDropMetricsRefreshLoop OutOfMemory in ${AWS::Region}'
+        Namespace: 'Lambda/OOM'
+        MetricName: 'waveDropMetricsRefreshLoop_OOMErrorCount'
+        Statistic: Sum
+        Period: 60
+        EvaluationPeriods: 1
+        Threshold: 1
+        ComparisonOperator: GreaterThanOrEqualToThreshold
+        TreatMissingData: notBreaching
+        AlarmActions:
+          - ${file(../../serverless-config/${opt:stage, self:provider.stage}/vpc.js):cwtopic}
+        OKActions:
+          - ${file(../../serverless-config/${opt:stage, self:provider.stage}/vpc.js):cwtopic}
+
+    WaveDropMetricsDirtyRefreshDLQDepthAlarm:
+      Type: AWS::CloudWatch::Alarm
+      Properties:
+        AlarmName: !Sub '${AWS::StackName}-waveDropMetricsRefreshLoop-DLQ'
+        AlarmDescription: !Sub 'waveDropMetricsRefreshLoop DLQ has visible messages in ${AWS::Region}'
+        Namespace: 'AWS/SQS'
+        MetricName: 'ApproximateNumberOfMessagesVisible'
+        Dimensions:
+          - Name: QueueName
+            Value:
+              Fn::GetAtt: [WaveDropMetricsDirtyRefreshDLQ, QueueName]
+        Statistic: Maximum
+        Period: 60
+        EvaluationPeriods: 1
+        Threshold: 1
+        ComparisonOperator: GreaterThanOrEqualToThreshold
+        TreatMissingData: notBreaching
+        AlarmActions:
+          - ${file(../../serverless-config/${opt:stage, self:provider.stage}/vpc.js):cwtopic}
+        OKActions:
+          - ${file(../../serverless-config/${opt:stage, self:provider.stage}/vpc.js):cwtopic}


### PR DESCRIPTION
## Summary
- add wave_drop_metrics_refresh_requests and a waveDropMetricsRefreshLoop worker with SQS + EventBridge fallback
- replace synchronous DELETE drop metric resync with bounded transactional decrement plus dirty-row repair
- enqueue post-commit drop metric repair from the public delete API

## Verification
- npm run lint
- npm test -- src/drops/wave-drop-metrics-refresh-service.test.ts src/drops/delete-drop-use-case.test.ts src/drops/drops-db.test.ts src/api-serverless/src/drops/drop-creation-api-service.test.ts --runInBand
- npm run tsc
- npm run build (from src/waveDropMetricsRefreshLoop)
- npm run check:changed (passed once with nested src/api-serverless dependencies installed; a later rerun hit local DB reset timeouts after 220s TRUNCATEs, focused tests still passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic refreshes for wave drop metrics after drop deletions.
  * Introduced a background process that keeps these metrics in sync and can continue processing in batches.
  * Added support for the new service in deployment and manual run options.

* **Bug Fixes**
  * Improved accuracy of wave-level and user-level drop counts and latest-drop timestamps after deletes.
  * Added retry handling for refresh failures so updates are less likely to be missed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->