### PR TITLE
Optimize wave overview caching

### DIFF
--- a/src/api-serverless/src/waves/api-wave-overview.mapper.ts
+++ b/src/api-serverless/src/waves/api-wave-overview.mapper.ts
@@ -145,6 +145,7 @@ export class ApiWaveOverviewMapper {
         .map((wave) => wave.id);
 
       const [
+        metricsByWaveId,
         staticContextsByWaveId,
         displayByWaveId,
         subscribedActionsByWaveId,
@@ -155,6 +156,7 @@ export class ApiWaveOverviewMapper {
         waveIdsWithVisibleSubwaves,
         followedSubwaveContextsByParentWaveId
       ] = await Promise.all([
+        this.wavesApiDb.findWavesMetricsByWaveIds(waveIds, ctx),
         this.findStaticOverviewContextsByWaveId(relatedEntities, ctx),
         contextProfileId
           ? this.directMessageWaveDisplayService.resolveWaveDisplayByWaveIdForContext(
@@ -230,7 +232,6 @@ export class ApiWaveOverviewMapper {
             )
       ]);
       const {
-        metricsByWaveId,
         descriptionDropPartOnesByDropId,
         descriptionDropPartOneMediaByDropId,
         profilesById
@@ -332,7 +333,6 @@ export class ApiWaveOverviewMapper {
     if (!waveEntities.length) {
       return {};
     }
-    const waveIds = waveEntities.map((wave) => wave.id);
     const descriptionDropIds = collections.distinct(
       waveEntities.map((wave) => wave.description_drop_id)
     );
@@ -342,12 +342,10 @@ export class ApiWaveOverviewMapper {
         .filter((profileId): profileId is string => !!profileId)
     );
     const [
-      metricsByWaveId,
       descriptionDropPartOnesByDropId,
       descriptionDropPartOneMediaByDropId,
       profilesById
     ] = await Promise.all([
-      this.wavesApiDb.findWavesMetricsByWaveIds(waveIds, ctx),
       this.dropsDb.getDropPartOnes(descriptionDropIds, ctx),
       this.dropsDb.getDropPartOneMedia(descriptionDropIds, ctx),
       creatorIds.length
@@ -359,7 +357,6 @@ export class ApiWaveOverviewMapper {
       (acc, wave) => {
         const creatorId = wave.created_by;
         acc[wave.id] = {
-          metrics: metricsByWaveId[wave.id] ?? null,
           descriptionDropPartOne:
             descriptionDropPartOnesByDropId[wave.description_drop_id] ?? null,
           descriptionDropPartOneMedia:
@@ -379,7 +376,6 @@ export class ApiWaveOverviewMapper {
     waveEntities: WaveEntity[];
     staticContextsByWaveId: Record<string, WaveOverviewStaticCacheEntry>;
   }): {
-    metricsByWaveId: Record<string, WaveMetricEntity>;
     descriptionDropPartOnesByDropId: Record<string, DropPartEntity>;
     descriptionDropPartOneMediaByDropId: Record<string, DropMediaEntity[]>;
     profilesById: Record<string, ApiProfileMin>;
@@ -389,9 +385,6 @@ export class ApiWaveOverviewMapper {
         const staticContext = staticContextsByWaveId[wave.id];
         if (!staticContext) {
           return acc;
-        }
-        if (staticContext.metrics) {
-          acc.metricsByWaveId[wave.id] = staticContext.metrics;
         }
         if (staticContext.descriptionDropPartOne) {
           acc.descriptionDropPartOnesByDropId[wave.description_drop_id] =
@@ -407,7 +400,6 @@ export class ApiWaveOverviewMapper {
         return acc;
       },
       {
-        metricsByWaveId: {} as Record<string, WaveMetricEntity>,
         descriptionDropPartOnesByDropId: {} as Record<string, DropPartEntity>,
         descriptionDropPartOneMediaByDropId: {} as Record<
           string,

--- a/src/api-serverless/src/waves/api-wave-overview.mapper.ts
+++ b/src/api-serverless/src/waves/api-wave-overview.mapper.ts
@@ -51,6 +51,12 @@ import {
   mapWaveScore
 } from '@/api/waves/wave-score.api-mapper';
 import { WaveUnreadSummary } from '@/api/waves/wave-unread-cache';
+import {
+  readWaveOverviewStaticCache,
+  WaveOverviewStaticCacheEntry,
+  withInFlightWaveOverviewStaticCacheRead,
+  writeWaveOverviewStaticCache
+} from '@/api/waves/wave-overview-static-cache';
 import { resolveNextDropAllowed } from '@/waves/wave-chat-slow-mode.helpers';
 
 export interface ApiWaveOverviewMapperOptions {
@@ -137,19 +143,9 @@ export class ApiWaveOverviewMapper {
       const rootWaveIds = relatedEntities
         .filter((wave) => wave.parent_wave_id === null)
         .map((wave) => wave.id);
-      const descriptionDropIds = collections.distinct(
-        relatedEntities.map((wave) => wave.description_drop_id)
-      );
-      const creatorIds = collections.distinct(
-        relatedEntities
-          .map((wave) => wave.created_by)
-          .filter((profileId): profileId is string => !!profileId)
-      );
 
       const [
-        metricsByWaveId,
-        descriptionDropPartOnesByDropId,
-        descriptionDropPartOneMediaByDropId,
+        staticContextsByWaveId,
         displayByWaveId,
         subscribedActionsByWaveId,
         pinnedWaveIds,
@@ -157,12 +153,9 @@ export class ApiWaveOverviewMapper {
         unreadSummariesByWaveId,
         chatDropCooldownsByWaveId,
         waveIdsWithVisibleSubwaves,
-        followedSubwaveContextsByParentWaveId,
-        profilesById
+        followedSubwaveContextsByParentWaveId
       ] = await Promise.all([
-        this.wavesApiDb.findWavesMetricsByWaveIds(waveIds, ctx),
-        this.dropsDb.getDropPartOnes(descriptionDropIds, ctx),
-        this.dropsDb.getDropPartOneMedia(descriptionDropIds, ctx),
+        this.findStaticOverviewContextsByWaveId(relatedEntities, ctx),
         contextProfileId
           ? this.directMessageWaveDisplayService.resolveWaveDisplayByWaveIdForContext(
               {
@@ -234,11 +227,17 @@ export class ApiWaveOverviewMapper {
             )
           : Promise.resolve(
               {} as Record<string, FollowedSubwaveOverviewContext>
-            ),
-        creatorIds.length
-          ? this.identityFetcher.getOverviewsByIds(creatorIds, ctx)
-          : Promise.resolve({} as Record<string, ApiProfileMin>)
+            )
       ]);
+      const {
+        metricsByWaveId,
+        descriptionDropPartOnesByDropId,
+        descriptionDropPartOneMediaByDropId,
+        profilesById
+      } = this.getStaticOverviewLookupMaps({
+        waveEntities: relatedEntities,
+        staticContextsByWaveId
+      });
 
       const overviewsByWaveId = relatedEntities.reduce(
         (acc, wave) => {
@@ -285,6 +284,138 @@ export class ApiWaveOverviewMapper {
     } finally {
       ctx.timer?.stop(timerKey);
     }
+  }
+
+  private async findStaticOverviewContextsByWaveId(
+    waveEntities: WaveEntity[],
+    ctx: RequestContext
+  ): Promise<Record<string, WaveOverviewStaticCacheEntry>> {
+    const entities = collections.distinctBy(waveEntities, (wave) => wave.id);
+    if (!entities.length) {
+      return {};
+    }
+    if (ctx.connection !== undefined) {
+      return await this.loadStaticOverviewContextsByWaveId(entities, ctx);
+    }
+
+    const { cachedByWaveId, uncachedWaveIds, cacheKeysByWaveId } =
+      await readWaveOverviewStaticCache(entities);
+    const uncachedWaveIdSet = new Set(uncachedWaveIds);
+    const uncachedEntities = entities.filter((wave) =>
+      uncachedWaveIdSet.has(wave.id)
+    );
+    const loadedByWaveId = await withInFlightWaveOverviewStaticCacheRead({
+      cacheKeysByWaveId,
+      waveIds: uncachedWaveIds,
+      getValue: async () => {
+        const loaded = await this.loadStaticOverviewContextsByWaveId(
+          uncachedEntities,
+          ctx
+        );
+        await writeWaveOverviewStaticCache({
+          entriesByWaveId: loaded,
+          cacheKeysByWaveId
+        });
+        return loaded;
+      }
+    });
+    return {
+      ...cachedByWaveId,
+      ...loadedByWaveId
+    };
+  }
+
+  private async loadStaticOverviewContextsByWaveId(
+    waveEntities: WaveEntity[],
+    ctx: RequestContext
+  ): Promise<Record<string, WaveOverviewStaticCacheEntry>> {
+    if (!waveEntities.length) {
+      return {};
+    }
+    const waveIds = waveEntities.map((wave) => wave.id);
+    const descriptionDropIds = collections.distinct(
+      waveEntities.map((wave) => wave.description_drop_id)
+    );
+    const creatorIds = collections.distinct(
+      waveEntities
+        .map((wave) => wave.created_by)
+        .filter((profileId): profileId is string => !!profileId)
+    );
+    const [
+      metricsByWaveId,
+      descriptionDropPartOnesByDropId,
+      descriptionDropPartOneMediaByDropId,
+      profilesById
+    ] = await Promise.all([
+      this.wavesApiDb.findWavesMetricsByWaveIds(waveIds, ctx),
+      this.dropsDb.getDropPartOnes(descriptionDropIds, ctx),
+      this.dropsDb.getDropPartOneMedia(descriptionDropIds, ctx),
+      creatorIds.length
+        ? this.identityFetcher.getOverviewsByIds(creatorIds, ctx)
+        : Promise.resolve({} as Record<string, ApiProfileMin>)
+    ]);
+
+    return waveEntities.reduce(
+      (acc, wave) => {
+        const creatorId = wave.created_by;
+        acc[wave.id] = {
+          metrics: metricsByWaveId[wave.id] ?? null,
+          descriptionDropPartOne:
+            descriptionDropPartOnesByDropId[wave.description_drop_id] ?? null,
+          descriptionDropPartOneMedia:
+            descriptionDropPartOneMediaByDropId[wave.description_drop_id] ?? [],
+          creator: creatorId ? (profilesById[creatorId] ?? null) : null
+        };
+        return acc;
+      },
+      {} as Record<string, WaveOverviewStaticCacheEntry>
+    );
+  }
+
+  private getStaticOverviewLookupMaps({
+    waveEntities,
+    staticContextsByWaveId
+  }: {
+    waveEntities: WaveEntity[];
+    staticContextsByWaveId: Record<string, WaveOverviewStaticCacheEntry>;
+  }): {
+    metricsByWaveId: Record<string, WaveMetricEntity>;
+    descriptionDropPartOnesByDropId: Record<string, DropPartEntity>;
+    descriptionDropPartOneMediaByDropId: Record<string, DropMediaEntity[]>;
+    profilesById: Record<string, ApiProfileMin>;
+  } {
+    return waveEntities.reduce(
+      (acc, wave) => {
+        const staticContext = staticContextsByWaveId[wave.id];
+        if (!staticContext) {
+          return acc;
+        }
+        if (staticContext.metrics) {
+          acc.metricsByWaveId[wave.id] = staticContext.metrics;
+        }
+        if (staticContext.descriptionDropPartOne) {
+          acc.descriptionDropPartOnesByDropId[wave.description_drop_id] =
+            staticContext.descriptionDropPartOne;
+        }
+        if (staticContext.descriptionDropPartOneMedia.length) {
+          acc.descriptionDropPartOneMediaByDropId[wave.description_drop_id] =
+            staticContext.descriptionDropPartOneMedia;
+        }
+        if (staticContext.creator && wave.created_by) {
+          acc.profilesById[wave.created_by] = staticContext.creator;
+        }
+        return acc;
+      },
+      {
+        metricsByWaveId: {} as Record<string, WaveMetricEntity>,
+        descriptionDropPartOnesByDropId: {} as Record<string, DropPartEntity>,
+        descriptionDropPartOneMediaByDropId: {} as Record<
+          string,
+          DropMediaEntity[]
+        >,
+        profilesById: {} as Record<string, ApiProfileMin>
+      }
+    );
   }
 
   private mapWaveOverview({

--- a/src/api-serverless/src/waves/api-wave-v2-service.test.ts
+++ b/src/api-serverless/src/waves/api-wave-v2-service.test.ts
@@ -224,7 +224,8 @@ describe('ApiWaveV2Service', () => {
     );
     expect(deps.apiWaveOverviewMapper.mapWaves).toHaveBeenCalledWith(
       waveEntities.slice(0, 2),
-      ctx
+      ctx,
+      { groupIdsUserIsEligibleFor: ['group-1'] }
     );
     expect(result).toEqual({
       data: [{ id: 'wave-1' }, { id: 'wave-2' }],
@@ -414,7 +415,8 @@ describe('ApiWaveV2Service', () => {
     );
     expect(deps.apiWaveOverviewMapper.mapWaves).toHaveBeenCalledWith(
       waveEntities,
-      ctx
+      ctx,
+      { groupIdsUserIsEligibleFor: ['group-1'] }
     );
     expect(result).toEqual([{ id: 'wave-1' }, { id: 'wave-2' }]);
   });

--- a/src/api-serverless/src/waves/api-wave-v2.service.ts
+++ b/src/api-serverless/src/waves/api-wave-v2.service.ts
@@ -94,6 +94,11 @@ export interface FindSubwavesRequest {
   readonly sort: ApiSubwavesSort;
 }
 
+interface ReadableWaveContext {
+  readonly authenticatedProfileId: string | null;
+  readonly eligibleGroups: string[];
+}
+
 export class ApiWaveV2Service {
   constructor(
     private readonly dropsDb: DropsDb,
@@ -112,19 +117,17 @@ export class ApiWaveV2Service {
     const timerKey = `${this.constructor.name}->findWaves`;
     ctx.timer?.start(timerKey);
     try {
-      const contextProfileId = getWaveReadContextProfileId(
-        ctx.authenticationContext
-      );
+      const readableContext = await this.getReadableWaveContext(ctx);
       const getValue = async () => {
         switch (request.view) {
           case ApiWavesV2ListType.Search:
-            return await this.findSearchedWaves(request, ctx);
+            return await this.findSearchedWaves(request, ctx, readableContext);
           case ApiWavesV2ListType.Overview:
-            return await this.findOverviewWaves(request, ctx);
+            return await this.findOverviewWaves(request, ctx, readableContext);
           case ApiWavesV2ListType.Hot:
-            return await this.findHotWaves(request, ctx);
+            return await this.findHotWaves(request, ctx, readableContext);
           case ApiWavesV2ListType.Favourites:
-            return await this.findFavouriteWaves(request, ctx);
+            return await this.findFavouriteWaves(request, ctx, readableContext);
           default:
             return assertUnreachable(request.view);
         }
@@ -132,7 +135,8 @@ export class ApiWaveV2Service {
       return ctx.connection
         ? await getValue()
         : await withWaveOverviewResponseCache({
-            contextProfileId,
+            contextProfileId: readableContext.authenticatedProfileId,
+            eligibleGroups: readableContext.eligibleGroups,
             request,
             getValue
           });
@@ -432,9 +436,9 @@ export class ApiWaveV2Service {
 
   private async findSearchedWaves(
     request: FindWavesV2Request,
-    ctx: RequestContext
+    ctx: RequestContext,
+    readableContext: ReadableWaveContext
   ): Promise<ApiWaveOverviewPage> {
-    const { eligibleGroups } = await this.getReadableWaveContext(ctx);
     const author = request.author
       ? await this.identityFetcher.getProfileIdByIdentityKeyOrThrow(
           { identityKey: request.author },
@@ -452,17 +456,18 @@ export class ApiWaveV2Service {
     };
     const waveEntities = await this.wavesApiDb.searchWaves(
       searchParams,
-      eligibleGroups,
+      readableContext.eligibleGroups,
       ctx
     );
     return await this.mapWaveEntitiesPage(waveEntities, request, ctx, {
-      groupIdsUserIsEligibleFor: eligibleGroups
+      groupIdsUserIsEligibleFor: readableContext.eligibleGroups
     });
   }
 
   private async findOverviewWaves(
     request: FindWavesV2Request,
-    ctx: RequestContext
+    ctx: RequestContext,
+    readableContext: ReadableWaveContext
   ): Promise<ApiWaveOverviewPage> {
     const overviewType = request.overview_type;
     if (!overviewType) {
@@ -470,27 +475,25 @@ export class ApiWaveV2Service {
         `overview_type is required for OVERVIEW view`
       );
     }
-    const { authenticatedProfileId, eligibleGroups } =
-      await this.getReadableWaveContext(ctx);
     const onlyFollowed =
       request.only_waves_followed_by_authenticated_user ?? false;
-    if (onlyFollowed && !authenticatedProfileId) {
+    if (onlyFollowed && !readableContext.authenticatedProfileId) {
       throw new BadRequestException(
         `You can't see waves organised by your behaviour unless you're authenticated`
       );
     }
     const excludeFollowed = request.exclude_followed ?? false;
-    if (excludeFollowed && !authenticatedProfileId) {
+    if (excludeFollowed && !readableContext.authenticatedProfileId) {
       throw new BadRequestException(
         `You can't exclude followed waves unless you're authenticated`
       );
     }
     const findParams = {
-      authenticated_user_id: authenticatedProfileId,
+      authenticated_user_id: readableContext.authenticatedProfileId,
       only_waves_followed_by_authenticated_user: onlyFollowed,
       offset: this.getOffset(request),
       limit: request.page_size + 1,
-      eligibleGroups,
+      eligibleGroups: readableContext.eligibleGroups,
       direct_message: request.direct_message,
       pinned: request.pinned ?? null
     };
@@ -512,19 +515,17 @@ export class ApiWaveV2Service {
               })
             : assertUnreachable(overviewType);
     return await this.mapWaveEntitiesPage(waveEntities, request, ctx, {
-      groupIdsUserIsEligibleFor: eligibleGroups
+      groupIdsUserIsEligibleFor: readableContext.eligibleGroups
     });
   }
 
   private async findHotWaves(
     request: FindWavesV2Request,
-    ctx: RequestContext
+    ctx: RequestContext,
+    readableContext: ReadableWaveContext
   ): Promise<ApiWaveOverviewPage> {
-    const authenticatedProfileId = getWaveReadContextProfileId(
-      ctx.authenticationContext
-    );
     const excludeFollowed = request.exclude_followed ?? false;
-    if (excludeFollowed && !authenticatedProfileId) {
+    if (excludeFollowed && !readableContext.authenticatedProfileId) {
       throw new BadRequestException(
         `You can't exclude followed waves unless you're authenticated`
       );
@@ -533,21 +534,23 @@ export class ApiWaveV2Service {
       cutoffTimestamp: Time.currentMillis() - Time.hours(24).toMillis(),
       limit: request.page_size + 1,
       offset: this.getOffset(request),
-      authenticated_user_id: authenticatedProfileId,
+      authenticated_user_id: readableContext.authenticatedProfileId,
       exclude_followed: excludeFollowed
     });
-    return await this.mapWaveEntitiesPage(waveEntities, request, ctx);
+    return await this.mapWaveEntitiesPage(waveEntities, request, ctx, {
+      groupIdsUserIsEligibleFor: readableContext.eligibleGroups
+    });
   }
 
   private async findFavouriteWaves(
     request: FindWavesV2Request,
-    ctx: RequestContext
+    ctx: RequestContext,
+    readableContext: ReadableWaveContext
   ): Promise<ApiWaveOverviewPage> {
     const identity = request.identity;
     if (!identity) {
       throw new BadRequestException(`identity is required for FAVOURITES view`);
     }
-    const { eligibleGroups } = await this.getReadableWaveContext(ctx);
     const targetProfileId =
       await this.identityFetcher.getProfileIdByIdentityKeyOrThrow(
         { identityKey: identity },
@@ -556,21 +559,20 @@ export class ApiWaveV2Service {
     const waveEntities = await this.wavesApiDb.findFavouriteWavesOfIdentity(
       {
         identityId: targetProfileId,
-        eligibleGroups,
+        eligibleGroups: readableContext.eligibleGroups,
         limit: request.page_size + 1,
         offset: this.getOffset(request)
       },
       ctx
     );
     return await this.mapWaveEntitiesPage(waveEntities, request, ctx, {
-      groupIdsUserIsEligibleFor: eligibleGroups
+      groupIdsUserIsEligibleFor: readableContext.eligibleGroups
     });
   }
 
-  private async getReadableWaveContext(ctx: RequestContext): Promise<{
-    authenticatedProfileId: string | null;
-    eligibleGroups: string[];
-  }> {
+  private async getReadableWaveContext(
+    ctx: RequestContext
+  ): Promise<ReadableWaveContext> {
     const authenticatedProfileId = getWaveReadContextProfileId(
       ctx.authenticationContext
     );

--- a/src/api-serverless/src/waves/api-wave-v2.service.ts
+++ b/src/api-serverless/src/waves/api-wave-v2.service.ts
@@ -45,6 +45,7 @@ import {
   wavesApiDb,
   WavesApiDb
 } from '@/api/waves/waves.api.db';
+import { withWaveOverviewResponseCache } from './wave-overview-response-cache';
 
 export interface FindWaveDropsFeedV2Request {
   readonly drop_id: string | null;
@@ -111,18 +112,30 @@ export class ApiWaveV2Service {
     const timerKey = `${this.constructor.name}->findWaves`;
     ctx.timer?.start(timerKey);
     try {
-      switch (request.view) {
-        case ApiWavesV2ListType.Search:
-          return await this.findSearchedWaves(request, ctx);
-        case ApiWavesV2ListType.Overview:
-          return await this.findOverviewWaves(request, ctx);
-        case ApiWavesV2ListType.Hot:
-          return await this.findHotWaves(request, ctx);
-        case ApiWavesV2ListType.Favourites:
-          return await this.findFavouriteWaves(request, ctx);
-        default:
-          return assertUnreachable(request.view);
-      }
+      const contextProfileId = getWaveReadContextProfileId(
+        ctx.authenticationContext
+      );
+      const getValue = async () => {
+        switch (request.view) {
+          case ApiWavesV2ListType.Search:
+            return await this.findSearchedWaves(request, ctx);
+          case ApiWavesV2ListType.Overview:
+            return await this.findOverviewWaves(request, ctx);
+          case ApiWavesV2ListType.Hot:
+            return await this.findHotWaves(request, ctx);
+          case ApiWavesV2ListType.Favourites:
+            return await this.findFavouriteWaves(request, ctx);
+          default:
+            return assertUnreachable(request.view);
+        }
+      };
+      return ctx.connection
+        ? await getValue()
+        : await withWaveOverviewResponseCache({
+            contextProfileId,
+            request,
+            getValue
+          });
     } finally {
       ctx.timer?.stop(timerKey);
     }
@@ -157,7 +170,9 @@ export class ApiWaveV2Service {
         },
         ctx
       );
-      return await this.mapWaveEntitiesPage(waveEntities, request, ctx);
+      return await this.mapWaveEntitiesPage(waveEntities, request, ctx, {
+        groupIdsUserIsEligibleFor: eligibleGroups
+      });
     } finally {
       ctx.timer?.stop(timerKey);
     }
@@ -176,7 +191,8 @@ export class ApiWaveV2Service {
       );
       const wavesById = await this.apiWaveOverviewMapper.mapWaves(
         waveEntities,
-        ctx
+        ctx,
+        { groupIdsUserIsEligibleFor: eligibleGroups }
       );
       return waveEntities
         .map((wave) => wavesById[wave.id])
@@ -439,7 +455,9 @@ export class ApiWaveV2Service {
       eligibleGroups,
       ctx
     );
-    return await this.mapWaveEntitiesPage(waveEntities, request, ctx);
+    return await this.mapWaveEntitiesPage(waveEntities, request, ctx, {
+      groupIdsUserIsEligibleFor: eligibleGroups
+    });
   }
 
   private async findOverviewWaves(
@@ -493,7 +511,9 @@ export class ApiWaveV2Service {
                 visibility_tier: request.visibility_tier
               })
             : assertUnreachable(overviewType);
-    return await this.mapWaveEntitiesPage(waveEntities, request, ctx);
+    return await this.mapWaveEntitiesPage(waveEntities, request, ctx, {
+      groupIdsUserIsEligibleFor: eligibleGroups
+    });
   }
 
   private async findHotWaves(
@@ -542,7 +562,9 @@ export class ApiWaveV2Service {
       },
       ctx
     );
-    return await this.mapWaveEntitiesPage(waveEntities, request, ctx);
+    return await this.mapWaveEntitiesPage(waveEntities, request, ctx, {
+      groupIdsUserIsEligibleFor: eligibleGroups
+    });
   }
 
   private async getReadableWaveContext(ctx: RequestContext): Promise<{
@@ -575,12 +597,16 @@ export class ApiWaveV2Service {
   private async mapWaveEntitiesPage(
     waveEntities: WaveEntity[],
     request: { readonly page: number; readonly page_size: number },
-    ctx: RequestContext
+    ctx: RequestContext,
+    options: {
+      readonly groupIdsUserIsEligibleFor?: string[];
+    } = {}
   ): Promise<ApiWaveOverviewPage> {
     const pageWaveEntities = waveEntities.slice(0, request.page_size);
     const wavesById = await this.apiWaveOverviewMapper.mapWaves(
       pageWaveEntities,
-      ctx
+      ctx,
+      options
     );
     return {
       data: pageWaveEntities.map((wave) => wavesById[wave.id]),

--- a/src/api-serverless/src/waves/wave-cache-key.test.ts
+++ b/src/api-serverless/src/waves/wave-cache-key.test.ts
@@ -1,0 +1,24 @@
+import { stableCacheHash } from './wave-cache-key';
+
+describe('stableCacheHash', () => {
+  it('ignores object key ordering and undefined values', () => {
+    expect(
+      stableCacheHash({
+        b: 2,
+        a: 1,
+        ignored: undefined
+      })
+    ).toEqual(
+      stableCacheHash({
+        a: 1,
+        b: 2
+      })
+    );
+  });
+
+  it('serializes dates consistently', () => {
+    expect(stableCacheHash({ updatedAt: new Date(1700000000000) })).toEqual(
+      stableCacheHash({ updatedAt: '2023-11-14T22:13:20.000Z' })
+    );
+  });
+});

--- a/src/api-serverless/src/waves/wave-cache-key.ts
+++ b/src/api-serverless/src/waves/wave-cache-key.ts
@@ -6,6 +6,10 @@ export function stableCacheHash(value: unknown): string {
     .digest('hex');
 }
 
+export function compareCacheStrings(a: string, b: string): number {
+  return a.localeCompare(b);
+}
+
 function stableCacheValue(value: unknown): unknown {
   if (Array.isArray(value)) {
     return value.map(stableCacheValue);
@@ -17,7 +21,7 @@ function stableCacheValue(value: unknown): unknown {
     return value;
   }
   return Object.keys(value)
-    .sort()
+    .sort(compareCacheStrings)
     .reduce(
       (acc, key) => {
         const rawValue = (value as Record<string, unknown>)[key];

--- a/src/api-serverless/src/waves/wave-cache-key.ts
+++ b/src/api-serverless/src/waves/wave-cache-key.ts
@@ -10,6 +10,9 @@ function stableCacheValue(value: unknown): unknown {
   if (Array.isArray(value)) {
     return value.map(stableCacheValue);
   }
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
   if (!value || typeof value !== 'object') {
     return value;
   }

--- a/src/api-serverless/src/waves/wave-cache-key.ts
+++ b/src/api-serverless/src/waves/wave-cache-key.ts
@@ -1,0 +1,28 @@
+import { createHash } from 'node:crypto';
+
+export function stableCacheHash(value: unknown): string {
+  return createHash('sha256')
+    .update(JSON.stringify(stableCacheValue(value)))
+    .digest('hex');
+}
+
+function stableCacheValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(stableCacheValue);
+  }
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+  return Object.keys(value)
+    .sort()
+    .reduce(
+      (acc, key) => {
+        const rawValue = (value as Record<string, unknown>)[key];
+        if (rawValue !== undefined) {
+          acc[key] = stableCacheValue(rawValue);
+        }
+        return acc;
+      },
+      {} as Record<string, unknown>
+    );
+}

--- a/src/api-serverless/src/waves/wave-followed-subwave-overview-cache.test.ts
+++ b/src/api-serverless/src/waves/wave-followed-subwave-overview-cache.test.ts
@@ -1,0 +1,77 @@
+import { redisGet, redisSetJson } from '@/redis';
+import { withFollowedSubwaveOverviewContextCache } from './wave-followed-subwave-overview-cache';
+
+jest.mock('@/redis', () => ({
+  redisGet: jest.fn(),
+  redisSetJson: jest.fn()
+}));
+
+const redisGetMock = jest.mocked(redisGet);
+const redisSetJsonMock = jest.mocked(redisSetJson);
+
+describe('followed subwave overview cache', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns cached context without calling the loader', async () => {
+    const cached = {
+      'wave-1': {
+        followed_subwaves_count: 2,
+        latest_followed_subwave_activity_timestamp: 100,
+        hidden_followed_subwave_unread_drops: 1,
+        first_hidden_followed_subwave_unread_drop_serial_no: 7
+      }
+    };
+    redisGetMock.mockResolvedValue(cached);
+    const getValue = jest.fn();
+
+    await expect(
+      withFollowedSubwaveOverviewContextCache({
+        identityId: 'viewer-1',
+        parentWaveIds: ['wave-1'],
+        eligibleGroups: ['group-1'],
+        cacheable: true,
+        getValue
+      })
+    ).resolves.toBe(cached);
+
+    expect(getValue).not.toHaveBeenCalled();
+    expect(redisSetJsonMock).not.toHaveBeenCalled();
+  });
+
+  it('coalesces equivalent misses regardless of input ordering', async () => {
+    redisGetMock.mockResolvedValue(null);
+    const loaded = {
+      'wave-1': {
+        followed_subwaves_count: 1,
+        latest_followed_subwave_activity_timestamp: null,
+        hidden_followed_subwave_unread_drops: 0,
+        first_hidden_followed_subwave_unread_drop_serial_no: null
+      }
+    };
+    const getValue = jest.fn().mockResolvedValue(loaded);
+
+    await expect(
+      Promise.all([
+        withFollowedSubwaveOverviewContextCache({
+          identityId: 'viewer-1',
+          parentWaveIds: ['wave-1', 'wave-2'],
+          eligibleGroups: ['group-2', 'group-1'],
+          cacheable: true,
+          getValue
+        }),
+        withFollowedSubwaveOverviewContextCache({
+          identityId: 'viewer-1',
+          parentWaveIds: ['wave-2', 'wave-1'],
+          eligibleGroups: ['group-1', 'group-2'],
+          cacheable: true,
+          getValue
+        })
+      ])
+    ).resolves.toEqual([loaded, loaded]);
+
+    expect(getValue).toHaveBeenCalledTimes(1);
+    expect(redisSetJsonMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/api-serverless/src/waves/wave-followed-subwave-overview-cache.test.ts
+++ b/src/api-serverless/src/waves/wave-followed-subwave-overview-cache.test.ts
@@ -1,5 +1,8 @@
 import { redisGet, redisSetJson } from '@/redis';
-import { withFollowedSubwaveOverviewContextCache } from './wave-followed-subwave-overview-cache';
+import {
+  withFollowedSubwaveOverviewContextCache,
+  withInFlightFollowedSubwaveUnreadRead
+} from './wave-followed-subwave-overview-cache';
 
 jest.mock('@/redis', () => ({
   redisGet: jest.fn(),
@@ -69,5 +72,46 @@ describe('followed subwave overview cache', () => {
 
     expect(getValue).toHaveBeenCalledTimes(1);
     expect(redisSetJsonMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('coalesces equivalent hidden unread reads without caching them', async () => {
+    const loaded = [
+      {
+        parent_wave_id: 'wave-1',
+        hidden_followed_subwave_unread_drops: 2,
+        first_hidden_followed_subwave_unread_drop_serial_no: 10
+      }
+    ];
+    const getValue = jest.fn().mockResolvedValue(loaded);
+
+    await expect(
+      Promise.all([
+        withInFlightFollowedSubwaveUnreadRead({
+          identityId: 'viewer-1',
+          parentWaveIds: ['wave-1', 'wave-2'],
+          eligibleGroups: ['group-2', 'group-1'],
+          getValue
+        }),
+        withInFlightFollowedSubwaveUnreadRead({
+          identityId: 'viewer-1',
+          parentWaveIds: ['wave-2', 'wave-1'],
+          eligibleGroups: ['group-1', 'group-2'],
+          getValue
+        })
+      ])
+    ).resolves.toEqual([loaded, loaded]);
+
+    expect(getValue).toHaveBeenCalledTimes(1);
+    expect(redisGetMock).not.toHaveBeenCalled();
+    expect(redisSetJsonMock).not.toHaveBeenCalled();
+
+    await withInFlightFollowedSubwaveUnreadRead({
+      identityId: 'viewer-1',
+      parentWaveIds: ['wave-1'],
+      eligibleGroups: ['group-1'],
+      getValue
+    });
+
+    expect(getValue).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/api-serverless/src/waves/wave-followed-subwave-overview-cache.test.ts
+++ b/src/api-serverless/src/waves/wave-followed-subwave-overview-cache.test.ts
@@ -18,9 +18,7 @@ describe('followed subwave overview cache', () => {
     const cached = {
       'wave-1': {
         followed_subwaves_count: 2,
-        latest_followed_subwave_activity_timestamp: 100,
-        hidden_followed_subwave_unread_drops: 1,
-        first_hidden_followed_subwave_unread_drop_serial_no: 7
+        latest_followed_subwave_activity_timestamp: 100
       }
     };
     redisGetMock.mockResolvedValue(cached);
@@ -45,9 +43,7 @@ describe('followed subwave overview cache', () => {
     const loaded = {
       'wave-1': {
         followed_subwaves_count: 1,
-        latest_followed_subwave_activity_timestamp: null,
-        hidden_followed_subwave_unread_drops: 0,
-        first_hidden_followed_subwave_unread_drop_serial_no: null
+        latest_followed_subwave_activity_timestamp: null
       }
     };
     const getValue = jest.fn().mockResolvedValue(loaded);

--- a/src/api-serverless/src/waves/wave-followed-subwave-overview-cache.ts
+++ b/src/api-serverless/src/waves/wave-followed-subwave-overview-cache.ts
@@ -15,6 +15,7 @@ const inFlightReads = new Map<
   string,
   Promise<Record<string, CachedFollowedSubwaveOverviewContext>>
 >();
+const inFlightUnreadReads = new Map<string, Promise<unknown>>();
 
 export async function withFollowedSubwaveOverviewContextCache({
   identityId,
@@ -57,6 +58,42 @@ export async function withFollowedSubwaveOverviewContextCache({
   } finally {
     if (inFlightReads.get(cacheKey) === promise) {
       inFlightReads.delete(cacheKey);
+    }
+  }
+}
+
+export async function withInFlightFollowedSubwaveUnreadRead<T>({
+  identityId,
+  parentWaveIds,
+  eligibleGroups,
+  getValue
+}: {
+  readonly identityId: string;
+  readonly parentWaveIds: string[];
+  readonly eligibleGroups: string[];
+  readonly getValue: () => Promise<T>;
+}): Promise<T> {
+  if (!parentWaveIds.length) {
+    return await getValue();
+  }
+
+  const cacheKey = `${CACHE_KEY_PREFIX}:unread:${stableCacheHash({
+    identityId,
+    parentWaveIds: distinctSorted(parentWaveIds),
+    eligibleGroups: distinctSorted(eligibleGroups)
+  })}`;
+  const existing = inFlightUnreadReads.get(cacheKey);
+  if (existing) {
+    return (await existing) as T;
+  }
+
+  const promise = getValue();
+  inFlightUnreadReads.set(cacheKey, promise);
+  try {
+    return await promise;
+  } finally {
+    if (inFlightUnreadReads.get(cacheKey) === promise) {
+      inFlightUnreadReads.delete(cacheKey);
     }
   }
 }

--- a/src/api-serverless/src/waves/wave-followed-subwave-overview-cache.ts
+++ b/src/api-serverless/src/waves/wave-followed-subwave-overview-cache.ts
@@ -1,7 +1,7 @@
 import { Logger } from '@/logging';
 import { redisGet, redisSetJson } from '@/redis';
 import { Time } from '@/time';
-import { stableCacheHash } from './wave-cache-key';
+import { compareCacheStrings, stableCacheHash } from './wave-cache-key';
 
 export interface CachedFollowedSubwaveOverviewContext {
   readonly followed_subwaves_count: number;
@@ -43,7 +43,7 @@ export async function withFollowedSubwaveOverviewContextCache({
   }
 
   const existing = inFlightReads.get(cacheKey);
-  if (existing) {
+  if (existing !== undefined) {
     return await existing;
   }
 
@@ -83,7 +83,7 @@ export async function withInFlightFollowedSubwaveUnreadRead<T>({
     eligibleGroups: distinctSorted(eligibleGroups)
   })}`;
   const existing = inFlightUnreadReads.get(cacheKey);
-  if (existing) {
+  if (existing !== undefined) {
     return (await existing) as T;
   }
 
@@ -115,7 +115,7 @@ function getCacheKey({
 }
 
 function distinctSorted(values: string[]): string[] {
-  return Array.from(new Set(values)).sort();
+  return Array.from(new Set(values)).sort(compareCacheStrings);
 }
 
 async function readCache(

--- a/src/api-serverless/src/waves/wave-followed-subwave-overview-cache.ts
+++ b/src/api-serverless/src/waves/wave-followed-subwave-overview-cache.ts
@@ -1,0 +1,102 @@
+import type { FollowedSubwaveOverviewContext } from '@/api/waves/waves.api.db';
+import { Logger } from '@/logging';
+import { redisGet, redisSetJson } from '@/redis';
+import { Time } from '@/time';
+import { stableCacheHash } from './wave-cache-key';
+
+const logger = Logger.get('WAVE_FOLLOWED_SUBWAVE_OVERVIEW_CACHE');
+const CACHE_TTL = Time.seconds(30);
+const CACHE_KEY_PREFIX = 'cache_6529_wave_followed_subwave_overview_v1';
+const inFlightReads = new Map<
+  string,
+  Promise<Record<string, FollowedSubwaveOverviewContext>>
+>();
+
+export async function withFollowedSubwaveOverviewContextCache({
+  identityId,
+  parentWaveIds,
+  eligibleGroups,
+  cacheable,
+  getValue
+}: {
+  readonly identityId: string;
+  readonly parentWaveIds: string[];
+  readonly eligibleGroups: string[];
+  readonly cacheable: boolean;
+  readonly getValue: () => Promise<
+    Record<string, FollowedSubwaveOverviewContext>
+  >;
+}): Promise<Record<string, FollowedSubwaveOverviewContext>> {
+  if (!cacheable || !parentWaveIds.length) {
+    return await getValue();
+  }
+
+  const cacheKey = getCacheKey({ identityId, parentWaveIds, eligibleGroups });
+  const cached = await readCache(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
+  const existing = inFlightReads.get(cacheKey);
+  if (existing) {
+    return await existing;
+  }
+
+  const promise = (async () => {
+    const value = await getValue();
+    await writeCache(cacheKey, value);
+    return value;
+  })();
+  inFlightReads.set(cacheKey, promise);
+  try {
+    return await promise;
+  } finally {
+    if (inFlightReads.get(cacheKey) === promise) {
+      inFlightReads.delete(cacheKey);
+    }
+  }
+}
+
+function getCacheKey({
+  identityId,
+  parentWaveIds,
+  eligibleGroups
+}: {
+  readonly identityId: string;
+  readonly parentWaveIds: string[];
+  readonly eligibleGroups: string[];
+}): string {
+  return `${CACHE_KEY_PREFIX}:${stableCacheHash({
+    identityId,
+    parentWaveIds: distinctSorted(parentWaveIds),
+    eligibleGroups: distinctSorted(eligibleGroups)
+  })}`;
+}
+
+function distinctSorted(values: string[]): string[] {
+  return Array.from(new Set(values)).sort();
+}
+
+async function readCache(
+  cacheKey: string
+): Promise<Record<string, FollowedSubwaveOverviewContext> | null> {
+  try {
+    return await redisGet<Record<string, FollowedSubwaveOverviewContext>>(
+      cacheKey
+    );
+  } catch (error) {
+    logger.warn('Failed to read followed subwave overview cache', error);
+    return null;
+  }
+}
+
+async function writeCache(
+  cacheKey: string,
+  value: Record<string, FollowedSubwaveOverviewContext>
+): Promise<void> {
+  try {
+    await redisSetJson(cacheKey, value, CACHE_TTL);
+  } catch (error) {
+    logger.warn('Failed to write followed subwave overview cache', error);
+  }
+}

--- a/src/api-serverless/src/waves/wave-followed-subwave-overview-cache.ts
+++ b/src/api-serverless/src/waves/wave-followed-subwave-overview-cache.ts
@@ -1,15 +1,19 @@
-import type { FollowedSubwaveOverviewContext } from '@/api/waves/waves.api.db';
 import { Logger } from '@/logging';
 import { redisGet, redisSetJson } from '@/redis';
 import { Time } from '@/time';
 import { stableCacheHash } from './wave-cache-key';
+
+export interface CachedFollowedSubwaveOverviewContext {
+  readonly followed_subwaves_count: number;
+  readonly latest_followed_subwave_activity_timestamp: number | null;
+}
 
 const logger = Logger.get('WAVE_FOLLOWED_SUBWAVE_OVERVIEW_CACHE');
 const CACHE_TTL = Time.seconds(30);
 const CACHE_KEY_PREFIX = 'cache_6529_wave_followed_subwave_overview_v1';
 const inFlightReads = new Map<
   string,
-  Promise<Record<string, FollowedSubwaveOverviewContext>>
+  Promise<Record<string, CachedFollowedSubwaveOverviewContext>>
 >();
 
 export async function withFollowedSubwaveOverviewContextCache({
@@ -24,9 +28,9 @@ export async function withFollowedSubwaveOverviewContextCache({
   readonly eligibleGroups: string[];
   readonly cacheable: boolean;
   readonly getValue: () => Promise<
-    Record<string, FollowedSubwaveOverviewContext>
+    Record<string, CachedFollowedSubwaveOverviewContext>
   >;
-}): Promise<Record<string, FollowedSubwaveOverviewContext>> {
+}): Promise<Record<string, CachedFollowedSubwaveOverviewContext>> {
   if (!cacheable || !parentWaveIds.length) {
     return await getValue();
   }
@@ -79,9 +83,9 @@ function distinctSorted(values: string[]): string[] {
 
 async function readCache(
   cacheKey: string
-): Promise<Record<string, FollowedSubwaveOverviewContext> | null> {
+): Promise<Record<string, CachedFollowedSubwaveOverviewContext> | null> {
   try {
-    return await redisGet<Record<string, FollowedSubwaveOverviewContext>>(
+    return await redisGet<Record<string, CachedFollowedSubwaveOverviewContext>>(
       cacheKey
     );
   } catch (error) {
@@ -92,7 +96,7 @@ async function readCache(
 
 async function writeCache(
   cacheKey: string,
-  value: Record<string, FollowedSubwaveOverviewContext>
+  value: Record<string, CachedFollowedSubwaveOverviewContext>
 ): Promise<void> {
   try {
     await redisSetJson(cacheKey, value, CACHE_TTL);

--- a/src/api-serverless/src/waves/wave-overview-response-cache.test.ts
+++ b/src/api-serverless/src/waves/wave-overview-response-cache.test.ts
@@ -1,0 +1,80 @@
+import { ApiWavesV2ListType } from '@/api/generated/models/ApiWavesV2ListType';
+import { redisGet, redisSetJson } from '@/redis';
+import { withWaveOverviewResponseCache } from './wave-overview-response-cache';
+
+jest.mock('@/redis', () => ({
+  redisGet: jest.fn(),
+  redisSetJson: jest.fn()
+}));
+
+const redisGetMock = jest.mocked(redisGet);
+const redisSetJsonMock = jest.mocked(redisSetJson);
+
+describe('wave overview response cache', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns cached responses without calling the loader', async () => {
+    const cached = {
+      data: [{ id: 'wave-1' }],
+      page: 1,
+      next: false
+    };
+    redisGetMock.mockResolvedValue(cached as any);
+    const getValue = jest.fn();
+
+    await expect(
+      withWaveOverviewResponseCache({
+        contextProfileId: 'viewer-1',
+        request: {
+          view: ApiWavesV2ListType.Overview,
+          page: 1,
+          page_size: 10
+        } as any,
+        getValue
+      })
+    ).resolves.toBe(cached);
+
+    expect(getValue).not.toHaveBeenCalled();
+    expect(redisSetJsonMock).not.toHaveBeenCalled();
+  });
+
+  it('coalesces concurrent misses and writes the loaded response', async () => {
+    redisGetMock.mockResolvedValue(null);
+    const loaded = {
+      data: [{ id: 'wave-1' }],
+      page: 1,
+      next: false
+    };
+    const getValue = jest.fn().mockResolvedValue(loaded);
+    const request = {
+      view: ApiWavesV2ListType.Overview,
+      page: 1,
+      page_size: 10
+    } as any;
+
+    await expect(
+      Promise.all([
+        withWaveOverviewResponseCache({
+          contextProfileId: 'viewer-1',
+          request,
+          getValue
+        }),
+        withWaveOverviewResponseCache({
+          contextProfileId: 'viewer-1',
+          request,
+          getValue
+        })
+      ])
+    ).resolves.toEqual([loaded, loaded]);
+
+    expect(getValue).toHaveBeenCalledTimes(1);
+    expect(redisSetJsonMock).toHaveBeenCalledTimes(1);
+    expect(redisSetJsonMock).toHaveBeenCalledWith(
+      expect.stringMatching(/^cache_6529_api_v2_waves_response_v1:/),
+      loaded,
+      expect.any(Object)
+    );
+  });
+});

--- a/src/api-serverless/src/waves/wave-overview-response-cache.test.ts
+++ b/src/api-serverless/src/waves/wave-overview-response-cache.test.ts
@@ -27,6 +27,7 @@ describe('wave overview response cache', () => {
     await expect(
       withWaveOverviewResponseCache({
         contextProfileId: 'viewer-1',
+        eligibleGroups: ['group-1'],
         request: {
           view: ApiWavesV2ListType.Overview,
           page: 1,
@@ -58,11 +59,13 @@ describe('wave overview response cache', () => {
       Promise.all([
         withWaveOverviewResponseCache({
           contextProfileId: 'viewer-1',
+          eligibleGroups: ['group-1'],
           request,
           getValue
         }),
         withWaveOverviewResponseCache({
           contextProfileId: 'viewer-1',
+          eligibleGroups: ['group-1'],
           request,
           getValue
         })
@@ -76,5 +79,40 @@ describe('wave overview response cache', () => {
       loaded,
       expect.any(Object)
     );
+  });
+
+  it('uses eligible groups to separate otherwise identical cache keys', async () => {
+    redisGetMock.mockResolvedValue(null);
+    const request = {
+      view: ApiWavesV2ListType.Overview,
+      page: 1,
+      page_size: 10
+    } as any;
+
+    await Promise.all([
+      withWaveOverviewResponseCache({
+        contextProfileId: 'viewer-1',
+        eligibleGroups: ['group-1'],
+        request,
+        getValue: jest.fn().mockResolvedValue({
+          data: [{ id: 'wave-1' }],
+          page: 1,
+          next: false
+        })
+      }),
+      withWaveOverviewResponseCache({
+        contextProfileId: 'viewer-1',
+        eligibleGroups: ['group-2'],
+        request,
+        getValue: jest.fn().mockResolvedValue({
+          data: [{ id: 'wave-2' }],
+          page: 1,
+          next: false
+        })
+      })
+    ]);
+
+    const writtenKeys = redisSetJsonMock.mock.calls.map(([key]) => key);
+    expect(new Set(writtenKeys).size).toBe(2);
   });
 });

--- a/src/api-serverless/src/waves/wave-overview-response-cache.ts
+++ b/src/api-serverless/src/waves/wave-overview-response-cache.ts
@@ -6,6 +6,8 @@ import { Time } from '@/time';
 import { stableCacheHash } from './wave-cache-key';
 
 const logger = Logger.get('WAVE_OVERVIEW_RESPONSE_CACHE');
+// The full response can hold viewer counters/unread badges up to 10 seconds
+// stale. Visibility stays isolated because eligible groups are part of the key.
 const CACHE_TTL = Time.seconds(10);
 const CACHE_KEY_PREFIX = 'cache_6529_api_v2_waves_response_v1';
 const inFlightResponseReads = new Map<string, Promise<ApiWaveOverviewPage>>();

--- a/src/api-serverless/src/waves/wave-overview-response-cache.ts
+++ b/src/api-serverless/src/waves/wave-overview-response-cache.ts
@@ -1,0 +1,81 @@
+import { ApiWaveOverviewPage } from '@/api/generated/models/ApiWaveOverviewPage';
+import type { FindWavesV2Request } from '@/api/waves/api-wave-v2.service';
+import { Logger } from '@/logging';
+import { redisGet, redisSetJson } from '@/redis';
+import { Time } from '@/time';
+import { stableCacheHash } from './wave-cache-key';
+
+const logger = Logger.get('WAVE_OVERVIEW_RESPONSE_CACHE');
+const CACHE_TTL = Time.seconds(10);
+const CACHE_KEY_PREFIX = 'cache_6529_api_v2_waves_response_v1';
+const inFlightResponseReads = new Map<string, Promise<ApiWaveOverviewPage>>();
+
+export async function withWaveOverviewResponseCache({
+  contextProfileId,
+  request,
+  getValue
+}: {
+  readonly contextProfileId: string | null;
+  readonly request: FindWavesV2Request;
+  readonly getValue: () => Promise<ApiWaveOverviewPage>;
+}): Promise<ApiWaveOverviewPage> {
+  const cacheKey = getResponseCacheKey({ contextProfileId, request });
+  const cached = await readResponseCache(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
+  const existing = inFlightResponseReads.get(cacheKey);
+  if (existing) {
+    return await existing;
+  }
+
+  const promise = (async () => {
+    const value = await getValue();
+    await writeResponseCache(cacheKey, value);
+    return value;
+  })();
+  inFlightResponseReads.set(cacheKey, promise);
+  try {
+    return await promise;
+  } finally {
+    if (inFlightResponseReads.get(cacheKey) === promise) {
+      inFlightResponseReads.delete(cacheKey);
+    }
+  }
+}
+
+function getResponseCacheKey({
+  contextProfileId,
+  request
+}: {
+  readonly contextProfileId: string | null;
+  readonly request: FindWavesV2Request;
+}): string {
+  return `${CACHE_KEY_PREFIX}:${stableCacheHash({
+    contextProfileId: contextProfileId ?? 'anonymous',
+    request
+  })}`;
+}
+
+async function readResponseCache(
+  cacheKey: string
+): Promise<ApiWaveOverviewPage | null> {
+  try {
+    return await redisGet<ApiWaveOverviewPage>(cacheKey);
+  } catch (error) {
+    logger.warn('Failed to read wave overview response cache', error);
+    return null;
+  }
+}
+
+async function writeResponseCache(
+  cacheKey: string,
+  value: ApiWaveOverviewPage
+): Promise<void> {
+  try {
+    await redisSetJson(cacheKey, value, CACHE_TTL);
+  } catch (error) {
+    logger.warn('Failed to write wave overview response cache', error);
+  }
+}

--- a/src/api-serverless/src/waves/wave-overview-response-cache.ts
+++ b/src/api-serverless/src/waves/wave-overview-response-cache.ts
@@ -12,14 +12,20 @@ const inFlightResponseReads = new Map<string, Promise<ApiWaveOverviewPage>>();
 
 export async function withWaveOverviewResponseCache({
   contextProfileId,
+  eligibleGroups,
   request,
   getValue
 }: {
   readonly contextProfileId: string | null;
+  readonly eligibleGroups: string[];
   readonly request: FindWavesV2Request;
   readonly getValue: () => Promise<ApiWaveOverviewPage>;
 }): Promise<ApiWaveOverviewPage> {
-  const cacheKey = getResponseCacheKey({ contextProfileId, request });
+  const cacheKey = getResponseCacheKey({
+    contextProfileId,
+    eligibleGroups,
+    request
+  });
   const cached = await readResponseCache(cacheKey);
   if (cached) {
     return cached;
@@ -47,13 +53,16 @@ export async function withWaveOverviewResponseCache({
 
 function getResponseCacheKey({
   contextProfileId,
+  eligibleGroups,
   request
 }: {
   readonly contextProfileId: string | null;
+  readonly eligibleGroups: string[];
   readonly request: FindWavesV2Request;
 }): string {
   return `${CACHE_KEY_PREFIX}:${stableCacheHash({
     contextProfileId: contextProfileId ?? 'anonymous',
+    eligibleGroups: Array.from(new Set(eligibleGroups)).sort(),
     request
   })}`;
 }

--- a/src/api-serverless/src/waves/wave-overview-response-cache.ts
+++ b/src/api-serverless/src/waves/wave-overview-response-cache.ts
@@ -3,7 +3,7 @@ import type { FindWavesV2Request } from '@/api/waves/api-wave-v2.service';
 import { Logger } from '@/logging';
 import { redisGet, redisSetJson } from '@/redis';
 import { Time } from '@/time';
-import { stableCacheHash } from './wave-cache-key';
+import { compareCacheStrings, stableCacheHash } from './wave-cache-key';
 
 const logger = Logger.get('WAVE_OVERVIEW_RESPONSE_CACHE');
 // The full response can hold viewer counters/unread badges up to 10 seconds
@@ -34,7 +34,7 @@ export async function withWaveOverviewResponseCache({
   }
 
   const existing = inFlightResponseReads.get(cacheKey);
-  if (existing) {
+  if (existing !== undefined) {
     return await existing;
   }
 
@@ -64,7 +64,9 @@ function getResponseCacheKey({
 }): string {
   return `${CACHE_KEY_PREFIX}:${stableCacheHash({
     contextProfileId: contextProfileId ?? 'anonymous',
-    eligibleGroups: Array.from(new Set(eligibleGroups)).sort(),
+    eligibleGroups: Array.from(new Set(eligibleGroups)).sort(
+      compareCacheStrings
+    ),
     request
   })}`;
 }

--- a/src/api-serverless/src/waves/wave-overview-static-cache.test.ts
+++ b/src/api-serverless/src/waves/wave-overview-static-cache.test.ts
@@ -30,7 +30,6 @@ describe('wave overview static cache', () => {
 
   it('maps cached entries by wave id and reports misses', async () => {
     const cachedEntry = {
-      metrics: null,
       descriptionDropPartOne: null,
       descriptionDropPartOneMedia: [],
       creator: null
@@ -63,7 +62,6 @@ describe('wave overview static cache', () => {
   it('writes entries and coalesces equivalent miss loads', async () => {
     const loaded = {
       'wave-1': {
-        metrics: null,
         descriptionDropPartOne: null,
         descriptionDropPartOneMedia: [],
         creator: null

--- a/src/api-serverless/src/waves/wave-overview-static-cache.test.ts
+++ b/src/api-serverless/src/waves/wave-overview-static-cache.test.ts
@@ -96,4 +96,20 @@ describe('wave overview static cache', () => {
       expect.any(Object)
     );
   });
+
+  it('normalizes date-shaped updated_at values in cache keys', async () => {
+    redisGetManyMock.mockResolvedValue({});
+    const updatedAt = new Date(1700000000000);
+
+    const dateResult = await readWaveOverviewStaticCache([
+      makeWave({ updated_at: updatedAt })
+    ]);
+    const timestampResult = await readWaveOverviewStaticCache([
+      makeWave({ updated_at: updatedAt.getTime() })
+    ]);
+
+    expect(dateResult.cacheKeysByWaveId['wave-1']).toEqual(
+      timestampResult.cacheKeysByWaveId['wave-1']
+    );
+  });
 });

--- a/src/api-serverless/src/waves/wave-overview-static-cache.test.ts
+++ b/src/api-serverless/src/waves/wave-overview-static-cache.test.ts
@@ -1,0 +1,101 @@
+import { redisGetMany, redisSetJson } from '@/redis';
+import {
+  readWaveOverviewStaticCache,
+  withInFlightWaveOverviewStaticCacheRead,
+  writeWaveOverviewStaticCache
+} from './wave-overview-static-cache';
+
+jest.mock('@/redis', () => ({
+  redisGetMany: jest.fn(),
+  redisSetJson: jest.fn()
+}));
+
+const redisGetManyMock = jest.mocked(redisGetMany);
+const redisSetJsonMock = jest.mocked(redisSetJson);
+
+function makeWave(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'wave-1',
+    created_by: 'creator-1',
+    description_drop_id: 'description-drop-1',
+    updated_at: null,
+    ...overrides
+  } as any;
+}
+
+describe('wave overview static cache', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('maps cached entries by wave id and reports misses', async () => {
+    const cachedEntry = {
+      metrics: null,
+      descriptionDropPartOne: null,
+      descriptionDropPartOneMedia: [],
+      creator: null
+    };
+    redisGetManyMock.mockImplementation(async (keys: string[]) => ({
+      [keys[0]]: cachedEntry
+    }));
+
+    await expect(
+      readWaveOverviewStaticCache([
+        makeWave({ id: 'wave-1' }),
+        makeWave({ id: 'wave-2' })
+      ])
+    ).resolves.toEqual({
+      cachedByWaveId: {
+        'wave-1': cachedEntry
+      },
+      uncachedWaveIds: ['wave-2'],
+      cacheKeysByWaveId: expect.objectContaining({
+        'wave-1': expect.stringMatching(
+          /^cache_6529_wave_overview_static_v1:wave-1:/
+        ),
+        'wave-2': expect.stringMatching(
+          /^cache_6529_wave_overview_static_v1:wave-2:/
+        )
+      })
+    });
+  });
+
+  it('writes entries and coalesces equivalent miss loads', async () => {
+    const loaded = {
+      'wave-1': {
+        metrics: null,
+        descriptionDropPartOne: null,
+        descriptionDropPartOneMedia: [],
+        creator: null
+      }
+    };
+    const getValue = jest.fn().mockResolvedValue(loaded);
+
+    await expect(
+      Promise.all([
+        withInFlightWaveOverviewStaticCacheRead({
+          cacheKeysByWaveId: { 'wave-1': 'cache-key-1' },
+          waveIds: ['wave-1'],
+          getValue
+        }),
+        withInFlightWaveOverviewStaticCacheRead({
+          cacheKeysByWaveId: { 'wave-1': 'cache-key-1' },
+          waveIds: ['wave-1'],
+          getValue
+        })
+      ])
+    ).resolves.toEqual([loaded, loaded]);
+
+    await writeWaveOverviewStaticCache({
+      entriesByWaveId: loaded,
+      cacheKeysByWaveId: { 'wave-1': 'cache-key-1' }
+    });
+
+    expect(getValue).toHaveBeenCalledTimes(1);
+    expect(redisSetJsonMock).toHaveBeenCalledWith(
+      'cache-key-1',
+      loaded['wave-1'],
+      expect.any(Object)
+    );
+  });
+});

--- a/src/api-serverless/src/waves/wave-overview-static-cache.ts
+++ b/src/api-serverless/src/waves/wave-overview-static-cache.ts
@@ -4,7 +4,7 @@ import { WaveEntity } from '@/entities/IWave';
 import { Logger } from '@/logging';
 import { redisGetMany, redisSetJson } from '@/redis';
 import { Time } from '@/time';
-import { stableCacheHash } from './wave-cache-key';
+import { compareCacheStrings, stableCacheHash } from './wave-cache-key';
 
 export interface WaveOverviewStaticCacheEntry {
   readonly descriptionDropPartOne: DropPartEntity | null;
@@ -109,10 +109,10 @@ export async function withInFlightWaveOverviewStaticCacheRead({
 
   const inFlightKey = waveIds
     .map((waveId) => cacheKeysByWaveId[waveId] ?? waveId)
-    .sort()
+    .sort(compareCacheStrings)
     .join('|');
   const existing = inFlightReads.get(inFlightKey);
-  if (existing) {
+  if (existing !== undefined) {
     return await existing;
   }
 

--- a/src/api-serverless/src/waves/wave-overview-static-cache.ts
+++ b/src/api-serverless/src/waves/wave-overview-static-cache.ts
@@ -133,12 +133,19 @@ function getCacheKeysByWaveId(waves: WaveEntity[]): Record<string, string> {
       acc[wave.id] = `${CACHE_KEY_PREFIX}:${wave.id}:${stableCacheHash({
         createdBy: wave.created_by,
         descriptionDropId: wave.description_drop_id,
-        updatedAt: wave.updated_at
+        updatedAt: normalizeUpdatedAt(wave.updated_at)
       })}`;
       return acc;
     },
     {} as Record<string, string>
   );
+}
+
+function normalizeUpdatedAt(updatedAt: unknown): number | string | null {
+  if (updatedAt instanceof Date) {
+    return updatedAt.getTime();
+  }
+  return (updatedAt as number | string | null) ?? null;
 }
 
 function distinctWaves(waves: WaveEntity[]): WaveEntity[] {

--- a/src/api-serverless/src/waves/wave-overview-static-cache.ts
+++ b/src/api-serverless/src/waves/wave-overview-static-cache.ts
@@ -1,14 +1,12 @@
 import { ApiProfileMin } from '@/api/generated/models/ApiProfileMin';
 import { DropMediaEntity, DropPartEntity } from '@/entities/IDrop';
 import { WaveEntity } from '@/entities/IWave';
-import { WaveMetricEntity } from '@/entities/IWaveMetric';
 import { Logger } from '@/logging';
 import { redisGetMany, redisSetJson } from '@/redis';
 import { Time } from '@/time';
 import { stableCacheHash } from './wave-cache-key';
 
 export interface WaveOverviewStaticCacheEntry {
-  readonly metrics: WaveMetricEntity | null;
   readonly descriptionDropPartOne: DropPartEntity | null;
   readonly descriptionDropPartOneMedia: DropMediaEntity[];
   readonly creator: ApiProfileMin | null;

--- a/src/api-serverless/src/waves/wave-overview-static-cache.ts
+++ b/src/api-serverless/src/waves/wave-overview-static-cache.ts
@@ -1,0 +1,155 @@
+import { ApiProfileMin } from '@/api/generated/models/ApiProfileMin';
+import { DropMediaEntity, DropPartEntity } from '@/entities/IDrop';
+import { WaveEntity } from '@/entities/IWave';
+import { WaveMetricEntity } from '@/entities/IWaveMetric';
+import { Logger } from '@/logging';
+import { redisGetMany, redisSetJson } from '@/redis';
+import { Time } from '@/time';
+import { stableCacheHash } from './wave-cache-key';
+
+export interface WaveOverviewStaticCacheEntry {
+  readonly metrics: WaveMetricEntity | null;
+  readonly descriptionDropPartOne: DropPartEntity | null;
+  readonly descriptionDropPartOneMedia: DropMediaEntity[];
+  readonly creator: ApiProfileMin | null;
+}
+
+export interface WaveOverviewStaticCacheReadResult {
+  readonly cachedByWaveId: Record<string, WaveOverviewStaticCacheEntry>;
+  readonly uncachedWaveIds: string[];
+  readonly cacheKeysByWaveId: Record<string, string>;
+}
+
+const logger = Logger.get('WAVE_OVERVIEW_STATIC_CACHE');
+const CACHE_TTL = Time.seconds(30);
+const CACHE_KEY_PREFIX = 'cache_6529_wave_overview_static_v1';
+const inFlightReads = new Map<
+  string,
+  Promise<Record<string, WaveOverviewStaticCacheEntry>>
+>();
+
+export async function readWaveOverviewStaticCache(
+  waves: WaveEntity[],
+  cacheable = true
+): Promise<WaveOverviewStaticCacheReadResult> {
+  const uniqueWaves = distinctWaves(waves);
+  const cacheKeysByWaveId = getCacheKeysByWaveId(uniqueWaves);
+  if (!cacheable || !uniqueWaves.length) {
+    return {
+      cachedByWaveId: {},
+      uncachedWaveIds: uniqueWaves.map((wave) => wave.id),
+      cacheKeysByWaveId
+    };
+  }
+
+  try {
+    const cachedByKey = await redisGetMany<WaveOverviewStaticCacheEntry>(
+      Object.values(cacheKeysByWaveId)
+    );
+    const cachedByWaveId = uniqueWaves.reduce(
+      (acc, wave) => {
+        const cached = cachedByKey[cacheKeysByWaveId[wave.id]];
+        if (cached) {
+          acc[wave.id] = cached;
+        }
+        return acc;
+      },
+      {} as Record<string, WaveOverviewStaticCacheEntry>
+    );
+    return {
+      cachedByWaveId,
+      uncachedWaveIds: uniqueWaves
+        .map((wave) => wave.id)
+        .filter((waveId) => !cachedByWaveId[waveId]),
+      cacheKeysByWaveId
+    };
+  } catch (error) {
+    logger.warn('Failed to read wave overview static cache', error);
+    return {
+      cachedByWaveId: {},
+      uncachedWaveIds: uniqueWaves.map((wave) => wave.id),
+      cacheKeysByWaveId
+    };
+  }
+}
+
+export async function writeWaveOverviewStaticCache({
+  entriesByWaveId,
+  cacheKeysByWaveId
+}: {
+  readonly entriesByWaveId: Record<string, WaveOverviewStaticCacheEntry>;
+  readonly cacheKeysByWaveId: Record<string, string>;
+}): Promise<void> {
+  try {
+    await Promise.all(
+      Object.entries(entriesByWaveId).map(async ([waveId, entry]) => {
+        const cacheKey = cacheKeysByWaveId[waveId];
+        if (cacheKey) {
+          await redisSetJson(cacheKey, entry, CACHE_TTL);
+        }
+      })
+    );
+  } catch (error) {
+    logger.warn('Failed to write wave overview static cache', error);
+  }
+}
+
+export async function withInFlightWaveOverviewStaticCacheRead({
+  cacheKeysByWaveId,
+  waveIds,
+  getValue
+}: {
+  readonly cacheKeysByWaveId: Record<string, string>;
+  readonly waveIds: string[];
+  readonly getValue: () => Promise<
+    Record<string, WaveOverviewStaticCacheEntry>
+  >;
+}): Promise<Record<string, WaveOverviewStaticCacheEntry>> {
+  if (!waveIds.length) {
+    return {};
+  }
+
+  const inFlightKey = waveIds
+    .map((waveId) => cacheKeysByWaveId[waveId] ?? waveId)
+    .sort()
+    .join('|');
+  const existing = inFlightReads.get(inFlightKey);
+  if (existing) {
+    return await existing;
+  }
+
+  const promise = getValue();
+  inFlightReads.set(inFlightKey, promise);
+  try {
+    return await promise;
+  } finally {
+    if (inFlightReads.get(inFlightKey) === promise) {
+      inFlightReads.delete(inFlightKey);
+    }
+  }
+}
+
+function getCacheKeysByWaveId(waves: WaveEntity[]): Record<string, string> {
+  return waves.reduce(
+    (acc, wave) => {
+      acc[wave.id] = `${CACHE_KEY_PREFIX}:${wave.id}:${stableCacheHash({
+        createdBy: wave.created_by,
+        descriptionDropId: wave.description_drop_id,
+        updatedAt: wave.updated_at
+      })}`;
+      return acc;
+    },
+    {} as Record<string, string>
+  );
+}
+
+function distinctWaves(waves: WaveEntity[]): WaveEntity[] {
+  const seen = new Set<string>();
+  return waves.filter((wave) => {
+    if (seen.has(wave.id)) {
+      return false;
+    }
+    seen.add(wave.id);
+    return true;
+  });
+}

--- a/src/api-serverless/src/waves/wave-unread-cache.test.ts
+++ b/src/api-serverless/src/waves/wave-unread-cache.test.ts
@@ -3,6 +3,7 @@ import {
   invalidateWaveUnreadCacheForReaderWave,
   invalidateWaveUnreadCacheForWave,
   readWaveUnreadSummaryCache,
+  withInFlightWaveUnreadSummaryCacheMiss,
   writeWaveUnreadSummaryCache
 } from './wave-unread-cache';
 
@@ -100,6 +101,33 @@ describe('wave unread cache', () => {
       },
       expect.any(Object)
     );
+  });
+
+  it('coalesces concurrent summary cache misses for the same versioned keys', async () => {
+    const summaries = {
+      'wave-1': {
+        unread_drops_count: 2,
+        first_unread_drop_serial_no: 12
+      }
+    };
+    const getValue = jest.fn().mockResolvedValue(summaries);
+    const params = {
+      identityId: 'reader-1',
+      waveIds: ['wave-1'],
+      cacheKeysByWaveId: {
+        'wave-1': 'cache-key-1'
+      },
+      getValue
+    };
+
+    await expect(
+      Promise.all([
+        withInFlightWaveUnreadSummaryCacheMiss(params),
+        withInFlightWaveUnreadSummaryCacheMiss(params)
+      ])
+    ).resolves.toEqual([summaries, summaries]);
+
+    expect(getValue).toHaveBeenCalledTimes(1);
   });
 
   it('bumps version keys for wave and reader invalidation', async () => {

--- a/src/api-serverless/src/waves/wave-unread-cache.ts
+++ b/src/api-serverless/src/waves/wave-unread-cache.ts
@@ -38,10 +38,14 @@ export function distinctWaveUnreadReaderWaves(
 }
 
 const logger = Logger.get('WAVE_UNREAD_CACHE');
-const CACHE_TTL = Time.seconds(30);
+const CACHE_TTL = Time.minutes(5);
 const CACHE_KEY_PREFIX = 'cache_6529_wave_unread_summary_v1';
 const WAVE_VERSION_KEY_PREFIX = 'cache_6529_wave_unread_wave_version_v1';
 const READER_VERSION_KEY_PREFIX = 'cache_6529_wave_unread_reader_version_v1';
+const inFlightSummaryMissReads = new Map<
+  string,
+  Promise<Record<string, WaveUnreadSummary>>
+>();
 
 function distinct(values: string[]): string[] {
   return Array.from(new Set(values));
@@ -182,6 +186,42 @@ export async function writeWaveUnreadSummaryCache({
     );
   } catch (error) {
     logger.warn('Failed to write wave unread summary cache', error);
+  }
+}
+
+export async function withInFlightWaveUnreadSummaryCacheMiss({
+  identityId,
+  waveIds,
+  cacheKeysByWaveId,
+  getValue
+}: {
+  readonly identityId: string;
+  readonly waveIds: string[];
+  readonly cacheKeysByWaveId: Record<string, string>;
+  readonly getValue: () => Promise<Record<string, WaveUnreadSummary>>;
+}): Promise<Record<string, WaveUnreadSummary>> {
+  const uniqueWaveIds = distinct(waveIds);
+  if (!uniqueWaveIds.length) {
+    return {};
+  }
+
+  const inFlightKey = `${identityId}:${uniqueWaveIds
+    .map((waveId) => cacheKeysByWaveId[waveId] ?? waveId)
+    .sort()
+    .join('|')}`;
+  const existing = inFlightSummaryMissReads.get(inFlightKey);
+  if (existing) {
+    return await existing;
+  }
+
+  const promise = getValue();
+  inFlightSummaryMissReads.set(inFlightKey, promise);
+  try {
+    return await promise;
+  } finally {
+    if (inFlightSummaryMissReads.get(inFlightKey) === promise) {
+      inFlightSummaryMissReads.delete(inFlightKey);
+    }
   }
 }
 

--- a/src/api-serverless/src/waves/wave-unread-cache.ts
+++ b/src/api-serverless/src/waves/wave-unread-cache.ts
@@ -1,6 +1,7 @@
 import { getRedisClient, redisGetMany, redisSetJson } from '@/redis';
 import { Logger } from '@/logging';
 import { Time } from '@/time';
+import { compareCacheStrings } from './wave-cache-key';
 
 export interface WaveUnreadSummary {
   readonly unread_drops_count: number;
@@ -207,10 +208,10 @@ export async function withInFlightWaveUnreadSummaryCacheMiss({
 
   const inFlightKey = `${identityId}:${uniqueWaveIds
     .map((waveId) => cacheKeysByWaveId[waveId] ?? waveId)
-    .sort()
+    .sort(compareCacheStrings)
     .join('|')}`;
   const existing = inFlightSummaryMissReads.get(inFlightKey);
-  if (existing) {
+  if (existing !== undefined) {
     return await existing;
   }
 

--- a/src/api-serverless/src/waves/waves-api-db-unread-cache.test.ts
+++ b/src/api-serverless/src/waves/waves-api-db-unread-cache.test.ts
@@ -7,6 +7,10 @@ import { WavesApiDb } from './waves.api.db';
 jest.mock('./wave-unread-cache', () => ({
   invalidateWaveUnreadCacheForReaderWave: jest.fn(),
   readWaveUnreadSummaryCache: jest.fn(),
+  withInFlightWaveUnreadSummaryCacheMiss: jest.fn(
+    async ({ getValue }: { getValue: () => Promise<unknown> }) =>
+      await getValue()
+  ),
   writeWaveUnreadSummaryCache: jest.fn()
 }));
 

--- a/src/api-serverless/src/waves/waves.api.db.ts
+++ b/src/api-serverless/src/waves/waves.api.db.ts
@@ -68,7 +68,10 @@ import {
   withInFlightWaveUnreadSummaryCacheMiss,
   writeWaveUnreadSummaryCache
 } from './wave-unread-cache';
-import { withFollowedSubwaveOverviewContextCache } from './wave-followed-subwave-overview-cache';
+import {
+  withFollowedSubwaveOverviewContextCache,
+  withInFlightFollowedSubwaveUnreadRead
+} from './wave-followed-subwave-overview-cache';
 
 type RawWaveEntity = Omit<
   WaveEntity,
@@ -1151,55 +1154,64 @@ export class WavesApiDb extends LazyDbAccessCompatibleService {
           }
         });
 
-      const unreadRows = await this.db.execute<HiddenFollowedSubwaveUnreadRow>(
-        `
-          select
-            child.parent_wave_id,
-            count(d.id) as hidden_followed_subwave_unread_drops,
-            min(d.serial_no) as first_hidden_followed_subwave_unread_drop_serial_no
-          from ${WAVES_TABLE} child
-          join ${WAVES_TABLE} parent
-            on parent.id = child.parent_wave_id
-           and parent.parent_wave_id is null
-          left join ${WAVE_READER_METRICS_TABLE} parent_reader
-            on parent_reader.wave_id = parent.id
-           and parent_reader.reader_id = :identityId
-          join ${IDENTITY_SUBSCRIPTIONS_TABLE} child_follow
-            on child_follow.subscriber_id = :identityId
-           and child_follow.target_id = child.id
-           and child_follow.target_type = :waveTargetType
-           and child_follow.target_action = :dropCreatedAction
-          join ${WAVE_READER_METRICS_TABLE} child_reader
-            on child_reader.wave_id = child.id
-           and child_reader.reader_id = :identityId
-           and child_reader.latest_read_timestamp is not null
-           and coalesce(child_reader.muted, false) = false
-          join ${DROPS_TABLE} d
-            on d.wave_id = child.id
-           and d.created_at > child_reader.latest_read_timestamp
-          where child.parent_wave_id in (:parentWaveIds)
-            and coalesce(parent_reader.muted, false) = false
-            and ${this.getWaveVisibilityFilter(
-              'child',
+      const unreadRows = await withInFlightFollowedSubwaveUnreadRead({
+        identityId,
+        parentWaveIds,
+        eligibleGroups,
+        getValue: async () => {
+          // Keep hidden unread live so wave-reader-metric invalidations are
+          // visible immediately; only coalesce identical concurrent reads.
+          return this.db.execute<HiddenFollowedSubwaveUnreadRow>(
+            `
+              select
+                child.parent_wave_id,
+                count(d.id) as hidden_followed_subwave_unread_drops,
+                min(d.serial_no) as first_hidden_followed_subwave_unread_drop_serial_no
+              from ${WAVES_TABLE} child
+              join ${WAVES_TABLE} parent
+                on parent.id = child.parent_wave_id
+               and parent.parent_wave_id is null
+              left join ${WAVE_READER_METRICS_TABLE} parent_reader
+                on parent_reader.wave_id = parent.id
+               and parent_reader.reader_id = :identityId
+              join ${IDENTITY_SUBSCRIPTIONS_TABLE} child_follow
+                on child_follow.subscriber_id = :identityId
+               and child_follow.target_id = child.id
+               and child_follow.target_type = :waveTargetType
+               and child_follow.target_action = :dropCreatedAction
+              join ${WAVE_READER_METRICS_TABLE} child_reader
+                on child_reader.wave_id = child.id
+               and child_reader.reader_id = :identityId
+               and child_reader.latest_read_timestamp is not null
+               and coalesce(child_reader.muted, false) = false
+              join ${DROPS_TABLE} d
+                on d.wave_id = child.id
+               and d.created_at > child_reader.latest_read_timestamp
+              where child.parent_wave_id in (:parentWaveIds)
+                and coalesce(parent_reader.muted, false) = false
+                and ${this.getWaveVisibilityFilter(
+                  'child',
+                  eligibleGroups,
+                  'eligibleGroups'
+                )}
+                and ${this.getWaveVisibilityFilter(
+                  'parent',
+                  eligibleGroups,
+                  'eligibleGroups'
+                )}
+              group by child.parent_wave_id
+            `,
+            {
+              identityId,
+              parentWaveIds,
               eligibleGroups,
-              'eligibleGroups'
-            )}
-            and ${this.getWaveVisibilityFilter(
-              'parent',
-              eligibleGroups,
-              'eligibleGroups'
-            )}
-          group by child.parent_wave_id
-        `,
-        {
-          identityId,
-          parentWaveIds,
-          eligibleGroups,
-          waveTargetType: ActivityEventTargetType.WAVE,
-          dropCreatedAction: ActivityEventAction.DROP_CREATED
-        },
-        { wrappedConnection: ctx.connection }
-      );
+              waveTargetType: ActivityEventTargetType.WAVE,
+              dropCreatedAction: ActivityEventAction.DROP_CREATED
+            },
+            { wrappedConnection: ctx.connection }
+          );
+        }
+      });
 
       const result = Object.entries(
         followedSubwaveActivityByParentWaveId

--- a/src/api-serverless/src/waves/waves.api.db.ts
+++ b/src/api-serverless/src/waves/waves.api.db.ts
@@ -1102,119 +1102,137 @@ export class WavesApiDb extends LazyDbAccessCompatibleService {
     const timerKey = `${this.constructor.name}->findFollowedSubwaveOverviewContextsByParentWaveId`;
     ctx.timer?.start(timerKey);
     try {
-      return await withFollowedSubwaveOverviewContextCache({
-        identityId,
-        parentWaveIds,
-        eligibleGroups,
-        cacheable: ctx.connection === undefined,
-        getValue: async () => {
-          const activityRows =
-            await this.db.execute<FollowedSubwaveActivityRow>(
-              `
-                ${this.getFollowedSubwaveActivitySelect({
-                  groupIds: eligibleGroups,
-                  identityParamName: 'identityId',
-                  eligibleGroupsParamName: 'eligibleGroups',
-                  parentWaveIdsParamName: 'parentWaveIds'
-                })}
-              `,
-              {
-                identityId,
-                parentWaveIds,
-                eligibleGroups,
-                wave_target_type: ActivityEventTargetType.WAVE,
-                drop_created_action: ActivityEventAction.DROP_CREATED
+      const followedSubwaveActivityByParentWaveId =
+        await withFollowedSubwaveOverviewContextCache({
+          identityId,
+          parentWaveIds,
+          eligibleGroups,
+          cacheable: ctx.connection === undefined,
+          getValue: async () => {
+            const activityRows =
+              await this.db.execute<FollowedSubwaveActivityRow>(
+                `
+                  ${this.getFollowedSubwaveActivitySelect({
+                    groupIds: eligibleGroups,
+                    identityParamName: 'identityId',
+                    eligibleGroupsParamName: 'eligibleGroups',
+                    parentWaveIdsParamName: 'parentWaveIds'
+                  })}
+                `,
+                {
+                  identityId,
+                  parentWaveIds,
+                  eligibleGroups,
+                  wave_target_type: ActivityEventTargetType.WAVE,
+                  drop_created_action: ActivityEventAction.DROP_CREATED
+                },
+                { wrappedConnection: ctx.connection }
+              );
+
+            return activityRows.reduce(
+              (acc, row) => {
+                acc[row.parent_wave_id] = {
+                  followed_subwaves_count: Number(row.followed_subwaves_count),
+                  latest_followed_subwave_activity_timestamp:
+                    this.toActivityTimestamp(
+                      row.latest_followed_subwave_activity_timestamp
+                    )
+                };
+                return acc;
               },
-              { wrappedConnection: ctx.connection }
+              {} as Record<
+                string,
+                {
+                  followed_subwaves_count: number;
+                  latest_followed_subwave_activity_timestamp: number | null;
+                }
+              >
             );
-
-          const unreadRows =
-            await this.db.execute<HiddenFollowedSubwaveUnreadRow>(
-              `
-                select
-                  child.parent_wave_id,
-                  count(d.id) as hidden_followed_subwave_unread_drops,
-                  min(d.serial_no) as first_hidden_followed_subwave_unread_drop_serial_no
-                from ${WAVES_TABLE} child
-                join ${WAVES_TABLE} parent
-                  on parent.id = child.parent_wave_id
-                 and parent.parent_wave_id is null
-                left join ${WAVE_READER_METRICS_TABLE} parent_reader
-                  on parent_reader.wave_id = parent.id
-                 and parent_reader.reader_id = :identityId
-                join ${IDENTITY_SUBSCRIPTIONS_TABLE} child_follow
-                  on child_follow.subscriber_id = :identityId
-                 and child_follow.target_id = child.id
-                 and child_follow.target_type = :waveTargetType
-                 and child_follow.target_action = :dropCreatedAction
-                join ${WAVE_READER_METRICS_TABLE} child_reader
-                  on child_reader.wave_id = child.id
-                 and child_reader.reader_id = :identityId
-                 and child_reader.latest_read_timestamp is not null
-                 and coalesce(child_reader.muted, false) = false
-                join ${DROPS_TABLE} d
-                  on d.wave_id = child.id
-                 and d.created_at > child_reader.latest_read_timestamp
-                where child.parent_wave_id in (:parentWaveIds)
-                  and coalesce(parent_reader.muted, false) = false
-                  and ${this.getWaveVisibilityFilter(
-                    'child',
-                    eligibleGroups,
-                    'eligibleGroups'
-                  )}
-                  and ${this.getWaveVisibilityFilter(
-                    'parent',
-                    eligibleGroups,
-                    'eligibleGroups'
-                  )}
-                group by child.parent_wave_id
-              `,
-              {
-                identityId,
-                parentWaveIds,
-                eligibleGroups,
-                waveTargetType: ActivityEventTargetType.WAVE,
-                dropCreatedAction: ActivityEventAction.DROP_CREATED
-              },
-              { wrappedConnection: ctx.connection }
-            );
-
-          const result = activityRows.reduce(
-            (acc, row) => {
-              acc[row.parent_wave_id] = {
-                followed_subwaves_count: Number(row.followed_subwaves_count),
-                latest_followed_subwave_activity_timestamp:
-                  this.toActivityTimestamp(
-                    row.latest_followed_subwave_activity_timestamp
-                  ),
-                hidden_followed_subwave_unread_drops: 0,
-                first_hidden_followed_subwave_unread_drop_serial_no: null
-              };
-              return acc;
-            },
-            {} as Record<string, FollowedSubwaveOverviewContext>
-          );
-
-          for (const row of unreadRows) {
-            const existing = result[row.parent_wave_id];
-            if (!existing) {
-              continue;
-            }
-            result[row.parent_wave_id] = {
-              ...existing,
-              hidden_followed_subwave_unread_drops: Number(
-                row.hidden_followed_subwave_unread_drops
-              ),
-              first_hidden_followed_subwave_unread_drop_serial_no:
-                this.toNullableNumber(
-                  row.first_hidden_followed_subwave_unread_drop_serial_no
-                )
-            };
           }
+        });
 
-          return result;
+      const unreadRows = await this.db.execute<HiddenFollowedSubwaveUnreadRow>(
+        `
+          select
+            child.parent_wave_id,
+            count(d.id) as hidden_followed_subwave_unread_drops,
+            min(d.serial_no) as first_hidden_followed_subwave_unread_drop_serial_no
+          from ${WAVES_TABLE} child
+          join ${WAVES_TABLE} parent
+            on parent.id = child.parent_wave_id
+           and parent.parent_wave_id is null
+          left join ${WAVE_READER_METRICS_TABLE} parent_reader
+            on parent_reader.wave_id = parent.id
+           and parent_reader.reader_id = :identityId
+          join ${IDENTITY_SUBSCRIPTIONS_TABLE} child_follow
+            on child_follow.subscriber_id = :identityId
+           and child_follow.target_id = child.id
+           and child_follow.target_type = :waveTargetType
+           and child_follow.target_action = :dropCreatedAction
+          join ${WAVE_READER_METRICS_TABLE} child_reader
+            on child_reader.wave_id = child.id
+           and child_reader.reader_id = :identityId
+           and child_reader.latest_read_timestamp is not null
+           and coalesce(child_reader.muted, false) = false
+          join ${DROPS_TABLE} d
+            on d.wave_id = child.id
+           and d.created_at > child_reader.latest_read_timestamp
+          where child.parent_wave_id in (:parentWaveIds)
+            and coalesce(parent_reader.muted, false) = false
+            and ${this.getWaveVisibilityFilter(
+              'child',
+              eligibleGroups,
+              'eligibleGroups'
+            )}
+            and ${this.getWaveVisibilityFilter(
+              'parent',
+              eligibleGroups,
+              'eligibleGroups'
+            )}
+          group by child.parent_wave_id
+        `,
+        {
+          identityId,
+          parentWaveIds,
+          eligibleGroups,
+          waveTargetType: ActivityEventTargetType.WAVE,
+          dropCreatedAction: ActivityEventAction.DROP_CREATED
+        },
+        { wrappedConnection: ctx.connection }
+      );
+
+      const result = Object.entries(
+        followedSubwaveActivityByParentWaveId
+      ).reduce(
+        (acc, [parentWaveId, activity]) => {
+          acc[parentWaveId] = {
+            ...activity,
+            hidden_followed_subwave_unread_drops: 0,
+            first_hidden_followed_subwave_unread_drop_serial_no: null
+          };
+          return acc;
+        },
+        {} as Record<string, FollowedSubwaveOverviewContext>
+      );
+
+      for (const row of unreadRows) {
+        const existing = result[row.parent_wave_id];
+        if (!existing) {
+          continue;
         }
-      });
+        result[row.parent_wave_id] = {
+          ...existing,
+          hidden_followed_subwave_unread_drops: Number(
+            row.hidden_followed_subwave_unread_drops
+          ),
+          first_hidden_followed_subwave_unread_drop_serial_no:
+            this.toNullableNumber(
+              row.first_hidden_followed_subwave_unread_drop_serial_no
+            )
+        };
+      }
+
+      return result;
     } finally {
       ctx.timer?.stop(timerKey);
     }

--- a/src/api-serverless/src/waves/waves.api.db.ts
+++ b/src/api-serverless/src/waves/waves.api.db.ts
@@ -65,8 +65,10 @@ import { ApiWaveVisibilityTier } from '../generated/models/ApiWaveVisibilityTier
 import {
   readWaveUnreadSummaryCache,
   WaveUnreadSummary,
+  withInFlightWaveUnreadSummaryCacheMiss,
   writeWaveUnreadSummaryCache
 } from './wave-unread-cache';
+import { withFollowedSubwaveOverviewContextCache } from './wave-followed-subwave-overview-cache';
 
 type RawWaveEntity = Omit<
   WaveEntity,
@@ -1100,109 +1102,119 @@ export class WavesApiDb extends LazyDbAccessCompatibleService {
     const timerKey = `${this.constructor.name}->findFollowedSubwaveOverviewContextsByParentWaveId`;
     ctx.timer?.start(timerKey);
     try {
-      const activityRows = await this.db.execute<FollowedSubwaveActivityRow>(
-        `
-            ${this.getFollowedSubwaveActivitySelect({
-              groupIds: eligibleGroups,
-              identityParamName: 'identityId',
-              eligibleGroupsParamName: 'eligibleGroups',
-              parentWaveIdsParamName: 'parentWaveIds'
-            })}
-          `,
-        {
-          identityId,
-          parentWaveIds,
-          eligibleGroups,
-          wave_target_type: ActivityEventTargetType.WAVE,
-          drop_created_action: ActivityEventAction.DROP_CREATED
-        },
-        { wrappedConnection: ctx.connection }
-      );
-
-      const unreadRows = await this.db.execute<HiddenFollowedSubwaveUnreadRow>(
-        `
-            select
-              child.parent_wave_id,
-              count(d.id) as hidden_followed_subwave_unread_drops,
-              min(d.serial_no) as first_hidden_followed_subwave_unread_drop_serial_no
-            from ${WAVES_TABLE} child
-            join ${WAVES_TABLE} parent
-              on parent.id = child.parent_wave_id
-             and parent.parent_wave_id is null
-            left join ${WAVE_READER_METRICS_TABLE} parent_reader
-              on parent_reader.wave_id = parent.id
-             and parent_reader.reader_id = :identityId
-            join ${IDENTITY_SUBSCRIPTIONS_TABLE} child_follow
-              on child_follow.subscriber_id = :identityId
-             and child_follow.target_id = child.id
-             and child_follow.target_type = :waveTargetType
-             and child_follow.target_action = :dropCreatedAction
-            join ${WAVE_READER_METRICS_TABLE} child_reader
-              on child_reader.wave_id = child.id
-             and child_reader.reader_id = :identityId
-             and child_reader.latest_read_timestamp is not null
-             and coalesce(child_reader.muted, false) = false
-            join ${DROPS_TABLE} d
-              on d.wave_id = child.id
-             and d.created_at > child_reader.latest_read_timestamp
-            where child.parent_wave_id in (:parentWaveIds)
-              and coalesce(parent_reader.muted, false) = false
-              and ${this.getWaveVisibilityFilter(
-                'child',
+      return await withFollowedSubwaveOverviewContextCache({
+        identityId,
+        parentWaveIds,
+        eligibleGroups,
+        cacheable: ctx.connection === undefined,
+        getValue: async () => {
+          const activityRows =
+            await this.db.execute<FollowedSubwaveActivityRow>(
+              `
+                ${this.getFollowedSubwaveActivitySelect({
+                  groupIds: eligibleGroups,
+                  identityParamName: 'identityId',
+                  eligibleGroupsParamName: 'eligibleGroups',
+                  parentWaveIdsParamName: 'parentWaveIds'
+                })}
+              `,
+              {
+                identityId,
+                parentWaveIds,
                 eligibleGroups,
-                'eligibleGroups'
-              )}
-              and ${this.getWaveVisibilityFilter(
-                'parent',
-                eligibleGroups,
-                'eligibleGroups'
-              )}
-            group by child.parent_wave_id
-          `,
-        {
-          identityId,
-          parentWaveIds,
-          eligibleGroups,
-          waveTargetType: ActivityEventTargetType.WAVE,
-          dropCreatedAction: ActivityEventAction.DROP_CREATED
-        },
-        { wrappedConnection: ctx.connection }
-      );
+                wave_target_type: ActivityEventTargetType.WAVE,
+                drop_created_action: ActivityEventAction.DROP_CREATED
+              },
+              { wrappedConnection: ctx.connection }
+            );
 
-      const result = activityRows.reduce(
-        (acc, row) => {
-          acc[row.parent_wave_id] = {
-            followed_subwaves_count: Number(row.followed_subwaves_count),
-            latest_followed_subwave_activity_timestamp:
-              this.toActivityTimestamp(
-                row.latest_followed_subwave_activity_timestamp
+          const unreadRows =
+            await this.db.execute<HiddenFollowedSubwaveUnreadRow>(
+              `
+                select
+                  child.parent_wave_id,
+                  count(d.id) as hidden_followed_subwave_unread_drops,
+                  min(d.serial_no) as first_hidden_followed_subwave_unread_drop_serial_no
+                from ${WAVES_TABLE} child
+                join ${WAVES_TABLE} parent
+                  on parent.id = child.parent_wave_id
+                 and parent.parent_wave_id is null
+                left join ${WAVE_READER_METRICS_TABLE} parent_reader
+                  on parent_reader.wave_id = parent.id
+                 and parent_reader.reader_id = :identityId
+                join ${IDENTITY_SUBSCRIPTIONS_TABLE} child_follow
+                  on child_follow.subscriber_id = :identityId
+                 and child_follow.target_id = child.id
+                 and child_follow.target_type = :waveTargetType
+                 and child_follow.target_action = :dropCreatedAction
+                join ${WAVE_READER_METRICS_TABLE} child_reader
+                  on child_reader.wave_id = child.id
+                 and child_reader.reader_id = :identityId
+                 and child_reader.latest_read_timestamp is not null
+                 and coalesce(child_reader.muted, false) = false
+                join ${DROPS_TABLE} d
+                  on d.wave_id = child.id
+                 and d.created_at > child_reader.latest_read_timestamp
+                where child.parent_wave_id in (:parentWaveIds)
+                  and coalesce(parent_reader.muted, false) = false
+                  and ${this.getWaveVisibilityFilter(
+                    'child',
+                    eligibleGroups,
+                    'eligibleGroups'
+                  )}
+                  and ${this.getWaveVisibilityFilter(
+                    'parent',
+                    eligibleGroups,
+                    'eligibleGroups'
+                  )}
+                group by child.parent_wave_id
+              `,
+              {
+                identityId,
+                parentWaveIds,
+                eligibleGroups,
+                waveTargetType: ActivityEventTargetType.WAVE,
+                dropCreatedAction: ActivityEventAction.DROP_CREATED
+              },
+              { wrappedConnection: ctx.connection }
+            );
+
+          const result = activityRows.reduce(
+            (acc, row) => {
+              acc[row.parent_wave_id] = {
+                followed_subwaves_count: Number(row.followed_subwaves_count),
+                latest_followed_subwave_activity_timestamp:
+                  this.toActivityTimestamp(
+                    row.latest_followed_subwave_activity_timestamp
+                  ),
+                hidden_followed_subwave_unread_drops: 0,
+                first_hidden_followed_subwave_unread_drop_serial_no: null
+              };
+              return acc;
+            },
+            {} as Record<string, FollowedSubwaveOverviewContext>
+          );
+
+          for (const row of unreadRows) {
+            const existing = result[row.parent_wave_id];
+            if (!existing) {
+              continue;
+            }
+            result[row.parent_wave_id] = {
+              ...existing,
+              hidden_followed_subwave_unread_drops: Number(
+                row.hidden_followed_subwave_unread_drops
               ),
-            hidden_followed_subwave_unread_drops: 0,
-            first_hidden_followed_subwave_unread_drop_serial_no: null
-          };
-          return acc;
-        },
-        {} as Record<string, FollowedSubwaveOverviewContext>
-      );
+              first_hidden_followed_subwave_unread_drop_serial_no:
+                this.toNullableNumber(
+                  row.first_hidden_followed_subwave_unread_drop_serial_no
+                )
+            };
+          }
 
-      for (const row of unreadRows) {
-        const existing = result[row.parent_wave_id];
-        if (!existing) {
-          continue;
+          return result;
         }
-        result[row.parent_wave_id] = {
-          ...existing,
-          hidden_followed_subwave_unread_drops: Number(
-            row.hidden_followed_subwave_unread_drops
-          ),
-          first_hidden_followed_subwave_unread_drop_serial_no:
-            this.toNullableNumber(
-              row.first_hidden_followed_subwave_unread_drop_serial_no
-            )
-        };
-      }
-
-      return result;
+      });
     } finally {
       ctx.timer?.stop(timerKey);
     }
@@ -2934,61 +2946,70 @@ export class WavesApiDb extends LazyDbAccessCompatibleService {
 
     const timerLabel = `${this.constructor.name}->findIdentityUnreadDropsSummaryByWaveId`;
     ctx.timer?.start(timerLabel);
-    const { cachedByWaveId, uncachedWaveIds, cacheKeysByWaveId } =
-      await readWaveUnreadSummaryCache(param.identityId, param.waveIds);
-    if (!uncachedWaveIds.length) {
+    try {
+      const { cachedByWaveId, uncachedWaveIds, cacheKeysByWaveId } =
+        await readWaveUnreadSummaryCache(param.identityId, param.waveIds);
+      if (!uncachedWaveIds.length) {
+        return cachedByWaveId;
+      }
+
+      const dbSummariesByWaveId = await withInFlightWaveUnreadSummaryCacheMiss({
+        identityId: param.identityId,
+        waveIds: uncachedWaveIds,
+        cacheKeysByWaveId,
+        getValue: async () => {
+          // Reader metrics are the unread baseline source of truth. Without
+          // a reader row we do not infer unread drops from old wave history.
+          const dbresult = await this.db.execute<WaveUnreadSummaryRow>(
+            `
+                SELECT d.wave_id AS wave_id,
+                       COUNT(d.id) AS unread_drops_count,
+                       MIN(d.serial_no) AS first_unread_drop_serial_no
+                FROM ${DROPS_TABLE} d USE INDEX (idx_drop_wave_created_at)
+                JOIN ${WAVE_READER_METRICS_TABLE} r
+                  ON r.wave_id = d.wave_id
+                  AND r.reader_id = :identityId
+                WHERE d.wave_id IN (:waveIds)
+                  AND d.author_id != :identityId
+                  AND d.created_at > r.latest_read_timestamp
+                  AND r.muted = false
+                GROUP BY d.wave_id
+              `,
+            { identityId: param.identityId, waveIds: uncachedWaveIds },
+            { wrappedConnection: ctx.connection }
+          );
+
+          const uncachedSummariesByWaveId = uncachedWaveIds.reduce(
+            (acc, waveId) => {
+              acc[waveId] = {
+                unread_drops_count: 0,
+                first_unread_drop_serial_no: null
+              };
+              return acc;
+            },
+            {} as Record<string, WaveUnreadSummary>
+          );
+          const summariesByWaveId = dbresult.reduce((acc, row) => {
+            acc[row.wave_id] = {
+              unread_drops_count: Number(row.unread_drops_count),
+              first_unread_drop_serial_no: this.toNullableNumber(
+                row.first_unread_drop_serial_no
+              )
+            };
+            return acc;
+          }, uncachedSummariesByWaveId);
+          await writeWaveUnreadSummaryCache({
+            summariesByWaveId,
+            cacheKeysByWaveId
+          });
+          return summariesByWaveId;
+        }
+      });
+
+      return { ...cachedByWaveId, ...dbSummariesByWaveId };
+    } finally {
       ctx.timer?.stop(timerLabel);
-      return cachedByWaveId;
     }
-
-    // Reader metrics are the unread baseline source of truth. Without a reader
-    // row we do not infer unread drops from old wave history.
-    const dbresult = await this.db.execute<WaveUnreadSummaryRow>(
-      `
-        SELECT d.wave_id AS wave_id,
-               COUNT(d.id) AS unread_drops_count,
-               MIN(d.serial_no) AS first_unread_drop_serial_no
-        FROM ${DROPS_TABLE} d USE INDEX (idx_drop_wave_created_at)
-        JOIN ${WAVE_READER_METRICS_TABLE} r
-          ON r.wave_id = d.wave_id
-          AND r.reader_id = :identityId
-        WHERE d.wave_id IN (:waveIds)
-          AND d.author_id != :identityId
-          AND d.created_at > r.latest_read_timestamp
-          AND r.muted = false
-        GROUP BY d.wave_id
-    `,
-      { identityId: param.identityId, waveIds: uncachedWaveIds },
-      { wrappedConnection: ctx.connection }
-    );
-
-    const uncachedSummariesByWaveId = uncachedWaveIds.reduce(
-      (acc, waveId) => {
-        acc[waveId] = {
-          unread_drops_count: 0,
-          first_unread_drop_serial_no: null
-        };
-        return acc;
-      },
-      {} as Record<string, WaveUnreadSummary>
-    );
-    const dbSummariesByWaveId = dbresult.reduce((acc, row) => {
-      acc[row.wave_id] = {
-        unread_drops_count: Number(row.unread_drops_count),
-        first_unread_drop_serial_no: this.toNullableNumber(
-          row.first_unread_drop_serial_no
-        )
-      };
-      return acc;
-    }, uncachedSummariesByWaveId);
-    await writeWaveUnreadSummaryCache({
-      summariesByWaveId: dbSummariesByWaveId,
-      cacheKeysByWaveId
-    });
-
-    ctx.timer?.stop(timerLabel);
-
-    return { ...cachedByWaveId, ...dbSummariesByWaveId };
   }
 
   async findIdentityUnreadDropsCountByWaveId(


### PR DESCRIPTION
## Summary
- add short-lived per-viewer response caching for GET /api/v2/waves
- cache static wave overview mapping data and followed-subwave overview context
- extend versioned unread summary cache TTL and coalesce identical cache misses
- pass already-computed eligibility into overview mapping for V2 list paths

## Verification
- npm test -- --runTestsByPath src/api-serverless/src/waves/api-wave-v2-service.test.ts src/api-serverless/src/waves/api-wave-overview-mapper.test.ts src/api-serverless/src/waves/wave-unread-cache.test.ts src/api-serverless/src/waves/waves-api-db-unread-cache.test.ts src/api-serverless/src/waves/wave-overview-response-cache.test.ts src/api-serverless/src/waves/wave-followed-subwave-overview-cache.test.ts src/api-serverless/src/waves/wave-overview-static-cache.test.ts --runInBand
- npm run lint
- npm run build

## Deployment
- Backend only: deploy API after merge to 1a-staging.