### PR TITLE
Fix DM unread reader metric fallback

### DIFF
--- a/src/api-serverless/src/drops/drop-creation-api-service.test.ts
+++ b/src/api-serverless/src/drops/drop-creation-api-service.test.ts
@@ -1,6 +1,7 @@
 import { DropCreationApiService } from '@/api/drops/drop-creation.api.service';
 import { waveScoreService } from '@/api/waves/wave-score.service';
 import { invalidateWaveUnreadCacheForWave } from '@/api/waves/wave-unread-cache';
+import { DropType } from '@/entities/IDrop';
 import { waveDropMetricsRefreshService } from '@/drops/wave-drop-metrics-refresh.service';
 
 jest.mock('@/api/waves/wave-unread-cache', () => ({
@@ -141,6 +142,95 @@ describe('DropCreationApiService.toggleHideLinkPreview', () => {
       ctx
     );
     expect(wsListenersNotifier.notifyAboutDropUpdate).not.toHaveBeenCalled();
+  });
+});
+
+describe('DropCreationApiService.createDrop', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
+  });
+
+  it('invalidates unread cache after the drop transaction commits', async () => {
+    const connection = {} as any;
+    const order: string[] = [];
+    const dropsDb = {
+      executeNativeQueriesInTransaction: jest.fn(
+        async (callback: (connection: unknown) => Promise<unknown>) => {
+          order.push('transaction');
+          const result = await callback(connection);
+          order.push('committed');
+          return result;
+        }
+      )
+    };
+    const dropsMappers = {
+      createDropApiToUseCaseModel: jest.fn().mockReturnValue({
+        wave_id: 'wave-1',
+        drop_type: DropType.CHAT
+      })
+    };
+    const createOrUpdateDrop = {
+      preResolveIdentityNomination: jest.fn().mockResolvedValue(null),
+      execute: jest.fn().mockImplementation(async () => {
+        order.push('drop-written');
+        return {
+          drop_id: 'drop-1',
+          pending_push_notification_ids: []
+        };
+      })
+    };
+    const dropPollsApiService = {
+      createPollForDrop: jest.fn().mockResolvedValue(undefined)
+    };
+    const dropsService = {
+      findDropByIdOrThrow: jest.fn().mockResolvedValue({
+        id: 'drop-1',
+        wave_id: 'wave-1'
+      })
+    };
+    const wsListenersNotifier = {
+      notifyAboutDropUpdate: jest.fn().mockResolvedValue(undefined)
+    };
+    const dropNftLinksDb = {
+      findByDropId: jest.fn().mockResolvedValue([])
+    };
+    const service = new DropCreationApiService(
+      dropsService as never,
+      dropsDb as never,
+      dropsMappers as never,
+      createOrUpdateDrop as never,
+      {} as never,
+      wsListenersNotifier as never,
+      dropNftLinksDb as never,
+      {} as never,
+      dropPollsApiService as never
+    );
+    jest
+      .spyOn(waveScoreService, 'requestWaveScoreRefreshBestEffort')
+      .mockResolvedValue(undefined);
+    (invalidateWaveUnreadCacheForWave as jest.Mock).mockImplementationOnce(
+      async () => {
+        order.push('unread-cache-invalidated');
+      }
+    );
+
+    await service.createDrop(
+      {
+        createDropRequest: {} as never,
+        authorId: 'author-profile',
+        representativeId: 'author-profile'
+      },
+      { timer: undefined } as never
+    );
+
+    expect(invalidateWaveUnreadCacheForWave).toHaveBeenCalledWith('wave-1');
+    expect(order).toEqual([
+      'transaction',
+      'drop-written',
+      'committed',
+      'unread-cache-invalidated'
+    ]);
   });
 });
 

