### PR TITLE
Optimize wave eligibility reuse

### DIFF
--- a/src/api-serverless/src/drops/api-drop-mapper.test.ts
+++ b/src/api-serverless/src/drops/api-drop-mapper.test.ts
@@ -194,9 +194,10 @@ describe('ApiDropMapper', () => {
       { 'drop-1': ['DROP_REPLIED'] }
     );
 
-    const result = await mapper.mapDrops([drop], {
+    const ctx = {
       authenticationContext: AuthenticationContext.fromProfileId('viewer-1')
-    });
+    };
+    const result = await mapper.mapDrops([drop], ctx);
 
     expect(result['drop-1']).toMatchObject({
       id: 'drop-1',
@@ -286,6 +287,47 @@ describe('ApiDropMapper', () => {
         { option_no: 2, option_string: 'Second', votes: 3 }
       ]
     });
+  });
+
+  it('uses provided eligible groups for mentioned wave overviews', async () => {
+    const { mapper, deps } = createMapper();
+    const ctx = {
+      authenticationContext: AuthenticationContext.fromProfileId('viewer-1')
+    };
+    deps.dropsDb.findMentionedWavesByDropIds.mockResolvedValue([
+      {
+        id: 'mention-1',
+        drop_id: 'drop-1',
+        wave_id: 'mentioned-wave-1',
+        wave_name_in_content: 'wave-name'
+      }
+    ]);
+    deps.wavesApiDb.findWaveMentionOverviewsByIds.mockResolvedValue({
+      'mentioned-wave-1': {
+        id: 'mentioned-wave-1',
+        name: 'Mentioned Wave',
+        picture: null,
+        visibility_group_id: null,
+        participation_group_id: null,
+        chat_group_id: null,
+        admin_group_id: null,
+        voting_group_id: null,
+        is_direct_message: false
+      }
+    });
+
+    await mapper.mapDrops([makeDrop()], ctx, {
+      groupIdsUserIsEligibleFor: ['visible-group']
+    });
+
+    expect(
+      deps.userGroupsService.getGroupsUserIsEligibleFor
+    ).not.toHaveBeenCalled();
+    expect(deps.wavesApiDb.findWaveMentionOverviewsByIds).toHaveBeenCalledWith(
+      ['mentioned-wave-1'],
+      ['visible-group'],
+      ctx
+    );
   });
 
   it('maps attachments, mentions, replies, and submission voting context', async () => {
@@ -425,9 +467,10 @@ describe('ApiDropMapper', () => {
     });
     deps.dropsDb.findDropIdsWithMetadata.mockResolvedValue(new Set(['drop-2']));
 
-    const result = await mapper.mapDrops([drop], {
+    const ctx = {
       authenticationContext: AuthenticationContext.fromProfileId('viewer-1')
-    });
+    };
+    const result = await mapper.mapDrops([drop], ctx);
 
     expect(result['drop-2']).toMatchObject({
       id: 'drop-2',
@@ -497,9 +540,7 @@ describe('ApiDropMapper', () => {
     });
     expect(deps.dropsDb.findDropIdsWithMetadata).toHaveBeenCalledWith(
       ['drop-2'],
-      {
-        authenticationContext: AuthenticationContext.fromProfileId('viewer-1')
-      }
+      ctx
     );
   });
 

--- a/src/api-serverless/src/drops/api-drop-v2-service.test.ts
+++ b/src/api-serverless/src/drops/api-drop-v2-service.test.ts
@@ -306,6 +306,7 @@ describe('ApiDropV2Service', () => {
     const authenticationContext =
       AuthenticationContext.fromProfileId('viewer-1');
     const connection = {} as any;
+    const ctx = { authenticationContext, connection };
     deps.dropsDb.findDropByIdWithEligibilityCheck.mockResolvedValue(parentDrop);
     deps.dropsDb.findVisibleDrops.mockResolvedValue([
       firstReply,
@@ -321,7 +322,7 @@ describe('ApiDropV2Service', () => {
         page_size: 2,
         page: 2
       },
-      { authenticationContext, connection }
+      ctx
     );
 
     expect(
@@ -341,11 +342,12 @@ describe('ApiDropV2Service', () => {
         limit: 3,
         offset: 2
       },
-      { authenticationContext, connection }
+      ctx
     );
     expect(deps.apiDropMapper.mapDrops).toHaveBeenCalledWith(
       [firstReply, secondReply],
-      { authenticationContext, connection }
+      ctx,
+      { groupIdsUserIsEligibleFor: ['group-1'] }
     );
     expect(deps.wavesApiDb.findWavesByIdsEligibleForRead).toHaveBeenCalledWith(
       ['wave-1'],
@@ -354,7 +356,8 @@ describe('ApiDropV2Service', () => {
     );
     expect(deps.apiWaveOverviewMapper.mapWaves).toHaveBeenCalledWith(
       [makeWave()],
-      { authenticationContext, connection }
+      ctx,
+      { groupIdsUserIsEligibleFor: ['group-1'] }
     );
     expect(result).toEqual({
       data: [
@@ -397,6 +400,7 @@ describe('ApiDropV2Service', () => {
     });
     const authenticationContext =
       AuthenticationContext.fromProfileId('viewer-1');
+    const ctx = { authenticationContext };
     deps.dropsDb.findVisibleDrops.mockResolvedValue([firstDrop, secondDrop]);
     deps.wavesApiDb.findWavesByIdsEligibleForRead.mockResolvedValue([
       makeWave(),
@@ -415,7 +419,7 @@ describe('ApiDropV2Service', () => {
         page_size: 50,
         page: 1
       },
-      { authenticationContext }
+      ctx
     );
 
     expect(
@@ -430,7 +434,7 @@ describe('ApiDropV2Service', () => {
         limit: 51,
         offset: 0
       },
-      { authenticationContext }
+      ctx
     );
     expect(deps.wavesApiDb.findWavesByIdsEligibleForRead).toHaveBeenCalledWith(
       ['wave-1', 'wave-2'],
@@ -457,6 +461,7 @@ describe('ApiDropV2Service', () => {
     });
     const authenticationContext =
       AuthenticationContext.fromProfileId('viewer-1');
+    const ctx = { authenticationContext };
     deps.dropsDb.findVisibleDrops.mockResolvedValue([firstDrop, secondDrop]);
     deps.wavesApiDb.findWavesByIdsEligibleForRead.mockResolvedValue([
       makeWave(),
@@ -475,7 +480,7 @@ describe('ApiDropV2Service', () => {
         page_size: 50,
         page: 1
       },
-      { authenticationContext }
+      ctx
     );
 
     expect(deps.dropsDb.findVisibleDrops).toHaveBeenCalledWith(
@@ -487,7 +492,7 @@ describe('ApiDropV2Service', () => {
         limit: 51,
         offset: 0
       },
-      { authenticationContext }
+      ctx
     );
     expect(deps.wavesApiDb.findWavesByIdsEligibleForRead).toHaveBeenCalledWith(
       ['wave-1', 'wave-2'],
@@ -551,13 +556,11 @@ describe('ApiDropV2Service', () => {
     const authenticationContext =
       AuthenticationContext.fromProfileId('viewer-1');
     const connection = {} as any;
+    const ctx = { authenticationContext, connection };
     deps.dropsDb.findDropByIdWithEligibilityCheck.mockResolvedValue(drop);
     deps.dropsDb.findWaveByIdOrNull.mockResolvedValue(wave);
 
-    const result = await service.findWithWaveByIdOrThrow('drop-1', {
-      authenticationContext,
-      connection
-    });
+    const result = await service.findWithWaveByIdOrThrow('drop-1', ctx);
 
     expect(result).toEqual({
       drop: { id: 'drop-1' },
@@ -575,14 +578,11 @@ describe('ApiDropV2Service', () => {
       'wave-1',
       connection
     );
-    expect(deps.apiDropMapper.mapDrops).toHaveBeenCalledWith([drop], {
-      authenticationContext,
-      connection
-    });
-    expect(deps.apiWaveOverviewMapper.mapWaves).toHaveBeenCalledWith([wave], {
-      authenticationContext,
-      connection
-    });
+    expect(deps.apiDropMapper.mapDrops).toHaveBeenCalledWith([drop], ctx);
+    expect(deps.apiWaveOverviewMapper.mapWaves).toHaveBeenCalledWith(
+      [wave],
+      ctx
+    );
   });
 
   it('throws when drop is missing or not visible', async () => {
@@ -597,7 +597,12 @@ describe('ApiDropV2Service', () => {
 
     expect(
       deps.userGroupsService.getGroupsUserIsEligibleFor
-    ).toHaveBeenCalledWith(null, undefined);
+    ).not.toHaveBeenCalled();
+    expect(deps.dropsDb.findDropByIdWithEligibilityCheck).toHaveBeenCalledWith(
+      'missing-drop',
+      [],
+      undefined
+    );
     expect(deps.dropsDb.findWaveByIdOrNull).not.toHaveBeenCalled();
     expect(deps.apiDropMapper.mapDrops).not.toHaveBeenCalled();
     expect(deps.apiWaveOverviewMapper.mapWaves).not.toHaveBeenCalled();
@@ -1005,7 +1010,11 @@ describe('ApiDropV2Service', () => {
       },
       ctx
     );
-    expect(deps.apiDropMapper.mapDrops).toHaveBeenCalledWith(dropEntities, ctx);
+    expect(deps.apiDropMapper.mapDrops).toHaveBeenCalledWith(
+      dropEntities,
+      ctx,
+      { groupIdsUserIsEligibleFor: ['group-1'] }
+    );
     expect(
       deps.wavesApiDb.findWavesByIdsEligibleForRead
     ).not.toHaveBeenCalled();
@@ -1060,7 +1069,8 @@ describe('ApiDropV2Service', () => {
     );
     expect(deps.apiWaveOverviewMapper.mapWaves).toHaveBeenCalledWith(
       waveEntities,
-      ctx
+      ctx,
+      { groupIdsUserIsEligibleFor: ['group-1'] }
     );
     expect(result).toEqual({
       data: [

--- a/src/api-serverless/src/drops/api-drop-v2.service.ts
+++ b/src/api-serverless/src/drops/api-drop-v2.service.ts
@@ -12,7 +12,7 @@ import {
   apiWaveOverviewMapper,
   ApiWaveOverviewMapper
 } from '@/api/waves/api-wave-overview.mapper';
-import { getWaveReadContextProfileId } from '@/api/waves/wave-access.helpers';
+import { getGroupsUserIsEligibleForReadContext } from '@/api/waves/wave-access.helpers';
 import {
   identityFetcher,
   IdentityFetcher
@@ -99,13 +99,10 @@ export class ApiDropV2Service {
     const timerKey = `${this.constructor.name}->findDrops`;
     ctx.timer?.start(timerKey);
     try {
-      const contextProfileId = getWaveReadContextProfileId(
-        ctx.authenticationContext
-      );
       const groupIdsUserIsEligibleFor =
-        await this.userGroupsService.getGroupsUserIsEligibleFor(
-          contextProfileId,
-          ctx.timer
+        await getGroupsUserIsEligibleForReadContext(
+          this.userGroupsService,
+          ctx
         );
       if (req.parent_drop_id) {
         const parentDrop = await this.dropsDb.findDropByIdWithEligibilityCheck(
@@ -134,7 +131,8 @@ export class ApiDropV2Service {
       );
       const dropsByIdPromise = this.apiDropMapper.mapDrops(
         pageDropEntities,
-        ctx
+        ctx,
+        { groupIdsUserIsEligibleFor }
       );
       const wavesByIdPromise = this.wavesApiDb
         .findWavesByIdsEligibleForRead(
@@ -142,7 +140,11 @@ export class ApiDropV2Service {
           groupIdsUserIsEligibleFor,
           ctx.connection
         )
-        .then((waves) => this.apiWaveOverviewMapper.mapWaves(waves, ctx));
+        .then((waves) =>
+          this.apiWaveOverviewMapper.mapWaves(waves, ctx, {
+            groupIdsUserIsEligibleFor
+          })
+        );
       const [dropsById, wavesById] = await Promise.all([
         dropsByIdPromise,
         wavesByIdPromise
@@ -410,13 +412,10 @@ export class ApiDropV2Service {
     const timerKey = `${this.constructor.name}->findBoostedDrops`;
     ctx.timer?.start(timerKey);
     try {
-      const contextProfileId = getWaveReadContextProfileId(
-        ctx.authenticationContext
-      );
       const groupIdsUserIsEligibleFor =
-        await this.userGroupsService.getGroupsUserIsEligibleFor(
-          contextProfileId,
-          ctx.timer
+        await getGroupsUserIsEligibleForReadContext(
+          this.userGroupsService,
+          ctx
         );
       const boosterId =
         req.booster === null
@@ -461,7 +460,9 @@ export class ApiDropV2Service {
           ctx
         )
       ]);
-      const dropsByIdPromise = this.apiDropMapper.mapDrops(dropEntities, ctx);
+      const dropsByIdPromise = this.apiDropMapper.mapDrops(dropEntities, ctx, {
+        groupIdsUserIsEligibleFor
+      });
       const wavesByIdPromise =
         req.wave_id === null
           ? this.mapBoostedDropWaves(
@@ -508,7 +509,9 @@ export class ApiDropV2Service {
       groupIdsUserIsEligibleFor,
       ctx.connection
     );
-    return this.apiWaveOverviewMapper.mapWaves(waveEntities, ctx);
+    return this.apiWaveOverviewMapper.mapWaves(waveEntities, ctx, {
+      groupIdsUserIsEligibleFor
+    });
   }
 
   public async findVoteEditLogsByDropIdOrThrow(
@@ -679,14 +682,8 @@ export class ApiDropV2Service {
     ctx: RequestContext,
     notFoundMessage = `Drop ${id} not found`
   ): Promise<DropEntity> {
-    const contextProfileId = getWaveReadContextProfileId(
-      ctx.authenticationContext
-    );
     const groupIdsUserIsEligibleFor =
-      await this.userGroupsService.getGroupsUserIsEligibleFor(
-        contextProfileId,
-        ctx.timer
-      );
+      await getGroupsUserIsEligibleForReadContext(this.userGroupsService, ctx);
     const dropEntity = await this.dropsDb.findDropByIdWithEligibilityCheck(
       id,
       groupIdsUserIsEligibleFor,

--- a/src/api-serverless/src/drops/api-drop.mapper.ts
+++ b/src/api-serverless/src/drops/api-drop.mapper.ts
@@ -46,7 +46,10 @@ import {
   identitySubscriptionsDb,
   IdentitySubscriptionsDb
 } from '@/api/identity-subscriptions/identity-subscriptions.db';
-import { getWaveReadContextProfileId } from '@/api/waves/wave-access.helpers';
+import {
+  getGroupsUserIsEligibleForReadContext,
+  getWaveReadContextProfileId
+} from '@/api/waves/wave-access.helpers';
 import {
   userGroupsService,
   UserGroupsService
@@ -99,6 +102,10 @@ type VoteRangeByDropId = Record<
 
 const PRIORITY_METADATA_ADDITIONAL_MEDIA_KEY = 'additional_media';
 
+export interface ApiDropMapperOptions {
+  readonly groupIdsUserIsEligibleFor?: string[];
+}
+
 export class ApiDropMapper {
   constructor(
     private readonly identityFetcher: IdentityFetcher,
@@ -121,7 +128,8 @@ export class ApiDropMapper {
 
   public async mapDrops(
     dropEntities: DropEntity[],
-    ctx: RequestContext
+    ctx: RequestContext,
+    options: ApiDropMapperOptions = {}
   ): Promise<Record<string, ApiDropV2>> {
     const timerKey = `${this.constructor.name}->mapDrops`;
     ctx.timer?.start(timerKey);
@@ -172,7 +180,14 @@ export class ApiDropMapper {
       );
       const mentionedWaveOverviewsPromise = mentionedWavesPromise.then(
         (mentionedWaves) =>
-          this.getMentionedWaveOverviews(mentionedWaves, contextProfileId, ctx)
+          this.getMentionedWaveOverviews(
+            {
+              mentionedWaves,
+              contextProfileId,
+              groupIdsUserIsEligibleFor: options.groupIdsUserIsEligibleFor
+            },
+            ctx
+          )
       );
 
       const [
@@ -655,8 +670,15 @@ export class ApiDropMapper {
   }
 
   private async getMentionedWaveOverviews(
-    mentionedWaves: DropMentionedWaveEntity[],
-    contextProfileId: string | null,
+    {
+      mentionedWaves,
+      contextProfileId,
+      groupIdsUserIsEligibleFor
+    }: {
+      readonly mentionedWaves: DropMentionedWaveEntity[];
+      readonly contextProfileId: string | null;
+      readonly groupIdsUserIsEligibleFor?: string[];
+    },
     ctx: RequestContext
   ): Promise<Record<string, WaveMentionOverview>> {
     const mentionedWaveIds = collections.distinct(
@@ -665,15 +687,16 @@ export class ApiDropMapper {
     if (!mentionedWaveIds.length) {
       return {};
     }
-    const groupIdsUserIsEligibleFor =
-      await this.userGroupsService.getGroupsUserIsEligibleFor(
-        contextProfileId,
-        ctx.timer
-      );
+    const eligibleGroupIds =
+      groupIdsUserIsEligibleFor ??
+      (await getGroupsUserIsEligibleForReadContext(
+        this.userGroupsService,
+        ctx
+      ));
     const waveOverviewsById =
       await this.wavesApiDb.findWaveMentionOverviewsByIds(
         mentionedWaveIds,
-        groupIdsUserIsEligibleFor,
+        eligibleGroupIds,
         ctx
       );
     const waveOverviews = Object.values(waveOverviewsById);

--- a/src/api-serverless/src/rep-categories/global-rep-category-api-service.test.ts
+++ b/src/api-serverless/src/rep-categories/global-rep-category-api-service.test.ts
@@ -530,10 +530,7 @@ describe('GlobalRepCategoryApiService', () => {
 
     await service.getWaveOverview({ category: 'Dev extraordinaire' }, ctx);
 
-    expect(userGroupsService.getGroupsUserIsEligibleFor).toHaveBeenCalledWith(
-      null,
-      undefined
-    );
+    expect(userGroupsService.getGroupsUserIsEligibleFor).not.toHaveBeenCalled();
     expect(globalRepCategoryDb.getWaveOverviewStats).toHaveBeenCalledWith(
       expect.objectContaining({
         category: 'Dev extraordinaire',

--- a/src/api-serverless/src/waves/api-wave-overview-mapper.test.ts
+++ b/src/api-serverless/src/waves/api-wave-overview-mapper.test.ts
@@ -466,6 +466,24 @@ describe('ApiWaveOverviewMapper', () => {
     );
   });
 
+  it('uses provided eligible groups instead of loading them again', async () => {
+    const { mapper, deps } = createMapper();
+    const ctx = {
+      authenticationContext: AuthenticationContext.fromProfileId('viewer-1')
+    };
+
+    await mapper.mapWaves([makeWave()], ctx, {
+      groupIdsUserIsEligibleFor: ['visible-group']
+    });
+
+    expect(
+      deps.userGroupsService.getGroupsUserIsEligibleFor
+    ).not.toHaveBeenCalled();
+    expect(
+      deps.wavesApiDb.findVisibleParentWavesByChildWaveIds
+    ).toHaveBeenCalledWith(['wave-1'], ['visible-group'], ctx);
+  });
+
   it('maps active chat slow mode cooldown in context profile context', async () => {
     const { mapper, deps } = createMapper();
     const nextDropTimestamp = Date.now() + 60000;

--- a/src/api-serverless/src/waves/api-wave-overview.mapper.ts
+++ b/src/api-serverless/src/waves/api-wave-overview.mapper.ts
@@ -37,7 +37,10 @@ import {
   resolveWavePictureOverride,
   WaveDisplayOverride
 } from '@/api/waves/direct-message-wave-display.service';
-import { getWaveReadContextProfileId } from '@/api/waves/wave-access.helpers';
+import {
+  getGroupsUserIsEligibleForReadContext,
+  getWaveReadContextProfileId
+} from '@/api/waves/wave-access.helpers';
 import {
   FollowedSubwaveOverviewContext,
   wavesApiDb,
@@ -49,6 +52,10 @@ import {
 } from '@/api/waves/wave-score.api-mapper';
 import { WaveUnreadSummary } from '@/api/waves/wave-unread-cache';
 import { resolveNextDropAllowed } from '@/waves/wave-chat-slow-mode.helpers';
+
+export interface ApiWaveOverviewMapperOptions {
+  readonly groupIdsUserIsEligibleFor?: string[];
+}
 
 export function createUnknownWaveCreatorProfile({
   profileId,
@@ -95,7 +102,8 @@ export class ApiWaveOverviewMapper {
 
   public async mapWaves(
     waveEntities: WaveEntity[],
-    ctx: RequestContext
+    ctx: RequestContext,
+    options: ApiWaveOverviewMapperOptions = {}
   ): Promise<Record<string, ApiWaveOverview>> {
     const timerKey = `${this.constructor.name}->mapWaves`;
     ctx.timer?.start(timerKey);
@@ -108,12 +116,12 @@ export class ApiWaveOverviewMapper {
       const contextProfileId = getWaveReadContextProfileId(
         ctx.authenticationContext
       );
-      const groupIdsUserIsEligibleFor = contextProfileId
-        ? await this.userGroupsService.getGroupsUserIsEligibleFor(
-            contextProfileId,
-            ctx.timer
-          )
-        : [];
+      const groupIdsUserIsEligibleFor =
+        options.groupIdsUserIsEligibleFor ??
+        (await getGroupsUserIsEligibleForReadContext(
+          this.userGroupsService,
+          ctx
+        ));
       const requestedWaveIds = entities.map((wave) => wave.id);
       const parentWavesByChildWaveId =
         await this.wavesApiDb.findVisibleParentWavesByChildWaveIds(

--- a/src/api-serverless/src/waves/api-wave-v2-service.test.ts
+++ b/src/api-serverless/src/waves/api-wave-v2-service.test.ts
@@ -463,9 +463,14 @@ describe('ApiWaveV2Service', () => {
     );
     expect(deps.apiWaveOverviewMapper.mapWaves).toHaveBeenCalledWith(
       [wave],
-      ctx
+      ctx,
+      { groupIdsUserIsEligibleFor: ['group-1'] }
     );
-    expect(deps.apiDropMapper.mapDrops).toHaveBeenCalledWith([makeDrop()], ctx);
+    expect(deps.apiDropMapper.mapDrops).toHaveBeenCalledWith(
+      [makeDrop()],
+      ctx,
+      { groupIdsUserIsEligibleFor: ['group-1'] }
+    );
   });
 
   it('finds curation drops and maps them with V2 models', async () => {
@@ -507,7 +512,8 @@ describe('ApiWaveV2Service', () => {
     );
     expect(deps.apiDropMapper.mapDrops).toHaveBeenCalledWith(
       curationDrops.slice(0, 2),
-      ctx
+      ctx,
+      { groupIdsUserIsEligibleFor: ['group-1'] }
     );
     expect(result).toEqual({
       data: [{ id: 'curated-drop-1' }, { id: 'curated-drop-2' }],
@@ -562,7 +568,8 @@ describe('ApiWaveV2Service', () => {
     );
     expect(deps.apiDropMapper.mapDrops).toHaveBeenCalledWith(
       [rootDrop, reply],
-      expect.any(Object)
+      expect.any(Object),
+      { groupIdsUserIsEligibleFor: ['group-1'] }
     );
   });
 
@@ -672,7 +679,8 @@ describe('ApiWaveV2Service', () => {
     );
     expect(deps.apiDropMapper.mapDrops).toHaveBeenCalledWith(
       [makeDrop({ id: 'search-drop-1' }), makeDrop({ id: 'search-drop-2' })],
-      ctx
+      ctx,
+      { groupIdsUserIsEligibleFor: ['group-1'] }
     );
     expect(result).toEqual({
       data: [{ id: 'search-drop-1' }, { id: 'search-drop-2' }],

--- a/src/api-serverless/src/waves/api-wave-v2.service.ts
+++ b/src/api-serverless/src/waves/api-wave-v2.service.ts
@@ -36,6 +36,7 @@ import {
 } from '@/api/waves/api-wave-overview.mapper';
 import {
   assertWaveAndParentVisibleOrThrow,
+  getGroupsUserIsEligibleForReadContext,
   getWaveReadContextProfileId
 } from '@/api/waves/wave-access.helpers';
 import {
@@ -192,14 +193,8 @@ export class ApiWaveV2Service {
     const timerKey = `${this.constructor.name}->findDropsFeed`;
     ctx.timer?.start(timerKey);
     try {
-      const contextProfileId = getWaveReadContextProfileId(
-        ctx.authenticationContext
-      );
       const groupIdsUserIsEligibleForPromise =
-        this.userGroupsService.getGroupsUserIsEligibleFor(
-          contextProfileId,
-          ctx.timer
-        );
+        getGroupsUserIsEligibleForReadContext(this.userGroupsService, ctx);
       const waveAndCurationFilterPromise = this.findWaveAndCurationFilter(
         {
           waveId: request.wave_id,
@@ -237,7 +232,8 @@ export class ApiWaveV2Service {
             {
               ...request,
               wave: visibleWave,
-              curationFilter
+              curationFilter,
+              groupIdsUserIsEligibleFor
             },
             ctx
           );
@@ -253,13 +249,10 @@ export class ApiWaveV2Service {
     const timerKey = `${this.constructor.name}->findDropRepliesFeed`;
     ctx.timer?.start(timerKey);
     try {
-      const contextProfileId = getWaveReadContextProfileId(
-        ctx.authenticationContext
-      );
       const groupIdsUserIsEligibleFor =
-        await this.userGroupsService.getGroupsUserIsEligibleFor(
-          contextProfileId,
-          ctx.timer
+        await getGroupsUserIsEligibleForReadContext(
+          this.userGroupsService,
+          ctx
         );
       const rootDrop = await this.findVisibleRootDropOrThrow(
         request.drop_id,
@@ -318,14 +311,11 @@ export class ApiWaveV2Service {
       if (!wave) {
         throw new NotFoundException(`Wave ${wave_id} not found`);
       }
-      const contextProfileId = getWaveReadContextProfileId(
-        ctx.authenticationContext
-      );
       const visibilityGroupId = wave.visibility_group_id;
       const groupIdsUserIsEligibleFor =
-        await this.userGroupsService.getGroupsUserIsEligibleFor(
-          contextProfileId,
-          ctx.timer
+        await getGroupsUserIsEligibleForReadContext(
+          this.userGroupsService,
+          ctx
         );
       await assertWaveAndParentVisibleOrThrow({
         wave: {
@@ -343,7 +333,9 @@ export class ApiWaveV2Service {
         ctx
       );
       const pageDropEntities = dropEntities.slice(0, size);
-      const drops = await this.apiDropMapper.mapDrops(pageDropEntities, ctx);
+      const drops = await this.apiDropMapper.mapDrops(pageDropEntities, ctx, {
+        groupIdsUserIsEligibleFor
+      });
       return {
         data: pageDropEntities.map((drop) => drops[drop.id]),
         next: dropEntities.length > size,
@@ -407,7 +399,10 @@ export class ApiWaveV2Service {
       const pageDropEntities = dropEntities.slice(0, page_size);
       const dropsById = await this.apiDropMapper.mapDrops(
         pageDropEntities,
-        ctx
+        ctx,
+        {
+          groupIdsUserIsEligibleFor: eligibleGroups
+        }
       );
       return {
         data: pageDropEntities.map((drop) => dropsById[drop.id]),
@@ -557,12 +552,10 @@ export class ApiWaveV2Service {
     const authenticatedProfileId = getWaveReadContextProfileId(
       ctx.authenticationContext
     );
-    const eligibleGroups = authenticatedProfileId
-      ? await this.userGroupsService.getGroupsUserIsEligibleFor(
-          authenticatedProfileId,
-          ctx.timer
-        )
-      : [];
+    const eligibleGroups = await getGroupsUserIsEligibleForReadContext(
+      this.userGroupsService,
+      ctx
+    );
     return {
       authenticatedProfileId,
       eligibleGroups
@@ -660,10 +653,12 @@ export class ApiWaveV2Service {
       serial_no_limit,
       search_strategy,
       curationFilter,
-      drop_type
+      drop_type,
+      groupIdsUserIsEligibleFor
     }: FindWaveDropsFeedV2Request & {
       readonly wave: WaveEntity;
       readonly curationFilter: string | null;
+      readonly groupIdsUserIsEligibleFor: string[];
     },
     ctx: RequestContext
   ): Promise<ApiWaveDropsFeedV2> {
@@ -679,9 +674,13 @@ export class ApiWaveV2Service {
         },
         ctx
       ),
-      this.apiWaveOverviewMapper.mapWaves([wave], ctx)
+      this.apiWaveOverviewMapper.mapWaves([wave], ctx, {
+        groupIdsUserIsEligibleFor
+      })
     ]);
-    const apiDropById = await this.apiDropMapper.mapDrops(dropEntities, ctx);
+    const apiDropById = await this.apiDropMapper.mapDrops(dropEntities, ctx, {
+      groupIdsUserIsEligibleFor
+    });
     return {
       drops: dropEntities.map((drop) => apiDropById[drop.id]),
       wave: apiWaveById[wave.id]
@@ -730,7 +729,9 @@ export class ApiWaveV2Service {
         },
         ctx
       ),
-      this.apiWaveOverviewMapper.mapWaves([wave], ctx)
+      this.apiWaveOverviewMapper.mapWaves([wave], ctx, {
+        groupIdsUserIsEligibleFor
+      })
     ]);
     // This remains defensive for callers that provide a wave separately from
     // the root drop lookup.
@@ -744,7 +745,8 @@ export class ApiWaveV2Service {
     );
     const apiDropById = await this.apiDropMapper.mapDrops(
       dropEntitiesToMap,
-      ctx
+      ctx,
+      { groupIdsUserIsEligibleFor }
     );
 
     return {

--- a/src/api-serverless/src/waves/wave-access.helpers.test.ts
+++ b/src/api-serverless/src/waves/wave-access.helpers.test.ts
@@ -1,6 +1,44 @@
 import { AuthenticationContext } from '@/auth-context';
 import { ForbiddenException } from '@/exceptions';
-import { getWaveManagementContextOrThrow } from './wave-access.helpers';
+import {
+  getGroupsUserIsEligibleForReadContext,
+  getWaveManagementContextOrThrow
+} from './wave-access.helpers';
+
+describe('getGroupsUserIsEligibleForReadContext', () => {
+  it('reuses the same eligible-groups promise within a request context', async () => {
+    const ctx = {
+      authenticationContext: AuthenticationContext.fromProfileId('viewer-1')
+    };
+    const getGroupsUserIsEligibleFor = jest.fn().mockResolvedValue(['group-1']);
+    const userGroupsService = { getGroupsUserIsEligibleFor };
+
+    const [first, second] = await Promise.all([
+      getGroupsUserIsEligibleForReadContext(userGroupsService as any, ctx),
+      getGroupsUserIsEligibleForReadContext(userGroupsService as any, ctx)
+    ]);
+
+    expect(first).toEqual(['group-1']);
+    expect(second).toEqual(['group-1']);
+    expect(getGroupsUserIsEligibleFor).toHaveBeenCalledTimes(1);
+    expect(getGroupsUserIsEligibleFor).toHaveBeenCalledWith(
+      'viewer-1',
+      undefined
+    );
+  });
+
+  it('does not call eligibility service without a wave read profile', async () => {
+    const getGroupsUserIsEligibleFor = jest.fn();
+
+    const result = await getGroupsUserIsEligibleForReadContext(
+      { getGroupsUserIsEligibleFor } as any,
+      { authenticationContext: AuthenticationContext.notAuthenticated() }
+    );
+
+    expect(result).toEqual([]);
+    expect(getGroupsUserIsEligibleFor).not.toHaveBeenCalled();
+  });
+});
 
 describe('getWaveManagementContextOrThrow', () => {
   it('does not validate the wave before authorization succeeds', async () => {

--- a/src/api-serverless/src/waves/wave-access.helpers.ts
+++ b/src/api-serverless/src/waves/wave-access.helpers.ts
@@ -34,6 +34,7 @@ export async function getGroupsUserIsEligibleForReadContext(
   if (!profileId) {
     return [];
   }
+  // Eligibility depends on profileId; ctx.timer only instruments the call.
   return await getRequestScopedPromise(
     ctx,
     `wave-read-eligible-groups:${profileId}`,

--- a/src/api-serverless/src/waves/wave-access.helpers.ts
+++ b/src/api-serverless/src/waves/wave-access.helpers.ts
@@ -1,7 +1,7 @@
 import { AuthenticationContext } from '@/auth-context';
 import { ProfileProxyActionType } from '@/entities/IProfileProxyAction';
 import { ForbiddenException, NotFoundException } from '@/exceptions';
-import { RequestContext } from '@/request.context';
+import { getRequestScopedPromise, RequestContext } from '@/request.context';
 import { UserGroupsService } from '@/api/community-members/user-groups.service';
 import { WavesApiDb } from '@/api/waves/waves.api.db';
 
@@ -31,9 +31,13 @@ export async function getGroupsUserIsEligibleForReadContext(
   ctx: RequestContext
 ): Promise<string[]> {
   const profileId = getWaveReadContextProfileId(ctx.authenticationContext);
-  return await userGroupsService.getGroupsUserIsEligibleFor(
-    profileId,
-    ctx.timer
+  if (!profileId) {
+    return [];
+  }
+  return await getRequestScopedPromise(
+    ctx,
+    `wave-read-eligible-groups:${profileId}`,
+    () => userGroupsService.getGroupsUserIsEligibleFor(profileId, ctx.timer)
   );
 }
 

--- a/src/api-serverless/src/waves/wave-metadata-api-service.test.ts
+++ b/src/api-serverless/src/waves/wave-metadata-api-service.test.ts
@@ -67,10 +67,7 @@ describe('WaveMetadataApiService', () => {
       }
     ]);
 
-    expect(userGroupsService.getGroupsUserIsEligibleFor).toHaveBeenCalledWith(
-      null,
-      undefined
-    );
+    expect(userGroupsService.getGroupsUserIsEligibleFor).not.toHaveBeenCalled();
     expect(waveMetadataDb.listByWaveId).toHaveBeenCalledWith('wave-1', {});
   });
 

--- a/src/request-context.test.ts
+++ b/src/request-context.test.ts
@@ -1,0 +1,42 @@
+import { getRequestScopedPromise, RequestContext } from './request.context';
+
+describe('getRequestScopedPromise', () => {
+  it('reuses an in-flight promise for matching keys on the same context', async () => {
+    const ctx: RequestContext = {};
+    const getValue = jest.fn().mockResolvedValue('value');
+
+    const [first, second] = await Promise.all([
+      getRequestScopedPromise(ctx, 'key', getValue),
+      getRequestScopedPromise(ctx, 'key', getValue)
+    ]);
+
+    expect(first).toBe('value');
+    expect(second).toBe('value');
+    expect(getValue).toHaveBeenCalledTimes(1);
+  });
+
+  it('evicts rejected promises so later calls retry', async () => {
+    const ctx: RequestContext = {};
+    const getValue = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('first failure'))
+      .mockResolvedValueOnce('retry value');
+
+    await expect(getRequestScopedPromise(ctx, 'key', getValue)).rejects.toThrow(
+      'first failure'
+    );
+    await expect(getRequestScopedPromise(ctx, 'key', getValue)).resolves.toBe(
+      'retry value'
+    );
+    expect(getValue).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps the request scope off enumerable context copies', async () => {
+    const ctx: RequestContext = {};
+
+    await getRequestScopedPromise(ctx, 'key', async () => 'value');
+
+    expect(Object.keys(ctx)).not.toContain('requestScope');
+    expect({ ...ctx }).not.toHaveProperty('requestScope');
+  });
+});

--- a/src/request.context.ts
+++ b/src/request.context.ts
@@ -42,7 +42,7 @@ export function getRequestScopedPromise<T>(
 ): Promise<T> {
   const requestScope = getOrCreateRequestScope(ctx);
   const existingPromise = requestScope.promisesByKey.get(key);
-  if (existingPromise) {
+  if (existingPromise !== undefined) {
     return existingPromise as Promise<T>;
   }
 

--- a/src/request.context.ts
+++ b/src/request.context.ts
@@ -2,8 +2,51 @@ import { ConnectionWrapper } from './sql-executor';
 import { Timer } from './time';
 import { AuthenticationContext } from './auth-context';
 
+export interface RequestScope {
+  readonly promisesByKey: Map<string, Promise<unknown>>;
+}
+
 export interface RequestContext {
   readonly connection?: ConnectionWrapper<any>;
   readonly timer?: Timer;
   readonly authenticationContext?: AuthenticationContext;
+  readonly requestScope?: RequestScope;
+}
+
+type MutableRequestContext = Omit<RequestContext, 'requestScope'> & {
+  requestScope?: RequestScope;
+};
+
+function getOrCreateRequestScope(ctx: RequestContext): RequestScope {
+  const mutableCtx = ctx as MutableRequestContext;
+  if (!mutableCtx.requestScope) {
+    Object.defineProperty(mutableCtx, 'requestScope', {
+      value: { promisesByKey: new Map() },
+      writable: true,
+      configurable: true,
+      enumerable: false
+    });
+  }
+  return mutableCtx.requestScope as RequestScope;
+}
+
+export function getRequestScopedPromise<T>(
+  ctx: RequestContext,
+  key: string,
+  getValue: () => Promise<T>
+): Promise<T> {
+  const requestScope = getOrCreateRequestScope(ctx);
+  const existingPromise = requestScope.promisesByKey.get(key);
+  if (existingPromise) {
+    return existingPromise as Promise<T>;
+  }
+
+  const promise = getValue().catch((error: unknown) => {
+    if (requestScope.promisesByKey.get(key) === promise) {
+      requestScope.promisesByKey.delete(key);
+    }
+    throw error;
+  });
+  requestScope.promisesByKey.set(key, promise);
+  return promise;
 }

--- a/src/request.context.ts
+++ b/src/request.context.ts
@@ -10,6 +10,11 @@ export interface RequestContext {
   readonly connection?: ConnectionWrapper<any>;
   readonly timer?: Timer;
   readonly authenticationContext?: AuthenticationContext;
+  /**
+   * Best-effort memoization for async work performed with the same ctx object.
+   * It is attached non-enumerably, so spreading ctx intentionally starts a new
+   * scope. Cache keys must include every input that changes the returned value.
+   */
   readonly requestScope?: RequestScope;
 }
 
@@ -41,12 +46,12 @@ export function getRequestScopedPromise<T>(
     return existingPromise as Promise<T>;
   }
 
-  const promise = getValue().catch((error: unknown) => {
+  const promise = getValue();
+  requestScope.promisesByKey.set(key, promise);
+  void promise.catch(() => {
     if (requestScope.promisesByKey.get(key) === promise) {
       requestScope.promisesByKey.delete(key);
     }
-    throw error;
   });
-  requestScope.promisesByKey.set(key, promise);
   return promise;
 }


### PR DESCRIPTION
## Summary
- add per-request promise memoization for wave read eligibility lookups
- pass already-loaded eligible groups through hot V2 drops/waves mapper paths
- avoid calling eligibility service for unauthenticated read contexts that resolve to empty groups

## Validation
- npm run lint
- npm run build

## Notes
- No architecture docs update needed: this changes API request-path memoization only and does not add or rewire lambdas, queues, topics, migrations, or external integrations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved wave and drop visibility handling so eligible-group information is reused across related requests.
  * Added request-level caching to avoid repeating the same eligibility lookup within a single request.

* **Bug Fixes**
  * Readable waves and proxy-user cases now avoid unnecessary eligibility checks.
  * Mentioned wave overviews and feed results now consistently respect the caller’s access scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->