### PR TITLE
Enforce npm as the pinned package manager

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -18,6 +18,8 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
+      - name: Check package manager discipline
+        run: node scripts/check-package-manager.mjs
       - name: Install dependencies
         run: npm i && pushd src/api-serverless && npm i && popd
       - name: Verify generated files are committed

--- a/package.json
+++ b/package.json
@@ -151,5 +151,6 @@
     "minimatch@5": {
       "brace-expansion": "^2.0.2"
     }
-  }
+  },
+  "packageManager": "npm@10.9.8"
 }

--- a/scripts/check-package-manager.mjs
+++ b/scripts/check-package-manager.mjs
@@ -1,0 +1,89 @@
+import { execSync } from 'node:child_process';
+import console from 'node:console';
+import fs from 'node:fs';
+import process from 'node:process';
+
+const PINNED_PACKAGE_MANAGER = 'npm@10.9.8';
+const FORBIDDEN_FILES = [
+  'yarn.lock',
+  'pnpm-lock.yaml',
+  'pnpm-workspace.yaml',
+  'bun.lockb',
+  'bun.lock',
+  '.yarnrc',
+  '.yarnrc.yml'
+];
+
+const fix = process.argv.includes('--fix');
+
+const trackedFiles = execSync('git ls-files', { encoding: 'utf8' })
+  .split('\n')
+  .filter(Boolean);
+
+const packageJsonFiles = trackedFiles.filter(
+  (file) => file === 'package.json' || file.endsWith('/package.json')
+);
+
+const errors = [];
+
+const strayLockfiles = trackedFiles.filter((file) => {
+  const basename = file.split('/').pop();
+  return FORBIDDEN_FILES.includes(basename);
+});
+for (const file of strayLockfiles) {
+  errors.push(
+    `${file}: forbidden package-manager file. This repo uses npm only; remove it.`
+  );
+}
+
+for (const file of packageJsonFiles) {
+  const raw = fs.readFileSync(file, 'utf8');
+  let manifest;
+  try {
+    manifest = JSON.parse(raw);
+  } catch {
+    errors.push(`${file}: not valid JSON`);
+    continue;
+  }
+  if (manifest.packageManager === PINNED_PACKAGE_MANAGER) {
+    continue;
+  }
+  if (fix) {
+    const updated = setPackageManager(raw, manifest);
+    fs.writeFileSync(file, updated);
+    console.log(`fixed: ${file}`);
+  } else {
+    errors.push(
+      `${file}: "packageManager" must be "${PINNED_PACKAGE_MANAGER}" (found ${JSON.stringify(
+        manifest.packageManager ?? null
+      )}). Run: node scripts/check-package-manager.mjs --fix`
+    );
+  }
+}
+
+function setPackageManager(raw, manifest) {
+  const eol = raw.includes('\r\n') ? '\r\n' : '\n';
+  const trailingNewline = raw.endsWith('\n');
+  manifest.packageManager = PINNED_PACKAGE_MANAGER;
+  let output = JSON.stringify(manifest, null, 2);
+  if (eol !== '\n') {
+    output = output.replaceAll('\n', eol);
+  }
+  return trailingNewline ? output + eol : output;
+}
+
+if (errors.length > 0) {
+  console.error(
+    `Package manager check failed (${errors.length} problem${
+      errors.length === 1 ? '' : 's'
+    }):`
+  );
+  for (const error of errors) {
+    console.error(`  - ${error}`);
+  }
+  process.exit(1);
+}
+
+console.log(
+  `Package manager check passed: ${packageJsonFiles.length} package.json files pinned to ${PINNED_PACKAGE_MANAGER}, no stray lockfiles.`
+);

--- a/scripts/check-package-manager.mjs
+++ b/scripts/check-package-manager.mjs
@@ -29,6 +29,7 @@ const repoRoot = path.resolve(
 );
 const fix = process.argv.includes('--fix');
 
+const gitignoreMatchers = loadGitignoreMatchers();
 const packageJsonFiles = [];
 const strayLockfiles = [];
 collectFiles(repoRoot);
