### PR TITLE
Fix unread wave summaries without reader metrics

### DIFF
--- a/src/api-serverless/src/waves/waves-api-db.test.ts
+++ b/src/api-serverless/src/waves/waves-api-db.test.ts
@@ -926,12 +926,27 @@ const mutedUnreadSummaryWave = aWave(
     name: 'Muted Unread Summary Wave'
   }
 );
+const noReaderMetricUnreadSummaryWave = aWave(
+  {
+    created_by: author.profile_id!
+  },
+  {
+    id: 'wave-no-reader-metric-unread-summary',
+    serial_no: 33,
+    name: 'No Reader Metric Unread Summary Wave'
+  }
+);
 
 describeWithSeed(
   'WavesApiDb unread summaries',
   [
     withIdentities([author, unreadReader]),
-    withWaves([unreadSummaryWave, noUnreadSummaryWave, mutedUnreadSummaryWave]),
+    withWaves([
+      unreadSummaryWave,
+      noUnreadSummaryWave,
+      mutedUnreadSummaryWave,
+      noReaderMetricUnreadSummaryWave
+    ]),
     {
       table: WAVE_READER_METRICS_TABLE,
       rows: [
@@ -1011,6 +1026,51 @@ describeWithSeed(
           drop_type: DropType.CHAT,
           signature: null,
           hide_link_preview: false
+        },
+        {
+          serial_no: 25,
+          id: 'reader-authored-summary-drop',
+          wave_id: unreadSummaryWave.id,
+          author_id: unreadReader.profile_id!,
+          created_at: 1300,
+          updated_at: null,
+          title: null,
+          parts_count: 1,
+          reply_to_drop_id: null,
+          reply_to_part_id: null,
+          drop_type: DropType.CHAT,
+          signature: null,
+          hide_link_preview: false
+        },
+        {
+          serial_no: 26,
+          id: 'no-reader-metric-unread-summary-drop',
+          wave_id: noReaderMetricUnreadSummaryWave.id,
+          author_id: author.profile_id!,
+          created_at: 1400,
+          updated_at: null,
+          title: null,
+          parts_count: 1,
+          reply_to_drop_id: null,
+          reply_to_part_id: null,
+          drop_type: DropType.CHAT,
+          signature: null,
+          hide_link_preview: false
+        },
+        {
+          serial_no: 27,
+          id: 'no-reader-metric-reader-authored-summary-drop',
+          wave_id: noReaderMetricUnreadSummaryWave.id,
+          author_id: unreadReader.profile_id!,
+          created_at: 1500,
+          updated_at: null,
+          title: null,
+          parts_count: 1,
+          reply_to_drop_id: null,
+          reply_to_part_id: null,
+          drop_type: DropType.CHAT,
+          signature: null,
+          hide_link_preview: false
         }
       ]
     }
@@ -1024,7 +1084,8 @@ describeWithSeed(
             waveIds: [
               unreadSummaryWave.id,
               noUnreadSummaryWave.id,
-              mutedUnreadSummaryWave.id
+              mutedUnreadSummaryWave.id,
+              noReaderMetricUnreadSummaryWave.id
             ]
           },
           ctx
@@ -1041,6 +1102,10 @@ describeWithSeed(
         [mutedUnreadSummaryWave.id]: {
           unread_drops_count: 0,
           first_unread_drop_serial_no: null
+        },
+        [noReaderMetricUnreadSummaryWave.id]: {
+          unread_drops_count: 1,
+          first_unread_drop_serial_no: 26
         }
       });
     });

--- a/src/api-serverless/src/waves/waves.api.db.ts
+++ b/src/api-serverless/src/waves/waves.api.db.ts
@@ -2876,18 +2876,18 @@ export class WavesApiDb extends LazyDbAccessCompatibleService {
 
     const dbresult = await this.db.execute<WaveUnreadSummaryRow>(
       `
-        SELECT r.wave_id AS wave_id,
+        SELECT d.wave_id AS wave_id,
                COUNT(d.id) AS unread_drops_count,
                MIN(d.serial_no) AS first_unread_drop_serial_no
-        FROM ${WAVE_READER_METRICS_TABLE} r
-        INNER JOIN ${DROPS_TABLE} d USE INDEX (idx_drop_wave_created_at)
-          ON d.wave_id = r.wave_id
-          AND d.created_at > r.latest_read_timestamp
-        WHERE r.reader_id = :identityId
-          AND r.wave_id IN (:waveIds)
-          AND r.latest_read_timestamp IS NOT NULL
+        FROM ${DROPS_TABLE} d USE INDEX (idx_drop_wave_created_at)
+        LEFT JOIN ${WAVE_READER_METRICS_TABLE} r
+          ON r.wave_id = d.wave_id
+          AND r.reader_id = :identityId
+        WHERE d.wave_id IN (:waveIds)
+          AND d.author_id != :identityId
+          AND d.created_at > COALESCE(r.latest_read_timestamp, 0)
           AND COALESCE(r.muted, false) = false
-        GROUP BY r.wave_id
+        GROUP BY d.wave_id
     `,
       { identityId: param.identityId, waveIds: uncachedWaveIds },
       { wrappedConnection: ctx.connection }


### PR DESCRIPTION
## Issue
- DM unread indicators can show zero when a reader has unread drops but no `wave_reader_metrics` row yet, especially for first-ever DM conversations.
- Reader-authored drops can also be counted by the unread summary query when the read timestamp is missing.

## Fix
- Count unread drops from the drops table and left-join reader metrics so a missing reader metric behaves like `latest_read_timestamp = 0`.
- Exclude drops authored by the reader from unread counts.
- Keep muted reader metrics suppressing unread counts.

## Changes
- Updated `findIdentityUnreadDropsSummaryByWaveId` to tolerate missing reader metrics.
- Added regression coverage for no-reader-metric unread summaries and reader-authored drops.
- No OpenAPI, entity, migration, or deploy config changes.
- No architecture doc update needed; this changes API query semantics only, not system shape.

## Validation
- `npm test -- src/api-serverless/src/waves/waves-api-db.test.ts`
- `npm run lint`
- `npm run build`
- `cd src/api-serverless && npm run build`

## Risk
- Level: Medium
- Why: Changes unread-count query semantics used by wave and DM list APIs. The query is backward-compatible and narrows counts by ignoring reader-authored drops.
- Rollback: Revert this PR and redeploy `api`.

## Deployment
- Backend services to redeploy, in order: `api`.

## Review Notes
- Focus on unread-count semantics for missing reader metrics, muted rows, and reader-authored drops.