### PR TITLE
perf(subscriptions): batch eligibility lookups and replace per-subscription table scans

### DIFF
--- a/src/api-serverless/src/subscriptions/api.subscriptions.db.ts
+++ b/src/api-serverless/src/subscriptions/api.subscriptions.db.ts
@@ -36,7 +36,10 @@ import { BadRequestException } from '@/exceptions';
 import { getMaxMemeId } from '@/nftsLoop/db.nfts';
 import { sqlExecutor } from '@/sql-executor';
 import { equalIgnoreCase } from '@/strings';
-import { fetchSubscriptionEligibility } from '@/subscriptionsDaily/db.subscriptions';
+import {
+  fetchSubscriptionEligibility,
+  fetchSubscriptionEligibilityForKeys
+} from '@/subscriptionsDaily/db.subscriptions';
 import { Time } from '@/time';
 
 const SUBSCRIPTIONS_START_ID = 220;
@@ -819,18 +822,9 @@ async function fetchEffectiveUpcomingMemeSubscriptionCounts(
     balanceMap.set(b.consolidation_key.toLowerCase(), b.balance);
   });
 
-  // Fetch subscription eligibility for auto subscriptions
-  const autoSubEligibilityMap = new Map<string, number>();
-  await Promise.all(
-    autoSubs.map(async (autoSub) => {
-      const eligibility = await fetchSubscriptionEligibility(
-        autoSub.consolidation_key
-      );
-      autoSubEligibilityMap.set(
-        autoSub.consolidation_key.toLowerCase(),
-        eligibility
-      );
-    })
+  // Fetch subscription eligibility for auto subscriptions in one batched query
+  const autoSubEligibilityMap = await fetchSubscriptionEligibilityForKeys(
+    autoSubs.map((autoSub) => autoSub.consolidation_key)
   );
 
   const counts: SubscriptionCounts[] = [];

--- a/src/subscriptionsDaily/db.subscriptions.ts
+++ b/src/subscriptionsDaily/db.subscriptions.ts
@@ -115,9 +115,11 @@ export async function fetchSubscriptionEligibilityForKeys(
   consolidationKeys: string[]
 ): Promise<Map<string, number>> {
   const eligibility = new Map<string, number>();
+  const queryKeys = new Set<string>();
   consolidationKeys.forEach((key) => {
     if (key) {
       eligibility.set(key.toLowerCase(), 1);
+      queryKeys.add(key);
     }
   });
   if (eligibility.size === 0) {
@@ -133,7 +135,7 @@ export async function fetchSubscriptionEligibilityForKeys(
   }
 
   const seasonId = maxSeasonId[0].max_id;
-  const distinctKeys = Array.from(eligibility.keys());
+  const distinctKeys = Array.from(queryKeys);
 
   for (let i = 0; i < distinctKeys.length; i += ELIGIBILITY_KEYS_CHUNK_SIZE) {
     const chunk = distinctKeys.slice(i, i + ELIGIBILITY_KEYS_CHUNK_SIZE);

--- a/src/subscriptionsDaily/db.subscriptions.ts
+++ b/src/subscriptionsDaily/db.subscriptions.ts
@@ -115,11 +115,9 @@ export async function fetchSubscriptionEligibilityForKeys(
   consolidationKeys: string[]
 ): Promise<Map<string, number>> {
   const eligibility = new Map<string, number>();
-  const queryKeys = new Set<string>();
   consolidationKeys.forEach((key) => {
     if (key) {
       eligibility.set(key.toLowerCase(), 1);
-      queryKeys.add(key);
     }
   });
   if (eligibility.size === 0) {
@@ -135,7 +133,7 @@ export async function fetchSubscriptionEligibilityForKeys(
   }
 
   const seasonId = maxSeasonId[0].max_id;
-  const distinctKeys = Array.from(queryKeys);
+  const distinctKeys = Array.from(eligibility.keys());
 
   for (let i = 0; i < distinctKeys.length; i += ELIGIBILITY_KEYS_CHUNK_SIZE) {
     const chunk = distinctKeys.slice(i, i + ELIGIBILITY_KEYS_CHUNK_SIZE);

--- a/src/subscriptionsDaily/db.subscriptions.ts
+++ b/src/subscriptionsDaily/db.subscriptions.ts
@@ -98,32 +98,59 @@ export async function persistNFTFinalSubscriptions(
 export async function fetchSubscriptionEligibility(
   consolidationKey: string
 ): Promise<number> {
+  const eligibility = await fetchSubscriptionEligibilityForKeys([
+    consolidationKey
+  ]);
+  return eligibility.get(consolidationKey.toLowerCase()) ?? 1;
+}
+
+const ELIGIBILITY_KEYS_CHUNK_SIZE = 5000;
+
+/**
+ * Eligible card-set count (min 1) per consolidation key, resolved with one
+ * MAX(season) query plus one chunked IN query instead of two queries per key.
+ * Keys of the returned map are lowercased.
+ */
+export async function fetchSubscriptionEligibilityForKeys(
+  consolidationKeys: string[]
+): Promise<Map<string, number>> {
+  const eligibility = new Map<string, number>();
+  consolidationKeys.forEach((key) => {
+    if (key) {
+      eligibility.set(key.toLowerCase(), 1);
+    }
+  });
+  if (eligibility.size === 0) {
+    return eligibility;
+  }
+
   const maxSeasonId = await sqlExecutor.execute<{ max_id: number }>(
     `SELECT MAX(id) as max_id FROM ${MEMES_SEASONS_TABLE}`
   );
 
   if (!maxSeasonId || maxSeasonId.length === 0 || !maxSeasonId[0].max_id) {
-    return 1;
+    return eligibility;
   }
 
   const seasonId = maxSeasonId[0].max_id;
+  const distinctKeys = Array.from(eligibility.keys());
 
-  const cardSetsResult = await sqlExecutor.execute<{
-    sets: number;
-  }>(
-    `SELECT sets FROM ${CONSOLIDATED_OWNERS_BALANCES_MEMES_TABLE} 
-     WHERE consolidation_key = :consolidationKey AND season = :seasonId`,
-    { consolidationKey, seasonId }
-  );
-
-  if (
-    !cardSetsResult ||
-    cardSetsResult.length === 0 ||
-    !cardSetsResult[0].sets ||
-    cardSetsResult[0].sets === 0
-  ) {
-    return 1;
+  for (let i = 0; i < distinctKeys.length; i += ELIGIBILITY_KEYS_CHUNK_SIZE) {
+    const chunk = distinctKeys.slice(i, i + ELIGIBILITY_KEYS_CHUNK_SIZE);
+    const cardSetsResult = await sqlExecutor.execute<{
+      consolidation_key: string;
+      sets: number;
+    }>(
+      `SELECT consolidation_key, sets FROM ${CONSOLIDATED_OWNERS_BALANCES_MEMES_TABLE}
+       WHERE consolidation_key IN (:chunk) AND season = :seasonId`,
+      { chunk, seasonId }
+    );
+    cardSetsResult.forEach((row) => {
+      if (row.consolidation_key && row.sets) {
+        eligibility.set(row.consolidation_key.toLowerCase(), row.sets);
+      }
+    });
   }
 
-  return cardSetsResult[0].sets;
+  return eligibility;
 }

--- a/src/subscriptionsDaily/fetch-subscription-eligibility-for-keys.test.ts
+++ b/src/subscriptionsDaily/fetch-subscription-eligibility-for-keys.test.ts
@@ -29,10 +29,10 @@ class MockSqlExecutor extends SqlExecutor {
     if (sql.includes('consolidation_key IN')) {
       const chunk: string[] = params?.chunk ?? [];
       return chunk
-        .filter((key) => this.setsByKey[key.toLowerCase()] !== undefined)
+        .filter((key) => this.setsByKey[key] !== undefined)
         .map((key) => ({
           consolidation_key: key,
-          sets: this.setsByKey[key.toLowerCase()]
+          sets: this.setsByKey[key]
         })) as T[];
     }
     throw new Error(`Unexpected query: ${sql}`);
@@ -80,8 +80,8 @@ describe('fetchSubscriptionEligibilityForKeys', () => {
     // one MAX query + one IN query for the three distinct keys
     expect(executor.queries).toHaveLength(2);
     expect(executor.queries[1].params?.chunk).toEqual([
-      '0xA-0xB',
-      '0xZERO',
+      '0xa-0xb',
+      '0xzero',
       '0xmissing'
     ]);
     expect(executor.queries[1].params?.seasonId).toBe(11);

--- a/src/subscriptionsDaily/fetch-subscription-eligibility-for-keys.test.ts
+++ b/src/subscriptionsDaily/fetch-subscription-eligibility-for-keys.test.ts
@@ -29,10 +29,10 @@ class MockSqlExecutor extends SqlExecutor {
     if (sql.includes('consolidation_key IN')) {
       const chunk: string[] = params?.chunk ?? [];
       return chunk
-        .filter((key) => this.setsByKey[key] !== undefined)
+        .filter((key) => this.setsByKey[key.toLowerCase()] !== undefined)
         .map((key) => ({
           consolidation_key: key,
-          sets: this.setsByKey[key]
+          sets: this.setsByKey[key.toLowerCase()]
         })) as T[];
     }
     throw new Error(`Unexpected query: ${sql}`);
@@ -80,8 +80,8 @@ describe('fetchSubscriptionEligibilityForKeys', () => {
     // one MAX query + one IN query for the three distinct keys
     expect(executor.queries).toHaveLength(2);
     expect(executor.queries[1].params?.chunk).toEqual([
-      '0xa-0xb',
-      '0xzero',
+      '0xA-0xB',
+      '0xZERO',
       '0xmissing'
     ]);
     expect(executor.queries[1].params?.seasonId).toBe(11);

--- a/src/subscriptionsDaily/fetch-subscription-eligibility-for-keys.test.ts
+++ b/src/subscriptionsDaily/fetch-subscription-eligibility-for-keys.test.ts
@@ -1,0 +1,119 @@
+import { DbQueryOptions } from '../db-query.options';
+import { setSqlExecutor, SqlExecutor } from '../sql-executor';
+import {
+  fetchSubscriptionEligibility,
+  fetchSubscriptionEligibilityForKeys
+} from './db.subscriptions';
+
+type ExecutedQuery = { sql: string; params?: Record<string, any> };
+
+class MockSqlExecutor extends SqlExecutor {
+  public readonly queries: ExecutedQuery[] = [];
+
+  constructor(
+    private readonly maxSeasonId: number | null,
+    private readonly setsByKey: Record<string, number>
+  ) {
+    super();
+  }
+
+  async execute<T = any>(
+    sql: string,
+    params?: Record<string, any>,
+    _options?: DbQueryOptions
+  ): Promise<T[]> {
+    this.queries.push({ sql, params });
+    if (sql.includes('MAX(id)')) {
+      return [{ max_id: this.maxSeasonId }] as T[];
+    }
+    if (sql.includes('consolidation_key IN')) {
+      const chunk: string[] = params?.chunk ?? [];
+      return chunk
+        .filter((key) => this.setsByKey[key] !== undefined)
+        .map((key) => ({
+          consolidation_key: key,
+          sets: this.setsByKey[key]
+        })) as T[];
+    }
+    throw new Error(`Unexpected query: ${sql}`);
+  }
+
+  async executeNativeQueriesInTransaction<T>(): Promise<T> {
+    throw new Error('Not supported in this test');
+  }
+}
+
+describe('fetchSubscriptionEligibilityForKeys', () => {
+  it('defaults every key to 1 with a single query when there are no seasons', async () => {
+    const executor = new MockSqlExecutor(null, {});
+    setSqlExecutor(executor);
+
+    const result = await fetchSubscriptionEligibilityForKeys([
+      '0xA-0xB',
+      '0xc'
+    ]);
+
+    expect(result.get('0xa-0xb')).toBe(1);
+    expect(result.get('0xc')).toBe(1);
+    expect(executor.queries).toHaveLength(1);
+  });
+
+  it('maps card sets per key, defaults missing/zero-set keys to 1 and lowercases keys', async () => {
+    const executor = new MockSqlExecutor(11, {
+      '0xa-0xb': 3,
+      '0xzero': 0
+    });
+    setSqlExecutor(executor);
+
+    const result = await fetchSubscriptionEligibilityForKeys([
+      '0xA-0xB',
+      '0xZERO',
+      '0xmissing',
+      '',
+      '0xA-0xB' // duplicate
+    ]);
+
+    expect(result.get('0xa-0xb')).toBe(3);
+    expect(result.get('0xzero')).toBe(1);
+    expect(result.get('0xmissing')).toBe(1);
+    expect(result.has('')).toBe(false);
+    // one MAX query + one IN query for the three distinct keys
+    expect(executor.queries).toHaveLength(2);
+    expect(executor.queries[1].params?.chunk).toEqual([
+      '0xa-0xb',
+      '0xzero',
+      '0xmissing'
+    ]);
+    expect(executor.queries[1].params?.seasonId).toBe(11);
+  });
+
+  it('chunks the IN query above 5000 distinct keys', async () => {
+    const keys = Array.from({ length: 5001 }, (_, i) => `0xkey${i}`);
+    const executor = new MockSqlExecutor(11, {});
+    setSqlExecutor(executor);
+
+    await fetchSubscriptionEligibilityForKeys(keys);
+
+    // 1 MAX query + 2 chunked IN queries
+    expect(executor.queries).toHaveLength(3);
+    expect(executor.queries[1].params?.chunk).toHaveLength(5000);
+    expect(executor.queries[2].params?.chunk).toHaveLength(1);
+  });
+});
+
+describe('fetchSubscriptionEligibility (single key, unchanged behavior)', () => {
+  it('returns the card set count when present', async () => {
+    setSqlExecutor(new MockSqlExecutor(11, { '0xa-0xb': 4 }));
+    await expect(fetchSubscriptionEligibility('0xA-0xB')).resolves.toBe(4);
+  });
+
+  it('returns 1 when the key has no card sets', async () => {
+    setSqlExecutor(new MockSqlExecutor(11, {}));
+    await expect(fetchSubscriptionEligibility('0xnobody')).resolves.toBe(1);
+  });
+
+  it('returns 1 when there are no seasons', async () => {
+    setSqlExecutor(new MockSqlExecutor(null, {}));
+    await expect(fetchSubscriptionEligibility('0xa-0xb')).resolves.toBe(1);
+  });
+});

--- a/src/subscriptionsDaily/subscriptions.ts
+++ b/src/subscriptionsDaily/subscriptions.ts
@@ -226,16 +226,16 @@ async function createFinalSubscriptions(
 
     if (balance) {
       if (balance.balance >= MEMES_MINT_PRICE) {
-        await addFundedFinalSubscription(
+        const { finalSub, subscriptionLog } = await addFundedFinalSubscription(
           sub,
           balance,
           autoSub,
           eligibilityByKey,
           newMeme,
-          dateStr,
-          finalSubscriptions,
-          newSubscriptionLogs
+          dateStr
         );
+        finalSubscriptions.push(finalSub);
+        newSubscriptionLogs.push(subscriptionLog);
       } else {
         logger.info(
           `[INSUFFICIENT BALANCE FOR ${sub.consolidation_key}] : [SKIPPING]`
@@ -278,10 +278,11 @@ async function addFundedFinalSubscription(
   autoSub: SubscriptionMode | undefined,
   eligibilityByKey: Map<string, number>,
   newMeme: number,
-  dateStr: string,
-  finalSubscriptions: NFTFinalSubscription[],
-  newSubscriptionLogs: SubscriptionLog[]
-) {
+  dateStr: string
+): Promise<{
+  finalSub: NFTFinalSubscription;
+  subscriptionLog: SubscriptionLog;
+}> {
   let createdAt = sub.updated_at?.getTime() ?? Time.now().toMillis();
   if (autoSub) {
     createdAt = autoSub.updated_at?.getTime() ?? Time.now().toMillis();
@@ -322,15 +323,16 @@ async function addFundedFinalSubscription(
     phase_position: -1,
     redeemed_count: 0
   };
-  finalSubscriptions.push(finalSub);
   const logText = `Added to Final Subscription for Meme #${newMeme} on ${dateStr}`;
   const additionalInfo = `Airdrop Address: ${finalSub.airdrop_address} - Subscription Count: x${subscribedCount} - Balance: ${finalSub.balance} ETH`;
 
-  newSubscriptionLogs.push({
+  const subscriptionLog: SubscriptionLog = {
     consolidation_key: sub.consolidation_key,
     log: logText,
     additional_info: additionalInfo
-  });
+  };
+
+  return { finalSub, subscriptionLog };
 }
 
 export function resolveRequestedSubscriptionCount(

--- a/src/subscriptionsDaily/subscriptions.ts
+++ b/src/subscriptionsDaily/subscriptions.ts
@@ -226,55 +226,16 @@ async function createFinalSubscriptions(
 
     if (balance) {
       if (balance.balance >= MEMES_MINT_PRICE) {
-        let createdAt = sub.updated_at?.getTime() ?? Time.now().toMillis();
-        if (autoSub) {
-          createdAt = autoSub.updated_at?.getTime() ?? Time.now().toMillis();
-        }
-        const subscribedAt = Time.millis(createdAt).toIsoString();
-        const eligibilityCount = sub.consolidation_key
-          ? (eligibilityByKey.get(sub.consolidation_key.toLowerCase()) ?? 1)
-          : 1;
-        const airdropAddress = await fetchAirdropAddressForConsolidationKey(
-          sub.consolidation_key
-        );
-        const affordableCount = Math.floor(balance.balance / MEMES_MINT_PRICE);
-        const requestedCount = resolveRequestedSubscriptionCount(
+        await addFundedFinalSubscription(
           sub,
+          balance,
           autoSub,
-          eligibilityCount
+          eligibilityByKey,
+          newMeme,
+          dateStr,
+          finalSubscriptions,
+          newSubscriptionLogs
         );
-        const subscribedCount = Math.min(
-          eligibilityCount,
-          requestedCount,
-          affordableCount
-        );
-        if (affordableCount < requestedCount) {
-          logger.info(
-            `[CAPPED BY BALANCE] ${sub.consolidation_key} requested x${requestedCount}, affordable x${affordableCount}, final x${subscribedCount}`
-          );
-        }
-        const finalSub: NFTFinalSubscription = {
-          subscribed_at: subscribedAt,
-          consolidation_key: sub.consolidation_key,
-          contract: sub.contract,
-          token_id: sub.token_id,
-          subscribed_count: subscribedCount,
-          airdrop_address: airdropAddress.airdrop_address,
-          balance: balance.balance,
-          phase: null,
-          phase_subscriptions: -1,
-          phase_position: -1,
-          redeemed_count: 0
-        };
-        finalSubscriptions.push(finalSub);
-        const logText = `Added to Final Subscription for Meme #${newMeme} on ${dateStr}`;
-        const additionalInfo = `Airdrop Address: ${finalSub.airdrop_address} - Subscription Count: x${subscribedCount} - Balance: ${finalSub.balance} ETH`;
-
-        newSubscriptionLogs.push({
-          consolidation_key: sub.consolidation_key,
-          log: logText,
-          additional_info: additionalInfo
-        });
       } else {
         logger.info(
           `[INSUFFICIENT BALANCE FOR ${sub.consolidation_key}] : [SKIPPING]`
@@ -309,6 +270,67 @@ async function createFinalSubscriptions(
   });
 
   return { finalSubscriptions, newSubscriptionLogs };
+}
+
+async function addFundedFinalSubscription(
+  sub: NFTSubscription,
+  balance: SubscriptionBalance,
+  autoSub: SubscriptionMode | undefined,
+  eligibilityByKey: Map<string, number>,
+  newMeme: number,
+  dateStr: string,
+  finalSubscriptions: NFTFinalSubscription[],
+  newSubscriptionLogs: SubscriptionLog[]
+) {
+  let createdAt = sub.updated_at?.getTime() ?? Time.now().toMillis();
+  if (autoSub) {
+    createdAt = autoSub.updated_at?.getTime() ?? Time.now().toMillis();
+  }
+  const subscribedAt = Time.millis(createdAt).toIsoString();
+  const eligibilityCount = sub.consolidation_key
+    ? (eligibilityByKey.get(sub.consolidation_key.toLowerCase()) ?? 1)
+    : 1;
+  const airdropAddress = await fetchAirdropAddressForConsolidationKey(
+    sub.consolidation_key
+  );
+  const affordableCount = Math.floor(balance.balance / MEMES_MINT_PRICE);
+  const requestedCount = resolveRequestedSubscriptionCount(
+    sub,
+    autoSub,
+    eligibilityCount
+  );
+  const subscribedCount = Math.min(
+    eligibilityCount,
+    requestedCount,
+    affordableCount
+  );
+  if (affordableCount < requestedCount) {
+    logger.info(
+      `[CAPPED BY BALANCE] ${sub.consolidation_key} requested x${requestedCount}, affordable x${affordableCount}, final x${subscribedCount}`
+    );
+  }
+  const finalSub: NFTFinalSubscription = {
+    subscribed_at: subscribedAt,
+    consolidation_key: sub.consolidation_key,
+    contract: sub.contract,
+    token_id: sub.token_id,
+    subscribed_count: subscribedCount,
+    airdrop_address: airdropAddress.airdrop_address,
+    balance: balance.balance,
+    phase: null,
+    phase_subscriptions: -1,
+    phase_position: -1,
+    redeemed_count: 0
+  };
+  finalSubscriptions.push(finalSub);
+  const logText = `Added to Final Subscription for Meme #${newMeme} on ${dateStr}`;
+  const additionalInfo = `Airdrop Address: ${finalSub.airdrop_address} - Subscription Count: x${subscribedCount} - Balance: ${finalSub.balance} ETH`;
+
+  newSubscriptionLogs.push({
+    consolidation_key: sub.consolidation_key,
+    log: logText,
+    additional_info: additionalInfo
+  });
 }
 
 export function resolveRequestedSubscriptionCount(

--- a/src/subscriptionsDaily/subscriptions.ts
+++ b/src/subscriptionsDaily/subscriptions.ts
@@ -37,7 +37,7 @@ import {
   fetchAllAutoSubscriptions,
   fetchAllNftSubscriptionBalances,
   fetchAllNftSubscriptions,
-  fetchSubscriptionEligibility,
+  fetchSubscriptionEligibilityForKeys,
   persistNFTFinalSubscriptions,
   persistSubscriptions
 } from './db.subscriptions';
@@ -85,11 +85,16 @@ async function populateAutoSubscriptionsForMemeId(
     `[NEW MEME ID ${newMeme}] : [SUBSCRIPTIONS ${newMemeSubscriptions.length}]`
   );
 
+  const newMemeSubscriptionKeys = new Set<string>();
+  newMemeSubscriptions.forEach((n) => {
+    if (n.consolidation_key) {
+      newMemeSubscriptionKeys.add(n.consolidation_key.toLowerCase());
+    }
+  });
   const autoSubscriptionsDelta = autoSubscriptions.filter(
     (s) =>
-      !newMemeSubscriptions.some((n) =>
-        equalIgnoreCase(n.consolidation_key, s.consolidation_key)
-      )
+      !s.consolidation_key ||
+      !newMemeSubscriptionKeys.has(s.consolidation_key.toLowerCase())
   );
 
   if (autoSubscriptionsDelta.length === 0) {
@@ -102,33 +107,34 @@ async function populateAutoSubscriptionsForMemeId(
     const newSubscriptions: NFTSubscription[] = [];
     const newSubscriptionLogs: SubscriptionLog[] = [];
 
-    await Promise.all(
-      autoSubscriptionsDelta.map(async (s) => {
-        let subscribedCount = 1;
-        const eligibilityCount = await fetchSubscriptionEligibility(
-          s.consolidation_key
-        );
-        if (s.subscribe_all_editions) {
-          subscribedCount = eligibilityCount;
-        }
-        const sub: NFTSubscription = {
-          consolidation_key: s.consolidation_key,
-          contract: MEMES_CONTRACT,
-          token_id: newMeme,
-          subscribed: true,
-          subscribed_count: subscribedCount,
-          automatic_subscription: true
-        };
-        newSubscriptions.push(sub);
-        const logText = `Auto-Subscribed to Meme #${newMeme}`;
-        const additionalInfo = `Edition Preference: ${s.subscribe_all_editions ? 'All eligible' : 'One edition'} - Eligibility: x${eligibilityCount} - Subscription Count: x${subscribedCount}`;
-        newSubscriptionLogs.push({
-          consolidation_key: s.consolidation_key,
-          log: logText,
-          additional_info: additionalInfo
-        });
-      })
+    const eligibilityByKey = await fetchSubscriptionEligibilityForKeys(
+      autoSubscriptionsDelta.map((s) => s.consolidation_key)
     );
+    autoSubscriptionsDelta.forEach((s) => {
+      let subscribedCount = 1;
+      const eligibilityCount = s.consolidation_key
+        ? (eligibilityByKey.get(s.consolidation_key.toLowerCase()) ?? 1)
+        : 1;
+      if (s.subscribe_all_editions) {
+        subscribedCount = eligibilityCount;
+      }
+      const sub: NFTSubscription = {
+        consolidation_key: s.consolidation_key,
+        contract: MEMES_CONTRACT,
+        token_id: newMeme,
+        subscribed: true,
+        subscribed_count: subscribedCount,
+        automatic_subscription: true
+      };
+      newSubscriptions.push(sub);
+      const logText = `Auto-Subscribed to Meme #${newMeme}`;
+      const additionalInfo = `Edition Preference: ${s.subscribe_all_editions ? 'All eligible' : 'One edition'} - Eligibility: x${eligibilityCount} - Subscription Count: x${subscribedCount}`;
+      newSubscriptionLogs.push({
+        consolidation_key: s.consolidation_key,
+        log: logText,
+        additional_info: additionalInfo
+      });
+    });
     await persistSubscriptions(newSubscriptions, newSubscriptionLogs);
     logger.info(
       `[NEW MEME ID ${newMeme}] : [CREATED ${newSubscriptions.length} AUTO SUBSCRIPTIONS]`
@@ -187,18 +193,36 @@ async function createFinalSubscriptions(
   const newSubscriptionLogs: SubscriptionLog[] = [];
   const finalSubscriptions: NFTFinalSubscription[] = [];
 
+  const balanceByKey = new Map<string, SubscriptionBalance>();
+  balances.forEach((b) => {
+    if (b.consolidation_key) {
+      const key = b.consolidation_key.toLowerCase();
+      if (!balanceByKey.has(key)) {
+        balanceByKey.set(key, b);
+      }
+    }
+  });
+  const autoSubscriptionByKey = new Map<string, SubscriptionMode>();
+  autoSubscriptions.forEach((a) => {
+    if (a.consolidation_key) {
+      const key = a.consolidation_key.toLowerCase();
+      if (!autoSubscriptionByKey.has(key)) {
+        autoSubscriptionByKey.set(key, a);
+      }
+    }
+  });
+  const eligibilityByKey = await fetchSubscriptionEligibilityForKeys(
+    filteredSubscriptions.map((sub) => sub.consolidation_key)
+  );
+
   const subscriptionPromises = filteredSubscriptions.map(async (sub) => {
-    const balance = balances.find((b) =>
-      equalIgnoreCase(b.consolidation_key, sub.consolidation_key)
-    );
+    const balance = sub.consolidation_key
+      ? balanceByKey.get(sub.consolidation_key.toLowerCase())
+      : undefined;
 
-    const airdropAddress = await fetchAirdropAddressForConsolidationKey(
-      sub.consolidation_key
-    );
-
-    const autoSub = autoSubscriptions.find((a) =>
-      equalIgnoreCase(a.consolidation_key, sub.consolidation_key)
-    );
+    const autoSub = sub.consolidation_key
+      ? autoSubscriptionByKey.get(sub.consolidation_key.toLowerCase())
+      : undefined;
 
     if (balance) {
       if (balance.balance >= MEMES_MINT_PRICE) {
@@ -207,7 +231,10 @@ async function createFinalSubscriptions(
           createdAt = autoSub.updated_at?.getTime() ?? Time.now().toMillis();
         }
         const subscribedAt = Time.millis(createdAt).toIsoString();
-        const eligibilityCount = await fetchSubscriptionEligibility(
+        const eligibilityCount = sub.consolidation_key
+          ? (eligibilityByKey.get(sub.consolidation_key.toLowerCase()) ?? 1)
+          : 1;
+        const airdropAddress = await fetchAirdropAddressForConsolidationKey(
           sub.consolidation_key
         );
         const affordableCount = Math.floor(balance.balance / MEMES_MINT_PRICE);


### PR DESCRIPTION
## Issue

`fetchSubscriptionEligibility(key)` costs two queries per call — one of them (`SELECT MAX(id) FROM memes_seasons`) identical every time. Two hot paths called it **once per subscription inside `Promise.all`**:

- the public **upcoming meme subscription counts** API endpoint (via `fetchEffectiveUpcomingMemeSubscriptionCounts`, which loads *every* auto-subscription) — thousands of queries per HTTP request against the API's 10-connection read pool;
- the **daily subscriptions job** (`populateAutoSubscriptionsForMemeId` and `createFinalSubscriptions`), which additionally scanned the entire `subscription_balances` result linearly per subscription (`balances.find(equalIgnoreCase(...))` — O(subscriptions × balances)) and fetched the airdrop address for *every* subscription even when the result was discarded.

Part of a batch of performance-only PRs from a full backend audit; all changes intended to be **output-identical**.

## Fix

- **New `fetchSubscriptionEligibilityForKeys(keys): Map<lowercased key, count>`** — one `MAX(id)` query + one `IN (...)` query per 5000 distinct keys. Semantics identical to the single-key version per key: no seasons → 1; key absent or `sets` falsy/0 → 1; otherwise `sets`. The single-key `fetchSubscriptionEligibility` now delegates to it — same two queries, same results, so the remaining per-identity call sites are untouched behaviorally.
- **API (`api.subscriptions.db.ts`)**: the per-autoSub `Promise.all` becomes one batch call. The map it produces is keyed by lowercased consolidation key with a default of 1 for every requested key — exactly the shape the downstream `getAutoSubscriptionEffectiveCount` (`.get(key.toLowerCase()) ?? 1`) already expects.
- **Daily job (`subscriptionsDaily/subscriptions.ts`)**:
  - balances and auto-subscriptions are now first-match-preserving lowercased maps (`.find` with `equalIgnoreCase` was first-match; keys are unique in both tables, and first-wins insertion preserves the tie-break exactly if they ever weren't);
  - eligibility is batched once for all filtered subscriptions;
  - the `fetchAirdropAddressForConsolidationKey` call moved **inside** the `balance >= mint price` branch — its result was only read there, so no-balance/insufficient-balance subscriptions no longer pay a TDH-wallet + delegations query (read-only calls; no side effects);
  - the auto-subscription delta check uses a lowercased `Set` instead of a nested `some(equalIgnoreCase(...))` scan (falsy-key handling preserved: falsy keys never matched before and are still always kept in the delta).

## Changes

- `src/subscriptionsDaily/db.subscriptions.ts` — adds `fetchSubscriptionEligibilityForKeys`; `fetchSubscriptionEligibility` delegates to it.
- `src/subscriptionsDaily/subscriptions.ts` — maps + batched eligibility + airdrop lookup moved into the funded branch.
- `src/api-serverless/src/subscriptions/api.subscriptions.db.ts` — batched eligibility for auto subscriptions.
- `src/subscriptionsDaily/fetch-subscription-eligibility-for-keys.test.ts` — **new** unit tests: defaulting, lowercasing, dedup, 5000-chunking, no-seasons behavior, and single-key wrapper equivalence.

## Validation

- New tests: 6/6 pass.
- Existing `src/api-serverless/src/subscriptions/api-subscriptions-db.test.ts` (covers `fetchUpcomingMemeSubscriptionCounts`, the changed API path) and `src/subscriptionsDaily/subscriptions.test.ts`: 13/13 pass unchanged.
- `npx tsc --noEmit` clean for touched files; `eslint --max-warnings=0` + `prettier` clean.
- Not tested live: a full daily-subscriptions run against production data.

## Risk

- Level: **Low–Medium** (touches a money-adjacent flow — final subscription lists — hence the extra test coverage and the strict semantics-preservation notes above)
- Why medium-ish: `createFinalSubscriptions` decides mint allocations; though every rewrite is mechanical (find→map, per-item→batch), reviewer scrutiny should focus here.
- Rollback: revert the single commit.

## Deployment

Not to be deployed yet — awaiting human review (@gelatogenesis). When approved: `api`, `subscriptionsDaily`, and `transactionsProcessingLoop` (imports the shared `db.subscriptions` module, even though its own call sites are unchanged).

## Review Notes

- One theoretical difference worth knowing: if `(consolidation_key, season)` ever had **duplicate rows** in `consolidated_owners_balances_memes`, the old single-key query took row `[0]`'s `sets` (even if 0 → 1), while the batch keeps the last truthy `sets`. That pair is the table's identity, so duplicates shouldn't exist — flagging for completeness.
- Ordering note: new auto-subscription rows are now appended in input order rather than `Promise.all` resolution order; both orders were semantically meaningless (rows are upserted; logs are inserts with auto-ids).
- Follow-up candidate spotted, out of scope: `consolidateSubscriptions` still queries the consolidation-keys view per wallet in a nested loop (small n — runs only for changed addresses) and builds a `LIKE '%...%'` filter by string concatenation, which is worth a look on its own.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Subscription eligibility and resulting counts are now calculated using batched lookups across multiple consolidation keys for better performance.

* **Bug Fixes**
  * Improved subscription counting for both automatic and final subscriptions, including cases with no available seasons and missing/empty eligibility data.
  * More consistent eligibility fallback behavior when eligibility isn’t found in the database.

* **Tests**
  * Added Jest coverage for batched eligibility lookup, key normalization and deduping, query chunking behavior, and default/fallback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->