@@ -69,21 +70,68 @@ for (const file of packageJsonFiles) {
 function collectFiles(directory) {
   for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
     const absolutePath = path.join(directory, entry.name);
+    const relativePath = path
+      .relative(repoRoot, absolutePath)
+      .replaceAll(path.sep, '/');
     if (entry.isDirectory()) {
-      if (!SKIPPED_DIRECTORIES.has(entry.name)) {
+      if (
+        !SKIPPED_DIRECTORIES.has(entry.name) &&
+        !isGitignored(relativePath, true)
+      ) {
         collectFiles(absolutePath);
       }
       continue;
     }
-    const relativePath = path
-      .relative(repoRoot, absolutePath)
-      .replaceAll(path.sep, '/');
+    if (isGitignored(relativePath, false)) {
+      continue;
+    }
     if (entry.name === 'package.json') {
       packageJsonFiles.push(relativePath);
     } else if (FORBIDDEN_FILES.has(entry.name)) {
       strayLockfiles.push(relativePath);
     }
   }
+}
+
+// Minimal .gitignore support so local-only files (scratch directories,
+// vendored tools) are not validated or rewritten. Handles the pattern
+// shapes used in this repo's root .gitignore: bare names, dir/ suffixes,
+// leading-/ anchors, and * / ? / ** globs. Negations are ignored, which
+// only makes the check skip more, never fail on a re-included file.
+function loadGitignoreMatchers() {
+  const gitignorePath = path.join(repoRoot, '.gitignore');
+  if (!fs.existsSync(gitignorePath)) {
+    return [];
+  }
+  return fs
+    .readFileSync(gitignorePath, 'utf8')
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith('#') && !line.startsWith('!'))
+    .map((pattern) => {
+      const directoryOnly = pattern.endsWith('/');
+      let body = directoryOnly ? pattern.slice(0, -1) : pattern;
+      const anchored = body.startsWith('/') || body.includes('/');
+      body = body.startsWith('/') ? body.slice(1) : body;
+      const regexBody = body
+        .split('**')
+        .map((part) =>
+          part
+            .replaceAll(/[.+^${}()|[\]\\]/g, '\\$&')
+            .replaceAll('*', '[^/]*')
+            .replaceAll('?', '[^/]')
+        )
+        .join('.*');
+      const prefix = anchored ? '^' : '(^|/)';
+      return { regex: new RegExp(`${prefix}${regexBody}$`), directoryOnly };
+    });
+}
+
+function isGitignored(relativePath, isDirectory) {
+  return gitignoreMatchers.some(
+    ({ regex, directoryOnly }) =>
+      (!directoryOnly || isDirectory) && regex.test(relativePath)
+  );
 }
 
 function setPackageManager(raw) {

--- a/scripts/check-package-manager.mjs
+++ b/scripts/check-package-manager.mjs
@@ -1,10 +1,11 @@
-import { execSync } from 'node:child_process';
 import console from 'node:console';
 import fs from 'node:fs';
+import path from 'node:path';
 import process from 'node:process';
+import { fileURLToPath } from 'node:url';
 
 const PINNED_PACKAGE_MANAGER = 'npm@10.9.8';
-const FORBIDDEN_FILES = [
+const FORBIDDEN_FILES = new Set([
   'yarn.lock',
   'pnpm-lock.yaml',
   'pnpm-workspace.yaml',
@@ -12,24 +13,28 @@ const FORBIDDEN_FILES = [
   'bun.lock',
   '.yarnrc',
   '.yarnrc.yml'
-];
+]);
+const SKIPPED_DIRECTORIES = new Set([
+  'node_modules',
+  '.git',
+  '.serverless',
+  'dist',
+  'build',
+  'coverage'
+]);
 
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..'
+);
 const fix = process.argv.includes('--fix');
 
-const trackedFiles = execSync('git ls-files', { encoding: 'utf8' })
-  .split('\n')
-  .filter(Boolean);
-
-const packageJsonFiles = trackedFiles.filter(
-  (file) => file === 'package.json' || file.endsWith('/package.json')
-);
+const packageJsonFiles = [];
+const strayLockfiles = [];
+collectFiles(repoRoot);
 
 const errors = [];
 
-const strayLockfiles = trackedFiles.filter((file) => {
-  const basename = file.split('/').pop();
-  return FORBIDDEN_FILES.includes(basename);
-});
 for (const file of strayLockfiles) {
   errors.push(
     `${file}: forbidden package-manager file. This repo uses npm only; remove it.`
@@ -37,7 +42,8 @@ for (const file of strayLockfiles) {
 }
 
 for (const file of packageJsonFiles) {
-  const raw = fs.readFileSync(file, 'utf8');
+  const absolutePath = path.join(repoRoot, file);
+  const raw = fs.readFileSync(absolutePath, 'utf8');
   let manifest;
   try {
     manifest = JSON.parse(raw);
@@ -49,8 +55,7 @@ for (const file of packageJsonFiles) {
     continue;
   }
   if (fix) {
-    const updated = setPackageManager(raw, manifest);
-    fs.writeFileSync(file, updated);
+    fs.writeFileSync(absolutePath, setPackageManager(raw));
     console.log(`fixed: ${file}`);
   } else {
     errors.push(
@@ -61,15 +66,45 @@ for (const file of packageJsonFiles) {
   }
 }
 
-function setPackageManager(raw, manifest) {
-  const eol = raw.includes('\r\n') ? '\r\n' : '\n';
-  const trailingNewline = raw.endsWith('\n');
-  manifest.packageManager = PINNED_PACKAGE_MANAGER;
-  let output = JSON.stringify(manifest, null, 2);
-  if (eol !== '\n') {
-    output = output.replaceAll('\n', eol);
+function collectFiles(directory) {
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const absolutePath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      if (!SKIPPED_DIRECTORIES.has(entry.name)) {
+        collectFiles(absolutePath);
+      }
+      continue;
+    }
+    const relativePath = path
+      .relative(repoRoot, absolutePath)
+      .replaceAll(path.sep, '/');
+    if (entry.name === 'package.json') {
+      packageJsonFiles.push(relativePath);
+    } else if (FORBIDDEN_FILES.has(entry.name)) {
+      strayLockfiles.push(relativePath);
+    }
   }
-  return trailingNewline ? output + eol : output;
+}
+
+function setPackageManager(raw) {
+  const eol = raw.includes('\r\n') ? '\r\n' : '\n';
+  const existingKey = /"packageManager"\s*:\s*"[^"]*"/;
+  if (existingKey.test(raw)) {
+    return raw.replace(
+      existingKey,
+      `"packageManager": "${PINNED_PACKAGE_MANAGER}"`
+    );
+  }
+  const indentMatch = raw.match(/^([ \t]+)"/m);
+  const indent = indentMatch ? indentMatch[1] : '  ';
+  const closingIndex = raw.lastIndexOf('}');
+  const head = raw.slice(0, closingIndex).replace(/\s*$/, '');
+  const needsComma = !head.endsWith('{');
+  return (
+    head +
+    `${needsComma ? ',' : ''}${eol}${indent}"packageManager": "${PINNED_PACKAGE_MANAGER}"${eol}` +
+    raw.slice(closingIndex)
+  );
 }
 
 if (errors.length > 0) {

--- a/src/aggregatedActivityLoop/package.json
+++ b/src/aggregatedActivityLoop/package.json
@@ -15,5 +15,6 @@
   "devDependencies": {
     "@types/aws-lambda": "^8.10.110",
     "esbuild": "^0.27.2"
-  }
+  },
+  "packageManager": "npm@10.9.8"
 }

--- a/src/api-serverless/package.json
+++ b/src/api-serverless/package.json
@@ -80,5 +80,6 @@
     "minimatch@5": {
       "brace-expansion": "^2.0.2"
     }
-  }
+  },
+  "packageManager": "npm@10.9.8"
 }

--- a/src/artCurationNftWatchLoop/package.json
+++ b/src/artCurationNftWatchLoop/package.json
@@ -16,5 +16,6 @@
     "@types/aws-lambda": "^8.10.110",
     "esbuild": "^0.27.2"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "packageManager": "npm@10.9.8"
 }

--- a/src/attachmentsOrchestrator/package.json
+++ b/src/attachmentsOrchestrator/package.json
@@ -15,5 +15,6 @@
   "devDependencies": {
     "@types/aws-lambda": "^8.10.110",
     "esbuild": "^0.27.2"
-  }
+  },
+  "packageManager": "npm@10.9.8"
 }