--- a/src/api-serverless/src/waves/waves-api-db.test.ts
+++ b/src/api-serverless/src/waves/waves-api-db.test.ts
@@ -928,7 +928,8 @@ const mutedUnreadSummaryWave = aWave(
 );
 const noReaderMetricUnreadSummaryWave = aWave(
   {
-    created_by: author.profile_id!
+    created_by: author.profile_id!,
+    is_direct_message: false
   },
   {
     id: 'wave-no-reader-metric-unread-summary',
@@ -1144,6 +1145,23 @@ describeWithSeed(
           unread_drops_count: 0,
           first_unread_drop_serial_no: null
         },
+        [noReaderMetricUnreadSummaryWave.id]: {
+          unread_drops_count: 0,
+          first_unread_drop_serial_no: null
+        }
+      });
+    });
+
+    it('does not infer unread history for a non-DM wave without reader metrics', async () => {
+      await expect(
+        repo.findIdentityUnreadDropsSummaryByWaveId(
+          {
+            identityId: unreadReader.profile_id!,
+            waveIds: [noReaderMetricUnreadSummaryWave.id]
+          },
+          ctx
+        )
+      ).resolves.toEqual({
         [noReaderMetricUnreadSummaryWave.id]: {
           unread_drops_count: 0,
           first_unread_drop_serial_no: null

--- a/src/api-serverless/src/waves/waves-api-db.test.ts
+++ b/src/api-serverless/src/waves/waves-api-db.test.ts
@@ -936,6 +936,16 @@ const noReaderMetricUnreadSummaryWave = aWave(
     name: 'No Reader Metric Unread Summary Wave'
   }
 );
+const seededReaderMetricUnreadSummaryWave = aWave(
+  {
+    created_by: author.profile_id!
+  },
+  {
+    id: 'wave-seeded-reader-metric-unread-summary',
+    serial_no: 34,
+    name: 'Seeded Reader Metric Unread Summary Wave'
+  }
+);
 
 describeWithSeed(
   'WavesApiDb unread summaries',
@@ -945,7 +955,8 @@ describeWithSeed(
       unreadSummaryWave,
       noUnreadSummaryWave,
       mutedUnreadSummaryWave,
-      noReaderMetricUnreadSummaryWave
+      noReaderMetricUnreadSummaryWave,
+      seededReaderMetricUnreadSummaryWave
     ]),
     {
       table: WAVE_READER_METRICS_TABLE,
@@ -1071,6 +1082,36 @@ describeWithSeed(
           drop_type: DropType.CHAT,
           signature: null,
           hide_link_preview: false
+        },
+        {
+          serial_no: 28,
+          id: 'seeded-reader-metric-old-summary-drop',
+          wave_id: seededReaderMetricUnreadSummaryWave.id,
+          author_id: author.profile_id!,
+          created_at: 1300,
+          updated_at: null,
+          title: null,
+          parts_count: 1,
+          reply_to_drop_id: null,
+          reply_to_part_id: null,
+          drop_type: DropType.CHAT,
+          signature: null,
+          hide_link_preview: false
+        },
+        {
+          serial_no: 29,
+          id: 'seeded-reader-metric-current-summary-drop',
+          wave_id: seededReaderMetricUnreadSummaryWave.id,
+          author_id: author.profile_id!,
+          created_at: 1400,
+          updated_at: null,
+          title: null,
+          parts_count: 1,
+          reply_to_drop_id: null,
+          reply_to_part_id: null,
+          drop_type: DropType.CHAT,
+          signature: null,
+          hide_link_preview: false
         }
       ]
     }
@@ -1104,8 +1145,34 @@ describeWithSeed(
           first_unread_drop_serial_no: null
         },
         [noReaderMetricUnreadSummaryWave.id]: {
+          unread_drops_count: 0,
+          first_unread_drop_serial_no: null
+        }
+      });
+    });
+
+    it('counts only drops after an explicitly seeded reader metric', async () => {
+      await repo.insertMissingWaveReaderMetrics(
+        {
+          waveId: seededReaderMetricUnreadSummaryWave.id,
+          readerIds: [unreadReader.profile_id!],
+          latestReadTimestamp: 1399
+        },
+        ctx
+      );
+
+      await expect(
+        repo.findIdentityUnreadDropsSummaryByWaveId(
+          {
+            identityId: unreadReader.profile_id!,
+            waveIds: [seededReaderMetricUnreadSummaryWave.id]
+          },
+          ctx
+        )
+      ).resolves.toEqual({
+        [seededReaderMetricUnreadSummaryWave.id]: {
           unread_drops_count: 1,
-          first_unread_drop_serial_no: 26
+          first_unread_drop_serial_no: 29
         }
       });
     });

