### PR TITLE
Activate pinned npm via Corepack in PR CI

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -25,7 +25,7 @@ jobs:
         env:
           COREPACK_ENABLE_DOWNLOAD_PROMPT: '0'
         run: |
-          expected="$(node -p "String(require('./package.json').packageManager ?? '').split('npm@')[1] ?? ''")"
+          expected="$(node -p "String(require('./package.json').packageManager ?? '').split('npm@')[1]?.split('+')[0] ?? ''")"
           if [[ -z "${expected}" ]]; then
             echo "::error::package.json has no npm packageManager pin; the discipline check should have caught this."
             exit 1

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -21,12 +21,17 @@ jobs:
       - name: Check package manager discipline
         run: node scripts/check-package-manager.mjs
       - name: Activate pinned npm via Corepack
+        shell: bash
         env:
           COREPACK_ENABLE_DOWNLOAD_PROMPT: '0'
         run: |
+          expected="$(node -p "String(require('./package.json').packageManager ?? '').split('npm@')[1] ?? ''")"
+          if [[ -z "${expected}" ]]; then
+            echo "::error::package.json has no npm packageManager pin; the discipline check should have caught this."
+            exit 1
+          fi
           corepack enable npm
           corepack install
-          expected="$(node -p "require('./package.json').packageManager.split('@')[1]")"
           resolved="$(npm --version)"
           echo "npm resolved to ${resolved} (pinned ${expected})"
           if [[ "${resolved}" != "${expected}" ]]; then

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -20,6 +20,19 @@ jobs:
           cache: 'npm'
       - name: Check package manager discipline
         run: node scripts/check-package-manager.mjs
+      - name: Activate pinned npm via Corepack
+        env:
+          COREPACK_ENABLE_DOWNLOAD_PROMPT: '0'
+        run: |
+          corepack enable npm
+          corepack install
+          expected="$(node -p "require('./package.json').packageManager.split('@')[1]")"
+          resolved="$(npm --version)"
+          echo "npm resolved to ${resolved} (pinned ${expected})"
+          if [[ "${resolved}" != "${expected}" ]]; then
+            echo "::error::Corepack did not activate the pinned npm (expected ${expected}, got ${resolved})."
+            exit 1
+          fi
       - name: Install dependencies
         run: npm i && pushd src/api-serverless && npm i && popd
       - name: Verify generated files are committed


### PR DESCRIPTION
## Issue
- #1698 pinned `packageManager: npm@10.9.8` across all 56 manifests, but the pin is advisory: plain npm ignores the field, so CI and non-Corepack dev machines can still run any npm version. This was noted as a deliberate deferral in #1698's review thread, with hard enforcement left as a follow-up.

## Fix
- Activate Corepack for npm in the PR workflow so the pin becomes binding where it matters most: the CI environment that gates merges.

## Changes
- `.github/workflows/on-pull-request.yml`: new "Activate pinned npm via Corepack" step between the discipline check and dependency install. It shims npm through Corepack, pre-installs the pinned version, and fails the build if `npm --version` does not resolve to the pin — with the expected version read from `package.json`, so the workflow has no second copy of the version to drift.
- `COREPACK_ENABLE_DOWNLOAD_PROMPT=0` set for the step so Corepack's interactive download prompt cannot hang a non-TTY runner.

## Validation
- actionlint clean; YAML parses.
- The verification logic is self-testing in CI: the step's own assertion proves Corepack resolved the pinned npm before any `npm i` runs.
- Not tested: developer machines — Corepack activation there remains opt-in (`corepack enable npm`), which is intentional.

## Risk
- Level: Low
- Why: CI-only; one extra step that either activates the pinned npm or fails loudly before installs. Adds a Corepack registry download to each PR run (same failure class as `npm i` itself). Trivially revertible.
- Rollback: revert the commit; the pin returns to advisory.

## Deployment
- None. CI-only change; no lambdas or services to redeploy. The deploy workflow is intentionally untouched — it installs with whatever npm ships on the runner, and changing prod deploy behavior deserves its own PR if ever wanted.

## Review Notes
- Expected-version extraction assumes the `npm@x.y.z` pin format that scripts/check-package-manager.mjs enforces one step earlier in the same job.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the pull request CI workflow to verify the project uses the pinned npm version during builds.
  * Added a check that fails the workflow if the installed npm version does not match the expected version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->