### PR TITLE
fix(api): use namespace import for Joi in drops-media routes

### DIFF
--- a/src/api-serverless/src/drops/drops-media.routes.ts
+++ b/src/api-serverless/src/drops/drops-media.routes.ts
@@ -1,6 +1,6 @@
 import { asyncRouter } from '../async.router';
 import { Request, Response } from 'express';
-import Joi from 'joi';
+import * as Joi from 'joi';
 import { ApiResponse } from '../api-response';
 import {
   getAuthenticatedProfileIdOrNull,


### PR DESCRIPTION
## Issue
- `src/api-serverless/src/drops/drops-media.routes.ts` used a default import (`import Joi from 'joi'`), while every other `*.routes.ts` uses a namespace import (`import * as Joi from 'joi'`).
- Joi 17 is a CommonJS module with no default export. Under `ts-node` (local dev) the default import resolves to `undefined`, so the API crashes at module load: `TypeError: Cannot read properties of undefined (reading 'object')` at the first `Joi.object(...)`.
- The esbuild production bundle applies CJS interop differently, so this does not surface in the built artifact or CI — only local `api:local` / `npm run dev` startup breaks.

## Fix
- Change the single import to `import * as Joi from 'joi'`, matching the convention used by all other route files. No behavioral change to the built API.

## Changes
- `src/api-serverless/src/drops/drops-media.routes.ts`: default Joi import → namespace import (1 line).

## Validation
- `eslint` on the changed file: clean (`--max-warnings=0`).
- Ran the API locally (`cd src/api-serverless && npm run dev`): previously crashed at load; now boots cleanly and serves `GET /api/ → 200`.
- Full repo lint/build not re-run locally; the PR CI covers lint, format, root build, and API build.

## Risk
- Level: Low
- Why: one-line import normalization, no runtime/contract change; only affects module interop under ts-node. Reversible by reverting the single line.
- Rollback: revert this commit.

## Deployment
- None required for this fix. (It only unblocks local ts-node dev; the built bundle was unaffected.) If bundled with a normal API release, the `api` service is the only relevant service.

## Review Notes
- Focus: confirm namespace-import style is the intended convention (it matches 9+ sibling route files).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated an internal module import style for improved compatibility and consistency.
  * No user-facing behavior, routes, or responses were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->