--- a/src/attachmentsProcessor/package.json
+++ b/src/attachmentsProcessor/package.json
@@ -15,5 +15,6 @@
   "devDependencies": {
     "@types/aws-lambda": "^8.10.110",
     "esbuild": "^0.27.2"
-  }
+  },
+  "packageManager": "npm@10.9.8"
 }

--- a/src/claimsBuilder/package.json
+++ b/src/claimsBuilder/package.json
@@ -16,5 +16,6 @@
     "@types/aws-lambda": "^8.10.110",
     "esbuild": "^0.27.3"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "packageManager": "npm@10.9.8"
 }

--- a/src/claimsMediaArweaveUploader/package.json
+++ b/src/claimsMediaArweaveUploader/package.json
@@ -15,5 +15,6 @@
   "devDependencies": {
     "@types/aws-lambda": "^8.10.110",
     "esbuild": "^0.27.2"
-  }
+  },
+  "packageManager": "npm@10.9.8"
 }

--- a/src/cloudwatchAlarmsToDiscordLoop/package.json
+++ b/src/cloudwatchAlarmsToDiscordLoop/package.json
@@ -17,5 +17,6 @@
   },
   "dependencies": {
     "discord.js": "^14.25.1"
-  }
+  },
+  "packageManager": "npm@10.9.8"
 }

