### PR TITLE
Support subscription counts by token

### DIFF
--- a/src/api-serverless/openapi.yaml
+++ b/src/api-serverless/openapi.yaml
@@ -6586,6 +6586,14 @@ paths:
             type: integer
             format: int64
             minimum: 1
+        - name: token_id
+          in: query
+          description: Specific Meme Card token ID to fetch. When provided, returns only that token.
+          required: false
+          schema:
+            type: integer
+            format: int64
+            minimum: 1
       responses:
         "200":
           description: successful operation

--- a/src/api-serverless/openapi.yaml
+++ b/src/api-serverless/openapi.yaml
@@ -6585,16 +6585,6 @@ paths:
             type: integer
             format: int64
             minimum: 1
-        - name: token_id
-          in: query
-          description: >-
-            Specific Meme Card token ID to fetch. When provided, returns only
-            that token.
-          required: false
-          schema:
-            type: integer
-            format: int64
-            minimum: 1
       responses:
         "200":
           description: successful operation

--- a/src/api-serverless/openapi.yaml
+++ b/src/api-serverless/openapi.yaml
@@ -3385,6 +3385,88 @@ paths:
                 $ref: "#/components/schemas/ApiMediaResolveResponse"
         "400":
           description: Invalid request shape
+  /memes_extended_data:
+    get:
+      tags:
+        - Memes
+      summary: Get paginated Memes extended data
+      description: >-
+        Returns Meme Card metadata joined with the card's NFT market and TDH
+        fields. `collection_size` is the total Meme Cards collection size.
+        `ranked_collection_size`, when present, is the denominator for rank
+        fields on rows included in TDH ranking. Rows not yet included in TDH
+        calculations can return `recorded_in_tdh: false`, `-1` rank values, and
+        `ranked_collection_size: null`. During migration or transient TDH lookup
+        fallback, `recorded_in_tdh` and `ranked_collection_size` can be `null`
+        or absent, and clients should treat that as legacy/transitional state.
+      operationId: getMemesExtendedData
+      parameters:
+        - name: page_size
+          in: query
+          description: Default is 101
+          required: false
+          schema:
+            type: number
+            format: int64
+            minimum: 1
+            maximum: 101
+        - name: page
+          in: query
+          description: Default is 1
+          required: false
+          schema:
+            type: number
+            format: int64
+            minimum: 1
+        - name: id
+          in: query
+          description: Comma-separated Meme Card IDs
+          required: false
+          schema:
+            type: string
+        - name: season
+          in: query
+          description: Comma-separated Meme seasons
+          required: false
+          schema:
+            type: string
+        - name: sort
+          in: query
+          description: Default is age
+          required: false
+          schema:
+            type: string
+            enum:
+              - age
+              - edition_size
+              - meme
+              - hodlers
+              - tdh
+              - percent_unique
+              - percent_unique_cleaned
+              - floor_price
+              - market_cap
+              - total_volume_last_24_hours
+              - total_volume_last_7_days
+              - total_volume_last_1_month
+              - total_volume
+              - highest_offer
+        - name: sort_direction
+          in: query
+          description: Default is DESC
+          required: false
+          schema:
+            type: string
+            enum:
+              - ASC
+              - DESC
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiMemesExtendedDataPage"
   /memes-mint-stats:
     get:
       tags:
@@ -3475,89 +3557,6 @@ paths:
                 $ref: "#/components/schemas/ApiMemesMintStat"
         "404":
           description: Memes mint stats for id not found
