### PR TITLE
Polish Meme edition size floor plumbing

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -2,9 +2,16 @@ import { Network } from '@/alchemy-sdk';
 
 export * from './db-tables';
 export * from './delegations';
+export * from './manifold';
 export * from './media';
 
 export const MEMES_CONTRACT = '0x33FD426905F149f8376e227d0C9D3340AaD17aF1';
+
+// Upper bound applied to Manifold claim totalMax when deriving a Meme's
+// edition-size floor. Meme drops are sized at no more than 310 editions, so
+// any larger on-chain totalMax is a placeholder/unbounded claim value rather
+// than a real edition size (see nfts.edition_size_floor).
+export const MEMES_EDITION_SIZE_FLOOR_CAP = 310;
 export const GRADIENT_CONTRACT = '0x0c58ef43ff3032005e472cb5709f8908acb00205';
 export const MEMELAB_CONTRACT = '0x4db52a61dc491e15a2f78f5ac001c14ffe3568cb';
 export const NULL_ADDRESS = '0x0000000000000000000000000000000000000000';

--- a/src/constants/manifold.ts
+++ b/src/constants/manifold.ts
@@ -1,0 +1,9 @@
+// Manifold ERC1155 lazy-claim extension contract used by The Memes mints.
+// Shared by every consumer that reads claim state on-chain so the address
+// and ABI cannot drift between services.
+export const MANIFOLD_LAZY_CLAIM_CONTRACT =
+  '0x26BBEA7803DcAc346D5F5f135b57Cf2c752A02bE';
+
+export const MANIFOLD_LAZY_CLAIM_ABI = [
+  'function getClaimForToken(address creatorContractAddress, uint256 tokenId) view returns (uint256 instanceId, tuple(uint32 total, uint32 totalMax, uint32 walletMax, uint48 startDate, uint48 endDate, uint8 storageProtocol, bytes32 merkleRoot, string location, uint256 tokenId, uint256 cost, address payable paymentReceiver, address erc20, address signingAddress) claim)'
+];

--- a/src/memes-edition-size-floor.ts
+++ b/src/memes-edition-size-floor.ts
@@ -1,5 +1,10 @@
 import { getRpcUrl } from '@/alchemy';
-import { MEMES_CONTRACT } from '@/constants';
+import {
+  MANIFOLD_LAZY_CLAIM_ABI,
+  MANIFOLD_LAZY_CLAIM_CONTRACT,
+  MEMES_CONTRACT,
+  MEMES_EDITION_SIZE_FLOOR_CAP
+} from '@/constants';
 import { Logger } from '@/logging';
 import { numbers } from '@/numbers';
 import { Time } from '@/time';
@@ -8,17 +13,8 @@ import pLimit from 'p-limit';
 
 const logger = Logger.get('MEMES_EDITION_SIZE_FLOOR');
 
-const MANIFOLD_LAZY_CLAIM_CONTRACT =
-  '0x26BBEA7803DcAc346D5F5f135b57Cf2c752A02bE';
-
-const MANIFOLD_LAZY_CLAIM_ABI = [
-  'function getClaimForToken(address creatorContractAddress, uint256 tokenId) view returns (uint256 instanceId, tuple(uint32 total, uint32 totalMax, uint32 walletMax, uint48 startDate, uint48 endDate, uint8 storageProtocol, bytes32 merkleRoot, string location, uint256 tokenId, uint256 cost, address payable paymentReceiver, address erc20, address signingAddress) claim)'
-];
-
 const MANIFOLD_CLAIM_FETCH_CONCURRENCY = 10;
 const MANIFOLD_CLAIM_FETCH_TIMEOUT_MS = Time.seconds(10).toMillis();
-
-export const MEMES_EDITION_SIZE_FLOOR_CAP = 310;
 
 export type MemeEditionSizeFloorMap = Record<number, number>;
 

--- a/src/mintAnnouncementsLoop/manifold-claim.service.ts
+++ b/src/mintAnnouncementsLoop/manifold-claim.service.ts
@@ -1,15 +1,12 @@
 import { ethers } from 'ethers';
-import { MEMES_CONTRACT } from '@/constants';
+import {
+  MANIFOLD_LAZY_CLAIM_ABI,
+  MANIFOLD_LAZY_CLAIM_CONTRACT,
+  MEMES_CONTRACT
+} from '@/constants';
 import { getRpcUrl } from '@/alchemy';
 import { numbers } from '@/numbers';
 import { RequestContext } from '@/request.context';