--- a/src/customReplayLoop/package.json
+++ b/src/customReplayLoop/package.json
@@ -15,5 +15,6 @@
   "devDependencies": {
     "@types/aws-lambda": "^8.10.110",
     "esbuild": "^0.27.2"
-  }
+  },
+  "packageManager": "npm@10.9.8"
 }

--- a/src/dbDumpsDaily/package.json
+++ b/src/dbDumpsDaily/package.json
@@ -15,5 +15,6 @@
   "devDependencies": {
     "@types/aws-lambda": "^8.10.110",
     "esbuild": "^0.27.2"
-  }
+  },
+  "packageManager": "npm@10.9.8"
 }

--- a/src/dbMigrationsLoop/package.json
+++ b/src/dbMigrationsLoop/package.json
@@ -15,5 +15,6 @@
   "dependencies": {
     "db-migrate": "^0.11.14",
     "db-migrate-mysql": "^3.0.0"
-  }
+  },
+  "packageManager": "npm@10.9.8"
 }

--- a/src/delegationsLoop/package.json
+++ b/src/delegationsLoop/package.json
@@ -15,5 +15,6 @@
   "devDependencies": {
     "@types/aws-lambda": "^8.10.110",
     "esbuild": "^0.27.2"
-  }
+  },
+  "packageManager": "npm@10.9.8"
 }

--- a/src/discoverEnsLoop/package.json
+++ b/src/discoverEnsLoop/package.json
@@ -15,5 +15,6 @@
   "devDependencies": {
     "@types/aws-lambda": "^8.10.110",
     "esbuild": "^0.27.2"
-  }
+  },
+  "packageManager": "npm@10.9.8"
 }

--- a/src/dropMediaIngestStorage/package.json
+++ b/src/dropMediaIngestStorage/package.json
@@ -8,5 +8,6 @@
     "sls-deploy:prod": "node ../../node_modules/serverless/bin/serverless.js deploy --stage=prod --region=us-east-1"
   },
   "author": "",
-  "license": "ISC"
+  "license": "ISC",
+  "packageManager": "npm@10.9.8"
 }