-  /memes_extended_data:
-    get:
-      tags:
-        - Memes
-      summary: Get paginated Memes extended data
-      description: >-
-        Returns Meme Card metadata joined with the card's NFT market and TDH
-        fields. `collection_size` is the total Meme Cards collection size.
-        `ranked_collection_size`, when present, is the denominator for
-        rank fields on rows included in TDH ranking. Rows not yet included in
-        TDH calculations can return `recorded_in_tdh: false`, `-1` rank values,
-        and `ranked_collection_size: null`. During migration or transient TDH
-        lookup fallback, `recorded_in_tdh` and `ranked_collection_size` can be
-        `null` or absent, and clients should treat that as legacy/transitional
-        state.
-      operationId: getMemesExtendedData
-      parameters:
-        - name: page_size
-          in: query
-          description: Default is 101
-          required: false
-          schema:
-            type: number
-            format: int64
-            minimum: 1
-            maximum: 101
-        - name: page
-          in: query
-          description: Default is 1
-          required: false
-          schema:
-            type: number
-            format: int64
-            minimum: 1
-        - name: id
-          in: query
-          description: Comma-separated Meme Card IDs
-          required: false
-          schema:
-            type: string
-        - name: season
-          in: query
-          description: Comma-separated Meme seasons
-          required: false
-          schema:
-            type: string
-        - name: sort
-          in: query
-          description: Default is age
-          required: false
-          schema:
-            type: string
-            enum:
-              - age
-              - edition_size
-              - meme
-              - hodlers
-              - tdh
-              - percent_unique
-              - percent_unique_cleaned
-              - floor_price
-              - market_cap
-              - total_volume_last_24_hours
-              - total_volume_last_7_days
-              - total_volume_last_1_month
-              - total_volume
-              - highest_offer
-        - name: sort_direction
-          in: query
-          description: Default is DESC
-          required: false
-          schema:
-            type: string
-            enum:
-              - ASC
-              - DESC
-      responses:
-        "200":
-          description: successful operation
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ApiMemesExtendedDataPage"
   /minting-claims/{contract}/{card_id}/{merkle_root}/proofs/{address}:
     get:
       tags:
@@ -6588,7 +6587,9 @@ paths:
             minimum: 1
         - name: token_id
           in: query
-          description: Specific Meme Card token ID to fetch. When provided, returns only that token.
+          description: >-
+            Specific Meme Card token ID to fetch. When provided, returns only
+            that token.
           required: false
           schema:
             type: integer
@@ -6657,6 +6658,30 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/SubscriptionCounts"
+  /subscriptions/memes/{token_id}/count:
+    get:
+      tags:
+        - Subscriptions
+      summary: Get meme subscription count
+      operationId: getMemeSubscriptionCount
+      parameters:
+        - name: token_id
+          in: path
+          description: Meme token ID
+          required: true
+          schema:
+            type: integer
+            format: int64
+            minimum: 1
+      responses:
+        "200":
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SubscriptionCounts"
+        "400":
+          description: Invalid token ID
   /subscriptions/redeemed-memes-counts:
     get:
       tags:

--- a/src/api-serverless/src/subscriptions/api-subscriptions-db.test.ts
+++ b/src/api-serverless/src/subscriptions/api-subscriptions-db.test.ts
@@ -1,15 +1,20 @@
 import * as dbApi from '@/db-api';
