### PR TITLE
Add drop voting summary indexes

### DIFF
--- a/migrations/20260701093000-add-drop-voting-summary-indexes.js
+++ b/migrations/20260701093000-add-drop-voting-summary-indexes.js
@@ -13,6 +13,10 @@ function addIndex(db, sql) {
   return ignoreMysqlError(db.runSql(sql), ['ER_DUP_KEYNAME']);
 }
 
+function dropIndex(db, sql) {
+  return ignoreMysqlError(db.runSql(sql), ['ER_CANT_DROP_FIELD_OR_KEY']);
+}
+
 exports.up = function(db) {
   return addIndex(
     db,
@@ -44,7 +48,36 @@ exports.up = function(db) {
     });
 };
 
-exports.down = function() {};
+exports.down = function(db) {
+  return dropIndex(
+    db,
+    'DROP INDEX idx_drops_wave_type_created_id ON drops'
+  )
+    .then(function() {
+      return dropIndex(
+        db,
+        'DROP INDEX idx_wave_leaderboard_entries_wave_vote_time_drop ON wave_leaderboard_entries'
+      );
+    })
+    .then(function() {
+      return dropIndex(
+        db,
+        'DROP INDEX idx_drop_ranks_wave_vote_last_drop ON drop_ranks'
+      );
+    })
+    .then(function() {
+      return dropIndex(
+        db,
+        'DROP INDEX idx_winner_drop_voter_votes_drop_votes_voter ON winner_drop_voter_votes'
+      );
+    })
+    .then(function() {
+      return dropIndex(
+        db,
+        'DROP INDEX idx_drop_voter_states_drop_votes_voter ON drop_voter_states'
+      );
+    });
+};
 
 exports._meta = {
   version: 1

--- a/migrations/20260701093000-add-drop-voting-summary-indexes.js
+++ b/migrations/20260701093000-add-drop-voting-summary-indexes.js
@@ -1,0 +1,51 @@
+'use strict';
+
+function ignoreMysqlError(promise, ignoredCodes) {
+  return promise.catch(function(error) {
+    if (error && ignoredCodes.indexOf(error.code) !== -1) {
+      return null;
+    }
+    throw error;
+  });
+}
+
+function addIndex(db, sql) {
+  return ignoreMysqlError(db.runSql(sql), ['ER_DUP_KEYNAME']);
+}
+
+exports.up = function(db) {
+  return addIndex(
+    db,
+    'ALTER TABLE drop_voter_states ADD INDEX idx_drop_voter_states_drop_votes_voter (drop_id, votes, voter_id), ALGORITHM=INPLACE, LOCK=NONE'
+  )
+    .then(function() {
+      return addIndex(
+        db,
+        'ALTER TABLE winner_drop_voter_votes ADD INDEX idx_winner_drop_voter_votes_drop_votes_voter (drop_id, votes, voter_id), ALGORITHM=INPLACE, LOCK=NONE'
+      );
+    })
+    .then(function() {
+      return addIndex(
+        db,
+        'ALTER TABLE drop_ranks ADD INDEX idx_drop_ranks_wave_vote_last_drop (wave_id, vote, last_increased, drop_id), ALGORITHM=INPLACE, LOCK=NONE'
+      );
+    })
+    .then(function() {
+      return addIndex(
+        db,
+        'ALTER TABLE wave_leaderboard_entries ADD INDEX idx_wave_leaderboard_entries_wave_vote_time_drop (wave_id, vote, timestamp, drop_id), ALGORITHM=INPLACE, LOCK=NONE'
+      );
+    })
+    .then(function() {
+      return addIndex(
+        db,
+        'ALTER TABLE drops ADD INDEX idx_drops_wave_type_created_id (wave_id, drop_type, created_at, id), ALGORITHM=INPLACE, LOCK=NONE'
+      );
+    });
+};
+
+exports.down = function() {};
+
+exports._meta = {
+  version: 1
+};

--- a/migrations/20260701093000-add-drop-voting-summary-indexes.js
+++ b/migrations/20260701093000-add-drop-voting-summary-indexes.js
@@ -17,66 +17,53 @@ function dropIndex(db, sql) {
   return ignoreMysqlError(db.runSql(sql), ['ER_CANT_DROP_FIELD_OR_KEY']);
 }
 
+var INDEXES = [
+  {
+    add: 'ALTER TABLE drop_voter_states ADD INDEX idx_drop_voter_states_drop_votes_voter (drop_id, votes, voter_id), ALGORITHM=INPLACE, LOCK=NONE',
+    drop: 'DROP INDEX idx_drop_voter_states_drop_votes_voter ON drop_voter_states'
+  },
+  {
+    add: 'ALTER TABLE winner_drop_voter_votes ADD INDEX idx_winner_drop_voter_votes_drop_votes_voter (drop_id, votes, voter_id), ALGORITHM=INPLACE, LOCK=NONE',
+    drop: 'DROP INDEX idx_winner_drop_voter_votes_drop_votes_voter ON winner_drop_voter_votes'
+  },
+  {
+    add: 'ALTER TABLE drop_ranks ADD INDEX idx_drop_ranks_wave_vote_last_drop (wave_id, vote, last_increased, drop_id), ALGORITHM=INPLACE, LOCK=NONE',
+    drop: 'DROP INDEX idx_drop_ranks_wave_vote_last_drop ON drop_ranks'
+  },
+  {
+    add: 'ALTER TABLE wave_leaderboard_entries ADD INDEX idx_wave_leaderboard_entries_wave_vote_time_drop (wave_id, vote, timestamp, drop_id), ALGORITHM=INPLACE, LOCK=NONE',
+    drop: 'DROP INDEX idx_wave_leaderboard_entries_wave_vote_time_drop ON wave_leaderboard_entries'
+  },
+  {
+    add: 'ALTER TABLE drops ADD INDEX idx_drops_wave_type_created_id (wave_id, drop_type, created_at, id), ALGORITHM=INPLACE, LOCK=NONE',
+    drop: 'DROP INDEX idx_drops_wave_type_created_id ON drops'
+  }
+];
+
+function cleanupIndexes(db) {
+  return INDEXES.slice()
+    .reverse()
+    .reduce(function(promise, index) {
+      return promise.then(function() {
+        return dropIndex(db, index.drop);
+      });
+    }, Promise.resolve());
+}
+
 exports.up = function(db) {
-  return addIndex(
-    db,
-    'ALTER TABLE drop_voter_states ADD INDEX idx_drop_voter_states_drop_votes_voter (drop_id, votes, voter_id), ALGORITHM=INPLACE, LOCK=NONE'
-  )
-    .then(function() {
-      return addIndex(
-        db,
-        'ALTER TABLE winner_drop_voter_votes ADD INDEX idx_winner_drop_voter_votes_drop_votes_voter (drop_id, votes, voter_id), ALGORITHM=INPLACE, LOCK=NONE'
-      );
-    })
-    .then(function() {
-      return addIndex(
-        db,
-        'ALTER TABLE drop_ranks ADD INDEX idx_drop_ranks_wave_vote_last_drop (wave_id, vote, last_increased, drop_id), ALGORITHM=INPLACE, LOCK=NONE'
-      );
-    })
-    .then(function() {
-      return addIndex(
-        db,
-        'ALTER TABLE wave_leaderboard_entries ADD INDEX idx_wave_leaderboard_entries_wave_vote_time_drop (wave_id, vote, timestamp, drop_id), ALGORITHM=INPLACE, LOCK=NONE'
-      );
-    })
-    .then(function() {
-      return addIndex(
-        db,
-        'ALTER TABLE drops ADD INDEX idx_drops_wave_type_created_id (wave_id, drop_type, created_at, id), ALGORITHM=INPLACE, LOCK=NONE'
-      );
+  return INDEXES.reduce(function(promise, index) {
+    return promise.then(function() {
+      return addIndex(db, index.add);
     });
+  }, Promise.resolve()).catch(function(error) {
+    return cleanupIndexes(db).then(function() {
+      throw error;
+    });
+  });
 };
 
 exports.down = function(db) {
-  return dropIndex(
-    db,
-    'DROP INDEX idx_drops_wave_type_created_id ON drops'
-  )
-    .then(function() {
-      return dropIndex(
-        db,
-        'DROP INDEX idx_wave_leaderboard_entries_wave_vote_time_drop ON wave_leaderboard_entries'
-      );
-    })
-    .then(function() {
-      return dropIndex(
-        db,
-        'DROP INDEX idx_drop_ranks_wave_vote_last_drop ON drop_ranks'
-      );
-    })
-    .then(function() {
-      return dropIndex(
-        db,
-        'DROP INDEX idx_winner_drop_voter_votes_drop_votes_voter ON winner_drop_voter_votes'
-      );
-    })
-    .then(function() {
-      return dropIndex(
-        db,
-        'DROP INDEX idx_drop_voter_states_drop_votes_voter ON drop_voter_states'
-      );
-    });
+  return cleanupIndexes(db);
 };
 
 exports._meta = {

--- a/migrations/20260701093000-add-drop-voting-summary-indexes.js
+++ b/migrations/20260701093000-add-drop-voting-summary-indexes.js
@@ -1,8 +1,12 @@
 'use strict';
 
+function isMysqlError(error, ignoredCodes) {
+  return error && ignoredCodes.indexOf(error.code) !== -1;
+}
+
 function ignoreMysqlError(promise, ignoredCodes) {
   return promise.catch(function(error) {
-    if (error && ignoredCodes.indexOf(error.code) !== -1) {
+    if (isMysqlError(error, ignoredCodes)) {
       return null;
     }
     throw error;
@@ -10,7 +14,17 @@ function ignoreMysqlError(promise, ignoredCodes) {
 }
 
 function addIndex(db, sql) {
-  return ignoreMysqlError(db.runSql(sql), ['ER_DUP_KEYNAME']);
+  return db
+    .runSql(sql)
+    .then(function() {
+      return true;
+    })
+    .catch(function(error) {
+      if (isMysqlError(error, ['ER_DUP_KEYNAME'])) {
+        return false;
+      }
+      throw error;
+    });
 }
 
 function dropIndex(db, sql) {
@@ -36,8 +50,9 @@ var INDEXES = [
   }
 ];
 
-function cleanupIndexes(db) {
-  return INDEXES.slice()
+function cleanupIndexes(db, indexes) {
+  return indexes
+    .slice()
     .reverse()
     .reduce(function(promise, index) {
       return promise.then(function() {
@@ -47,19 +62,31 @@ function cleanupIndexes(db) {
 }
 
 exports.up = function(db) {
+  var createdIndexes = [];
+
   return INDEXES.reduce(function(promise, index) {
     return promise.then(function() {
-      return addIndex(db, index.add);
+      return addIndex(db, index.add).then(function(created) {
+        if (created) {
+          createdIndexes.push(index);
+        }
+      });
     });
   }, Promise.resolve()).catch(function(error) {
-    return cleanupIndexes(db).then(function() {
-      throw error;
-    });
+    return cleanupIndexes(db, createdIndexes)
+      .catch(function(cleanupError) {
+        if (error && typeof error === 'object') {
+          error.cleanupError = cleanupError;
+        }
+      })
+      .then(function() {
+        throw error;
+      });
   });
 };
 
 exports.down = function(db) {
-  return cleanupIndexes(db);
+  return cleanupIndexes(db, INDEXES);
 };
 
 exports._meta = {

--- a/migrations/20260701093000-add-drop-voting-summary-indexes.js
+++ b/migrations/20260701093000-add-drop-voting-summary-indexes.js
@@ -27,10 +27,6 @@ var INDEXES = [
     drop: 'DROP INDEX idx_winner_drop_voter_votes_drop_votes_voter ON winner_drop_voter_votes'
   },
   {
-    add: 'ALTER TABLE drop_ranks ADD INDEX idx_drop_ranks_wave_vote_last_drop (wave_id, vote, last_increased, drop_id), ALGORITHM=INPLACE, LOCK=NONE',
-    drop: 'DROP INDEX idx_drop_ranks_wave_vote_last_drop ON drop_ranks'
-  },
-  {
     add: 'ALTER TABLE wave_leaderboard_entries ADD INDEX idx_wave_leaderboard_entries_wave_vote_time_drop (wave_id, vote, timestamp, drop_id), ALGORITHM=INPLACE, LOCK=NONE',
     drop: 'DROP INDEX idx_wave_leaderboard_entries_wave_vote_time_drop ON wave_leaderboard_entries'
   },

--- a/src/entities/IDrop.ts
+++ b/src/entities/IDrop.ts
@@ -30,6 +30,11 @@ export enum DropType {
 @Index('idx_drop_wave_serial_no', ['wave_id', 'serial_no'])
 @Index('idx_drop_wave_type_author', ['wave_id', 'drop_type', 'author_id'])
 @Index('idx_drop_wave_created_at', ['wave_id', 'created_at'])
+@Index(
+  'idx_drops_wave_type_created_id',
+  ['wave_id', 'drop_type', 'created_at', 'id'],
+  { synchronize: false }
+)
 export class DropEntity {
   @PrimaryGeneratedColumn('increment', { type: 'bigint' })
   readonly serial_no!: number;

--- a/src/entities/IDropRank.ts
+++ b/src/entities/IDropRank.ts
@@ -2,11 +2,6 @@ import { Column, Entity, Index, PrimaryColumn } from 'typeorm';
 import { DROP_RANK_TABLE } from '@/constants';
 
 @Entity(DROP_RANK_TABLE)
-@Index(
-  'idx_drop_ranks_wave_vote_last_drop',
-  ['wave_id', 'vote', 'last_increased', 'drop_id'],
-  { synchronize: false }
-)
 export class DropRankEntity {
   @PrimaryColumn({ type: 'varchar', length: 100 })
   readonly drop_id!: string;

--- a/src/entities/IDropRank.ts
+++ b/src/entities/IDropRank.ts
@@ -2,6 +2,11 @@ import { Column, Entity, Index, PrimaryColumn } from 'typeorm';
 import { DROP_RANK_TABLE } from '@/constants';
 
 @Entity(DROP_RANK_TABLE)
+@Index(
+  'idx_drop_ranks_wave_vote_last_drop',
+  ['wave_id', 'vote', 'last_increased', 'drop_id'],
+  { synchronize: false }
+)
 export class DropRankEntity {
   @PrimaryColumn({ type: 'varchar', length: 100 })
   readonly drop_id!: string;

--- a/src/entities/IDropVoterState.ts
+++ b/src/entities/IDropVoterState.ts
@@ -2,6 +2,11 @@ import { Column, Entity, Index, PrimaryColumn } from 'typeorm';
 import { DROP_VOTER_STATE_TABLE } from '@/constants';
 
 @Entity(DROP_VOTER_STATE_TABLE)
+@Index(
+  'idx_drop_voter_states_drop_votes_voter',
+  ['drop_id', 'votes', 'voter_id'],
+  { synchronize: false }
+)
 export class DropVoterStateEntity {
   @PrimaryColumn({ type: 'varchar', length: 100 })
   readonly voter_id!: string;

--- a/src/entities/IWaveLeaderboardEntry.ts
+++ b/src/entities/IWaveLeaderboardEntry.ts
@@ -2,6 +2,11 @@ import { Column, Entity, Index, PrimaryColumn } from 'typeorm';
 import { WAVE_LEADERBOARD_ENTRIES_TABLE } from '@/constants';
 
 @Entity(WAVE_LEADERBOARD_ENTRIES_TABLE)
+@Index(
+  'idx_wave_leaderboard_entries_wave_vote_time_drop',
+  ['wave_id', 'vote', 'timestamp', 'drop_id'],
+  { synchronize: false }
+)
 export class WaveLeaderboardEntryEntity {
   @PrimaryColumn({ type: 'varchar', length: 100, nullable: false })
   readonly drop_id!: string;

--- a/src/entities/IWinnerDropVoterVote.ts
+++ b/src/entities/IWinnerDropVoterVote.ts
@@ -2,6 +2,11 @@ import { Column, Entity, Index, PrimaryColumn } from 'typeorm';
 import { WINNER_DROP_VOTER_VOTES_TABLE } from '@/constants';
 
 @Entity(WINNER_DROP_VOTER_VOTES_TABLE)
+@Index(
+  'idx_winner_drop_voter_votes_drop_votes_voter',
+  ['drop_id', 'votes', 'voter_id'],
+  { synchronize: false }
+)
 export class WinnerDropVoterVoteEntity {
   @PrimaryColumn({ type: 'varchar', length: 100 })
   readonly voter_id!: string;

--- a/src/typeorm-index-options.d.ts
+++ b/src/typeorm-index-options.d.ts
@@ -1,0 +1,7 @@
+import 'typeorm/decorator/options/IndexOptions';
+
+declare module 'typeorm/decorator/options/IndexOptions' {
+  interface IndexOptions {
+    synchronize?: false;
+  }
+}

--- a/src/typeorm-index-options.d.ts
+++ b/src/typeorm-index-options.d.ts
@@ -2,6 +2,6 @@ import 'typeorm/decorator/options/IndexOptions';
 
 declare module 'typeorm/decorator/options/IndexOptions' {
   interface IndexOptions {
-    synchronize?: false;
+    synchronize?: boolean;
   }
 }


### PR DESCRIPTION
## Summary
- add online db-migrate indexes for drop voting summary lookups and rank ordering inputs
- mark the new composite indexes as migration-managed in TypeORM metadata
- add a TypeORM declaration merge so composite indexes can use the already-supported synchronize:false option

## Risk
- index-only change; no API query semantics, vote logic, or winner conversion logic changed

## Verification
- npm run lint
- npm run build

## Docs
- docs/architecture.md not updated; this does not add, remove, rename, or rewire any Lambda, API boundary, SQS/SNS resource, DB runtime pattern, deployable service, or external integration