-
-const MANIFOLD_LAZY_CLAIM_CONTRACT =
-  '0x26BBEA7803DcAc346D5F5f135b57Cf2c752A02bE';
-
-const MANIFOLD_LAZY_CLAIM_ABI = [
-  'function getClaimForToken(address creatorContractAddress, uint256 tokenId) view returns (uint256 instanceId, tuple(uint32 total, uint32 totalMax, uint32 walletMax, uint48 startDate, uint48 endDate, uint8 storageProtocol, bytes32 merkleRoot, string location, uint256 tokenId, uint256 cost, address payable paymentReceiver, address erc20, address signingAddress) claim)'
-];
 
 export class ManifoldClaimService {
   async getMintStatsFromMemeClaim(

--- a/src/nftsLoop/nfts.test.ts
+++ b/src/nftsLoop/nfts.test.ts
@@ -58,14 +58,18 @@ describe('getAnimationPaths', () => {
 });
 
 describe('NFT edition size floor calculations', () => {
-  it('refreshes the on-chain edition size floor only for the latest Meme', () => {
+  const NOW_MILLIS = new Date('2026-07-04T00:00:00Z').getTime();
+  const DAY_MILLIS = 24 * 60 * 60 * 1000;
+
+  it('refreshes only the latest Meme when older Memes are outside the refresh window', () => {
     const nftMap = new Map([
       [
         'memes-515',
         {
           nft: {
             contract: '0x33FD426905F149f8376e227d0C9D3340AaD17aF1',
-            id: 515
+            id: 515,
+            mint_date: new Date(NOW_MILLIS - 45 * DAY_MILLIS)
           }
         }
       ],
@@ -74,7 +78,8 @@ describe('NFT edition size floor calculations', () => {
         {
           nft: {
             contract: '0x33FD426905F149f8376e227d0C9D3340AaD17aF1',
-            id: 516
+            id: 516,
+            mint_date: new Date(NOW_MILLIS - 40 * DAY_MILLIS)
           }
         }
       ],
@@ -83,13 +88,74 @@ describe('NFT edition size floor calculations', () => {
         {
           nft: {
             contract: '0x0c58ef43ff3032005e472cb5709f8908acb00205',
-            id: 1000
+            id: 1000,
+            mint_date: new Date(NOW_MILLIS - DAY_MILLIS)
           }
         }
       ]
     ]);
 
-    expect(getMemeTokenIdsForEditionSizeFloorRefresh(nftMap)).toEqual([516]);
+    expect(
+      getMemeTokenIdsForEditionSizeFloorRefresh(nftMap, NOW_MILLIS)
+    ).toEqual([516]);
+  });
+
+  it('also refreshes non-latest Memes minted inside the refresh window', () => {
+    const nftMap = new Map([
+      [
+        'memes-514',
+        {
+          nft: {
+            contract: '0x33FD426905F149f8376e227d0C9D3340AaD17aF1',
+            id: 514,
+            mint_date: new Date(NOW_MILLIS - 60 * DAY_MILLIS)
+          }
+        }
+      ],
+      [
+        'memes-515',
+        {
+          nft: {
+            contract: '0x33FD426905F149f8376e227d0C9D3340AaD17aF1',
+            id: 515,
+            mint_date: new Date(NOW_MILLIS - 8 * DAY_MILLIS)
+          }
+        }
+      ],
+      [
+        'memes-516',
+        {
+          nft: {
+            contract: '0x33FD426905F149f8376e227d0C9D3340AaD17aF1',
+            id: 516,
+            mint_date: new Date(NOW_MILLIS - DAY_MILLIS)
+          }
+        }
+      ]
+    ]);
+
+    expect(
+      getMemeTokenIdsForEditionSizeFloorRefresh(nftMap, NOW_MILLIS)
+    ).toEqual([515, 516]);
+  });
+
+  it('still refreshes the latest Meme when its mint_date is missing', () => {
+    const nftMap = new Map([
+      [
+        'memes-516',
+        {
+          nft: {
+            contract: '0x33FD426905F149f8376e227d0C9D3340AaD17aF1',
+            id: 516,
+            mint_date: undefined
+          }
+        }
+      ]
+    ]);
+
+    expect(
+      getMemeTokenIdsForEditionSizeFloorRefresh(nftMap, NOW_MILLIS)
+    ).toEqual([516]);
   });
 
   it('uses resolved Meme floors and current supply for non-Memes', () => {

--- a/src/nftsLoop/nfts.ts
+++ b/src/nftsLoop/nfts.ts
@@ -1061,22 +1061,39 @@ export function calculateNftHodlRate(
   return rate;
 }
 
-export function getMemeTokenIdsForEditionSizeFloorRefresh(
-  nftMap: Map<string, { nft: Pick<NFT, 'contract' | 'id'> }>
-): number[] {
-  // Only the latest Meme's Manifold totalMax should still be mutable.
-  // Older Meme floors are treated as finalized once a newer Meme exists.
-  const latestMeme = Array.from(nftMap.values())
-    .map((entry) => entry.nft)
-    .filter((nft) => equalIgnoreCase(nft.contract, MEMES_CONTRACT))
-    .reduce<Pick<NFT, 'id'> | null>((latest, nft) => {
-      if (latest === null || nft.id > latest.id) {
-        return nft;
-      }
-      return latest;
-    }, null);
+const MEMES_EDITION_SIZE_FLOOR_REFRESH_WINDOW_MS = Time.days(30).toMillis();
 
-  return latestMeme ? [latestMeme.id] : [];
+export function getMemeTokenIdsForEditionSizeFloorRefresh(
+  nftMap: Map<string, { nft: Pick<NFT, 'contract' | 'id' | 'mint_date'> }>,
+  nowMillis: number = Time.currentMillis()
+): number[] {
+  // A Meme's Manifold totalMax is only mutable around its mint window. Refresh
+  // the latest Meme plus any Meme minted inside the refresh window, so a loop
+  // outage spanning a whole drop cannot leave that drop's floor stuck at its
+  // migration-backfilled supply once a newer Meme exists.
+  const memes = Array.from(nftMap.values())
+    .map((entry) => entry.nft)
+    .filter((nft) => equalIgnoreCase(nft.contract, MEMES_CONTRACT));
+
+  if (memes.length === 0) {
+    return [];
+  }
+
+  const refreshCutoff = nowMillis - MEMES_EDITION_SIZE_FLOOR_REFRESH_WINDOW_MS;
+  const latestMemeId = memes.reduce(
+    (latest, nft) => Math.max(latest, nft.id),
+    0
+  );
+
+  const tokenIds = new Set<number>([latestMemeId]);
+  for (const nft of memes) {
+    const mintMillis = nft.mint_date ? new Date(nft.mint_date).getTime() : NaN;
+    if (Number.isFinite(mintMillis) && mintMillis >= refreshCutoff) {
+      tokenIds.add(nft.id);
+    }
+  }
+
+  return Array.from(tokenIds).sort((a, b) => a - b);
 }
 
 async function populateMintStatsForEligibleNFTs(


### PR DESCRIPTION
## Issue
- Review follow-ups from #1692 (all noted in its review thread as polish-level):
  1. The Manifold lazy-claim contract address and ABI were duplicated between `src/memes-edition-size-floor.ts` and `src/mintAnnouncementsLoop/manifold-claim.service.ts`, so a change could drift.
  2. `MEMES_EDITION_SIZE_FLOOR_CAP = 310` lived in the resolver module with its rationale only in the PR body.
  3. Floors were refreshed only for the single latest Meme: if the nftsLoop were down across an entire drop window, that drop's floor would stay at its migration-backfilled supply forever once a newer Meme existed.

## Fix
- Extract the shared contract constants, relocate the cap next to the other Memes business constants with an explanatory comment, and widen the refresh set to "latest Meme + any Meme minted in the last 30 days" so missed refreshes self-heal.

## Changes
- New `src/constants/manifold.ts` with `MANIFOLD_LAZY_CLAIM_CONTRACT` and `MANIFOLD_LAZY_CLAIM_ABI`; both consumers now import it (re-exported via `@/constants`).
- `MEMES_EDITION_SIZE_FLOOR_CAP` moved to `src/constants/index.ts` with the 310-editions rationale.
- `getMemeTokenIdsForEditionSizeFloorRefresh` now takes `mint_date` into account: refreshes the latest Meme (unconditionally, even with a missing mint_date) plus any Meme minted within a 30-day window; injectable `nowMillis` keeps it pure and testable.
- Tests extended: outage-recovery case (non-latest Meme inside the window is refreshed), outside-window case, and missing-mint_date case.

## Validation
- `npx jest src/nftsLoop/nfts.test.ts src/memes-edition-size-floor.test.ts src/nftsLoop/nft-extended-data.test.ts`: 26/26 pass.
- eslint clean on all changed files.
- No schema, API-contract, or generated-file changes.

## Risk
- Level: Low
- Why: behavior-preserving refactors plus a strictly-wider refresh set; the widened window adds at most a handful of extra bounded, timeboxed RPC lookups per loop run (concurrency 10, 10s timeout, failure falls back to existing floor).
- Rollback: revert the commit; floors persist in the DB and are unaffected.

## Deployment
- `nftsLoop` (refresh window + shared constants), `mintAnnouncementsLoop` (shared constants import). No migration. `tdhLoop`/`api` unaffected at runtime (pure import-path changes compile identically).

## Review Notes
- The 30-day window intentionally covers multiple missed drops; old fully-minted Memes stay excluded, preserving #1692's forward-looking design.