--- a/src/api-serverless/src/waves/waves.api.db.ts
+++ b/src/api-serverless/src/waves/waves.api.db.ts
@@ -2839,6 +2839,39 @@ export class WavesApiDb extends LazyDbAccessCompatibleService {
     );
   }
 
+  async insertMissingWaveReaderMetrics(
+    param: {
+      waveId: string;
+      readerIds: string[];
+      latestReadTimestamp: number;
+    },
+    ctx: RequestContext
+  ) {
+    const readerIds = Array.from(new Set(param.readerIds));
+    if (!readerIds.length) {
+      return;
+    }
+    ctx.timer?.start(
+      `${this.constructor.name}->insertMissingWaveReaderMetrics`
+    );
+    await Promise.all(
+      readerIds.map((readerId) =>
+        this.db.execute(
+          `insert into ${WAVE_READER_METRICS_TABLE} (wave_id, reader_id, latest_read_timestamp)
+           values (:waveId, :readerId, :latestReadTimestamp)
+           on duplicate key update reader_id = reader_id`,
+          {
+            waveId: param.waveId,
+            readerId,
+            latestReadTimestamp: param.latestReadTimestamp
+          },
+          { wrappedConnection: ctx.connection }
+        )
+      )
+    );
+    ctx.timer?.stop(`${this.constructor.name}->insertMissingWaveReaderMetrics`);
+  }
+
   async setWaveMuted(
     param: { waveId: string; readerId: string; muted: boolean },
     ctx: RequestContext
@@ -2880,13 +2913,13 @@ export class WavesApiDb extends LazyDbAccessCompatibleService {
                COUNT(d.id) AS unread_drops_count,
                MIN(d.serial_no) AS first_unread_drop_serial_no
         FROM ${DROPS_TABLE} d USE INDEX (idx_drop_wave_created_at)
-        LEFT JOIN ${WAVE_READER_METRICS_TABLE} r
+        JOIN ${WAVE_READER_METRICS_TABLE} r
           ON r.wave_id = d.wave_id
           AND r.reader_id = :identityId
         WHERE d.wave_id IN (:waveIds)
           AND d.author_id != :identityId
-          AND d.created_at > COALESCE(r.latest_read_timestamp, 0)
-          AND COALESCE(r.muted, false) = false
+          AND d.created_at > r.latest_read_timestamp
+          AND r.muted = false
         GROUP BY d.wave_id
     `,
       { identityId: param.identityId, waveIds: uncachedWaveIds },

--- a/src/api-serverless/src/waves/waves.api.db.ts
+++ b/src/api-serverless/src/waves/waves.api.db.ts
@@ -2907,6 +2907,8 @@ export class WavesApiDb extends LazyDbAccessCompatibleService {
       return cachedByWaveId;
     }
 
+    // Reader metrics are the unread baseline source of truth. Without a reader
+    // row we do not infer unread drops from old wave history.
     const dbresult = await this.db.execute<WaveUnreadSummaryRow>(
       `
         SELECT d.wave_id AS wave_id,

--- a/src/api-serverless/src/waves/waves.api.db.ts
+++ b/src/api-serverless/src/waves/waves.api.db.ts
@@ -2854,22 +2854,52 @@ export class WavesApiDb extends LazyDbAccessCompatibleService {
     ctx.timer?.start(
       `${this.constructor.name}->insertMissingWaveReaderMetrics`
     );
-    await Promise.all(
-      readerIds.map((readerId) =>
-        this.db.execute(
-          `insert into ${WAVE_READER_METRICS_TABLE} (wave_id, reader_id, latest_read_timestamp)
-           values (:waveId, :readerId, :latestReadTimestamp)
-           on duplicate key update reader_id = reader_id`,
-          {
-            waveId: param.waveId,
-            readerId,
-            latestReadTimestamp: param.latestReadTimestamp
-          },
-          { wrappedConnection: ctx.connection }
-        )
-      )
+    await this.db.bulkInsert(
+      WAVE_READER_METRICS_TABLE,
+      readerIds.map((readerId) => ({
+        wave_id: param.waveId,
+        reader_id: readerId,
+        latest_read_timestamp: param.latestReadTimestamp
+      })),
+      ['wave_id', 'reader_id', 'latest_read_timestamp'],
+      ctx,
+      {
+        connection: ctx.connection,
+        ignoreDuplicates: true
+      }
     );
     ctx.timer?.stop(`${this.constructor.name}->insertMissingWaveReaderMetrics`);
+  }
+
+  async findExistingWaveReaderMetricReaderIds(
+    param: {
+      waveId: string;
+      readerIds: string[];
+    },
+    ctx: RequestContext
+  ): Promise<string[]> {
+    const readerIds = Array.from(new Set(param.readerIds));
+    if (!readerIds.length) {
+      return [];
+    }
+    ctx.timer?.start(
+      `${this.constructor.name}->findExistingWaveReaderMetricReaderIds`
+    );
+    const result = await this.db.execute<{ reader_id: string }>(
+      `select reader_id
+       from ${WAVE_READER_METRICS_TABLE}
+       where wave_id = :waveId
+         and reader_id in (:readerIds)`,
+      {
+        waveId: param.waveId,
+        readerIds
+      },
+      { wrappedConnection: ctx.connection }
+    );
+    ctx.timer?.stop(
+      `${this.constructor.name}->findExistingWaveReaderMetricReaderIds`
+    );
+    return result.map((row) => row.reader_id);
   }
 
   async setWaveMuted(

--- a/src/drops/create-or-update-drop-use-case.test.ts
+++ b/src/drops/create-or-update-drop-use-case.test.ts
@@ -676,16 +676,17 @@ describe('CreateOrUpdateDropUseCase', () => {
       ...createSlowModeWave({
         chat_slow_mode_cooldown_ms: null,
         is_direct_message: true,
-        visibility_group_id: 'dm-group',
-        participation_group_id: 'dm-group',
-        chat_group_id: 'dm-group',
-        admin_group_id: 'dm-group',
-        voting_group_id: 'dm-group'
+        visibility_group_id: 'visibility-group',
+        participation_group_id: 'participation-group',
+        chat_group_id: 'chat-dm-group',
+        admin_group_id: 'admin-group',
+        voting_group_id: 'voting-group'
       }),
       type: WaveType.CHAT,
       next_decision_time: null
     };
     const wavesApiDb = {
+      findExistingWaveReaderMetricReaderIds: jest.fn().mockResolvedValue([]),
       insertMissingWaveReaderMetrics: jest.fn().mockResolvedValue(undefined)
     };
     const userGroupsService = {
@@ -708,7 +709,16 @@ describe('CreateOrUpdateDropUseCase', () => {
     );
 
     expect(userGroupsService.findIdentitiesInGroups).toHaveBeenCalledWith(
-      ['dm-group'],
+      ['chat-dm-group'],
+      { timer: undefined, connection }
+    );
+    expect(
+      wavesApiDb.findExistingWaveReaderMetricReaderIds
+    ).toHaveBeenCalledWith(
+      {
+        waveId: 'wave-1',
+        readerIds: ['reader-profile']
+      },
       { timer: undefined, connection }
     );
     expect(wavesApiDb.insertMissingWaveReaderMetrics).toHaveBeenCalledWith(
@@ -719,6 +729,45 @@ describe('CreateOrUpdateDropUseCase', () => {
       },
       { timer: undefined, connection }
     );
+  });
+
+  it('skips direct-message reader metric seeding when recipients already have metrics', async () => {
+    const connection = {};
+    const wave = {
+      ...createSlowModeWave({
+        chat_slow_mode_cooldown_ms: null,
+        is_direct_message: true,
+        chat_group_id: 'chat-dm-group'
+      }),
+      type: WaveType.CHAT,
+      next_decision_time: null
+    };
+    const wavesApiDb = {
+      findExistingWaveReaderMetricReaderIds: jest
+        .fn()
+        .mockResolvedValue(['reader-profile']),
+      insertMissingWaveReaderMetrics: jest.fn().mockResolvedValue(undefined)
+    };
+    const userGroupsService = {
+      findIdentitiesInGroups: jest
+        .fn()
+        .mockResolvedValue(['author-profile', 'reader-profile'])
+    };
+    const useCase = createUseCaseWithMocks({
+      wavesApiDb,
+      userGroupsService
+    });
+
+    await (useCase as any).ensureDirectMessageReaderMetricsForNewDrop(
+      {
+        wave,
+        authorId: 'author-profile',
+        createdAt: 1400
+      },
+      { connection }
+    );
+
+    expect(wavesApiDb.insertMissingWaveReaderMetrics).not.toHaveBeenCalled();
   });
 
   it('allows scheme-less Tenor candidates in chat link allowlist', () => {

--- a/src/drops/create-or-update-drop-use-case.test.ts
+++ b/src/drops/create-or-update-drop-use-case.test.ts
@@ -59,6 +59,7 @@ describe('CreateOrUpdateDropUseCase', () => {
     overrides: {
       dropsDb?: any;
       wavesApiDb?: any;
+      userGroupsService?: any;
       userNotifier?: any;
       identitySubscriptionsDb?: any;
       deleteDropUseCase?: any;
@@ -69,7 +70,7 @@ describe('CreateOrUpdateDropUseCase', () => {
     return new CreateOrUpdateDropUseCase(
       overrides.dropsDb ?? ({} as any),
       {} as any,
-      {} as any,
+      overrides.userGroupsService ?? ({} as any),
       overrides.wavesApiDb ?? ({} as any),
       overrides.userNotifier ?? ({} as any),
       {} as any,
@@ -139,6 +140,8 @@ describe('CreateOrUpdateDropUseCase', () => {
     return {
       drop_id: null,
       wave_id: 'wave-1',
+      reply_to: null,
+      title: null,
       drop_type: DropType.CHAT,
       author_identity: 'author-profile',
       author_id: 'author-profile',
@@ -149,6 +152,13 @@ describe('CreateOrUpdateDropUseCase', () => {
           media: []
         }
       ],
+      referenced_nfts: [],
+      mentioned_users: [],
+      mentioned_waves: [],
+      metadata: [],
+      mentioned_groups: [],
+      signature: null,
+      is_additional_action_promised: null,
       ...overrides
     };
   }
@@ -658,6 +668,56 @@ describe('CreateOrUpdateDropUseCase', () => {
         'https://d3lqz0a4bldqgf.cloudfront.net/drops/asset.html'
       )
     ).toBe(true);
+  });
+
+  it('seeds missing reader metrics before a new direct-message drop', async () => {
+    const connection = {};
+    const wave = {
+      ...createSlowModeWave({
+        chat_slow_mode_cooldown_ms: null,
+        is_direct_message: true,
+        visibility_group_id: 'dm-group',
+        participation_group_id: 'dm-group',
+        chat_group_id: 'dm-group',
+        admin_group_id: 'dm-group',
+        voting_group_id: 'dm-group'
+      }),
+      type: WaveType.CHAT,
+      next_decision_time: null
+    };
+    const wavesApiDb = {
+      insertMissingWaveReaderMetrics: jest.fn().mockResolvedValue(undefined)
+    };
+    const userGroupsService = {
+      findIdentitiesInGroups: jest
+        .fn()
+        .mockResolvedValue(['author-profile', 'reader-profile'])
+    };
+    const useCase = createUseCaseWithMocks({
+      wavesApiDb,
+      userGroupsService
+    });
+
+    await (useCase as any).ensureDirectMessageReaderMetricsForNewDrop(
+      {
+        wave,
+        createdAt: 1400
+      },
+      { connection }
+    );
+
+    expect(userGroupsService.findIdentitiesInGroups).toHaveBeenCalledWith(
+      ['dm-group'],
+      { timer: undefined, connection }
+    );
+    expect(wavesApiDb.insertMissingWaveReaderMetrics).toHaveBeenCalledWith(
+      {
+        waveId: 'wave-1',
+        readerIds: ['author-profile', 'reader-profile'],
+        latestReadTimestamp: 1399
+      },
+      { timer: undefined, connection }
+    );
   });
 
   it('allows scheme-less Tenor candidates in chat link allowlist', () => {

--- a/src/drops/create-or-update-drop-use-case.test.ts
+++ b/src/drops/create-or-update-drop-use-case.test.ts
@@ -701,6 +701,7 @@ describe('CreateOrUpdateDropUseCase', () => {
     await (useCase as any).ensureDirectMessageReaderMetricsForNewDrop(
       {
         wave,
+        authorId: 'author-profile',
         createdAt: 1400
       },
       { connection }
@@ -713,7 +714,7 @@ describe('CreateOrUpdateDropUseCase', () => {
     expect(wavesApiDb.insertMissingWaveReaderMetrics).toHaveBeenCalledWith(
       {
         waveId: 'wave-1',
-        readerIds: ['author-profile', 'reader-profile'],
+        readerIds: ['reader-profile'],
         latestReadTimestamp: 1399
       },
       { timer: undefined, connection }

--- a/src/drops/create-or-update-drop.use-case.ts
+++ b/src/drops/create-or-update-drop.use-case.ts
@@ -571,12 +571,28 @@ export class CreateOrUpdateDropUseCase {
       [directMessageGroupId],
       { timer, connection }
     );
+    const recipientIds = readerIds.filter((readerId) => readerId !== authorId);
+    const existingReaderMetricIds =
+      await this.wavesApiDb.findExistingWaveReaderMetricReaderIds(
+        {
+          waveId: wave.id,
+          readerIds: recipientIds
+        },
+        { timer, connection }
+      );
+    const existingReaderMetricIdSet = new Set(existingReaderMetricIds);
+    const missingReaderMetricIds = recipientIds.filter(
+      (readerId) => !existingReaderMetricIdSet.has(readerId)
+    );
+    if (!missingReaderMetricIds.length) {
+      return;
+    }
     // Reader metrics are part of DM write consistency: without this row the
     // unread summary cannot distinguish current unread activity from old history.
     await this.wavesApiDb.insertMissingWaveReaderMetrics(
       {
         waveId: wave.id,
-        readerIds: readerIds.filter((readerId) => readerId !== authorId),
+        readerIds: missingReaderMetricIds,
         latestReadTimestamp: Math.max(0, createdAt - 1)
       },
       { timer, connection }

--- a/src/drops/create-or-update-drop.use-case.ts
+++ b/src/drops/create-or-update-drop.use-case.ts
@@ -498,13 +498,21 @@ export class CreateOrUpdateDropUseCase {
       );
     } else {
       dropId = randomUUID();
+      const createdAt = Time.currentMillis();
       pendingPushNotificationIds = await this.insertAllDropComponents(
         {
           model: { ...validatedModel, drop_id: dropId },
-          createdAt: Time.currentMillis(),
+          createdAt,
           serialNo: null,
           updatedAt: null,
           wave
+        },
+        { connection, timer }
+      );
+      await this.ensureDirectMessageReaderMetricsForNewDrop(
+        {
+          wave,
+          createdAt
         },
         { connection, timer }
       );
@@ -537,6 +545,45 @@ export class CreateOrUpdateDropUseCase {
       drop_id: dropId,
       pending_push_notification_ids: pendingPushNotificationIds
     };
+  }
+
+  private async ensureDirectMessageReaderMetricsForNewDrop(
+    {
+      wave,
+      createdAt
+    }: {
+      wave: WaveEntity;
+      createdAt: number;
+    },
+    { connection, timer }: { connection: ConnectionWrapper<any>; timer?: Timer }
+  ) {
+    if (wave.is_direct_message !== true) {
+      return;
+    }
+    const waveGroupIds = collections.distinct(
+      [
+        wave.visibility_group_id,
+        wave.participation_group_id,
+        wave.chat_group_id,
+        wave.admin_group_id,
+        wave.voting_group_id
+      ].filter((groupId): groupId is string => groupId !== null)
+    );
+    if (!waveGroupIds.length) {
+      return;
+    }
+    const readerIds = await this.userGroupsService.findIdentitiesInGroups(
+      waveGroupIds,
+      { timer, connection }
+    );
+    await this.wavesApiDb.insertMissingWaveReaderMetrics(
+      {
+        waveId: wave.id,
+        readerIds,
+        latestReadTimestamp: Math.max(0, createdAt - 1)
+      },
+      { timer, connection }
+    );
   }
 
   private async validateReferences(

--- a/src/drops/create-or-update-drop.use-case.ts
+++ b/src/drops/create-or-update-drop.use-case.ts
@@ -512,6 +512,7 @@ export class CreateOrUpdateDropUseCase {
       await this.ensureDirectMessageReaderMetricsForNewDrop(
         {
           wave,
+          authorId,
           createdAt
         },
         { connection, timer }
@@ -550,9 +551,11 @@ export class CreateOrUpdateDropUseCase {
   private async ensureDirectMessageReaderMetricsForNewDrop(
     {
       wave,
+      authorId,
       createdAt
     }: {
       wave: WaveEntity;
+      authorId: string;
       createdAt: number;
     },
     { connection, timer }: { connection: ConnectionWrapper<any>; timer?: Timer }
@@ -560,26 +563,20 @@ export class CreateOrUpdateDropUseCase {
     if (wave.is_direct_message !== true) {
       return;
     }
-    const waveGroupIds = collections.distinct(
-      [
-        wave.visibility_group_id,
-        wave.participation_group_id,
-        wave.chat_group_id,
-        wave.admin_group_id,
-        wave.voting_group_id
-      ].filter((groupId): groupId is string => groupId !== null)
-    );
-    if (!waveGroupIds.length) {
+    const directMessageGroupId = wave.chat_group_id;
+    if (!directMessageGroupId) {
       return;
     }
     const readerIds = await this.userGroupsService.findIdentitiesInGroups(
-      waveGroupIds,
+      [directMessageGroupId],
       { timer, connection }
     );
+    // Reader metrics are part of DM write consistency: without this row the
+    // unread summary cannot distinguish current unread activity from old history.
     await this.wavesApiDb.insertMissingWaveReaderMetrics(
       {
         waveId: wave.id,
-        readerIds,
+        readerIds: readerIds.filter((readerId) => readerId !== authorId),
         latestReadTimestamp: Math.max(0, createdAt - 1)
       },
       { timer, connection }


### PR DESCRIPTION
## Summary
- restore unread summaries to require explicit wave reader metrics, so old waves without reader rows do not report historical drops as unread
- seed missing reader metrics for direct-message participants when a new DM drop is created, using the new drop timestamp as the baseline
- add regression coverage for old no-metric waves and seeded DM-style unread baselines

## Validation
- npm test -- src/api-serverless/src/waves/waves-api-db.test.ts src/drops/create-or-update-drop-use-case.test.ts
- npm run lint
- cd src/api-serverless && npm run build