--- a/src/dropMediaSanitizer/package.json
+++ b/src/dropMediaSanitizer/package.json
@@ -18,5 +18,6 @@
   },
   "devDependencies": {
     "@types/aws-lambda": "^8.10.110"
-  }
+  },
+  "packageManager": "npm@10.9.8"
 }

--- a/src/dropVideoConversionInvokerLoop/package.json
+++ b/src/dropVideoConversionInvokerLoop/package.json
@@ -15,5 +15,6 @@
   "devDependencies": {
     "@types/aws-lambda": "^8.10.110",
     "esbuild": "^0.27.2"
-  }
+  },
+  "packageManager": "npm@10.9.8"
 }

--- a/src/ethPriceLoop/package.json
+++ b/src/ethPriceLoop/package.json
@@ -15,5 +15,6 @@
   "devDependencies": {
     "@types/aws-lambda": "^8.10.110",
     "esbuild": "^0.27.2"
-  }
+  },
+  "packageManager": "npm@10.9.8"
 }

--- a/src/externalCollectionLiveTailingLoop/package.json
+++ b/src/externalCollectionLiveTailingLoop/package.json
@@ -16,5 +16,6 @@
     "@types/aws-lambda": "^8.10.110",
     "esbuild": "^0.27.2"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "packageManager": "npm@10.9.8"
 }

--- a/src/externalCollectionSnapshottingLoop/package.json
+++ b/src/externalCollectionSnapshottingLoop/package.json
@@ -16,5 +16,6 @@
     "@types/aws-lambda": "^8.10.110",
     "esbuild": "^0.27.2"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "packageManager": "npm@10.9.8"
 }

--- a/src/helpBotReplyLoop/package.json
+++ b/src/helpBotReplyLoop/package.json
@@ -16,5 +16,6 @@
     "@types/aws-lambda": "^8.10.110",
     "esbuild": "^0.27.3"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "packageManager": "npm@10.9.8"
 }

--- a/src/marketStatsLoop/package.json
+++ b/src/marketStatsLoop/package.json
@@ -15,5 +15,6 @@
   "devDependencies": {
     "@types/aws-lambda": "^8.10.110",
     "esbuild": "^0.27.2"
-  }
+  },
+  "packageManager": "npm@10.9.8"
 }

--- a/src/mediaResizerLoop/package.json
+++ b/src/mediaResizerLoop/package.json
@@ -19,5 +19,6 @@
   "devDependencies": {
     "@aws-sdk/client-s3": "^3.980.0",
     "@aws-sdk/lib-storage": "^3.980.0"
-  }
+  },
+  "packageManager": "npm@10.9.8"
 }

--- a/src/mintAnnouncementsLoop/package.json
+++ b/src/mintAnnouncementsLoop/package.json
@@ -16,5 +16,6 @@
     "@types/aws-lambda": "^8.10.110",
     "esbuild": "^0.27.2"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "packageManager": "npm@10.9.8"
 }

--- a/src/nextgenContractLoop/package.json
+++ b/src/nextgenContractLoop/package.json
@@ -15,5 +15,6 @@
   "devDependencies": {
     "esbuild": "^0.27.2"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "packageManager": "npm@10.9.8"
 }

--- a/src/nextgenMediaImageResolutions/package.json
+++ b/src/nextgenMediaImageResolutions/package.json
@@ -15,5 +15,6 @@
   "devDependencies": {
     "esbuild": "^0.27.2"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "packageManager": "npm@10.9.8"
 }

--- a/src/nextgenMediaProxyInterceptor/package.json
+++ b/src/nextgenMediaProxyInterceptor/package.json
@@ -13,5 +13,6 @@
   "devDependencies": {
     "esbuild": "^0.27.2"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "packageManager": "npm@10.9.8"
 }

--- a/src/nextgenMediaUploader/package.json
+++ b/src/nextgenMediaUploader/package.json
@@ -15,5 +15,6 @@
   "devDependencies": {
     "esbuild": "^0.27.2"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "packageManager": "npm@10.9.8"
 }

