### PR TITLE
Await drop push notification enqueue

### DIFF
--- a/src/api-serverless/src/drops/drop-creation-api-service.test.ts
+++ b/src/api-serverless/src/drops/drop-creation-api-service.test.ts
@@ -3,9 +3,14 @@ import { waveScoreService } from '@/api/waves/wave-score.service';
 import { invalidateWaveUnreadCacheForWave } from '@/api/waves/wave-unread-cache';
 import { DropType } from '@/entities/IDrop';
 import { waveDropMetricsRefreshService } from '@/drops/wave-drop-metrics-refresh.service';
+import { sendIdentityPushNotifications } from '@/api/push-notifications/push-notifications.service';
 
 jest.mock('@/api/waves/wave-unread-cache', () => ({
   invalidateWaveUnreadCacheForWave: jest.fn().mockResolvedValue(undefined)
+}));
+
+jest.mock('@/api/push-notifications/push-notifications.service', () => ({
+  sendIdentityPushNotifications: jest.fn().mockResolvedValue(undefined)
 }));
 
 function makeService({
@@ -146,6 +151,10 @@ describe('DropCreationApiService.toggleHideLinkPreview', () => {
 });
 
 describe('DropCreationApiService.createDrop', () => {
+  beforeEach(() => {
+    (sendIdentityPushNotifications as jest.Mock).mockResolvedValue(undefined);
+  });
+
   afterEach(() => {
     jest.restoreAllMocks();
     jest.clearAllMocks();
@@ -231,6 +240,98 @@ describe('DropCreationApiService.createDrop', () => {
       'committed',
       'unread-cache-invalidated'
     ]);
+  });
+
+  it('waits for pending push notifications to be enqueued before resolving', async () => {
+    const connection = {} as any;
+    let resolvePush!: () => void;
+    const pushStarted = new Promise<void>((resolveStarted) => {
+      (sendIdentityPushNotifications as jest.Mock).mockImplementationOnce(
+        () => {
+          resolveStarted();
+          return new Promise<void>((resolve) => {
+            resolvePush = resolve;
+          });
+        }
+      );
+    });
+    const dropsDb = {
+      executeNativeQueriesInTransaction: jest.fn(
+        async (callback: (connection: unknown) => Promise<unknown>) =>
+          callback(connection)
+      )
+    };
+    const dropsMappers = {
+      createDropApiToUseCaseModel: jest.fn().mockReturnValue({
+        wave_id: 'wave-1',
+        drop_type: DropType.CHAT
+      })
+    };
+    const createOrUpdateDrop = {
+      preResolveIdentityNomination: jest.fn().mockResolvedValue(null),
+      execute: jest.fn().mockResolvedValue({
+        drop_id: 'drop-1',
+        pending_push_notification_ids: [3711]
+      })
+    };
+    const dropPollsApiService = {
+      createPollForDrop: jest.fn().mockResolvedValue(undefined)
+    };
+    const dropsService = {
+      findDropByIdOrThrow: jest.fn().mockResolvedValue({
+        id: 'drop-1',
+        wave_id: 'wave-1'
+      })
+    };
+    const wsListenersNotifier = {
+      notifyAboutDropUpdate: jest.fn().mockResolvedValue(undefined)
+    };
+    const dropNftLinksDb = {
+      findByDropId: jest.fn().mockResolvedValue([])
+    };
+    const service = new DropCreationApiService(
+      dropsService as never,
+      dropsDb as never,
+      dropsMappers as never,
+      createOrUpdateDrop as never,
+      {} as never,
+      wsListenersNotifier as never,
+      dropNftLinksDb as never,
+      {} as never,
+      dropPollsApiService as never
+    );
+    jest
+      .spyOn(waveScoreService, 'requestWaveScoreRefreshBestEffort')
+      .mockResolvedValue(undefined);
+
+    let resolved = false;
+    const createDrop = service
+      .createDrop(
+        {
+          createDropRequest: {} as never,
+          authorId: 'author-profile',
+          representativeId: 'author-profile'
+        },
+        { timer: undefined } as never
+      )
+      .then((drop) => {
+        resolved = true;
+        return drop;
+      });
+
+    await pushStarted;
+    await Promise.resolve();
+
+    expect(sendIdentityPushNotifications).toHaveBeenCalledWith([3711]);
+    expect(resolved).toBe(false);
+
+    resolvePush();
+
+    await expect(createDrop).resolves.toEqual({
+      id: 'drop-1',
+      wave_id: 'wave-1'
+    });
+    expect(resolved).toBe(true);
   });
 });
 

--- a/src/api-serverless/src/drops/drop-creation.api.service.ts
+++ b/src/api-serverless/src/drops/drop-creation.api.service.ts
@@ -116,7 +116,7 @@ export class DropCreationApiService {
       ctx
     );
     await invalidateWaveUnreadCacheForWave(model.wave_id);
-    void this.sendPendingPushNotifications({
+    await this.sendPendingPushNotifications({
       dropId: drop.id,
       pendingPushNotificationIds
     });
@@ -351,7 +351,7 @@ export class DropCreationApiService {
       ctx
     );
     await invalidateWaveUnreadCacheForWave(model.wave_id);
-    void this.sendPendingPushNotifications({
+    await this.sendPendingPushNotifications({
       dropId: apiDrop.id,
       pendingPushNotificationIds
     });

--- a/src/notifications/identity-notifications.db.test.ts
+++ b/src/notifications/identity-notifications.db.test.ts
@@ -135,7 +135,9 @@ describe('IdentityNotificationsDb mute filtering', () => {
     );
     expect(db.execute).toHaveBeenNthCalledWith(
       2,
-      expect.stringContaining('select id'),
+      expect.stringContaining(
+        '`additional_data` <=> CAST(:additional_data_0 AS JSON)'
+      ),
       expect.objectContaining({
         firstInsertId: 301,
         identity_id_0: 'recipient-2',

--- a/src/notifications/identity-notifications.db.ts
+++ b/src/notifications/identity-notifications.db.ts
@@ -217,6 +217,9 @@ export class IdentityNotificationsDb extends LazyDbAccessCompatibleService {
         (column) => {
           const paramName = `${column}_${rowIndex}`;
           params[paramName] = row[column];
+          if (column === 'additional_data') {
+            return `\`${column}\` <=> CAST(:${paramName} AS JSON)`;
+          }
           return `\`${column}\` <=> :${paramName}`;
         }
       );


### PR DESCRIPTION
## Summary
- await drop-created pending push notification enqueue before returning from create/update drop paths
- add regression coverage that createDrop does not resolve before pending push IDs are handed to the push enqueue service

## Verification
- npm test -- src/api-serverless/src/drops/drop-creation-api-service.test.ts --runInBand
- npm run lint
- git diff --check

## Deployment
- Deploy backend api Lambda only
- No DB migration
- No pushNotificationsHandler deployment required

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved drop creation and update flow so background notifications finish before the next steps continue.
  * This helps ensure related updates happen in the correct order and reduces the chance of missed or out-of-sync notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->