### PR TITLE
Optimize wave overview candidate lookups

### DIFF
--- a/src/api-serverless/src/waves/wave-overview-candidate-cache.test.ts
+++ b/src/api-serverless/src/waves/wave-overview-candidate-cache.test.ts
@@ -1,0 +1,81 @@
+import { redisGet, redisSetJson } from '@/redis';
+import { withWaveOverviewCandidateCache } from './wave-overview-candidate-cache';
+
+jest.mock('@/redis', () => ({
+  redisGet: jest.fn(),
+  redisSetJson: jest.fn()
+}));
+
+const redisGetMock = jest.mocked(redisGet);
+const redisSetJsonMock = jest.mocked(redisSetJson);
+
+describe('wave overview candidate cache', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns cached candidates without calling the loader', async () => {
+    const cached = [
+      {
+        waveId: 'wave-1',
+        tierRank: 1,
+        sortVal: 100,
+        latestDropTimestamp: 10
+      }
+    ];
+    redisGetMock.mockResolvedValue(cached);
+    const getValue = jest.fn();
+
+    await expect(
+      withWaveOverviewCandidateCache({
+        keyParts: {
+          overviewType: 'scored',
+          eligibleGroups: ['group-1']
+        },
+        getValue
+      })
+    ).resolves.toBe(cached);
+
+    expect(getValue).not.toHaveBeenCalled();
+    expect(redisSetJsonMock).not.toHaveBeenCalled();
+  });
+
+  it('coalesces equivalent misses and writes the loaded candidates', async () => {
+    redisGetMock.mockResolvedValue(null);
+    const loaded = [
+      {
+        waveId: 'wave-1',
+        tierRank: 1,
+        sortVal: 100,
+        latestDropTimestamp: 10
+      }
+    ];
+    const getValue = jest.fn().mockResolvedValue(loaded);
+
+    await expect(
+      Promise.all([
+        withWaveOverviewCandidateCache({
+          keyParts: {
+            b: 2,
+            a: 1
+          },
+          getValue
+        }),
+        withWaveOverviewCandidateCache({
+          keyParts: {
+            a: 1,
+            b: 2
+          },
+          getValue
+        })
+      ])
+    ).resolves.toEqual([loaded, loaded]);
+
+    expect(getValue).toHaveBeenCalledTimes(1);
+    expect(redisSetJsonMock).toHaveBeenCalledWith(
+      expect.stringMatching(/^cache_6529_wave_overview_candidates_v1:/),
+      loaded,
+      expect.any(Object)
+    );
+  });
+});

--- a/src/api-serverless/src/waves/wave-overview-candidate-cache.ts
+++ b/src/api-serverless/src/waves/wave-overview-candidate-cache.ts
@@ -1,0 +1,71 @@
+import { Logger } from '@/logging';
+import { redisGet, redisSetJson } from '@/redis';
+import { Time } from '@/time';
+import { stableCacheHash } from './wave-cache-key';
+
+export interface WaveOverviewCandidate {
+  readonly waveId: string;
+  readonly tierRank: number;
+  readonly sortVal: number;
+  readonly latestDropTimestamp: number;
+}
+
+const logger = Logger.get('WAVE_OVERVIEW_CANDIDATE_CACHE');
+const CACHE_TTL = Time.seconds(10);
+const CACHE_KEY_PREFIX = 'cache_6529_wave_overview_candidates_v1';
+const inFlightReads = new Map<string, Promise<WaveOverviewCandidate[]>>();
+
+export async function withWaveOverviewCandidateCache({
+  keyParts,
+  getValue
+}: {
+  readonly keyParts: unknown;
+  readonly getValue: () => Promise<WaveOverviewCandidate[]>;
+}): Promise<WaveOverviewCandidate[]> {
+  const cacheKey = `${CACHE_KEY_PREFIX}:${stableCacheHash(keyParts)}`;
+  const cached = await readCache(cacheKey);
+  if (cached !== null) {
+    return cached;
+  }
+
+  const existing = inFlightReads.get(cacheKey);
+  if (existing !== undefined) {
+    return await existing;
+  }
+
+  const promise = (async () => {
+    const value = await getValue();
+    await writeCache(cacheKey, value);
+    return value;
+  })();
+  inFlightReads.set(cacheKey, promise);
+  try {
+    return await promise;
+  } finally {
+    if (inFlightReads.get(cacheKey) === promise) {
+      inFlightReads.delete(cacheKey);
+    }
+  }
+}
+
+async function readCache(
+  cacheKey: string
+): Promise<WaveOverviewCandidate[] | null> {
+  try {
+    return await redisGet<WaveOverviewCandidate[]>(cacheKey);
+  } catch (error) {
+    logger.warn('Failed to read wave overview candidate cache', error);
+    return null;
+  }
+}
+
+async function writeCache(
+  cacheKey: string,
+  value: WaveOverviewCandidate[]
+): Promise<void> {
+  try {
+    await redisSetJson(cacheKey, value, CACHE_TTL);
+  } catch (error) {
+    logger.warn('Failed to write wave overview candidate cache', error);
+  }
+}

--- a/src/api-serverless/src/waves/waves-api-db.test.ts
+++ b/src/api-serverless/src/waves/waves-api-db.test.ts
@@ -180,10 +180,10 @@ type CandidateFallbackTestRepo = {
   ) => WaveOverviewCandidate[];
   findRecentlyDroppedToWavesFromCandidates: (
     param: Record<string, unknown>
-  ) => Promise<unknown>;
+  ) => Promise<readonly { id: string }[] | null>;
   findScoredRecentlyDroppedToWavesFromCandidates: (
     param: Record<string, unknown>
-  ) => Promise<unknown>;
+  ) => Promise<readonly { id: string }[] | null>;
   findRecentlyDroppedToWaveCandidates: jest.Mock;
   findScoredRecentlyDroppedToWaveCandidates: jest.Mock;
   findPinnedCandidateWaveIds: jest.Mock;
