### PR TITLE
perf(ownersBalancesLoop): group owners once and batch consolidation key lookups

### DIFF
--- a/src/entities/IDelegation.ts
+++ b/src/entities/IDelegation.ts
@@ -89,6 +89,7 @@ export interface DelegationEvent extends ConsolidationEvent {
 export class NFTDelegationBlock extends BlockEntity {}
 
 export interface WalletConsolidationKey {
-  wallet: string;
+  // matches the address_consolidation_keys view columns
+  address: string;
   consolidation_key: string;
 }

--- a/src/ownersBalancesLoop/db.owners_balances.ts
+++ b/src/ownersBalancesLoop/db.owners_balances.ts
@@ -32,6 +32,15 @@ export async function fetchAllOwnerBalances(addresses?: string[]) {
   return await queryBuilder.getMany();
 }
 
+export async function fetchAllOwnerBalancesWallets(): Promise<string[]> {
+  const rows: { wallet: string }[] = await getDataSource()
+    .getRepository(OwnerBalances)
+    .createQueryBuilder('ownerBalances')
+    .select('ownerBalances.wallet', 'wallet')
+    .getRawMany();
+  return rows.map((r) => r.wallet);
+}
+
 export async function fetchAllOwnerBalancesMemes(addresses?: string[]) {
   const queryBuilder = getDataSource()
     .getRepository(OwnerBalancesMemes)

--- a/src/ownersBalancesLoop/owners-balances.test.ts
+++ b/src/ownersBalancesLoop/owners-balances.test.ts
@@ -1,0 +1,235 @@
+import {
+  fetchAllSeasons,
+  fetchTransactionAddressesFromBlock,
+  fetchWalletConsolidationKeysViewForWallet
+} from '../db';
+import { NFTOwner } from '../entities/INFTOwner';
+import { MemesSeason } from '../entities/ISeason';
+import {
+  fetchAllNftOwners,
+  getMaxNftOwnersBlockReference
+} from '../nftOwnersLoop/db.nft_owners';
+import {
+  fetchAllOwnerBalancesWallets,
+  fetchRefreshOutdatedBalances,
+  getMaxOwnerBalancesBlockReference,
+  persistConsolidatedOwnerBalances,
+  persistOwnerBalances
+} from './db.owners_balances';
+import {
+  consolidateOwnerBalances,
+  updateOwnerBalances
+} from './owners_balances';
+
+jest.mock('../db', () => ({
+  fetchAllSeasons: jest.fn(),
+  fetchTransactionAddressesFromBlock: jest.fn(),
+  fetchWalletConsolidationKeysViewForWallet: jest.fn()
+}));
+
+jest.mock('./db.owners_balances', () => ({
+  fetchAllOwnerBalancesWallets: jest.fn(),
+  fetchRefreshOutdatedBalances: jest.fn(),
+  getMaxOwnerBalancesBlockReference: jest.fn(),
+  persistConsolidatedOwnerBalances: jest.fn(),
+  persistOwnerBalances: jest.fn()
+}));
+
+jest.mock('../nftOwnersLoop/db.nft_owners', () => ({
+  fetchAllNftOwners: jest.fn(),
+  getMaxNftOwnersBlockReference: jest.fn()
+}));
+
+const mockedFetchAllSeasons = fetchAllSeasons as jest.MockedFunction<
+  typeof fetchAllSeasons
+>;
+const mockedFetchTransactionAddressesFromBlock =
+  fetchTransactionAddressesFromBlock as jest.MockedFunction<
+    typeof fetchTransactionAddressesFromBlock
+  >;
+const mockedFetchWalletConsolidationKeysViewForWallet =
+  fetchWalletConsolidationKeysViewForWallet as jest.MockedFunction<
+    typeof fetchWalletConsolidationKeysViewForWallet
+  >;
+const mockedFetchAllNftOwners = fetchAllNftOwners as jest.MockedFunction<
+  typeof fetchAllNftOwners
+>;
+const mockedGetMaxNftOwnersBlockReference =
+  getMaxNftOwnersBlockReference as jest.MockedFunction<
+    typeof getMaxNftOwnersBlockReference
+  >;
+const mockedFetchAllOwnerBalancesWallets =
+  fetchAllOwnerBalancesWallets as jest.MockedFunction<
+    typeof fetchAllOwnerBalancesWallets
+  >;
+const mockedFetchRefreshOutdatedBalances =
+  fetchRefreshOutdatedBalances as jest.MockedFunction<
+    typeof fetchRefreshOutdatedBalances
+  >;
+const mockedGetMaxOwnerBalancesBlockReference =
+  getMaxOwnerBalancesBlockReference as jest.MockedFunction<
+    typeof getMaxOwnerBalancesBlockReference
+  >;
+const mockedPersistConsolidatedOwnerBalances =
+  persistConsolidatedOwnerBalances as jest.MockedFunction<
+    typeof persistConsolidatedOwnerBalances
+  >;
+const mockedPersistOwnerBalances = persistOwnerBalances as jest.MockedFunction<
+  typeof persistOwnerBalances
+>;
+
+const MEMES = '0x33FD426905F149f8376e227d0C9D3340AaD17aF1';
+
+function season(id: number, startIndex: number, endIndex: number): MemesSeason {
+  return {
+    id,
+    start_index: startIndex,
+    end_index: endIndex,
+    count: endIndex - startIndex + 1,
+    name: `SZN${id}`,
+    display: `SZN${id}`
+  } as MemesSeason;
+}
+
+function owner(wallet: string, tokenId: number, balance: number): NFTOwner {
+  return {
+    wallet,
+    contract: MEMES.toLowerCase(),
+    token_id: tokenId,
+    balance,
+    block_reference: 200
+  } as NFTOwner;
+}
+
+// DB collation is case-insensitive: mimic wallet IN (...) matching accordingly
+function ownersForWallets(fixture: NFTOwner[], pk?: string[]): NFTOwner[] {
+  if (!pk) {
+    return fixture;
+  }
+  const lowered = pk.map((p) => p.toLowerCase());
+  return fixture.filter((o) => lowered.includes(o.wallet.toLowerCase()));
+}
+
+describe('updateOwnerBalances (incremental)', () => {
+  // wallet case in nft_owners intentionally differs from the transaction
+  // addresses to prove case-insensitive matching survived the Map rewrite
+  const fixture: NFTOwner[] = [
+    owner('0xAliceAA', 1, 2),
+    owner('0xaliceaa', 2, 3),
+    owner('0xBobBB', 1, 1)
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedGetMaxOwnerBalancesBlockReference.mockResolvedValue(100);
+    mockedGetMaxNftOwnersBlockReference.mockResolvedValue(200);
+    mockedFetchAllSeasons.mockResolvedValue([season(1, 1, 2)]);
+    mockedFetchRefreshOutdatedBalances.mockResolvedValue([]);
+    mockedFetchTransactionAddressesFromBlock.mockResolvedValue([
+      { from_address: '0xALICEaa', to_address: '0xbobbb' },
+      { from_address: '0xGoneCC', to_address: '0xALICEaa' }
+    ]);
+    mockedFetchAllNftOwners.mockImplementation(async (_contracts, pk) =>
+      ownersForWallets(fixture, pk)
+    );
+    mockedFetchWalletConsolidationKeysViewForWallet.mockImplementation(
+      async (addresses) =>
+        addresses
+          .filter((a) => ['0xaliceaa', '0xbobbb'].includes(a.toLowerCase()))
+          .map(
+            (a) =>
+              ({
+                address: a.toLowerCase(),
+                consolidation_key: '0xaliceaa-0xbobbb'
+              }) as any
+          )
+    );
+    mockedPersistOwnerBalances.mockResolvedValue(undefined);
+    mockedPersistConsolidatedOwnerBalances.mockResolvedValue(undefined);
+  });
+
+  it('aggregates the same owned NFTs per address as the previous per-address filter', async () => {
+    await updateOwnerBalances(false);
+
+    expect(mockedPersistOwnerBalances).toHaveBeenCalledTimes(1);
+    const [ownersBalances, ownersBalancesMemes, deleteDelta] =
+      mockedPersistOwnerBalances.mock.calls[0];
+
+    const byWallet = new Map(ownersBalances.map((b: any) => [b.wallet, b]));
+    expect(byWallet.size).toBe(2);
+
+    const alice = byWallet.get('0xaliceaa') as any;
+    expect(alice.total_balance).toBe(5);
+    expect(alice.memes_balance).toBe(5);
+    expect(alice.unique_memes).toBe(2);
+    expect(alice.memes_cards_sets).toBe(2);
+
+    const bob = byWallet.get('0xbobbb') as any;
+    expect(bob.total_balance).toBe(1);
+    expect(bob.unique_memes).toBe(1);
+    expect(bob.memes_cards_sets).toBe(0);
+
+    expect(deleteDelta).toEqual(new Set(['0xgonecc']));
+
+    const seasonRows = ownersBalancesMemes.filter(
+      (m: any) => m.wallet === '0xaliceaa'
+    );
+    expect(seasonRows).toEqual([
+      expect.objectContaining({ season: 1, balance: 5, unique: 2, sets: 2 })
+    ]);
+  });
+
+  it('resolves consolidation keys through one batched view query with identical fallback semantics', async () => {
+    await updateOwnerBalances(false);
+
+    expect(
+      mockedFetchWalletConsolidationKeysViewForWallet
+    ).toHaveBeenCalledTimes(1);
+    const queried =
+      mockedFetchWalletConsolidationKeysViewForWallet.mock.calls[0][0];
+    expect([...queried].sort((a, b) => a.localeCompare(b))).toEqual([
+      '0xaliceaa',
+      '0xbobbb',
+      '0xgonecc'
+    ]);
+
+    const [consolidatedBalances] =
+      mockedPersistConsolidatedOwnerBalances.mock.calls[0];
+    const keys = consolidatedBalances
+      .map((b: any) => b.consolidation_key)
+      .sort((a: string, b: string) => a.localeCompare(b));
+    // consolidated wallets resolve through the view; unknown wallet falls back
+    // to itself, exactly like the old per-address [0]-or-fallback logic
+    expect(keys).toEqual(['0xaliceaa-0xbobbb', '0xgonecc']);
+  });
+});
+
+describe('consolidateOwnerBalances chunking', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedFetchAllSeasons.mockResolvedValue([season(1, 1, 2)]);
+    mockedFetchAllNftOwners.mockResolvedValue([]);
+    mockedFetchWalletConsolidationKeysViewForWallet.mockResolvedValue([]);
+    mockedPersistConsolidatedOwnerBalances.mockResolvedValue(undefined);
+    mockedFetchAllOwnerBalancesWallets.mockResolvedValue([]);
+  });
+
+  it('splits the consolidation key lookup into 5000-address chunks', async () => {
+    const addresses = new Set<string>();
+    for (let i = 0; i < 5001; i++) {
+      addresses.add(`0xwallet${i}`);
+    }
+
+    await consolidateOwnerBalances(addresses, false);
+
+    expect(
+      mockedFetchWalletConsolidationKeysViewForWallet
+    ).toHaveBeenCalledTimes(2);
+    expect(
+      mockedFetchWalletConsolidationKeysViewForWallet.mock.calls[0][0]
+    ).toHaveLength(5000);
+    expect(
+      mockedFetchWalletConsolidationKeysViewForWallet.mock.calls[1][0]
+    ).toHaveLength(1);
+  });
+});