--- a/src/nextgenMetadataLoop/package.json
+++ b/src/nextgenMetadataLoop/package.json
@@ -15,5 +15,6 @@
   "devDependencies": {
     "esbuild": "^0.27.2"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "packageManager": "npm@10.9.8"
 }

--- a/src/nftHistoryLoop/package.json
+++ b/src/nftHistoryLoop/package.json
@@ -9,5 +9,6 @@
     "postbuild": "cd dist && zip -r index.zip index.js*",
     "sls-deploy:prod": "node ../../node_modules/serverless/bin/serverless.js deploy --stage=prod --region=us-east-1",
     "sls-deploy:staging": "node ../../node_modules/serverless/bin/serverless.js deploy --stage=staging --region=eu-west-1"
-  }
+  },
+  "packageManager": "npm@10.9.8"
 }

--- a/src/nftLinkMediaPreviewLoop/package.json
+++ b/src/nftLinkMediaPreviewLoop/package.json
@@ -18,5 +18,6 @@
   "devDependencies": {
     "@types/aws-lambda": "^8.10.110",
     "esbuild": "^0.27.2"
-  }
+  },
+  "packageManager": "npm@10.9.8"
 }

--- a/src/nftLinkRefresherLoop/package.json
+++ b/src/nftLinkRefresherLoop/package.json
@@ -15,5 +15,6 @@
   "devDependencies": {
     "@types/aws-lambda": "^8.10.110",
     "esbuild": "^0.27.2"
-  }
+  },
+  "packageManager": "npm@10.9.8"
 }

--- a/src/nftOwnersLoop/package.json
+++ b/src/nftOwnersLoop/package.json
@@ -15,5 +15,6 @@
   "devDependencies": {
     "@types/aws-lambda": "^8.10.110",
     "esbuild": "^0.27.2"
-  }
+  },
+  "packageManager": "npm@10.9.8"
 }

--- a/src/nftsLoop/package.json
+++ b/src/nftsLoop/package.json
@@ -15,5 +15,6 @@
   "devDependencies": {
     "@types/aws-lambda": "^8.10.110",
     "esbuild": "^0.27.2"
-  }
+  },
+  "packageManager": "npm@10.9.8"
 }

--- a/src/overRatesRevocationLoop/package.json
+++ b/src/overRatesRevocationLoop/package.json
@@ -16,5 +16,6 @@
     "@types/aws-lambda": "^8.10.110",
     "esbuild": "^0.27.2"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "packageManager": "npm@10.9.8"
 }

--- a/src/ownersBalancesLoop/package.json
+++ b/src/ownersBalancesLoop/package.json
@@ -15,5 +15,6 @@
   "devDependencies": {
     "@types/aws-lambda": "^8.10.110",
     "esbuild": "^0.27.2"
-  }
+  },
+  "packageManager": "npm@10.9.8"
 }

--- a/src/populateHistoricConsolidatedTdh/package.json
+++ b/src/populateHistoricConsolidatedTdh/package.json
@@ -15,6 +15,6 @@
   "devDependencies": {
     "@types/aws-lambda": "^8.10.110",
     "esbuild": "^0.27.2"
-  }
+  },
+  "packageManager": "npm@10.9.8"
 }
-

--- a/src/pushNotificationsHandler/package.json
+++ b/src/pushNotificationsHandler/package.json
@@ -15,5 +15,6 @@
   "devDependencies": {
     "@types/aws-lambda": "^8.10.110",
     "esbuild": "^0.27.2"
-  }
+  },
+  "packageManager": "npm@10.9.8"
 }

--- a/src/rateEventProcessingLoop/package.json
+++ b/src/rateEventProcessingLoop/package.json
@@ -16,5 +16,6 @@
     "@types/aws-lambda": "^8.10.110",
     "esbuild": "^0.27.2"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "packageManager": "npm@10.9.8"
 }