+import * as nftsDb from '@/nftsLoop/db.nfts';
 import {
   MEMES_CONTRACT,
   MEMES_EXTENDED_DATA_TABLE,
   MEMES_MINT_PRICE,
   NFTS_TABLE,
+  SUBSCRIPTIONS_MODE_TABLE,
+  SUBSCRIPTIONS_NFTS_FINAL_TABLE,
+  SUBSCRIPTIONS_NFTS_TABLE,
   SUBSCRIPTIONS_REDEEMED_TABLE
 } from '@/constants';
 import { sqlExecutor } from '@/sql-executor';
 import {
   fetchPastMemeSubscriptionCounts,
-  fetchRedeemedMemeSubscriptionCountsDownload
+  fetchRedeemedMemeSubscriptionCountsDownload,
+  fetchUpcomingMemeSubscriptionCounts
 } from './api.subscriptions.db';
 
 describe('fetchPastMemeSubscriptionCounts', () => {
@@ -57,6 +62,53 @@ describe('fetchPastMemeSubscriptionCounts', () => {
       expect.any(String),
       `${NFTS_TABLE}.contract, ${NFTS_TABLE}.id`,
       { skipJoinsOnCountQuery: false }
+    );
+  });
+});
+
+describe('fetchUpcomingMemeSubscriptionCounts', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('keeps card_count behavior based on the next meme IDs', async () => {
+    jest.spyOn(nftsDb, 'getMaxMemeId').mockResolvedValue(516);
+    const executeSpy = jest
+      .spyOn(sqlExecutor, 'execute')
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+
+    await expect(fetchUpcomingMemeSubscriptionCounts(2)).resolves.toEqual([
+      { contract: MEMES_CONTRACT, token_id: 517, count: 0 },
+      { contract: MEMES_CONTRACT, token_id: 518, count: 0 }
+    ]);
+
+    expect(executeSpy).toHaveBeenNthCalledWith(
+      1,
+      `SELECT * FROM ${SUBSCRIPTIONS_MODE_TABLE} WHERE automatic = :automatic`,
+      { automatic: true }
+    );
+    expect(executeSpy).toHaveBeenNthCalledWith(
+      2,
+      `SELECT * FROM ${SUBSCRIPTIONS_NFTS_TABLE} WHERE token_id IN (:tokenIds)`,
+      { tokenIds: [517, 518] }
+    );
+  });
+
+  it('returns baked final subscribed count for an explicit dropped meme ID', async () => {
+    jest.spyOn(nftsDb, 'getMaxMemeId').mockResolvedValue(516);
+    const executeSpy = jest
+      .spyOn(sqlExecutor, 'execute')
+      .mockResolvedValue([{ count: '13' }]);
+
+    await expect(fetchUpcomingMemeSubscriptionCounts(1, 516)).resolves.toEqual([
+      { contract: MEMES_CONTRACT, token_id: 516, count: 13 }
+    ]);
+
+    expect(executeSpy).toHaveBeenCalledTimes(1);
+    expect(executeSpy).toHaveBeenCalledWith(
+      expect.stringContaining(`FROM ${SUBSCRIPTIONS_NFTS_FINAL_TABLE}`),
+      { contract: MEMES_CONTRACT, tokenId: 516 }
     );
   });
 });

--- a/src/api-serverless/src/subscriptions/api-subscriptions-db.test.ts
+++ b/src/api-serverless/src/subscriptions/api-subscriptions-db.test.ts
@@ -12,6 +12,7 @@ import {
 } from '@/constants';
 import { sqlExecutor } from '@/sql-executor';
 import {
+  fetchMemeSubscriptionCount,
   fetchPastMemeSubscriptionCounts,
   fetchRedeemedMemeSubscriptionCountsDownload,
   fetchUpcomingMemeSubscriptionCounts
@@ -94,21 +95,54 @@ describe('fetchUpcomingMemeSubscriptionCounts', () => {
       { tokenIds: [517, 518] }
     );
   });
+});
 
-  it('returns baked final subscribed count for an explicit dropped meme ID', async () => {
+describe('fetchMemeSubscriptionCount', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns baked final subscribed count for a dropped meme ID', async () => {
     jest.spyOn(nftsDb, 'getMaxMemeId').mockResolvedValue(516);
     const executeSpy = jest
       .spyOn(sqlExecutor, 'execute')
       .mockResolvedValue([{ count: '13' }]);
 
-    await expect(fetchUpcomingMemeSubscriptionCounts(1, 516)).resolves.toEqual([
-      { contract: MEMES_CONTRACT, token_id: 516, count: 13 }
-    ]);
+    await expect(fetchMemeSubscriptionCount(516)).resolves.toEqual({
+      contract: MEMES_CONTRACT,
+      token_id: 516,
+      count: 13
+    });
 
     expect(executeSpy).toHaveBeenCalledTimes(1);
     expect(executeSpy).toHaveBeenCalledWith(
       expect.stringContaining(`FROM ${SUBSCRIPTIONS_NFTS_FINAL_TABLE}`),
       { contract: MEMES_CONTRACT, tokenId: 516 }
+    );
+  });
+
+  it('returns effective upcoming subscribed count for a future meme ID', async () => {
+    jest.spyOn(nftsDb, 'getMaxMemeId').mockResolvedValue(516);
+    const executeSpy = jest
+      .spyOn(sqlExecutor, 'execute')
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+
+    await expect(fetchMemeSubscriptionCount(517)).resolves.toEqual({
+      contract: MEMES_CONTRACT,
+      token_id: 517,
+      count: 0
+    });
+
+    expect(executeSpy).toHaveBeenNthCalledWith(
+      1,
+      `SELECT * FROM ${SUBSCRIPTIONS_MODE_TABLE} WHERE automatic = :automatic`,
+      { automatic: true }
+    );
+    expect(executeSpy).toHaveBeenNthCalledWith(
+      2,
+      `SELECT * FROM ${SUBSCRIPTIONS_NFTS_TABLE} WHERE token_id IN (:tokenIds)`,
+      { tokenIds: [517] }
     );
   });
 });

