### PR TITLE
perf(tdhLoop): remove O(n²) scans and dead work from TDH consolidation and ranking

### DIFF
--- a/src/tdhLoop/tdh-consolidation.test.ts
+++ b/src/tdhLoop/tdh-consolidation.test.ts
@@ -5,9 +5,9 @@ import {
   fetchLatestTDHBlockNumber,
   retrieveConsolidationsForWallets,
   retrieveWalletConsolidations
-} from '../db';
-import { TDHENS } from '../entities/ITDH';
-import { equalIgnoreCase } from '../strings';
+} from '@/db';
+import { TDHENS } from '@/entities/ITDH';
+import { equalIgnoreCase } from '@/strings';
 import { createMemesData, getGenesisAndNaka } from './tdh';
 import {
   consolidateCards,
@@ -15,7 +15,7 @@ import {
   consolidateTDHForWallets
 } from './tdh_consolidation';
 
-jest.mock('../db', () => ({
+jest.mock('@/db', () => ({
   fetchAllConsolidatedTdh: jest.fn(),
   fetchAllTDH: jest.fn(),
   fetchConsolidationDisplay: jest.fn(),
@@ -27,7 +27,7 @@ jest.mock('../db', () => ({
   retrieveWalletConsolidations: jest.fn()
 }));
 
-jest.mock('../nextgen/nextgen.db', () => ({
+jest.mock('@/nextgen/nextgen.db', () => ({
   fetchNextgenTokens: jest.fn()
 }));
 
@@ -103,6 +103,7 @@ function distinctByTokenId(tokens: TokenLike[]): TokenLike[] {
 const tdhEntryArb: fc.Arbitrary<TDHENS> = fc
   .record({
     walletIdx: fc.integer({ min: 0, max: WALLET_POOL.length - 1 }),
+    block: fc.integer({ min: 1, max: 99 }),
     tdh: fc.integer({ min: 0, max: 100000 }),
     tdh__raw: fc.integer({ min: 0, max: 100000 }),
     balance: fc.integer({ min: 0, max: 100 }),
@@ -124,7 +125,7 @@ const tdhEntryArb: fc.Arbitrary<TDHENS> = fc
       ({
         wallet: WALLET_POOL[r.walletIdx],
         ensName: '',
-        block: 42,
+        block: r.block,
         tdh: r.tdh,
         tdh__raw: r.tdh__raw,
         balance: r.balance,

--- a/src/tdhLoop/tdh-consolidation.test.ts
+++ b/src/tdhLoop/tdh-consolidation.test.ts
@@ -1,0 +1,386 @@
+import fc from 'fast-check';
+import {
+  fetchConsolidationDisplay,
+  fetchConsolidationDisplays,
+  fetchLatestTDHBlockNumber,
+  retrieveConsolidationsForWallets,
+  retrieveWalletConsolidations
+} from '../db';
+import { TDHENS } from '../entities/ITDH';
+import { equalIgnoreCase } from '../strings';
+import { createMemesData, getGenesisAndNaka } from './tdh';
+import {
+  consolidateCards,
+  consolidateMissingWallets,
+  consolidateTDHForWallets
+} from './tdh_consolidation';
+
+jest.mock('../db', () => ({
+  fetchAllConsolidatedTdh: jest.fn(),
+  fetchAllTDH: jest.fn(),
+  fetchConsolidationDisplay: jest.fn(),
+  fetchConsolidationDisplays: jest.fn(),
+  fetchLatestTDHBlockNumber: jest.fn(),
+  persistConsolidatedTDH: jest.fn(),
+  persistTDHBlock: jest.fn(),
+  retrieveConsolidationsForWallets: jest.fn(),
+  retrieveWalletConsolidations: jest.fn()
+}));
+
+jest.mock('../nextgen/nextgen.db', () => ({
+  fetchNextgenTokens: jest.fn()
+}));
+
+const mockedRetrieveConsolidationsForWallets =
+  retrieveConsolidationsForWallets as jest.MockedFunction<
+    typeof retrieveConsolidationsForWallets
+  >;
+const mockedFetchConsolidationDisplays =
+  fetchConsolidationDisplays as jest.MockedFunction<
+    typeof fetchConsolidationDisplays
+  >;
+const mockedRetrieveWalletConsolidations =
+  retrieveWalletConsolidations as jest.MockedFunction<
+    typeof retrieveWalletConsolidations
+  >;
+const mockedFetchConsolidationDisplay =
+  fetchConsolidationDisplay as jest.MockedFunction<
+    typeof fetchConsolidationDisplay
+  >;
+const mockedFetchLatestTDHBlockNumber =
+  fetchLatestTDHBlockNumber as jest.MockedFunction<
+    typeof fetchLatestTDHBlockNumber
+  >;
+
+const WALLET_POOL = [
+  '0xAaA1',
+  '0xbbb2',
+  '0xCcC3',
+  '0xddd4',
+  '0xEee5',
+  '0xfff6'
+];
+
+function buildConsolidationKey(wallets: string[]): string {
+  return wallets
+    .map((it) => it.toLowerCase())
+    .slice()
+    .sort((a, b) => a.localeCompare(b))
+    .join('-');
+}
+
+type TokenLike = {
+  id: number;
+  balance: number;
+  tdh: number;
+  tdh__raw: number;
+  days_held_per_edition: number[];
+};
+
+function tokenArb(maxId: number): fc.Arbitrary<TokenLike> {
+  return fc.record({
+    id: fc.integer({ min: 1, max: maxId }),
+    balance: fc.integer({ min: 1, max: 5 }),
+    tdh: fc.integer({ min: 0, max: 1000 }),
+    tdh__raw: fc.integer({ min: 0, max: 1000 }),
+    days_held_per_edition: fc.array(fc.integer({ min: 0, max: 500 }), {
+      maxLength: 3
+    })
+  });
+}
+
+function distinctByTokenId(tokens: TokenLike[]): TokenLike[] {
+  const seen = new Set<number>();
+  return tokens.filter((t) => {
+    if (seen.has(t.id)) {
+      return false;
+    }
+    seen.add(t.id);
+    return true;
+  });
+}
+
+const tdhEntryArb: fc.Arbitrary<TDHENS> = fc
+  .record({
+    walletIdx: fc.integer({ min: 0, max: WALLET_POOL.length - 1 }),
+    tdh: fc.integer({ min: 0, max: 100000 }),
+    tdh__raw: fc.integer({ min: 0, max: 100000 }),
+    balance: fc.integer({ min: 0, max: 100 }),
+    memes_tdh: fc.integer({ min: 0, max: 1000 }),
+    memes_tdh__raw: fc.integer({ min: 0, max: 1000 }),
+    memes_balance: fc.integer({ min: 0, max: 100 }),
+    gradients_tdh: fc.integer({ min: 0, max: 1000 }),
+    gradients_tdh__raw: fc.integer({ min: 0, max: 1000 }),
+    gradients_balance: fc.integer({ min: 0, max: 100 }),
+    nextgen_tdh: fc.integer({ min: 0, max: 1000 }),
+    nextgen_tdh__raw: fc.integer({ min: 0, max: 1000 }),
+    nextgen_balance: fc.integer({ min: 0, max: 100 }),
+    memes: fc.array(tokenArb(2), { maxLength: 3 }),
+    gradients: fc.array(tokenArb(4), { maxLength: 2 }),
+    nextgen: fc.array(tokenArb(4), { maxLength: 2 })
+  })
+  .map(
+    (r) =>
+      ({
+        wallet: WALLET_POOL[r.walletIdx],
+        ensName: '',
+        block: 42,
+        tdh: r.tdh,
+        tdh__raw: r.tdh__raw,
+        balance: r.balance,
+        memes_tdh: r.memes_tdh,
+        memes_tdh__raw: r.memes_tdh__raw,
+        memes_balance: r.memes_balance,
+        gradients_tdh: r.gradients_tdh,
+        gradients_tdh__raw: r.gradients_tdh__raw,
+        gradients_balance: r.gradients_balance,
+        nextgen_tdh: r.nextgen_tdh,
+        nextgen_tdh__raw: r.nextgen_tdh__raw,
+        nextgen_balance: r.nextgen_balance,
+        memes: distinctByTokenId(r.memes),
+        gradients: distinctByTokenId(r.gradients),
+        nextgen: distinctByTokenId(r.nextgen)
+      }) as unknown as TDHENS
+  );
+
+/**
+ * Random partition of the wallet pool into consolidation clusters of size 1-3.
+ * Returns wallet (lowercase) -> consolidation key.
+ */
+const partitionArb: fc.Arbitrary<Record<string, string>> = fc
+  .array(fc.integer({ min: 0, max: 2 }), {
+    minLength: WALLET_POOL.length,
+    maxLength: WALLET_POOL.length
+  })
+  .map((sizes) => {
+    const remaining = [...WALLET_POOL];
+    const mapping: Record<string, string> = {};
+    let i = 0;
+    while (remaining.length) {
+      const size = Math.min(sizes[i % sizes.length] + 1, remaining.length);
+      i++;
+      const cluster = remaining.splice(0, size);
+      const key = buildConsolidationKey(cluster);
+      cluster.forEach((w) => {
+        mapping[w.toLowerCase()] = key;
+      });
+    }
+    return mapping;
+  });
+
+/**
+ * Reference implementation: the exact pre-optimization algorithm of
+ * consolidateTDHForWallets (quadratic scans included), kept here to prove the
+ * optimized version produces identical output.
+ */
+function referenceConsolidateTDHForWallets(
+  tdh: TDHENS[],
+  MEMES_COUNT: number,
+  walletToKey: Record<string, string>,
+  displays: Record<string, string>
+) {
+  const consolidatedTdh: any[] = [];
+  const processedWallets = new Set<string>();
+  const allGradientsTDH: any[] = [];
+  const allNextgenTDH: any[] = [];
+
+  for (const tdhEntry of tdh) {
+    const wallet = tdhEntry.wallet;
+    const consolidationKey = walletToKey[wallet.toLowerCase()];
+    const display = displays[consolidationKey];
+    const consolidations = consolidationKey.split('-');
+
+    if (
+      !Array.from(processedWallets).some((pw) => equalIgnoreCase(wallet, pw))
+    ) {
+      const consolidatedWalletsTdh = [...tdh].filter((t) =>
+        consolidations.some((c) => equalIgnoreCase(c, t.wallet))
+      );
+
+      let totalTDH = 0;
+      let totalTDH__raw = 0;
+      let totalBalance = 0;
+      const memesData = createMemesData();
+      let gradientsTDH = 0;
+      let gradientsTDH__raw = 0;
+      let gradientsBalance = 0;
+      let nextgenTDH = 0;
+      let nextgenTDH__raw = 0;
+      let nextgenBalance = 0;
+      let consolidationMemes: any[] = [];
+      let consolidationGradients: any[] = [];
+      let consolidationNextgen: any[] = [];
+
+      consolidatedWalletsTdh.forEach((wTdh) => {
+        totalTDH += wTdh.tdh;
+        totalTDH__raw += wTdh.tdh__raw;
+        totalBalance += wTdh.balance;
+        memesData.memes_tdh += wTdh.memes_tdh;
+        memesData.memes_tdh__raw += wTdh.memes_tdh__raw;
+        memesData.memes_balance += wTdh.memes_balance;
+        gradientsTDH += wTdh.gradients_tdh;
+        gradientsTDH__raw += wTdh.gradients_tdh__raw;
+        gradientsBalance += wTdh.gradients_balance;
+        nextgenTDH += wTdh.nextgen_tdh;
+        nextgenTDH__raw += wTdh.nextgen_tdh__raw;
+        nextgenBalance += wTdh.nextgen_balance;
+        consolidationMemes = consolidateCards(consolidationMemes, wTdh.memes);
+        consolidationGradients = consolidateCards(
+          consolidationGradients,
+          wTdh.gradients
+        );
+        consolidationNextgen = consolidateCards(
+          consolidationNextgen,
+          wTdh.nextgen
+        );
+      });
+
+      let memesCardSets = 0;
+      if (consolidationMemes.length == MEMES_COUNT) {
+        memesCardSets = Math.min(
+          ...consolidationMemes.map((o: any) => o.balance)
+        );
+      }
+      const genNaka = getGenesisAndNaka(consolidationMemes);
+
+      consolidatedTdh.push({
+        consolidation_display: display,
+        consolidation_key: consolidationKey,
+        wallets: consolidations,
+        tdh_rank: 0,
+        tdh_rank_memes: 0,
+        tdh_rank_gradients: 0,
+        tdh_rank_nextgen: 0,
+        block: tdhEntry.block,
+        tdh: totalTDH,
+        boost: 0,
+        boosted_tdh: 0,
+        tdh__raw: totalTDH__raw,
+        balance: totalBalance,
+        memes_cards_sets: memesCardSets,
+        genesis: genNaka.genesis,
+        nakamoto: genNaka.naka,
+        unique_memes: consolidationMemes.length,
+        memes_tdh: memesData.memes_tdh,
+        memes_tdh__raw: memesData.memes_tdh__raw,
+        memes_balance: memesData.memes_balance,
+        boosted_memes_tdh: memesData.boosted_memes_tdh,
+        memes_ranks: memesData.memes_ranks,
+        memes: consolidationMemes,
+        boosted_gradients_tdh: 0,
+        gradients_tdh: gradientsTDH,
+        gradients_tdh__raw: gradientsTDH__raw,
+        gradients_balance: gradientsBalance,
+        gradients: consolidationGradients,
+        gradients_ranks: [],
+        boosted_nextgen_tdh: 0,
+        nextgen_tdh: nextgenTDH,
+        nextgen_tdh__raw: nextgenTDH__raw,
+        nextgen_balance: nextgenBalance,
+        nextgen: consolidationNextgen,
+        nextgen_ranks: [],
+        boost_breakdown: {},
+        boosted_tdh_rate: 0
+      });
+      consolidationGradients.forEach((wg) => allGradientsTDH.push(wg));
+      consolidationNextgen.forEach((wn) => allNextgenTDH.push(wn));
+    }
+    consolidations.forEach((c) => {
+      processedWallets.add(c);
+    });
+  }
+
+  return { consolidatedTdh, allGradientsTDH, allNextgenTDH };
+}
+
+function stripDates(consolidations: any[]): any[] {
+  return consolidations.map((c) => {
+    const { date, ...rest } = c;
+    expect(date).toBeInstanceOf(Date);
+    return rest;
+  });
+}
+
+describe('consolidateTDHForWallets', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('produces exactly the same output as the pre-optimization reference implementation', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.array(tdhEntryArb, { maxLength: 12 }),
+        partitionArb,
+        fc.integer({ min: 1, max: 3 }),
+        async (tdh, walletToKey, memesCount) => {
+          const displays = Object.values(walletToKey).reduce(
+            (acc, key) => {
+              acc[key] = `display:${key}`;
+              return acc;
+            },
+            {} as Record<string, string>
+          );
+          mockedRetrieveConsolidationsForWallets.mockResolvedValue(walletToKey);
+          mockedFetchConsolidationDisplays.mockResolvedValue(displays);
+
+          const actual = await consolidateTDHForWallets(
+            structuredClone(tdh),
+            memesCount
+          );
+          const expected = referenceConsolidateTDHForWallets(
+            structuredClone(tdh),
+            memesCount,
+            walletToKey,
+            displays
+          );
+
+          expect(stripDates(actual.consolidatedTdh)).toEqual(
+            expected.consolidatedTdh
+          );
+          expect(actual.allGradientsTDH).toEqual(expected.allGradientsTDH);
+          expect(actual.allNextgenTDH).toEqual(expected.allNextgenTDH);
+        }
+      ),
+      { numRuns: 50 }
+    );
+  });
+});
+
+describe('consolidateMissingWallets', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedFetchLatestTDHBlockNumber.mockResolvedValue(77);
+    mockedRetrieveWalletConsolidations.mockImplementation(async (wallet) => {
+      const key = buildConsolidationKey(['0xAaA1', '0xbbb2']);
+      if (key.split('-').some((w) => equalIgnoreCase(w, wallet))) {
+        return key.split('-');
+      }
+      return [wallet];
+    });
+    mockedFetchConsolidationDisplay.mockImplementation(
+      async (wallets) => `display:${buildConsolidationKey(wallets)}`
+    );
+  });
+
+  it('emits one entry per consolidation and dedupes case-insensitively', async () => {
+    const result = await consolidateMissingWallets([
+      '0xaaa1',
+      '0xBBB2',
+      '0xAAA1',
+      '0xccc3'
+    ]);
+
+    expect(result.map((r) => r.consolidation_key)).toEqual([
+      buildConsolidationKey(['0xAaA1', '0xbbb2']),
+      '0xccc3'
+    ]);
+    expect(result.every((r) => r.block === 77)).toBe(true);
+  });
+
+  it('does not hit the database for wallets already covered by an earlier consolidation', async () => {
+    await consolidateMissingWallets(['0xaaa1', '0xBBB2', '0xAAA1']);
+
+    expect(mockedRetrieveWalletConsolidations).toHaveBeenCalledTimes(1);
+    expect(mockedFetchConsolidationDisplay).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/tdhLoop/tdh.ts
+++ b/src/tdhLoop/tdh.ts
@@ -929,6 +929,19 @@ export async function calculateRanks(
     return a;
   });
 
+  const gradientsRanksById = new Map<number, number>();
+  for (const rankedGradient of rankedGradientsTdh) {
+    if (rankedGradient.id !== null && rankedGradient.id !== undefined) {
+      gradientsRanksById.set(Number(rankedGradient.id), rankedGradient.rank);
+    }
+  }
+  const nextgenRanksById = new Map<number, number>();
+  for (const rankedNextgen of rankedNextgenTdh) {
+    if (rankedNextgen.id !== null && rankedNextgen.id !== undefined) {
+      nextgenRanksById.set(Number(rankedNextgen.id), rankedNextgen.rank);
+    }
+  }
+
   ADJUSTED_NFTS.forEach((nft) => {
     boostedTDH
       .filter(
@@ -970,40 +983,16 @@ export async function calculateRanks(
           if (gradient) {
             w.gradients_ranks.push({
               id: nft.id,
-              rank: rankedGradientsTdh.find((s) => s.id == nft.id)?.rank
+              rank: gradientsRanksById.get(Number(nft.id))
             });
           }
           return w;
         }
       });
-
-    if (equalIgnoreCase(nft.contract, MEMES_CONTRACT)) {
-      const wallets = [...boostedTDH].filter((w) =>
-        w.memes?.some((m: any) => m.id == nft.id)
-      );
-
-      wallets.sort((a, b) => {
-        const aNftBalance = a.memes.find((m: any) => m.id == nft.id).tdh;
-        const bNftBalance = b.memes.find((m: any) => m.id == nft.id).tdh;
-
-        if (aNftBalance > bNftBalance) {
-          return -1;
-        }
-        if (aNftBalance > bNftBalance) {
-          return -1;
-        } else if (aNftBalance < bNftBalance) {
-          return 1;
-        } else {
-          if (a.boosted_tdh > b.boosted_tdh) {
-            return -1;
-          }
-          return 1;
-        }
-      });
-    }
   });
 
   NEXTGEN_NFTS.forEach((nft) => {
+    const nextgenRank = nextgenRanksById.get(Number(nft.id));
     boostedTDH
       .filter((w) => w.nextgen?.some((n: any) => n.id == nft.id && n.tdh > 0))
       .forEach((w) => {
@@ -1011,7 +1000,7 @@ export async function calculateRanks(
         if (nextgen) {
           w.nextgen_ranks.push({
             id: nft.id,
-            rank: rankedNextgenTdh.find((s) => s.id == nft.id)?.rank
+            rank: nextgenRank
           });
         }
         return w;

--- a/src/tdhLoop/tdh_consolidation.ts
+++ b/src/tdhLoop/tdh_consolidation.ts
@@ -39,7 +39,6 @@ export async function consolidateTDHForWallets(
   MEMES_COUNT: number
 ) {
   const consolidatedTdh: ConsolidatedTDH[] = [];
-  const processedWallets = new Set<string>();
   const allGradientsTDH: any[] = [];
   const allNextgenTDH: any[] = [];
 
@@ -66,125 +65,123 @@ export async function consolidateTDHForWallets(
       { consolidationKey: string; consolidationDisplay: string }
     >
   );
+  const tdhByConsolidationKey = new Map<string, TDHENS[]>();
   for (const tdhEntry of tdh) {
-    const wallet = tdhEntry.wallet;
-    const consolidationInfo = walletConsolidationInfos[wallet.toLowerCase()]!;
-    const display = consolidationInfo.consolidationDisplay;
-    const consolidationKey = consolidationInfo.consolidationKey;
+    const consolidationKey =
+      walletConsolidationInfos[tdhEntry.wallet.toLowerCase()]!.consolidationKey;
+    const group = tdhByConsolidationKey.get(consolidationKey);
+    if (group) {
+      group.push(tdhEntry);
+    } else {
+      tdhByConsolidationKey.set(consolidationKey, [tdhEntry]);
+    }
+  }
+
+  tdhByConsolidationKey.forEach((consolidatedWalletsTdh, consolidationKey) => {
+    const display = allConsolidationDisplays[consolidationKey]!;
     const consolidations = consolidationKey.split('-');
 
-    if (
-      !Array.from(processedWallets).some((pw) => equalIgnoreCase(wallet, pw))
-    ) {
-      const consolidatedWalletsTdh = [...tdh].filter((t) =>
-        consolidations.some((c) => equalIgnoreCase(c, t.wallet))
+    let totalTDH = 0;
+    let totalTDH__raw = 0;
+    let totalBalance = 0;
+
+    const memesData = createMemesData();
+
+    let gradientsTDH = 0;
+    let gradientsTDH__raw = 0;
+    let gradientsBalance = 0;
+    let nextgenTDH = 0;
+    let nextgenTDH__raw = 0;
+    let nextgenBalance = 0;
+    let consolidationMemes: any[] = [];
+    let consolidationGradients: any[] = [];
+    let consolidationNextgen: any[] = [];
+
+    consolidatedWalletsTdh.forEach((wTdh) => {
+      totalTDH += wTdh.tdh;
+      totalTDH__raw += wTdh.tdh__raw;
+      totalBalance += wTdh.balance;
+      memesData.memes_tdh += wTdh.memes_tdh;
+      memesData.memes_tdh__raw += wTdh.memes_tdh__raw;
+      memesData.memes_balance += wTdh.memes_balance;
+      gradientsTDH += wTdh.gradients_tdh;
+      gradientsTDH__raw += wTdh.gradients_tdh__raw;
+      gradientsBalance += wTdh.gradients_balance;
+      nextgenTDH += wTdh.nextgen_tdh;
+      nextgenTDH__raw += wTdh.nextgen_tdh__raw;
+      nextgenBalance += wTdh.nextgen_balance;
+      consolidationMemes = consolidateCards(consolidationMemes, wTdh.memes);
+      consolidationGradients = consolidateCards(
+        consolidationGradients,
+        wTdh.gradients
       );
-
-      let totalTDH = 0;
-      let totalTDH__raw = 0;
-      let totalBalance = 0;
-
-      const memesData = createMemesData();
-
-      let gradientsTDH = 0;
-      let gradientsTDH__raw = 0;
-      let gradientsBalance = 0;
-      let nextgenTDH = 0;
-      let nextgenTDH__raw = 0;
-      let nextgenBalance = 0;
-      let consolidationMemes: any[] = [];
-      let consolidationGradients: any[] = [];
-      let consolidationNextgen: any[] = [];
-
-      consolidatedWalletsTdh.forEach((wTdh) => {
-        totalTDH += wTdh.tdh;
-        totalTDH__raw += wTdh.tdh__raw;
-        totalBalance += wTdh.balance;
-        memesData.memes_tdh += wTdh.memes_tdh;
-        memesData.memes_tdh__raw += wTdh.memes_tdh__raw;
-        memesData.memes_balance += wTdh.memes_balance;
-        gradientsTDH += wTdh.gradients_tdh;
-        gradientsTDH__raw += wTdh.gradients_tdh__raw;
-        gradientsBalance += wTdh.gradients_balance;
-        nextgenTDH += wTdh.nextgen_tdh;
-        nextgenTDH__raw += wTdh.nextgen_tdh__raw;
-        nextgenBalance += wTdh.nextgen_balance;
-        consolidationMemes = consolidateCards(consolidationMemes, wTdh.memes);
-        consolidationGradients = consolidateCards(
-          consolidationGradients,
-          wTdh.gradients
-        );
-        consolidationNextgen = consolidateCards(
-          consolidationNextgen,
-          wTdh.nextgen
-        );
-      });
-
-      let memesCardSets = 0;
-      if (consolidationMemes.length == MEMES_COUNT) {
-        memesCardSets = Math.min(
-          ...[...consolidationMemes].map(function (o) {
-            return o.balance;
-          })
-        );
-      }
-
-      const unique_memes = consolidationMemes.length;
-
-      const genNaka = getGenesisAndNaka(consolidationMemes);
-
-      const consolidation: ConsolidatedTDH = {
-        date: new Date(),
-        consolidation_display: display,
-        consolidation_key: consolidationKey,
-        wallets: consolidations,
-        tdh_rank: 0, //assigned later
-        tdh_rank_memes: 0, //assigned later
-        tdh_rank_gradients: 0, //assigned later
-        tdh_rank_nextgen: 0, //assigned later
-        block: tdhEntry.block,
-        tdh: totalTDH,
-        boost: 0,
-        boosted_tdh: 0,
-        tdh__raw: totalTDH__raw,
-        balance: totalBalance,
-        memes_cards_sets: memesCardSets,
-        genesis: genNaka.genesis,
-        nakamoto: genNaka.naka,
-        unique_memes: unique_memes,
-        memes_tdh: memesData.memes_tdh,
-        memes_tdh__raw: memesData.memes_tdh__raw,
-        memes_balance: memesData.memes_balance,
-        boosted_memes_tdh: memesData.boosted_memes_tdh,
-        memes_ranks: memesData.memes_ranks,
-        memes: consolidationMemes,
-        boosted_gradients_tdh: 0,
-        gradients_tdh: gradientsTDH,
-        gradients_tdh__raw: gradientsTDH__raw,
-        gradients_balance: gradientsBalance,
-        gradients: consolidationGradients,
-        gradients_ranks: [],
-        boosted_nextgen_tdh: 0,
-        nextgen_tdh: nextgenTDH,
-        nextgen_tdh__raw: nextgenTDH__raw,
-        nextgen_balance: nextgenBalance,
-        nextgen: consolidationNextgen,
-        nextgen_ranks: [],
-        boost_breakdown: {},
-        boosted_tdh_rate: 0
-      };
-      consolidationGradients.forEach((wg) => {
-        allGradientsTDH.push(wg);
-      });
-      consolidationNextgen.forEach((wn) => {
-        allNextgenTDH.push(wn);
-      });
-      consolidatedTdh.push(consolidation);
-    }
-    consolidations.forEach((c) => {
-      processedWallets.add(c);
+      consolidationNextgen = consolidateCards(
+        consolidationNextgen,
+        wTdh.nextgen
+      );
     });
-  }
+
+    let memesCardSets = 0;
+    if (consolidationMemes.length == MEMES_COUNT) {
+      memesCardSets = Math.min(
+        ...consolidationMemes.map(function (o) {
+          return o.balance;
+        })
+      );
+    }
+
+    const unique_memes = consolidationMemes.length;
+
+    const genNaka = getGenesisAndNaka(consolidationMemes);
+
+    const consolidation: ConsolidatedTDH = {
+      date: new Date(),
+      consolidation_display: display,
+      consolidation_key: consolidationKey,
+      wallets: consolidations,
+      tdh_rank: 0, //assigned later
+      tdh_rank_memes: 0, //assigned later
+      tdh_rank_gradients: 0, //assigned later
+      tdh_rank_nextgen: 0, //assigned later
+      block: consolidatedWalletsTdh[0].block,
+      tdh: totalTDH,
+      boost: 0,
+      boosted_tdh: 0,
+      tdh__raw: totalTDH__raw,
+      balance: totalBalance,
+      memes_cards_sets: memesCardSets,
+      genesis: genNaka.genesis,
+      nakamoto: genNaka.naka,
+      unique_memes: unique_memes,
+      memes_tdh: memesData.memes_tdh,
+      memes_tdh__raw: memesData.memes_tdh__raw,
+      memes_balance: memesData.memes_balance,
+      boosted_memes_tdh: memesData.boosted_memes_tdh,
+      memes_ranks: memesData.memes_ranks,
+      memes: consolidationMemes,
+      boosted_gradients_tdh: 0,
+      gradients_tdh: gradientsTDH,
+      gradients_tdh__raw: gradientsTDH__raw,
+      gradients_balance: gradientsBalance,
+      gradients: consolidationGradients,
+      gradients_ranks: [],
+      boosted_nextgen_tdh: 0,
+      nextgen_tdh: nextgenTDH,
+      nextgen_tdh__raw: nextgenTDH__raw,
+      nextgen_balance: nextgenBalance,
+      nextgen: consolidationNextgen,
+      nextgen_ranks: [],
+      boost_breakdown: {},
+      boosted_tdh_rate: 0
+    };
+    consolidationGradients.forEach((wg) => {
+      allGradientsTDH.push(wg);
+    });
+    consolidationNextgen.forEach((wn) => {
+      allNextgenTDH.push(wn);
+    });
+    consolidatedTdh.push(consolidation);
+  });
 
   return {
     consolidatedTdh: consolidatedTdh,
@@ -201,59 +198,58 @@ export const consolidateMissingWallets = async (
   const tdhBlock = await fetchLatestTDHBlockNumber();
 
   for (const wallet of wallets) {
+    if (processedWallets.has(wallet.toLowerCase())) {
+      continue;
+    }
     const consolidations = await retrieveWalletConsolidations(wallet);
     const display = await fetchConsolidationDisplay(consolidations);
     const consolidationKey =
       consolidationTools.buildConsolidationKey(consolidations);
 
-    if (
-      !Array.from(processedWallets).some((pw) => equalIgnoreCase(wallet, pw))
-    ) {
-      processedWallets.add(wallet);
-      missingTdh.push({
-        date: new Date(),
-        consolidation_display: display,
-        consolidation_key: consolidationKey,
-        wallets: consolidations,
-        tdh_rank: 0,
-        tdh_rank_memes: 0,
-        tdh_rank_gradients: 0,
-        tdh_rank_nextgen: 0,
-        block: tdhBlock,
-        tdh: 0,
-        boost: 0,
-        boosted_tdh: 0,
-        tdh__raw: 0,
-        balance: 0,
-        memes_cards_sets: 0,
-        genesis: 0,
-        nakamoto: 0,
-        unique_memes: 0,
-        boosted_memes_tdh: 0,
-        memes_tdh: 0,
-        memes_tdh__raw: 0,
-        memes_balance: 0,
-        memes: [],
-        memes_ranks: [],
-        boosted_gradients_tdh: 0,
-        gradients_tdh: 0,
-        gradients_tdh__raw: 0,
-        gradients_balance: 0,
-        gradients: [],
-        gradients_ranks: [],
-        boosted_nextgen_tdh: 0,
-        nextgen_tdh: 0,
-        nextgen_tdh__raw: 0,
-        nextgen_balance: 0,
-        nextgen: [],
-        nextgen_ranks: [],
-        boost_breakdown: {},
-        boosted_tdh_rate: 0
-      });
-      consolidations.forEach((c) => {
-        processedWallets.add(c);
-      });
-    }
+    processedWallets.add(wallet.toLowerCase());
+    missingTdh.push({
+      date: new Date(),
+      consolidation_display: display,
+      consolidation_key: consolidationKey,
+      wallets: consolidations,
+      tdh_rank: 0,
+      tdh_rank_memes: 0,
+      tdh_rank_gradients: 0,
+      tdh_rank_nextgen: 0,
+      block: tdhBlock,
+      tdh: 0,
+      boost: 0,
+      boosted_tdh: 0,
+      tdh__raw: 0,
+      balance: 0,
+      memes_cards_sets: 0,
+      genesis: 0,
+      nakamoto: 0,
+      unique_memes: 0,
+      boosted_memes_tdh: 0,
+      memes_tdh: 0,
+      memes_tdh__raw: 0,
+      memes_balance: 0,
+      memes: [],
+      memes_ranks: [],
+      boosted_gradients_tdh: 0,
+      gradients_tdh: 0,
+      gradients_tdh__raw: 0,
+      gradients_balance: 0,
+      gradients: [],
+      gradients_ranks: [],
+      boosted_nextgen_tdh: 0,
+      nextgen_tdh: 0,
+      nextgen_tdh__raw: 0,
+      nextgen_balance: 0,
+      nextgen: [],
+      nextgen_ranks: [],
+      boost_breakdown: {},
+      boosted_tdh_rate: 0
+    });
+    consolidations.forEach((c) => {
+      processedWallets.add(c.toLowerCase());
+    });
   }
 
   return missingTdh;
@@ -315,11 +311,16 @@ export const consolidateTDH = async (
   );
 
   if (startingWallets) {
+    const consolidatedWallets = new Set<string>();
+    consolidatedBoostedTdh.forEach((c) => {
+      c.wallets.forEach((w: string) => {
+        if (w) {
+          consolidatedWallets.add(w.toLowerCase());
+        }
+      });
+    });
     const missingWallets = startingWallets?.filter(
-      (s) =>
-        !consolidatedBoostedTdh.some((c) =>
-          c.wallets.some((w: string) => equalIgnoreCase(w, s))
-        )
+      (s) => !s || !consolidatedWallets.has(s.toLowerCase())
     );
     const missingConsolidatedTdh =
       await consolidateMissingWallets(missingWallets);
@@ -329,14 +330,16 @@ export const consolidateTDH = async (
 
   let rankedTdh: ConsolidatedTDH[];
   if (startingWallets) {
+    const startingWalletsSet = new Set(
+      startingWallets.filter(Boolean).map((sw) => sw.toLowerCase())
+    );
+    const containsStartingWallet = (t: ConsolidatedTDH) =>
+      t.wallets.some(
+        (tw: string) => !!tw && startingWalletsSet.has(tw.toLowerCase())
+      );
     const allCurrentTdh = await fetchAllConsolidatedTdh();
     const allTdh = allCurrentTdh
-      .filter(
-        (t: ConsolidatedTDH) =>
-          !startingWallets.some((sw) =>
-            t.wallets.some((tw: string) => equalIgnoreCase(tw, sw))
-          )
-      )
+      .filter((t: ConsolidatedTDH) => !containsStartingWallet(t))
       .concat(consolidatedBoostedTdh);
     const allRankedTdh = await calculateRanks(
       allGradientsTDH,
@@ -346,9 +349,7 @@ export const consolidateTDH = async (
       NEXTGEN_NFTS
     );
     rankedTdh = allRankedTdh.filter((t: ConsolidatedTDH) =>
-      startingWallets.some((sw) =>
-        t.wallets.some((tw: string) => equalIgnoreCase(tw, sw))
-      )
+      containsStartingWallet(t)
     );
   } else {
     rankedTdh = await calculateRanks(

--- a/src/tdhLoop/tdh_nft.ts
+++ b/src/tdhLoop/tdh_nft.ts
@@ -54,8 +54,9 @@ const findContractTDH = (
   tokenTdh: TokenTDH[],
   ranks: TokenTDHRank[]
 ): NftTDH[] => {
+  const ranksById = new Map(ranks.map((r) => [r.id, r]));
   return tokenTdh.map((t) => {
-    const rank = ranks.find((r) => r.id === t.id);
+    const rank = ranksById.get(t.id);
     return {
       consolidation_key: consolidationKey,
       contract: contract.toLowerCase(),


### PR DESCRIPTION
## Issue

The daily TDH job contains several accidentally-quadratic patterns and one block of dead-but-expensive code. With tens of thousands of wallet consolidations and hundreds of meme cards, these dominate the job's CPU time. This PR is part of a batch of performance-only PRs from a full backend audit; every change is intended to be **output-identical** — no behavior change, only less work.

## Fix

Four independent micro-fixes in the TDH pipeline, each replacing repeated linear scans with a lookup built once (or deleting work whose result was discarded):

### 1. `calculateRanks` — delete dead code (`src/tdhLoop/tdh.ts`)

For every meme NFT, the old code copied **all** wallet consolidations, filtered them to holders, and sorted them with a comparator that itself did linear `.find()` calls per comparison — into a local variable `wallets` that was **never read** (note the duplicated `if (aNftBalance > bNftBalance)` branch — vestigial code). Deleting it cannot change output: the value was discarded, and the filter/sort callbacks only read data. This was roughly half the cost of the meme-ranking phase.

### 2. `calculateRanks` — invariant rank lookups hoisted (`src/tdhLoop/tdh.ts`)

`rankedGradientsTdh.find((s) => s.id == nft.id)?.rank` (and the NextGen equivalent) ran **once per holder**, though the result only depends on the NFT. Now: two `Map<id, rank>` built once. NextGen alone was a scan of ~10k ranked tokens per holder. Loose `==` matching is preserved via `Number()` normalization with null/undefined entries skipped (matching `==` semantics for real ids; `null == x` never matched before, and null ids are excluded from the maps now).

### 3. `consolidateTDHForWallets` — group once instead of rescanning (`src/tdhLoop/tdh_consolidation.ts`)

Old: for each TDH row, scan a growing `processedWallets` set via `Array.from(set).some(equalIgnoreCase(...))` **and**, for each new consolidation, re-filter a copy of the whole TDH array — O(n²) twice over.

New: one pass builds `Map<consolidationKey, TDHENS[]>`, then we iterate the groups. **Why this is exactly equivalent:**
- `retrieveConsolidationsForWallets` maps every wallet to exactly one consolidation key (clusters are disjoint — `extractConsolidations` guards `usedWallets`; singletons map to themselves).
- `buildConsolidationKey` includes every cluster wallet, so `key.split('-')` membership ≡ cluster membership ≡ "same key".
- Map insertion order = first time a member of the group is seen in `tdh` order = exactly the order the old code emitted consolidations; members keep `tdh` order like the old `filter`.
- `block` comes from the group's first member — the same entry the old code read it from.

The diff looks large because the loop body de-indents one level; **review with whitespace hidden** — the logical diff is ±38 lines.

### 4. `consolidateMissingWallets` + `findContractTDH` (`tdh_consolidation.ts`, `tdh_nft.ts`)

- The per-wallet dedup guard now runs **before** the two DB lookups whose results are only used inside the guarded branch (previously duplicates still paid both queries; results were discarded). Lowercased `Set.has` replaces the per-wallet set scan — same case-insensitive semantics.
- `findContractTDH` used `ranks.find(...)` per token (holdings × ranks per consolidation, per consolidation); now an id-keyed `Map` built once per call. Original used strict `===`, and `Map` keys use SameValueZero — identical for integer ids.

## Changes

- `src/tdhLoop/tdh.ts` — dead block removed; two rank-lookup maps added.
- `src/tdhLoop/tdh_consolidation.ts` — single-pass grouping; guard-before-query + `Set` dedup in `consolidateMissingWallets`; two `Set`-based membership rewrites in the `startingWallets` path of `consolidateTDH` (falsy-guarded to match `equalIgnoreCase`'s null-safe behavior); removed two pointless array copies before non-mutating `filter`/`map`.
- `src/tdhLoop/tdh_nft.ts` — id-keyed rank map.
- `src/tdhLoop/tdh-consolidation.test.ts` — **new**: fast-check property test proving `consolidateTDHForWallets` output is deep-equal to the verbatim pre-optimization algorithm (kept in the test as a reference implementation) across randomized consolidation partitions, duplicate wallets, mixed-case wallets and card sets; plus tests that `consolidateMissingWallets` dedupes case-insensitively and skips DB lookups for already-covered wallets.

## Validation

- `npx jest src/tdhLoop/tdh-consolidation.test.ts` — 3/3 pass (property test runs 50 randomized scenarios against the reference implementation).
- `npx tsc --noEmit` — clean for touched files (pre-existing, unrelated `pdf-lib`/`zod` resolution errors in `src/attachments`/`src/profile-cms` are untouched by this PR).
- `npx eslint --max-warnings=0` and `prettier --check` on all touched files — clean.
- Not tested live: a full `tdhLoop` run against production-size data. Residual risk is limited to the equivalence arguments above, which the property test exercises.

## Risk

- Level: **Low**
- Why: hot-path daily batch job (blast radius = TDH numbers everywhere) but every rewrite is mechanically equivalence-argued and property-tested against the old algorithm; no schema, API or persistence changes.
- Rollback: revert the single commit; no data migration involved.

## Deployment

Not to be deployed yet — awaiting human review (@gelatogenesis). When approved, services that ship this code: `tdhLoop`, `delegationsLoop`, `populateHistoricConsolidatedTdh` (both import the consolidation module).

## Review Notes

- The one place to scrutinize is the grouping equivalence in `consolidateTDHForWallets` (change 3) — the disjoint-cluster argument is laid out above and enforced by the property test.
- `consolidateMissingWallets` appears to have **no callers** in the repo (only the export). Left in place and optimized anyway — flagging in case you want a follow-up deletion.
- Use "Hide whitespace" when reviewing `tdh_consolidation.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TDH consolidation so wallets are grouped more consistently, including case-insensitive handling of wallet addresses.
  * Reduced duplicate processing for already-covered wallets, helping consolidation results stay accurate.

* **Performance**
  * Speeded up rank lookups and consolidation calculations by using faster precomputed mappings instead of repeated searches.

* **Tests**
  * Added broader automated coverage for TDH consolidation behavior, including randomized validation and targeted checks for deduplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->