--- a/src/refreshEnsLoop/package.json
+++ b/src/refreshEnsLoop/package.json
@@ -15,5 +15,6 @@
   "devDependencies": {
     "@types/aws-lambda": "^8.10.110",
     "esbuild": "^0.27.2"
-  }
+  },
+  "packageManager": "npm@10.9.8"
 }

--- a/src/rememesLoop/package.json
+++ b/src/rememesLoop/package.json
@@ -24,5 +24,6 @@
     "fluent-ffmpeg": "^2.1.3",
     "imagescript": "^1.3.1",
     "sharp": "^0.34.5"
-  }
+  },
+  "packageManager": "npm@10.9.8"
 }

--- a/src/royaltiesLoop/package.json
+++ b/src/royaltiesLoop/package.json
@@ -15,5 +15,6 @@
   "devDependencies": {
     "@types/aws-lambda": "^8.10.110",
     "esbuild": "^0.27.2"
-  }
+  },
+  "packageManager": "npm@10.9.8"
 }

--- a/src/s3Uploader/package.json
+++ b/src/s3Uploader/package.json
@@ -20,5 +20,6 @@
     "fluent-ffmpeg": "^2.1.3",
     "imagescript": "^1.3.1",
     "sharp": "^0.34.5"
-  }
+  },
+  "packageManager": "npm@10.9.8"
 }

--- a/src/subscriptionsDaily/package.json
+++ b/src/subscriptionsDaily/package.json
@@ -15,5 +15,6 @@
   "devDependencies": {
     "@types/aws-lambda": "^8.10.110",
     "esbuild": "^0.27.2"
-  }
+  },
+  "packageManager": "npm@10.9.8"
 }

--- a/src/subscriptionsTopUpLoop/package.json
+++ b/src/subscriptionsTopUpLoop/package.json
@@ -15,5 +15,6 @@
   "devDependencies": {
     "@types/aws-lambda": "^8.10.110",
     "esbuild": "^0.27.2"
-  }
+  },
+  "packageManager": "npm@10.9.8"
 }

--- a/src/tdhHistoryLoop/package.json
+++ b/src/tdhHistoryLoop/package.json
@@ -15,5 +15,6 @@
   "devDependencies": {
     "@types/aws-lambda": "^8.10.110",
     "esbuild": "^0.27.2"
-  }
+  },
+  "packageManager": "npm@10.9.8"
 }

--- a/src/tdhLoop/package.json
+++ b/src/tdhLoop/package.json
@@ -14,5 +14,6 @@
   "license": "ISC",
   "dependencies": {
     "node-fetch": "^3.3.0"
-  }
+  },
+  "packageManager": "npm@10.9.8"
 }

--- a/src/teamLoop/package.json
+++ b/src/teamLoop/package.json
@@ -15,5 +15,6 @@
   "devDependencies": {
     "@types/aws-lambda": "^8.10.110",
     "esbuild": "^0.27.2"
-  }
+  },
+  "packageManager": "npm@10.9.8"
 }

--- a/src/transactionsLoop/package.json
+++ b/src/transactionsLoop/package.json
@@ -15,5 +15,6 @@
   "devDependencies": {
     "@types/aws-lambda": "^8.10.110",
     "esbuild": "^0.27.2"
-  }
+  },
+  "packageManager": "npm@10.9.8"
 }

--- a/src/transactionsProcessingLoop/package.json
+++ b/src/transactionsProcessingLoop/package.json
@@ -15,5 +15,6 @@
   "devDependencies": {
     "@types/aws-lambda": "^8.10.110",
     "esbuild": "^0.27.2"
-  }
+  },
+  "packageManager": "npm@10.9.8"
 }

--- a/src/waveDecisionExecutionLoop/package.json
+++ b/src/waveDecisionExecutionLoop/package.json
@@ -16,5 +16,6 @@
     "@types/aws-lambda": "^8.10.110",
     "esbuild": "^0.27.3"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "packageManager": "npm@10.9.8"
 }

--- a/src/waveDropMetricsRefreshLoop/package.json
+++ b/src/waveDropMetricsRefreshLoop/package.json
@@ -16,5 +16,6 @@
     "@types/aws-lambda": "^8.10.110",
     "esbuild": "^0.27.2"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "packageManager": "npm@10.9.8"
 }