--- a/src/api-serverless/src/subscriptions/api.subscriptions.db.ts
+++ b/src/api-serverless/src/subscriptions/api.subscriptions.db.ts
@@ -702,24 +702,41 @@ export async function fetchAllPublicFinalSubscriptionsForContractAndToken(
   );
 }
 
-export async function fetchUpcomingMemeSubscriptionCounts(
-  cardCount: number
+async function fetchFinalMemeSubscriptionCount(
+  tokenId: number
+): Promise<SubscriptionCounts> {
+  const results = await sqlExecutor.execute<{ count: number | string | null }>(
+    `SELECT COALESCE(SUM(subscribed_count), 0) AS count
+    FROM ${SUBSCRIPTIONS_NFTS_FINAL_TABLE}
+    WHERE contract = :contract
+      AND token_id = :tokenId`,
+    { contract: MEMES_CONTRACT, tokenId }
+  );
+
+  return {
+    contract: MEMES_CONTRACT,
+    token_id: tokenId,
+    count: Number(results[0]?.count ?? 0)
+  };
+}
+
+async function fetchEffectiveUpcomingMemeSubscriptionCounts(
+  tokenIds: number[]
 ): Promise<SubscriptionCounts[]> {
+  if (tokenIds.length === 0) {
+    return [];
+  }
+
   const autoSubs: SubscriptionMode[] = await sqlExecutor.execute(
     `SELECT * FROM ${SUBSCRIPTIONS_MODE_TABLE} WHERE automatic = :automatic`,
     { automatic: true }
   );
 
-  const maxMemeId = await getMaxMemeId();
-
   // Fetch all subscription records (both subscribed = true and false)
   // to check if someone manually unsubscribed from a specific card
   const subs: NFTSubscription[] = await sqlExecutor.execute(
-    `SELECT * FROM ${SUBSCRIPTIONS_NFTS_TABLE} WHERE token_id > :startIndex AND token_id <= :endIndex`,
-    {
-      startIndex: maxMemeId,
-      endIndex: maxMemeId + cardCount
-    }
+    `SELECT * FROM ${SUBSCRIPTIONS_NFTS_TABLE} WHERE token_id IN (:tokenIds)`,
+    { tokenIds }
   );
 
   // Get all unique consolidation keys from subscriptions and auto subscriptions
@@ -757,8 +774,7 @@ export async function fetchUpcomingMemeSubscriptionCounts(
   );
 
   const counts: SubscriptionCounts[] = [];
-  for (let i = 1; i <= cardCount; i++) {
-    const id = maxMemeId + i;
+  for (const id of tokenIds) {
     // Get all manual subscription records for this token (both subscribed = true and false)
     const allTokenSubs = [...subs].filter((s) => s.token_id === id);
     // Only count manual subscriptions where subscribed = true
@@ -808,6 +824,28 @@ export async function fetchUpcomingMemeSubscriptionCounts(
     });
   }
   return counts;
+}
+
+export async function fetchUpcomingMemeSubscriptionCounts(
+  cardCount: number,
+  tokenId?: number
+): Promise<SubscriptionCounts[]> {
+  const maxMemeId = await getMaxMemeId();
+
+  if (tokenId !== undefined) {
+    if (tokenId <= maxMemeId) {
+      return [await fetchFinalMemeSubscriptionCount(tokenId)];
+    }
+
+    return fetchEffectiveUpcomingMemeSubscriptionCounts([tokenId]);
+  }
+
+  const tokenIds = Array.from(
+    { length: cardCount },
+    (_value, index) => maxMemeId + index + 1
+  );
+
+  return fetchEffectiveUpcomingMemeSubscriptionCounts(tokenIds);
 }
 
 const REDEEMED_COUNTS_JOINS = `

--- a/src/api-serverless/src/subscriptions/api.subscriptions.db.ts
+++ b/src/api-serverless/src/subscriptions/api.subscriptions.db.ts
@@ -720,6 +720,66 @@ async function fetchFinalMemeSubscriptionCount(
   };
 }
 
+function getEffectiveSubscriptionCount(
+  balance: number,
+  requestedCount: number
+): number {
+  const affordableCount = Math.floor(balance / MEMES_MINT_PRICE);
+  return Math.min(requestedCount, Math.max(0, affordableCount));
+}
+
+function getSubscriptionBalance(
+  balanceMap: Map<string, number>,
+  consolidationKey: string
+): number {
+  return balanceMap.get(consolidationKey.toLowerCase()) ?? 0;
+}
+
+function getTokenSubscriptionPartitions(
+  tokenId: number,
+  subs: NFTSubscription[],
+  autoSubs: SubscriptionMode[]
+): {
+  tokenSubs: NFTSubscription[];
+  tokenAutoSubs: SubscriptionMode[];
+} {
+  const allTokenSubs = subs.filter((s) => s.token_id === tokenId);
+  const tokenSubs = allTokenSubs.filter((s) => s.subscribed);
+  const tokenAutoSubs = autoSubs.filter(
+    (s) =>
+      !allTokenSubs.some((ts) =>
+        equalIgnoreCase(ts.consolidation_key, s.consolidation_key)
+      )
+  );
+
+  return { tokenSubs, tokenAutoSubs };
+}
+
+function getManualSubscriptionEffectiveCount(
+  sub: NFTSubscription,
+  balanceMap: Map<string, number>
+): number {
+  return getEffectiveSubscriptionCount(
+    getSubscriptionBalance(balanceMap, sub.consolidation_key),
+    sub.subscribed_count ?? 1
+  );
+}
+
+function getAutomaticSubscriptionEffectiveCount(
+  autoSub: SubscriptionMode,
+  balanceMap: Map<string, number>,
+  autoSubEligibilityMap: Map<string, number>
+): number {
+  const eligibility =
+    autoSubEligibilityMap.get(autoSub.consolidation_key.toLowerCase()) ?? 1;
+  const subscribedCount = autoSub.subscribe_all_editions ? eligibility : 1;
+
+  return getEffectiveSubscriptionCount(
+    getSubscriptionBalance(balanceMap, autoSub.consolidation_key),
+    subscribedCount
+  );
+}
+
 async function fetchEffectiveUpcomingMemeSubscriptionCounts(
   tokenIds: number[]
 ): Promise<SubscriptionCounts[]> {
@@ -775,52 +835,31 @@ async function fetchEffectiveUpcomingMemeSubscriptionCounts(
 
   const counts: SubscriptionCounts[] = [];
   for (const id of tokenIds) {
-    // Get all manual subscription records for this token (both subscribed = true and false)
-    const allTokenSubs = [...subs].filter((s) => s.token_id === id);
-    // Only count manual subscriptions where subscribed = true
-    const tokenSubs = allTokenSubs.filter((s) => s.subscribed);
-    // For auto subscriptions, only count if they don't have ANY manual record for this token
-    // (if they have a manual record with subscribed = false, they manually unsubscribed)
-    const tokenAutoSubs = [...autoSubs].filter(
-      (s) =>
-        !allTokenSubs.some((ts) =>
-          equalIgnoreCase(ts.consolidation_key, s.consolidation_key)
-        )
+    const { tokenSubs, tokenAutoSubs } = getTokenSubscriptionPartitions(
+      id,
+      subs,
+      autoSubs
     );
-
-    let totalCount = 0;
-
-    // Calculate effective count for manual subscriptions (only those with subscribed = true)
-    for (const sub of tokenSubs) {
-      const balance = balanceMap.get(sub.consolidation_key.toLowerCase()) ?? 0;
-      const affordableCount = Math.floor(balance / MEMES_MINT_PRICE);
-      const effectiveCount = Math.min(
-        sub.subscribed_count ?? 1,
-        Math.max(0, affordableCount)
-      );
-      totalCount += effectiveCount;
-    }
-
-    // Calculate effective count for auto subscriptions
-    // (only those without any manual subscription record for this token)
-    for (const autoSub of tokenAutoSubs) {
-      const balance =
-        balanceMap.get(autoSub.consolidation_key.toLowerCase()) ?? 0;
-      const eligibility =
-        autoSubEligibilityMap.get(autoSub.consolidation_key.toLowerCase()) ?? 1;
-      const subscribedCount = autoSub.subscribe_all_editions ? eligibility : 1;
-      const affordableCount = Math.floor(balance / MEMES_MINT_PRICE);
-      const effectiveCount = Math.min(
-        subscribedCount,
-        Math.max(0, affordableCount)
-      );
-      totalCount += effectiveCount;
-    }
+    const manualCount = tokenSubs.reduce(
+      (total, sub) =>
+        total + getManualSubscriptionEffectiveCount(sub, balanceMap),
+      0
+    );
+    const automaticCount = tokenAutoSubs.reduce(
+      (total, autoSub) =>
+        total +
+        getAutomaticSubscriptionEffectiveCount(
+          autoSub,
+          balanceMap,
+          autoSubEligibilityMap
+        ),
+      0
+    );
 
     counts.push({
       contract: MEMES_CONTRACT,
       token_id: id,
-      count: totalCount
+      count: manualCount + automaticCount
     });
   }
   return counts;
@@ -836,7 +875,13 @@ export async function fetchMemeSubscriptionCount(
   }
 
   const [count] = await fetchEffectiveUpcomingMemeSubscriptionCounts([tokenId]);
-  return count;
+  return (
+    count ?? {
+      contract: MEMES_CONTRACT,
+      token_id: tokenId,
+      count: 0
+    }
+  );
 }
 
 export async function fetchUpcomingMemeSubscriptionCounts(

--- a/src/api-serverless/src/subscriptions/api.subscriptions.db.ts
+++ b/src/api-serverless/src/subscriptions/api.subscriptions.db.ts
@@ -826,19 +826,23 @@ async function fetchEffectiveUpcomingMemeSubscriptionCounts(
   return counts;
 }
 
-export async function fetchUpcomingMemeSubscriptionCounts(
-  cardCount: number,
-  tokenId?: number
-): Promise<SubscriptionCounts[]> {
+export async function fetchMemeSubscriptionCount(
+  tokenId: number
+): Promise<SubscriptionCounts> {
   const maxMemeId = await getMaxMemeId();
 
-  if (tokenId !== undefined) {
-    if (tokenId <= maxMemeId) {
-      return [await fetchFinalMemeSubscriptionCount(tokenId)];
-    }
-
-    return fetchEffectiveUpcomingMemeSubscriptionCounts([tokenId]);
+  if (tokenId <= maxMemeId) {
+    return fetchFinalMemeSubscriptionCount(tokenId);
   }
+
+  const [count] = await fetchEffectiveUpcomingMemeSubscriptionCounts([tokenId]);
+  return count;
+}
+
+export async function fetchUpcomingMemeSubscriptionCounts(
+  cardCount: number
+): Promise<SubscriptionCounts[]> {
+  const maxMemeId = await getMaxMemeId();
 
   const tokenIds = Array.from(
     { length: cardCount },

--- a/src/api-serverless/src/subscriptions/api.subscriptions.routes.ts
+++ b/src/api-serverless/src/subscriptions/api.subscriptions.routes.ts
@@ -411,7 +411,7 @@ router.get(
     const cardCount = numbers.parseIntOrNull(req.query.card_count) ?? 3;
     const tokenId = numbers.parseIntOrNull(req.query.token_id);
     if (req.query.token_id !== undefined && (tokenId === null || tokenId < 1)) {
-      return res.status(400).send('Invalid token ID');
+      throw new BadRequestException('Invalid token ID');
     }
 
     const result = await fetchUpcomingMemeSubscriptionCounts(

--- a/src/api-serverless/src/subscriptions/api.subscriptions.routes.ts
+++ b/src/api-serverless/src/subscriptions/api.subscriptions.routes.ts
@@ -403,13 +403,21 @@ router.get(
       any,
       {
         card_count?: string;
+        token_id?: string;
       }
     >,
     res: Response<SubscriptionCounts[]>
   ) {
     const cardCount = numbers.parseIntOrNull(req.query.card_count) ?? 3;
+    const tokenId = numbers.parseIntOrNull(req.query.token_id);
+    if (req.query.token_id !== undefined && (tokenId === null || tokenId < 1)) {
+      return res.status(400).send('Invalid token ID');
+    }
 
-    const result = await fetchUpcomingMemeSubscriptionCounts(cardCount);
+    const result = await fetchUpcomingMemeSubscriptionCounts(
+      cardCount,
+      tokenId ?? undefined
+    );
     return res.json(result);
   }
 );

--- a/src/api-serverless/src/subscriptions/api.subscriptions.routes.ts
+++ b/src/api-serverless/src/subscriptions/api.subscriptions.routes.ts
@@ -49,6 +49,7 @@ import {
   fetchFinalSubscription,
   fetchFinalSubscriptionsByPhase,
   fetchLogsForConsolidationKey,
+  fetchMemeSubscriptionCount,
   fetchPastMemeSubscriptionCounts,
   fetchRedeemedMemeSubscriptionCountsDownload,
   fetchRedeemedSubscriptionsForConsolidationKey,
@@ -141,6 +142,10 @@ async function invalidateSubscriptionCache(consolidationKey: string) {
     {
       label: 'subscription-upcoming-memes-counts',
       path: `/api/subscriptions/upcoming-memes-counts`
+    },
+    {
+      label: 'subscription-meme-count',
+      path: `/api/subscriptions/memes/*/count`
     }
   ];
 
@@ -403,21 +408,36 @@ router.get(
       any,
       {
         card_count?: string;
-        token_id?: string;
       }
     >,
     res: Response<SubscriptionCounts[]>
   ) {
     const cardCount = numbers.parseIntOrNull(req.query.card_count) ?? 3;
-    const tokenId = numbers.parseIntOrNull(req.query.token_id);
-    if (req.query.token_id !== undefined && (tokenId === null || tokenId < 1)) {
+    const result = await fetchUpcomingMemeSubscriptionCounts(cardCount);
+    return res.json(result);
+  }
+);
+
+router.get(
+  `/memes/:token_id/count`,
+  cacheRequest(),
+  async function (
+    req: Request<
+      {
+        token_id: string;
+      },
+      any,
+      any,
+      any
+    >,
+    res: Response<SubscriptionCounts>
+  ) {
+    const tokenId = numbers.parseIntOrNull(req.params.token_id);
+    if (tokenId === null || tokenId < 1) {
       throw new BadRequestException('Invalid token ID');
     }
 
-    const result = await fetchUpcomingMemeSubscriptionCounts(
-      cardCount,
-      tokenId ?? undefined
-    );
+    const result = await fetchMemeSubscriptionCount(tokenId);
     return res.json(result);
   }
 );


### PR DESCRIPTION
Adds an optional token_id query parameter to the upcoming meme subscription counts endpoint so callers can request the subscription-copy count for a specific Meme Card without changing existing card_count behavior. For already-dropped cards, the endpoint returns the baked final subscribed_count aggregate instead of redeemed/airdropped counts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new endpoint to fetch the subscription count for a single meme token (`GET /subscriptions/memes/{token_id}/count`).
* **Bug Fixes**
  * Added stricter validation for `token_id`; invalid values now return a clear `400` error.
  * Updated subscription count logic to distinguish finalized counts (dropped) from effective upcoming counts (future).
* **Tests**
  * Expanded unit test coverage for single-token counts and upcoming-count query behavior.
* **Documentation**
  * Updated the OpenAPI spec to include the new endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->