@@ -198,6 +198,29 @@ function buildCandidateWindow(count: number): WaveOverviewCandidate[] {
     sortVal: count - index,
     latestDropTimestamp: count - index
   }));
+}
+
+function getWaveIds(waves: readonly { id: string }[] | null): string[] {
+  if (!waves) {
+    throw new Error('Expected wave list');
+  }
+  return waves.map((wave) => wave.id);
+}
+
+function buildLegacyOverviewRepo(): WavesApiDb {
+  const legacyRepo = new WavesApiDb(() => sqlExecutor);
+  const candidateMethods = legacyRepo as unknown as Pick<
+    CandidateFallbackTestRepo,
+    | 'findRecentlyDroppedToWavesFromCandidates'
+    | 'findScoredRecentlyDroppedToWavesFromCandidates'
+  >;
+  candidateMethods.findRecentlyDroppedToWavesFromCandidates = jest
+    .fn()
+    .mockResolvedValue(null);
+  candidateMethods.findScoredRecentlyDroppedToWavesFromCandidates = jest
+    .fn()
+    .mockResolvedValue(null);
+  return legacyRepo;
 }
 
 describeWithSeed(
@@ -999,6 +1022,61 @@ describeWithSeed(
     }
   ],
   () => {
+    it('matches legacy recently-dropped ordering for muted waves in partial candidate windows', async () => {
+      const params = {
+        authenticated_user_id: author.profile_id!,
+        only_waves_followed_by_authenticated_user: false,
+        offset: 0,
+        limit: 10,
+        eligibleGroups: [],
+        direct_message: false,
+        pinned: null
+      };
+      const candidateMethods = repo as unknown as CandidateFallbackTestRepo;
+      const candidatePathWaves =
+        await candidateMethods.findRecentlyDroppedToWavesFromCandidates(params);
+      const candidateWaves = await repo.findRecentlyDroppedToWaves(params);
+      const legacyWaves =
+        await buildLegacyOverviewRepo().findRecentlyDroppedToWaves(params);
+
+      expect(getWaveIds(candidatePathWaves)).toEqual([
+        visibleScoredWave.id,
+        mutedHighScoreWave.id
+      ]);
+      expect(getWaveIds(candidateWaves)).toEqual(getWaveIds(legacyWaves));
+    });
+
+    it('matches legacy scored ordering for muted waves in partial candidate windows', async () => {
+      const params = {
+        authenticated_user_id: author.profile_id!,
+        only_waves_followed_by_authenticated_user: false,
+        offset: 0,
+        limit: 10,
+        eligibleGroups: [],
+        direct_message: false,
+        pinned: null,
+        score_sort: ApiWaveScoreSort.Quality,
+        exclude_followed: false
+      };
+      const candidateMethods = repo as unknown as CandidateFallbackTestRepo;
+      const candidatePathWaves =
+        await candidateMethods.findScoredRecentlyDroppedToWavesFromCandidates(
+          params
+        );
+      const candidateWaves =
+        await repo.findScoredRecentlyDroppedToWaves(params);
+      const legacyWaves =
+        await buildLegacyOverviewRepo().findScoredRecentlyDroppedToWaves(
+          params
+        );
+
+      expect(getWaveIds(candidatePathWaves)).toEqual([
+        visibleScoredWave.id,
+        mutedHighScoreWave.id
+      ]);
+      expect(getWaveIds(candidateWaves)).toEqual(getWaveIds(legacyWaves));
+    });
+
     it('applies muted score floors to scored min filters and tier filters', async () => {
       const waves = await repo.findScoredRecentlyDroppedToWaves({
         authenticated_user_id: author.profile_id!,

--- a/src/api-serverless/src/waves/waves-api-db.test.ts
+++ b/src/api-serverless/src/waves/waves-api-db.test.ts
@@ -2,6 +2,7 @@ import 'reflect-metadata';
 import {
   DROPS_TABLE,
   IDENTITY_SUBSCRIPTIONS_TABLE,
+  PINNED_WAVES_TABLE,
   WAVE_CHAT_DROP_COOLDOWNS_TABLE,
   WAVE_DROPPER_METRICS_TABLE,
   WAVE_METRICS_TABLE,
@@ -21,6 +22,8 @@ import { Time } from '@/time';
 import { WavesApiDb, WaveSubwavesSort } from './waves.api.db';
 import { ApiWaveScoreSort } from '../generated/models/ApiWaveScoreSort';
 import { ApiWaveVisibilityTier } from '../generated/models/ApiWaveVisibilityTier';
+import { ApiWavesPinFilter } from '../generated/models/ApiWavesPinFilter';
+import { WaveOverviewCandidate } from './wave-overview-candidate-cache';
 
 const repo = new WavesApiDb(() => sqlExecutor);
 const ctx: RequestContext = { timer: undefined };
@@ -154,6 +157,49 @@ const mutedContainerComparatorWave = aWave(
   { id: 'wave-muted-container-comparator', serial_no: 19, name: 'Comparator' }
 );
 
+const pinnedCandidateWave = aWave(
+  {
+    created_by: author.profile_id!
+  },
+  { id: 'wave-pinned-candidate', serial_no: 20, name: 'Pinned Candidate' }
+);
+
+const unpinnedCandidateWave = aWave(
+  {
+    created_by: author.profile_id!
+  },
+  { id: 'wave-unpinned-candidate', serial_no: 21, name: 'Unpinned Candidate' }
+);
+
+type CandidateFallbackTestRepo = {
+  sortRecentlyDroppedCandidates: (
+    candidates: WaveOverviewCandidate[]
+  ) => WaveOverviewCandidate[];
+  sortScoredCandidates: (
+    candidates: WaveOverviewCandidate[]
+  ) => WaveOverviewCandidate[];
+  findRecentlyDroppedToWavesFromCandidates: (
+    param: Record<string, unknown>
+  ) => Promise<unknown>;
+  findScoredRecentlyDroppedToWavesFromCandidates: (
+    param: Record<string, unknown>
+  ) => Promise<unknown>;
+  findRecentlyDroppedToWaveCandidates: jest.Mock;
+  findScoredRecentlyDroppedToWaveCandidates: jest.Mock;
+  findPinnedCandidateWaveIds: jest.Mock;
+  findMutedCandidateWaveIds: jest.Mock;
+  findVisibleCandidatePageOrFallback: jest.Mock;
+};
+
+function buildCandidateWindow(count: number): WaveOverviewCandidate[] {
+  return Array.from({ length: count }, (_, index) => ({
+    waveId: `candidate-wave-${index}`,
+    tierRank: 1,
+    sortVal: count - index,
+    latestDropTimestamp: count - index
+  }));
+}
+
 describeWithSeed(
   'WavesApiDb read visibility',
   [
@@ -241,6 +287,235 @@ describeWithSeed(
         )
       ).resolves.toEqual([
         expect.objectContaining({ id: privateWave.id }),
+        expect.objectContaining({ id: publicWave.id })
+      ]);
+    });
+  }
+);
+
+describe('WavesApiDb overview candidate fallback guards', () => {
+  const baseParams = {
+    authenticated_user_id: author.profile_id!,
+    only_waves_followed_by_authenticated_user: false,
+    offset: 0,
+    limit: 20,
+    eligibleGroups: [],
+    direct_message: false,
+    pinned: null
+  };
+
+  it('uses SQL-compatible id-desc tie-breakers for candidate ordering', () => {
+    const testRepo = new WavesApiDb(
+      () => sqlExecutor
+    ) as unknown as CandidateFallbackTestRepo;
+    const tiedCandidates: WaveOverviewCandidate[] = [
+      {
+        waveId: 'wave-a',
+        tierRank: 1,
+        sortVal: 100,
+        latestDropTimestamp: 100
+      },
+      {
+        waveId: 'wave_',
+        tierRank: 1,
+        sortVal: 100,
+        latestDropTimestamp: 100
+      }
+    ];
+
+    expect(
+      testRepo
+        .sortRecentlyDroppedCandidates(tiedCandidates)
+        .map((candidate) => candidate.waveId)
+    ).toEqual(['wave_', 'wave-a']);
+    expect(
+      testRepo
+        .sortScoredCandidates(tiedCandidates)
+        .map((candidate) => candidate.waveId)
+    ).toEqual(['wave_', 'wave-a']);
+  });
+
+  it('falls back for recently dropped candidates when muting affects a full window', async () => {
+    const testRepo = new WavesApiDb(
+      () => sqlExecutor
+    ) as unknown as CandidateFallbackTestRepo;
+    const candidates = buildCandidateWindow(250);
+    testRepo.findRecentlyDroppedToWaveCandidates = jest
+      .fn()
+      .mockResolvedValue(candidates);
+    testRepo.findPinnedCandidateWaveIds = jest
+      .fn()
+      .mockResolvedValue(new Set());
+    testRepo.findMutedCandidateWaveIds = jest
+      .fn()
+      .mockResolvedValue(new Set([candidates[0]!.waveId]));
+    testRepo.findVisibleCandidatePageOrFallback = jest.fn();
+
+    await expect(
+      testRepo.findRecentlyDroppedToWavesFromCandidates(baseParams)
+    ).resolves.toBeNull();
+    expect(testRepo.findVisibleCandidatePageOrFallback).not.toHaveBeenCalled();
+  });
+
+  it('falls back for scored candidates when muting affects a full window', async () => {
+    const testRepo = new WavesApiDb(
+      () => sqlExecutor
+    ) as unknown as CandidateFallbackTestRepo;
+    const candidates = buildCandidateWindow(250);
+    testRepo.findScoredRecentlyDroppedToWaveCandidates = jest
+      .fn()
+      .mockResolvedValue(candidates);
+    testRepo.findPinnedCandidateWaveIds = jest
+      .fn()
+      .mockResolvedValue(new Set());
+    testRepo.findMutedCandidateWaveIds = jest
+      .fn()
+      .mockResolvedValue(new Set([candidates[0]!.waveId]));
+    testRepo.findVisibleCandidatePageOrFallback = jest.fn();
+
+    await expect(
+      testRepo.findScoredRecentlyDroppedToWavesFromCandidates({
+        ...baseParams,
+        score_sort: ApiWaveScoreSort.Balanced,
+        exclude_followed: false
+      })
+    ).resolves.toBeNull();
+    expect(testRepo.findVisibleCandidatePageOrFallback).not.toHaveBeenCalled();
+  });
+});
+
+describeWithSeed(
+  'WavesApiDb overview candidate safety',
+  [
+    withIdentities([author]),
+    withWaves([
+      publicWave,
+      privateWave,
+      pinnedCandidateWave,
+      unpinnedCandidateWave
+    ]),
+    {
+      table: WAVE_METRICS_TABLE,
+      rows: [
+        {
+          wave_id: publicWave.id,
+          latest_drop_timestamp: 100,
+          wave_visibility_tier: ApiWaveVisibilityTier.TrustedVisible,
+          wave_visibility_rank: 1,
+          wave_visibility_score: 40,
+          wave_quality_score: 40,
+          wave_hotness_score: 40,
+          wave_rep_sort_score: 40
+        },
+        {
+          wave_id: privateWave.id,
+          latest_drop_timestamp: 200,
+          wave_visibility_tier: ApiWaveVisibilityTier.TrustedVisible,
+          wave_visibility_rank: 1,
+          wave_visibility_score: 90,
+          wave_quality_score: 90,
+          wave_hotness_score: 90,
+          wave_rep_sort_score: 90
+        },
+        {
+          wave_id: pinnedCandidateWave.id,
+          latest_drop_timestamp: 300,
+          wave_visibility_tier: ApiWaveVisibilityTier.TrustedVisible,
+          wave_visibility_rank: 1,
+          wave_visibility_score: 60,
+          wave_quality_score: 60,
+          wave_hotness_score: 60,
+          wave_rep_sort_score: 60
+        },
+        {
+          wave_id: unpinnedCandidateWave.id,
+          latest_drop_timestamp: 400,
+          wave_visibility_tier: ApiWaveVisibilityTier.TrustedVisible,
+          wave_visibility_rank: 1,
+          wave_visibility_score: 70,
+          wave_quality_score: 70,
+          wave_hotness_score: 70,
+          wave_rep_sort_score: 70
+        }
+      ]
+    },
+    {
+      table: PINNED_WAVES_TABLE,
+      rows: [
+        {
+          wave_id: pinnedCandidateWave.id,
+          profile_id: author.profile_id!
+        }
+      ]
+    }
+  ],
+  () => {
+    it('keeps scored candidate results behind current visibility groups', async () => {
+      await expect(
+        repo.findScoredRecentlyDroppedToWaves({
+          authenticated_user_id: null,
+          only_waves_followed_by_authenticated_user: false,
+          offset: 0,
+          limit: 10,
+          eligibleGroups: [],
+          direct_message: false,
+          pinned: null,
+          score_sort: ApiWaveScoreSort.Balanced,
+          exclude_followed: false
+        })
+      ).resolves.toEqual([
+        expect.objectContaining({ id: unpinnedCandidateWave.id }),
+        expect.objectContaining({ id: pinnedCandidateWave.id }),
+        expect.objectContaining({ id: publicWave.id })
+      ]);
+
+      await expect(
+        repo.findScoredRecentlyDroppedToWaves({
+          authenticated_user_id: null,
+          only_waves_followed_by_authenticated_user: false,
+          offset: 0,
+          limit: 10,
+          eligibleGroups: ['visibility-group'],
+          direct_message: false,
+          pinned: null,
+          score_sort: ApiWaveScoreSort.Balanced,
+          exclude_followed: false
+        })
+      ).resolves.toEqual([
+        expect.objectContaining({ id: privateWave.id }),
+        expect.objectContaining({ id: unpinnedCandidateWave.id }),
+        expect.objectContaining({ id: pinnedCandidateWave.id }),
+        expect.objectContaining({ id: publicWave.id })
+      ]);
+    });
+
+    it('applies pin filters from live per-user state after candidate ranking', async () => {
+      await expect(
+        repo.findRecentlyDroppedToWaves({
+          authenticated_user_id: author.profile_id!,
+          only_waves_followed_by_authenticated_user: false,
+          offset: 0,
+          limit: 10,
+          eligibleGroups: [],
+          direct_message: false,
+          pinned: ApiWavesPinFilter.Pinned
+        })
+      ).resolves.toEqual([
+        expect.objectContaining({ id: pinnedCandidateWave.id })
+      ]);
+
+      await expect(
+        repo.findRecentlyDroppedToWaves({
+          authenticated_user_id: author.profile_id!,
+          only_waves_followed_by_authenticated_user: false,
+          offset: 0,
+          limit: 10,
+          eligibleGroups: [],
+          direct_message: false,
+          pinned: ApiWavesPinFilter.NotPinned
+        })
+      ).resolves.toEqual([
+        expect.objectContaining({ id: unpinnedCandidateWave.id }),
         expect.objectContaining({ id: publicWave.id })
       ]);
     });

--- a/src/api-serverless/src/waves/waves.api.db.ts
+++ b/src/api-serverless/src/waves/waves.api.db.ts
@@ -591,6 +591,7 @@ export class WavesApiDb extends LazyDbAccessCompatibleService {
     // Eligible groups are part of the candidate cache key. A mismatch here
     // means stale or visibility-changed rows, so fall back to legacy SQL.
     logger.info('[WAVE_OVERVIEW_CANDIDATE_FALLBACK]', {
+      event: 'wave_overview_candidate_fallback',
       reason: 'visibility_mismatch',
       candidate_count: candidateIds.length,
       visible_count: waves.length,

--- a/src/api-serverless/src/waves/waves.api.db.ts
+++ b/src/api-serverless/src/waves/waves.api.db.ts
@@ -27,6 +27,7 @@ import {
   WAVES_DECISIONS_TABLE,
   WAVES_TABLE
 } from '@/constants';
+import { Logger } from '@/logging';
 import {
   groupWaveVotingCreditNftsByContract,
   normalizeWaveVotingCreditNfts,
@@ -72,6 +73,13 @@ import {
   withFollowedSubwaveOverviewContextCache,
   withInFlightFollowedSubwaveUnreadRead
 } from './wave-followed-subwave-overview-cache';
+import {
+  WaveOverviewCandidate,
+  withWaveOverviewCandidateCache
+} from './wave-overview-candidate-cache';
+import { compareCacheStrings } from './wave-cache-key';
+
+const logger = Logger.get('WAVES_API_DB');
 
 type RawWaveEntity = Omit<
   WaveEntity,
@@ -125,6 +133,17 @@ type WaveUnreadSummaryRow = {
   first_unread_drop_serial_no: number | string | null;
 };
 
+type WaveOverviewCandidateRow = {
+  wave_id: string;
+  tier_rank: number | string;
+  sort_val: number | string;
+  latest_drop_timestamp: number | string;
+};
+
+type WaveIdRow = {
+  wave_id: string;
+};
+
 type UnreadDmDropsCountRow = {
   count: number | string;
 };
@@ -167,6 +186,63 @@ export class WavesApiDb extends LazyDbAccessCompatibleService {
     }
   }
 
+  private getOverviewCandidateLimit({
+    offset,
+    limit
+  }: {
+    offset: number;
+    limit: number;
+  }): number | null {
+    const needed = offset + limit;
+    if (needed > 500) {
+      return null;
+    }
+    return Math.min(Math.max(needed * 5, 250), 1_000);
+  }
+
+  private parseWaveOverviewCandidates(
+    rows: WaveOverviewCandidateRow[]
+  ): WaveOverviewCandidate[] {
+    return rows.map((row) => ({
+      waveId: row.wave_id,
+      tierRank: Number(row.tier_rank),
+      sortVal: Number(row.sort_val),
+      latestDropTimestamp: Number(row.latest_drop_timestamp)
+    }));
+  }
+
+  private sortRecentlyDroppedCandidates(
+    candidates: WaveOverviewCandidate[]
+  ): WaveOverviewCandidate[] {
+    return [...candidates].sort((left, right) => {
+      const sortDiff = right.sortVal - left.sortVal;
+      return sortDiff || this.compareWaveIdsDesc(left.waveId, right.waveId);
+    });
+  }
+
+  private sortScoredCandidates(
+    candidates: WaveOverviewCandidate[]
+  ): WaveOverviewCandidate[] {
+    return [...candidates].sort((left, right) => {
+      const tierDiff = left.tierRank - right.tierRank;
+      const scoreDiff = right.sortVal - left.sortVal;
+      const activityDiff = right.latestDropTimestamp - left.latestDropTimestamp;
+      return (
+        tierDiff ||
+        scoreDiff ||
+        activityDiff ||
+        this.compareWaveIdsDesc(left.waveId, right.waveId)
+      );
+    });
+  }
+
+  private compareWaveIdsDesc(left: string, right: string): number {
+    if (left === right) {
+      return 0;
+    }
+    return left > right ? -1 : 1;
+  }
+
   private getWaveVisibilityFilter(
     alias: string,
     groupIds: readonly string[],
@@ -194,6 +270,481 @@ export class WavesApiDb extends LazyDbAccessCompatibleService {
       groupIds,
       groupIdsParamName
     )}))`;
+  }
+
+  private getSortedEligibleGroups(eligibleGroups: readonly string[]): string[] {
+    return [...eligibleGroups].sort(compareCacheStrings);
+  }
+
+  private hasScoredOverviewFilters(param: {
+    min_visibility_score?: number;
+    min_quality_score?: number;
+    min_hotness_score?: number;
+    min_rep_sort_score?: number;
+    visibility_tier?: ApiWaveVisibilityTier;
+  }): boolean {
+    return (
+      param.min_visibility_score !== undefined ||
+      param.min_quality_score !== undefined ||
+      param.min_hotness_score !== undefined ||
+      param.min_rep_sort_score !== undefined ||
+      param.visibility_tier !== undefined
+    );
+  }
+
+  private async findVisibleWavesByOrderedCandidateIds({
+    candidateIds,
+    eligibleGroups
+  }: {
+    candidateIds: string[];
+    eligibleGroups: string[];
+  }): Promise<WaveEntity[]> {
+    if (!candidateIds.length) {
+      return [];
+    }
+    // Candidate caches are only a ranking hint; this final DB read applies
+    // the current request's visibility groups before any wave is returned.
+    const visibleWaves = await this.findWavesByIdsEligibleForRead(
+      candidateIds,
+      eligibleGroups
+    );
+    const wavesById = new Map(visibleWaves.map((wave) => [wave.id, wave]));
+    const orderedWaves: WaveEntity[] = [];
+    candidateIds.forEach((id) => {
+      const wave = wavesById.get(id);
+      if (wave) {
+        orderedWaves.push(wave);
+      }
+    });
+    return orderedWaves;
+  }
+
+  private async findPinnedCandidateWaveIds({
+    authenticated_user_id,
+    waveIds
+  }: {
+    authenticated_user_id: string | null;
+    waveIds: string[];
+  }): Promise<Set<string>> {
+    if (!authenticated_user_id || !waveIds.length) {
+      return new Set();
+    }
+    const rows = await this.db.execute<WaveIdRow>(
+      `
+        select wave_id
+        from ${PINNED_WAVES_TABLE}
+        where profile_id = :authenticated_user_id
+          and wave_id in (:waveIds)
+      `,
+      { authenticated_user_id, waveIds }
+    );
+    return new Set(rows.map((row) => row.wave_id));
+  }
+
+  private async findMutedCandidateWaveIds({
+    authenticated_user_id,
+    waveIds
+  }: {
+    authenticated_user_id: string | null;
+    waveIds: string[];
+  }): Promise<Set<string>> {
+    if (!authenticated_user_id || !waveIds.length) {
+      return new Set();
+    }
+    const rows = await this.db.execute<WaveIdRow>(
+      `
+        select wave_id
+        from ${WAVE_READER_METRICS_TABLE}
+        where reader_id = :authenticated_user_id
+          and wave_id in (:waveIds)
+          and coalesce(muted, false) = true
+      `,
+      { authenticated_user_id, waveIds }
+    );
+    return new Set(rows.map((row) => row.wave_id));
+  }
+
+  private async findFollowedCandidateWaveIds({
+    authenticated_user_id,
+    waveIds,
+    eligibleGroups
+  }: {
+    authenticated_user_id: string | null;
+    waveIds: string[];
+    eligibleGroups: string[];
+  }): Promise<Set<string>> {
+    if (!authenticated_user_id || !waveIds.length) {
+      return new Set();
+    }
+    const rows = await this.db.execute<WaveIdRow>(
+      `
+        select target_id as wave_id
+        from ${IDENTITY_SUBSCRIPTIONS_TABLE}
+        where subscriber_id = :authenticated_user_id
+          and target_id in (:waveIds)
+          and target_type = :wave_target_type
+          and target_action = :drop_created_action
+        union
+        select distinct child.parent_wave_id as wave_id
+        from ${WAVES_TABLE} child
+          join ${WAVES_TABLE} parent
+            on parent.id = child.parent_wave_id
+           and parent.parent_wave_id is null
+          join ${IDENTITY_SUBSCRIPTIONS_TABLE} child_follow
+            on child_follow.subscriber_id = :authenticated_user_id
+           and child_follow.target_id = child.id
+           and child_follow.target_type = :wave_target_type
+           and child_follow.target_action = :drop_created_action
+        where child.parent_wave_id in (:waveIds)
+          and ${this.getWaveVisibilityFilter(
+            'child',
+            eligibleGroups,
+            'eligibleGroups'
+          )}
+          and ${this.getWaveVisibilityFilter(
+            'parent',
+            eligibleGroups,
+            'eligibleGroups'
+          )}
+      `,
+      {
+        authenticated_user_id,
+        waveIds,
+        eligibleGroups,
+        wave_target_type: ActivityEventTargetType.WAVE,
+        drop_created_action: ActivityEventAction.DROP_CREATED
+      }
+    );
+    return new Set(rows.map((row) => row.wave_id));
+  }
+
+  private applyPinnedCandidateFilter({
+    candidates,
+    pinned,
+    pinnedWaveIds,
+    authenticated_user_id
+  }: {
+    candidates: WaveOverviewCandidate[];
+    pinned: ApiWavesPinFilter | null;
+    pinnedWaveIds: Set<string>;
+    authenticated_user_id: string | null;
+  }): WaveOverviewCandidate[] {
+    if (!authenticated_user_id) {
+      return candidates;
+    }
+    if (pinned === ApiWavesPinFilter.Pinned) {
+      return candidates.filter((candidate) =>
+        pinnedWaveIds.has(candidate.waveId)
+      );
+    }
+    if (pinned === ApiWavesPinFilter.NotPinned) {
+      return candidates.filter(
+        (candidate) => !pinnedWaveIds.has(candidate.waveId)
+      );
+    }
+    return candidates;
+  }
+
+  private async findRecentlyDroppedToWaveCandidates(
+    param: {
+      eligibleGroups: string[];
+      direct_message?: boolean;
+    },
+    candidateLimit: number
+  ): Promise<WaveOverviewCandidate[]> {
+    return await withWaveOverviewCandidateCache({
+      keyParts: {
+        kind: 'recently-dropped-to-waves',
+        candidateLimit,
+        direct_message: param.direct_message,
+        eligibleGroups: this.getSortedEligibleGroups(param.eligibleGroups)
+      },
+      getValue: async () => {
+        const rows = await this.db.execute<WaveOverviewCandidateRow>(
+          `
+            select
+              w.id as wave_id,
+              0 as tier_rank,
+              coalesce(wm.latest_drop_timestamp, 0) as sort_val,
+              coalesce(wm.latest_drop_timestamp, 0) as latest_drop_timestamp
+            from ${WAVES_TABLE} w
+              join ${WAVE_METRICS_TABLE} wm on wm.wave_id = w.id
+            where w.parent_wave_id is null
+              ${
+                param.direct_message !== undefined
+                  ? `and w.is_direct_message = :direct_message`
+                  : ``
+              }
+              and ${this.getWaveVisibilityFilter(
+                'w',
+                param.eligibleGroups,
+                'eligibleGroups'
+              )}
+            order by sort_val desc, w.id desc
+            limit :candidateLimit
+          `,
+          { ...param, candidateLimit }
+        );
+        return this.parseWaveOverviewCandidates(rows);
+      }
+    });
+  }
+
+  private async findScoredRecentlyDroppedToWaveCandidates(
+    param: {
+      eligibleGroups: string[];
+      direct_message?: boolean;
+      score_sort: ApiWaveScoreSort;
+      min_visibility_score?: number;
+      min_quality_score?: number;
+      min_hotness_score?: number;
+      min_rep_sort_score?: number;
+      visibility_tier?: ApiWaveVisibilityTier;
+    },
+    candidateLimit: number
+  ): Promise<WaveOverviewCandidate[]> {
+    const scoreColumn = this.getWaveScoreSortColumn(param.score_sort);
+    const filters = [
+      param.min_visibility_score !== undefined
+        ? `wm.wave_visibility_score >= :min_visibility_score`
+        : null,
+      param.min_quality_score !== undefined
+        ? `wm.wave_quality_score >= :min_quality_score`
+        : null,
+      param.min_hotness_score !== undefined
+        ? `wm.wave_hotness_score >= :min_hotness_score`
+        : null,
+      param.min_rep_sort_score !== undefined
+        ? `wm.wave_rep_sort_score >= :min_rep_sort_score`
+        : null,
+      param.visibility_tier !== undefined
+        ? `wm.wave_visibility_tier = :visibility_tier`
+        : null
+    ]
+      .filter((filter): filter is string => !!filter)
+      .join(' and ');
+    const scoreFilters = filters ? `and ${filters}` : ``;
+    return await withWaveOverviewCandidateCache({
+      keyParts: {
+        kind: 'scored-recently-dropped-to-waves',
+        candidateLimit,
+        direct_message: param.direct_message,
+        eligibleGroups: this.getSortedEligibleGroups(param.eligibleGroups),
+        score_sort: param.score_sort,
+        min_visibility_score: param.min_visibility_score,
+        min_quality_score: param.min_quality_score,
+        min_hotness_score: param.min_hotness_score,
+        min_rep_sort_score: param.min_rep_sort_score,
+        visibility_tier: param.visibility_tier
+      },
+      getValue: async () => {
+        const rows = await this.db.execute<WaveOverviewCandidateRow>(
+          `
+            select
+              w.id as wave_id,
+              wm.wave_visibility_rank as tier_rank,
+              ${scoreColumn} as sort_val,
+              coalesce(wm.latest_drop_timestamp, 0) as latest_drop_timestamp
+            from ${WAVES_TABLE} w
+              join ${WAVE_METRICS_TABLE} wm on wm.wave_id = w.id
+            where w.parent_wave_id is null
+              ${
+                param.direct_message !== undefined
+                  ? `and w.is_direct_message = :direct_message`
+                  : ``
+              }
+              and ${this.getWaveVisibilityFilter(
+                'w',
+                param.eligibleGroups,
+                'eligibleGroups'
+              )}
+              ${scoreFilters}
+            order by
+              tier_rank asc,
+              sort_val desc,
+              latest_drop_timestamp desc,
+              w.id desc
+            limit :candidateLimit
+          `,
+          { ...param, candidateLimit }
+        );
+        return this.parseWaveOverviewCandidates(rows);
+      }
+    });
+  }
+
+  private async findVisibleCandidatePageOrFallback({
+    pageCandidates,
+    eligibleGroups
+  }: {
+    pageCandidates: WaveOverviewCandidate[];
+    eligibleGroups: string[];
+  }): Promise<WaveEntity[] | null> {
+    const candidateIds = pageCandidates.map((candidate) => candidate.waveId);
+    const waves = await this.findVisibleWavesByOrderedCandidateIds({
+      candidateIds,
+      eligibleGroups
+    });
+    if (waves.length === candidateIds.length) {
+      return waves;
+    }
+    // Eligible groups are part of the candidate cache key. A mismatch here
+    // means stale or visibility-changed rows, so fall back to legacy SQL.
+    logger.info('[WAVE_OVERVIEW_CANDIDATE_FALLBACK]', {
+      reason: 'visibility_mismatch',
+      candidate_count: candidateIds.length,
+      visible_count: waves.length,
+      eligible_group_count: eligibleGroups.length
+    });
+    return null;
+  }
+
+  private async findRecentlyDroppedToWavesFromCandidates(param: {
+    authenticated_user_id: string | null;
+    only_waves_followed_by_authenticated_user: boolean;
+    offset: number;
+    limit: number;
+    eligibleGroups: string[];
+    direct_message?: boolean;
+    pinned: ApiWavesPinFilter | null;
+  }): Promise<WaveEntity[] | null> {
+    if (param.only_waves_followed_by_authenticated_user) {
+      return null;
+    }
+    const candidateLimit = this.getOverviewCandidateLimit(param);
+    if (candidateLimit === null) {
+      return null;
+    }
+    const candidates = await this.findRecentlyDroppedToWaveCandidates(
+      param,
+      candidateLimit
+    );
+    if (!candidates.length) {
+      return [];
+    }
+    const candidateIds = candidates.map((candidate) => candidate.waveId);
+    const [pinnedWaveIds, mutedWaveIds] = await Promise.all([
+      this.findPinnedCandidateWaveIds({
+        authenticated_user_id: param.authenticated_user_id,
+        waveIds: candidateIds
+      }),
+      this.findMutedCandidateWaveIds({
+        authenticated_user_id: param.authenticated_user_id,
+        waveIds: candidateIds
+      })
+    ]);
+    if (mutedWaveIds.size > 0 && candidates.length >= candidateLimit) {
+      return null;
+    }
+    const filteredCandidates = this.applyPinnedCandidateFilter({
+      candidates,
+      pinned: param.pinned,
+      pinnedWaveIds,
+      authenticated_user_id: param.authenticated_user_id
+    });
+    const orderedCandidates = this.sortRecentlyDroppedCandidates(
+      filteredCandidates.map((candidate) =>
+        mutedWaveIds.has(candidate.waveId)
+          ? { ...candidate, sortVal: 0 }
+          : candidate
+      )
+    );
+    const pageCandidates = orderedCandidates.slice(
+      param.offset,
+      param.offset + param.limit
+    );
+    const needsCompleteCandidateWindow = pageCandidates.length < param.limit;
+    if (needsCompleteCandidateWindow && candidates.length >= candidateLimit) {
+      return null;
+    }
+    return await this.findVisibleCandidatePageOrFallback({
+      pageCandidates,
+      eligibleGroups: param.eligibleGroups
+    });
+  }
+
+  private async findScoredRecentlyDroppedToWavesFromCandidates(param: {
+    authenticated_user_id: string | null;
+    only_waves_followed_by_authenticated_user: boolean;
+    offset: number;
+    limit: number;
+    eligibleGroups: string[];
+    direct_message?: boolean;
+    pinned: ApiWavesPinFilter | null;
+    score_sort: ApiWaveScoreSort;
+    exclude_followed: boolean;
+    min_visibility_score?: number;
+    min_quality_score?: number;
+    min_hotness_score?: number;
+    min_rep_sort_score?: number;
+    visibility_tier?: ApiWaveVisibilityTier;
+  }): Promise<WaveEntity[] | null> {
+    if (param.only_waves_followed_by_authenticated_user) {
+      return null;
+    }
+    if (param.authenticated_user_id && this.hasScoredOverviewFilters(param)) {
+      return null;
+    }
+    const candidateLimit = this.getOverviewCandidateLimit(param);
+    if (candidateLimit === null) {
+      return null;
+    }
+    const candidates = await this.findScoredRecentlyDroppedToWaveCandidates(
+      param,
+      candidateLimit
+    );
+    if (!candidates.length) {
+      return [];
+    }
+    const candidateIds = candidates.map((candidate) => candidate.waveId);
+    const [pinnedWaveIds, mutedWaveIds, followedWaveIds] = await Promise.all([
+      this.findPinnedCandidateWaveIds({
+        authenticated_user_id: param.authenticated_user_id,
+        waveIds: candidateIds
+      }),
+      this.findMutedCandidateWaveIds({
+        authenticated_user_id: param.authenticated_user_id,
+        waveIds: candidateIds
+      }),
+      param.exclude_followed
+        ? this.findFollowedCandidateWaveIds({
+            authenticated_user_id: param.authenticated_user_id,
+            waveIds: candidateIds,
+            eligibleGroups: param.eligibleGroups
+          })
+        : Promise.resolve(new Set<string>())
+    ]);
+    if (mutedWaveIds.size > 0 && candidates.length >= candidateLimit) {
+      return null;
+    }
+    const filteredCandidates = this.applyPinnedCandidateFilter({
+      candidates,
+      pinned: param.pinned,
+      pinnedWaveIds,
+      authenticated_user_id: param.authenticated_user_id
+    }).filter(
+      (candidate) =>
+        !param.exclude_followed || !followedWaveIds.has(candidate.waveId)
+    );
+    const orderedCandidates = this.sortScoredCandidates(
+      filteredCandidates.map((candidate) =>
+        mutedWaveIds.has(candidate.waveId)
+          ? { ...candidate, tierRank: 999, sortVal: 0 }
+          : candidate
+      )
+    );
+    const pageCandidates = orderedCandidates.slice(
+      param.offset,
+      param.offset + param.limit
+    );
+    const needsCompleteCandidateWindow = pageCandidates.length < param.limit;
+    if (needsCompleteCandidateWindow && candidates.length >= candidateLimit) {
+      return null;
+    }
+    return await this.findVisibleCandidatePageOrFallback({
+      pageCandidates,
+      eligibleGroups: param.eligibleGroups
+    });
   }
 
   private toNullableNumber(
@@ -2225,6 +2776,11 @@ export class WavesApiDb extends LazyDbAccessCompatibleService {
     direct_message?: boolean;
     pinned: ApiWavesPinFilter | null;
   }): Promise<WaveEntity[]> {
+    const candidateResult =
+      await this.findRecentlyDroppedToWavesFromCandidates(param);
+    if (candidateResult !== null) {
+      return candidateResult;
+    }
     const useFollowedSubwaveActivity =
       !!param.authenticated_user_id &&
       param.only_waves_followed_by_authenticated_user;
@@ -2346,6 +2902,11 @@ export class WavesApiDb extends LazyDbAccessCompatibleService {
       throw new Error(
         'Cannot request followed-only waves and exclude-followed waves together'
       );
+    }
+    const candidateResult =
+      await this.findScoredRecentlyDroppedToWavesFromCandidates(param);
+    if (candidateResult !== null) {
+      return candidateResult;
     }
     const useFollowedSubwaveActivity =
       !!param.authenticated_user_id &&

--- a/src/entities/IWaveMetric.ts
+++ b/src/entities/IWaveMetric.ts
@@ -21,7 +21,25 @@ import { WAVE_METRICS_TABLE } from '@/constants';
   'latest_drop_timestamp',
   'wave_id'
 ])
+@Index('idx_wmet_rank_quality_score', [
+  'wave_visibility_rank',
+  'wave_quality_score',
+  'latest_drop_timestamp',
+  'wave_id'
+])
 @Index('idx_wmet_rep_score', [
+  'wave_rep_sort_score',
+  'latest_drop_timestamp',
+  'wave_id'
+])
+@Index('idx_wmet_rank_hot_score', [
+  'wave_visibility_rank',
+  'wave_hotness_score',
+  'latest_drop_timestamp',
+  'wave_id'
+])
+@Index('idx_wmet_rank_rep_score', [
+  'wave_visibility_rank',
   'wave_rep_sort_score',
   'latest_drop_timestamp',
   'wave_id'

--- a/src/entities/IWaveReaderMetric.ts
+++ b/src/entities/IWaveReaderMetric.ts
@@ -1,7 +1,8 @@
-import { Column, Entity, PrimaryColumn } from 'typeorm';
+import { Column, Entity, Index, PrimaryColumn } from 'typeorm';
 import { WAVE_READER_METRICS_TABLE } from '@/constants';
 
 @Entity(WAVE_READER_METRICS_TABLE)
+@Index('idx_wrm_reader_wave', ['reader_id', 'wave_id'])
 export class WaveReaderMetricEntity {
   @PrimaryColumn({ type: 'varchar', length: 100, nullable: false })
   readonly wave_id!: string;


### PR DESCRIPTION
## Summary
- Add a short-lived global candidate cache for wave overview ranking queries.
- Keep per-user pin, mute, and followed filtering live after candidate selection.
- Re-read selected wave ids through the existing DB visibility filter before returning results, falling back to the old SQL path if the candidate window is not sufficient.
- Add wave metric score-order indexes for scored overview candidate scans and a reader/wave index for live mute probes.

## Safety
- Candidate cache keys include request-visible global filters and sorted eligible group ids.
- Cached candidates are ranking hints only; final returned waves still pass current DB visibility checks.
- Followed-only requests, deep pages, authenticated scored filter requests, incomplete candidate windows, and full windows containing muted candidates continue using the existing SQL path.
- Candidate tie-breaks now use deterministic id-desc ordering matching the SQL fallback instead of locale-aware JS ordering.

## Schema deployment
- This repository applies entity-index changes through `dbMigrationsLoop` with TypeORM `syncEntities: true`; no manual migration file is used for this repo path unless explicitly requested.
- Deploy `dbMigrationsLoop` before API so the new indexes are applied before the API uses the candidate query path.

## Validation
- `npm test -- --runTestsByPath src/api-serverless/src/waves/wave-overview-candidate-cache.test.ts src/api-serverless/src/waves/waves-api-db.test.ts`
- `npm run lint`
- `npm run build`