--- a/src/waveLeaderboardSnapshotterLoop/package.json
+++ b/src/waveLeaderboardSnapshotterLoop/package.json
@@ -16,5 +16,6 @@
     "@types/aws-lambda": "^8.10.110",
     "esbuild": "^0.27.2"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "packageManager": "npm@10.9.8"
 }

--- a/src/waveScoreRefreshLoop/package.json
+++ b/src/waveScoreRefreshLoop/package.json
@@ -16,5 +16,6 @@
     "@types/aws-lambda": "^8.10.110",
     "esbuild": "^0.27.2"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "packageManager": "npm@10.9.8"
 }

--- a/src/xTdhGrantsReviewerLoop/package.json
+++ b/src/xTdhGrantsReviewerLoop/package.json
@@ -16,5 +16,6 @@
     "@types/aws-lambda": "^8.10.110",
     "esbuild": "^0.27.2"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "packageManager": "npm@10.9.8"
 }

--- a/src/xTdhLoop/package.json
+++ b/src/xTdhLoop/package.json
@@ -16,5 +16,6 @@
     "@types/aws-lambda": "^8.10.110",
     "esbuild": "^0.27.2"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "packageManager": "npm@10.9.8"
 }


### PR DESCRIPTION
## Issue
- PR #1511 attempted an npm→pnpm migration with a bespoke CLI shim layer; it went stale (640 commits behind, 16 conflicts, 7 newer services never converted) and was closed.
- The enforcement goal it chased is still valid: one package manager, consistently pinned, with no way for a new service or a stray `pnpm-lock.yaml`/`yarn.lock` to drift in unnoticed.

## Fix
- Keep npm (no migration) and enforce discipline with a single dependency-free checker script plus a fast-fail CI step — roughly 90% of the enforcement value of #1511 at a fraction of the surface.

## Changes
- New `scripts/check-package-manager.mjs`: validates every tracked `package.json` (root + all 55 service/module manifests) carries `"packageManager": "npm@10.9.8"`, and that no forbidden package-manager files are tracked (`yarn.lock`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`, `bun.lockb`, `.yarnrc*`). `--fix` mode applies the pin everywhere, so onboarding a new service is one command and CI catches omissions by construction.
- `.github/workflows/on-pull-request.yml`: new "Check package manager discipline" step before dependency install (script has zero dependencies, so it fails fast).
- Applied the pin to all 56 `package.json` files.

## Validation
- `node scripts/check-package-manager.mjs` passes on the branch (56 files pinned, no stray lockfiles).
- Negative tests: removing a pin and adding a tracked `pnpm-lock.yaml` each fail the check with actionable messages; `--fix` restores the pin.
- `npx eslint scripts/check-package-manager.mjs --max-warnings=0` clean; actionlint clean on the workflow; YAML parses.
- Not tested: corepack behavior on developer machines (the pin is advisory for plain npm and only binding under corepack — that is the intended 90/10 trade-off).

## Risk
- Level: Low
- Why: no runtime, dependency, or deploy-config changes; the pin field is inert metadata for npm itself; CI gains one fast read-only step.
- Rollback: revert the commit.

## Deployment
- None. CI-only change; no lambdas or services need redeploying.

## Review Notes
- npm version pinned to 10.9.8 to match the npm bundled with the Node 22 line used by PR CI (`actions/setup-node` `node-version: 22`), not the newest npm 11 — happy to bump if the team prefers tracking npm 11.
- `packageManager` is intentionally the only enforcement (no `engines`/`engine-strict`, no shim wrappers) to keep the surface minimal per the #1511 closure note.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a repo-wide npm version pin to keep package management consistent.
  * Included a CI check that verifies the expected package manager version during pull requests.

* **Bug Fixes**
  * Updated many project manifests to declare the same npm version, reducing setup and build drift.
  * Added support for automatically correcting mismatched package manager settings when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->