--- a/src/ownersBalancesLoop/owners-balances.test.ts
+++ b/src/ownersBalancesLoop/owners-balances.test.ts
@@ -2,13 +2,13 @@ import {
   fetchAllSeasons,
   fetchTransactionAddressesFromBlock,
   fetchWalletConsolidationKeysViewForWallet
-} from '../db';
-import { NFTOwner } from '../entities/INFTOwner';
-import { MemesSeason } from '../entities/ISeason';
+} from '@/db';
+import { NFTOwner } from '@/entities/INFTOwner';
+import { MemesSeason } from '@/entities/ISeason';
 import {
   fetchAllNftOwners,
   getMaxNftOwnersBlockReference
-} from '../nftOwnersLoop/db.nft_owners';
+} from '@/nftOwnersLoop/db.nft_owners';
 import {
   fetchAllOwnerBalancesWallets,
   fetchRefreshOutdatedBalances,
@@ -21,7 +21,7 @@ import {
   updateOwnerBalances
 } from './owners_balances';
 
-jest.mock('../db', () => ({
+jest.mock('@/db', () => ({
   fetchAllSeasons: jest.fn(),
   fetchTransactionAddressesFromBlock: jest.fn(),
   fetchWalletConsolidationKeysViewForWallet: jest.fn()
@@ -35,7 +35,7 @@ jest.mock('./db.owners_balances', () => ({
   persistOwnerBalances: jest.fn()
 }));
 
-jest.mock('../nftOwnersLoop/db.nft_owners', () => ({
+jest.mock('@/nftOwnersLoop/db.nft_owners', () => ({
   fetchAllNftOwners: jest.fn(),
   getMaxNftOwnersBlockReference: jest.fn()
 }));
@@ -201,6 +201,10 @@ describe('updateOwnerBalances (incremental)', () => {
     // consolidated wallets resolve through the view; unknown wallet falls back
     // to itself, exactly like the old per-address [0]-or-fallback logic
     expect(keys).toEqual(['0xaliceaa-0xbobbb', '0xgonecc']);
+
+    // consolidated balances are computed once per unique consolidation, not
+    // once per member address: 1 incremental owners fetch + 2 unique groups
+    expect(mockedFetchAllNftOwners).toHaveBeenCalledTimes(3);
   });
 });
 

--- a/src/ownersBalancesLoop/owners_balances.ts
+++ b/src/ownersBalancesLoop/owners_balances.ts
@@ -407,54 +407,59 @@ export async function consolidateOwnerBalances(
     const chunk = addressArray.slice(i, i + CONSOLIDATION_KEYS_CHUNK_SIZE);
     const rows = await fetchWalletConsolidationKeysViewForWallet(chunk);
     rows.forEach((row) => {
-      // the view's row shape is { address, consolidation_key }
-      const rowAddress = (row as unknown as { address: string }).address;
       if (
-        rowAddress &&
-        !consolidationKeyByAddress.has(rowAddress.toLowerCase())
+        row.address &&
+        !consolidationKeyByAddress.has(row.address.toLowerCase())
       ) {
         consolidationKeyByAddress.set(
-          rowAddress.toLowerCase(),
+          row.address.toLowerCase(),
           row.consolidation_key
         );
       }
     });
   }
 
-  await Promise.all(
-    addressArray.map(async (address) => {
-      const viewConsolidationKey = consolidationKeyByAddress.get(
+  // multiple addresses can resolve to the same consolidation: compute each
+  // consolidation's balances once, not once per member address
+  const consolidationAddressesByKey = new Map<string, string[]>();
+  addressArray.forEach((address) => {
+    const viewConsolidationKey = consolidationKeyByAddress.get(
+      address.toLowerCase()
+    );
+    if (viewConsolidationKey === undefined) {
+      consolidationAddressesByKey.set(address.toLowerCase(), [
         address.toLowerCase()
+      ]);
+    } else if (!consolidationAddressesByKey.has(viewConsolidationKey)) {
+      consolidationAddressesByKey.set(
+        viewConsolidationKey,
+        viewConsolidationKey.split('-')
       );
+    }
+  });
 
-      let consolidationKey: string;
-      let consolidationAddresses: string[] = [];
-      if (viewConsolidationKey === undefined) {
-        consolidationKey = address.toLowerCase();
-        consolidationAddresses.push(address.toLowerCase());
-      } else {
-        consolidationKey = viewConsolidationKey;
-        consolidationAddresses = viewConsolidationKey.split('-');
+  await Promise.all(
+    Array.from(consolidationAddressesByKey.entries()).map(
+      async ([consolidationKey, consolidationAddresses]) => {
+        const consolidatedBalances = await getConsolidatedBalances(
+          seasons,
+          allContracts,
+          consolidationKey,
+          consolidationAddresses
+        );
+        consolidatedOwnersBalancesMap.set(
+          consolidationKey,
+          consolidatedBalances.balance
+        );
+        consolidatedOwnersBalancesMemesMap.set(
+          consolidationKey,
+          consolidatedBalances.memes
+        );
+        consolidationAddresses.forEach((address) => {
+          deleteDelta.add(address);
+        });
       }
-
-      const consolidatedBalances = await getConsolidatedBalances(
-        seasons,
-        allContracts,
-        consolidationKey,
-        consolidationAddresses
-      );
-      consolidatedOwnersBalancesMap.set(
-        consolidationKey,
-        consolidatedBalances.balance
-      );
-      consolidatedOwnersBalancesMemesMap.set(
-        consolidationKey,
-        consolidatedBalances.memes
-      );
-      consolidationAddresses.forEach((address) => {
-        deleteDelta.add(address);
-      });
-    })
+    )
   );
 
   const consolidatedOwnersBalances = Array.from(

--- a/src/ownersBalancesLoop/owners_balances.ts
+++ b/src/ownersBalancesLoop/owners_balances.ts
@@ -6,7 +6,7 @@ import {
   NULL_ADDRESS
 } from '@/constants';
 import {
-  fetchAllOwnerBalances,
+  fetchAllOwnerBalancesWallets,
   fetchRefreshOutdatedBalances,
   getMaxOwnerBalancesBlockReference,
   persistConsolidatedOwnerBalances,
@@ -40,6 +40,7 @@ const logger = Logger.get('OWNER_BALANCES');
 
 const REFRESH_INTERVAL_BLOCKS = 7500;
 const REFRESH_ADDRESSES_LIMIT = 250;
+const CONSOLIDATION_KEYS_CHUNK_SIZE = 5000;
 
 const validateNftOwners = (
   owners: NFTOwner[],
@@ -150,8 +151,24 @@ export const updateOwnerBalances = async (reset?: boolean) => {
   const ownersBalancesMemesMap = new Map<string, OwnerBalancesMemes[]>();
   const deleteDelta = new Set<string>();
 
+  const ownersByWallet = new Map<string, NFTOwner[]>();
+  owners.forEach((o) => {
+    if (!o.wallet) {
+      return;
+    }
+    const walletKey = o.wallet.toLowerCase();
+    const walletOwners = ownersByWallet.get(walletKey);
+    if (walletOwners) {
+      walletOwners.push(o);
+    } else {
+      ownersByWallet.set(walletKey, [o]);
+    }
+  });
+
   addresses.forEach((address) => {
-    const ownedNfts = owners.filter((o) => equalIgnoreCase(o.wallet, address));
+    const ownedNfts = address
+      ? (ownersByWallet.get(address.toLowerCase()) ?? [])
+      : [];
     if (!ownedNfts.length) {
       deleteDelta.add(address);
       return;
@@ -356,8 +373,8 @@ export async function consolidateOwnerBalances(
   reset?: boolean
 ) {
   if (reset) {
-    const ownerBalances = await fetchAllOwnerBalances();
-    ownerBalances.forEach((o) => addresses.add(o.wallet));
+    const ownerBalanceWallets = await fetchAllOwnerBalancesWallets();
+    ownerBalanceWallets.forEach((wallet) => addresses.add(wallet));
   }
 
   logger.info(
@@ -384,20 +401,40 @@ export async function consolidateOwnerBalances(
   >();
   const deleteDelta = new Set<string>();
 
+  const addressArray = Array.from(addresses);
+  const consolidationKeyByAddress = new Map<string, string>();
+  for (let i = 0; i < addressArray.length; i += CONSOLIDATION_KEYS_CHUNK_SIZE) {
+    const chunk = addressArray.slice(i, i + CONSOLIDATION_KEYS_CHUNK_SIZE);
+    const rows = await fetchWalletConsolidationKeysViewForWallet(chunk);
+    rows.forEach((row) => {
+      // the view's row shape is { address, consolidation_key }
+      const rowAddress = (row as unknown as { address: string }).address;
+      if (
+        rowAddress &&
+        !consolidationKeyByAddress.has(rowAddress.toLowerCase())
+      ) {
+        consolidationKeyByAddress.set(
+          rowAddress.toLowerCase(),
+          row.consolidation_key
+        );
+      }
+    });
+  }
+
   await Promise.all(
-    Array.from(addresses).map(async (address) => {
-      const consolidation = (
-        await fetchWalletConsolidationKeysViewForWallet([address])
-      )[0];
+    addressArray.map(async (address) => {
+      const viewConsolidationKey = consolidationKeyByAddress.get(
+        address.toLowerCase()
+      );
 
       let consolidationKey: string;
       let consolidationAddresses: string[] = [];
-      if (!consolidation) {
+      if (viewConsolidationKey === undefined) {
         consolidationKey = address.toLowerCase();
         consolidationAddresses.push(address.toLowerCase());
       } else {
-        consolidationKey = consolidation.consolidation_key;
-        consolidationAddresses = consolidation.consolidation_key.split('-');
+        consolidationKey = viewConsolidationKey;
+        consolidationAddresses = viewConsolidationKey.split('-');
       }
 
       const consolidatedBalances = await getConsolidatedBalances(


### PR DESCRIPTION
## Issue

`ownersBalancesLoop` does two kinds of avoidable work on every run, and both explode on reset runs:

1. `updateOwnerBalances` filters the **entire** `owners` array once **per address** (`owners.filter(o => equalIgnoreCase(o.wallet, address))`). On a reset that is (all addresses) × (all owner rows) case-insensitive comparisons.
2. `consolidateOwnerBalances` queries the `address_consolidation_keys` view **once per address** inside an unbounded `Promise.all` — one DB round trip per wallet, even though the query helper already accepts an address array. The reset path additionally hydrates every `owner_balances` entity just to read `.wallet`.

Part of a batch of performance-only PRs from a full backend audit; all changes are intended to be **output-identical**.

## Fix

- **Group once, look up per address**: build `Map<lowercased wallet, NFTOwner[]>` in one pass over `owners`, then `get(address.toLowerCase())` per address. Equivalent because: the old `equalIgnoreCase` never matched falsy wallets (falsy-walleted rows are skipped when building the map); per-wallet row order is the `owners` array order, same as `filter` preserved; a missing wallet yields `[]`, feeding the same `deleteDelta` branch as an empty filter result.
- **Batch the consolidation-key view lookups**: fetch keys for all addresses in `5000`-address chunks (`fetchWalletConsolidationKeysViewForWallet` already takes `string[]`), build `Map<address, consolidation_key>`, then resolve per address in memory. Fallback semantics preserved exactly: address not in the view → `consolidationKey = address.toLowerCase()`, `consolidationAddresses = [address.toLowerCase()]`, same as the old `[0]`-undefined branch. First row wins per address, matching the old per-address `[0]`. (View addresses are stored lowercased — see the 20240619220628 migration — and every address added to the `addresses` set is lowercased at insertion, so map key casing is exact.)
- **Reset path fetches only wallets**: new `fetchAllOwnerBalancesWallets()` selects the `wallet` column (`getRawMany`) instead of `getMany()` on full entities. Same strings end up in the same `Set`.

## Changes

- `src/ownersBalancesLoop/owners_balances.ts` — owner grouping map; chunked view lookup + in-memory key resolution; reset path uses the wallet-only query.
- `src/ownersBalancesLoop/db.owners_balances.ts` — adds `fetchAllOwnerBalancesWallets()`. `fetchAllOwnerBalances` itself is left untouched (still used by `tdh_upload.ts`).
- `src/ownersBalancesLoop/owners-balances.test.ts` — **new**: aggregation equivalence with mixed-case wallets (the exact thing `equalIgnoreCase` used to cover), delete-delta behavior, batched-view fallback semantics, and 5000-chunking.

## Validation

- `npx jest src/ownersBalancesLoop/owners-balances.test.ts` — 3/3 pass.
- `npx tsc --noEmit` clean for touched files (pre-existing unrelated `pdf-lib`/`zod` errors in untouched dirs); `eslint --max-warnings=0` + `prettier --check` clean.
- Not tested live: a reset-mode loop run against production-size data.

## Risk

- Level: **Low**
- Why: batch job only (no API surface); rewrites are mechanical with fallback semantics preserved and tested; chunk size 5000 is well under typical `max_allowed_packet` for a list of 42-char strings.
- Rollback: revert the single commit.

## Deployment

Not to be deployed yet — awaiting human review (@gelatogenesis). When approved: `ownersBalancesLoop` only.

## Review Notes

- One pre-existing oddity spotted while auditing (NOT changed here, flagging for a decision): `fetchAllNftOwners(contracts?, pk?)` in `src/nftOwnersLoop/db.nft_owners.ts` calls `.where()` twice, so when both args are passed (as `updateOwnerBalances` does) TypeORM silently **drops the contract filter**. Harmless today if `nft_owners` only contains tracked contracts, but `.andWhere` was almost certainly intended. Fixing it changes fetched rows, so it's out of scope for this behavior-identical PR.
- Update (review round 1): consolidations are now deduped by key before the fan-out, so `getConsolidatedBalances` runs once per unique consolidation instead of once per member address, and `WalletConsolidationKey` was corrected to the view's real column shape (`address`), removing a cast. The remaining per-consolidation `fetchAllNftOwners` call inside `getConsolidatedBalances` is still one query per consolidation — left alone deliberately: batching it would hold every owner row of every consolidation in memory at once on reset runs, which is a trade-off rather than a free win.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Improved owner balance updates for large wallet sets, including more efficient handling during consolidation.

* **Bug Fixes**
  * Fixed wallet matching to be case-insensitive, ensuring balances group correctly.
  * Strengthened consolidation-key resolution with chunked lookups and safer fallback behavior when consolidation data is missing.

* **Tests**
  * Added Jest coverage for incremental updates and consolidation chunking, including edge cases and fallback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
