### PR TITLE
Upgrade json-2-csv to v5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "image-size": "^2.0.2",
         "imagescript": "^1.3.1",
         "joi": "^17.11.0",
-        "json-2-csv": "^3.18.0",
+        "json-2-csv": "^5.5.11",
         "memory-cache": "^0.2.0",
         "merkletreejs": "^0.6.0",
         "moment-timezone": "^0.5.45",
@@ -11010,10 +11010,12 @@
       }
     },
     "node_modules/deeks": {
-      "version": "2.6.1",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/deeks/-/deeks-3.2.1.tgz",
+      "integrity": "sha512-D/o0k3pCG1aI1cxb/dDiWmtMc4Rh7ZQBybXpfMsw9Rbtqwg8kUA9SpYkWcw0pAUjZSnPm8MluctiS0o68r69jQ==",
       "license": "MIT",
       "engines": {
-        "node": ">= 12"
+        "node": ">= 16"
       }
     },
     "node_modules/deep-extend": {
@@ -11236,10 +11238,12 @@
       }
     },
     "node_modules/doc-path": {
-      "version": "3.1.0",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/doc-path/-/doc-path-4.1.4.tgz",
+      "integrity": "sha512-yw5D++UCIB6a033PvQaUvSpW2QuKW0+DOId763n0Q4z3brxS7G8oQr8yBQ1nQFkognKrAVrV6I55TLeU9cfXTg==",
       "license": "MIT",
       "engines": {
-        "node": ">=12"
+        "node": ">=16"
       }
     },
     "node_modules/docker-compose": {
@@ -17178,14 +17182,16 @@
       }
     },
     "node_modules/json-2-csv": {
-      "version": "3.20.0",
+      "version": "5.5.11",
+      "resolved": "https://registry.npmjs.org/json-2-csv/-/json-2-csv-5.5.11.tgz",
+      "integrity": "sha512-kVuwgVL7rfad9ETf02ZZxJPuMR5ZSUn139+T34BfmVxYhb/IsAIm/LzEeQ8YLJmXfuQ5z7LUAFrgPZZM6VLJPw==",
       "license": "MIT",
       "dependencies": {
-        "deeks": "2.6.1",
-        "doc-path": "3.1.0"
+        "deeks": "3.2.1",
+        "doc-path": "4.1.4"
       },
       "engines": {
-        "node": ">= 12"
+        "node": ">= 16"
       }
     },
     "node_modules/json-bigint": {

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "image-size": "^2.0.2",
     "imagescript": "^1.3.1",
     "joi": "^17.11.0",
-    "json-2-csv": "^3.18.0",
+    "json-2-csv": "^5.5.11",
     "memory-cache": "^0.2.0",
     "merkletreejs": "^0.6.0",
     "moment-timezone": "^0.5.45",

--- a/src/api-serverless/src/api-helpers.ts
+++ b/src/api-serverless/src/api-helpers.ts
@@ -8,7 +8,7 @@ import {
   SORT_DIRECTIONS
 } from './api-constants';
 
-const converter = require('json-2-csv');
+const { json2csv } = require('json-2-csv');
 
 function getCacheKeyPrefix(): string {
   return `__SEIZE_CACHE_${process.env.NODE_ENV}__`;
@@ -49,7 +49,7 @@ export async function returnCSVResult(
   results: any,
   response: Response
 ) {
-  const csv = await converter.json2csvAsync(results);
+  const csv = json2csv(results);
   response.header(CONTENT_TYPE_HEADER, 'text/csv');
   response.attachment(`${fileName}.csv`);
   return response.send(csv);

--- a/src/dbDumpsDaily/index.ts
+++ b/src/dbDumpsDaily/index.ts
@@ -7,7 +7,7 @@ import {
   TRANSACTIONS_TABLE
 } from '@/constants';
 import { sqlExecutor } from '../sql-executor';
-import converter from 'json-2-csv';
+import { json2csv } from 'json-2-csv';
 import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import { doInDbContext } from '../secrets';
 
@@ -38,7 +38,7 @@ async function dumpTable(tableName: string) {
 }
 
 async function dumpData(tableName: string, data: any) {
-  const csv = await converter.json2csvAsync(data);
+  const csv = json2csv(data);
 
   logger.info(
     `[TABLE ${tableName}] : [FOUND ${data.length} ROWS] : [UPLOADING TO S3]`

--- a/src/rates/ratings.service.ts
+++ b/src/rates/ratings.service.ts
@@ -1,5 +1,5 @@
 import { Request } from 'express';
-import converter from 'json-2-csv';
+import { json2csv } from 'json-2-csv';
 import { ApiAvailableRatingCredit } from '../api-serverless/src/generated/models/ApiAvailableRatingCredit';
 import { ApiBulkRateRequest } from '../api-serverless/src/generated/models/ApiBulkRateRequest';
 import { ApiBulkRepRequest } from '../api-serverless/src/generated/models/ApiBulkRepRequest';
@@ -555,7 +555,7 @@ export class RatingsService {
       ...it,
       snapshot_time: now.toMillis()
     }));
-    const csv = await converter.json2csvAsync(respWithTimes);
+    const csv = json2csv(respWithTimes);
     this.logger.info(`Uploading snapshot of ${matter} ratings to Arweave`);
     const { url } = await this.arweaveFileUploader.uploadFile(
       Buffer.from(csv),

--- a/src/rememesLoop/index.ts
+++ b/src/rememesLoop/index.ts
@@ -10,7 +10,7 @@ import {
   persistRememes,
   persistRememesUpload
 } from '../db';
-import converter from 'json-2-csv';
+import { json2csv } from 'json-2-csv';
 import { persistRememesS3 } from '../s3_rememes';
 import { Logger } from '../logging';
 import * as sentryContext from '../sentry.context';
@@ -312,7 +312,7 @@ async function upload(rememes: Rememe[]) {
 
   logger.info(`[UPLOADING TO ARWEAVE]`);
 
-  const csv = await converter.json2csvAsync(rememes);
+  const csv = json2csv(rememes);
 
   const transaction = await myarweave.createTransaction(
     { data: Buffer.from(csv) },

--- a/src/royalties.ts
+++ b/src/royalties.ts
@@ -1,5 +1,5 @@
 import { fetchRoyalties, persistRoyaltiesUpload } from './db';
-import converter from 'json-2-csv';
+import { json2csv } from 'json-2-csv';
 import { Logger } from './logging';
 
 const logger = Logger.get('ROYALTIES');
@@ -93,7 +93,7 @@ async function uploadRoyalties(formattedDate: string, royalties: Royalty[]) {
     return 0;
   });
 
-  const csv = await converter.json2csvAsync(uploadArray);
+  const csv = json2csv(uploadArray);
 
   const arweaveKey = process.env.ARWEAVE_KEY
     ? JSON.parse(process.env.ARWEAVE_KEY)

--- a/src/subscriptionsDaily/subscriptions.ts
+++ b/src/subscriptionsDaily/subscriptions.ts
@@ -1,4 +1,4 @@
-import converter from 'json-2-csv';
+import { json2csv } from 'json-2-csv';
 import { arweaveFileUploader } from '../arweave';
 import { collections } from '../collections';
 import {
@@ -332,7 +332,7 @@ async function uploadFinalSubscriptions(
         subscribed_at: sub.subscribed_at
       };
     });
-  const csv = await converter.json2csvAsync(finalUpload);
+  const csv = json2csv(finalUpload);
   const { url } = await arweaveFileUploader.uploadFile(
     Buffer.from(csv),
     'text/csv'

--- a/src/tdhLoop/tdh_upload.ts
+++ b/src/tdhLoop/tdh_upload.ts
@@ -1,4 +1,4 @@
-import converter from 'json-2-csv';
+import { json2csv } from 'json-2-csv';
 import { CLOUDFRONT_LINK } from '@/constants';
 import { s3ObjectExists, s3UploadObject } from '@/helpers/s3_helpers';
 import { persistConsolidatedTdhUpload, persistTdhUpload } from '../db';
@@ -162,7 +162,7 @@ async function persistUpload(
 ) {
   logger.info(`[CREATING CSV]`);
 
-  const csv = await converter.json2csvAsync(tdhUpload);
+  const csv = json2csv(tdhUpload);
 
   const size = csv.length / (1024 * 1024);
   logger.info(`[CSV CREATED - SIZE ${size.toFixed(2)} MB]`);


### PR DESCRIPTION
## Issue
- `json-2-csv@3.18.0` carries a moderate CSV-injection advisory (its `preventCsvInjection` option is ineffective in affected versions). It is the only remaining root audit finding fixable without touching the serverless v3 chain, and `npm audit fix` cannot apply it because the fix is a semver-major.
- Note the codebase never passes `preventCsvInjection`, so the flaw is not directly exploitable here — this clears the advisory and modernizes the API.

## Fix
- Bump to `json-2-csv@^5.5.11` and adapt the seven call sites to the v5 API.

## Changes
- `package.json` / `package-lock.json`: json-2-csv `^3.18.0` → `^5.5.11`.
- v5 renamed `json2csvAsync` → `json2csv` and made it synchronous. All call sites switched to named imports and dropped the now-meaningless `await`: `api-helpers.ts` (API CSV downloads), `dbDumpsDaily`, `rates/ratings.service.ts`, `rememesLoop`, `royalties.ts`, `subscriptionsDaily`, `tdhLoop/tdh_upload.ts`.

## Validation
- Output equivalence: v3 `json2csvAsync` and v5 `json2csv` produce byte-identical CSV for representative shapes (header derivation, comma quoting) and the empty-array edge case (both yield `"\n"`).
- Full root build + test suite green locally (all suites, 319s).
- eslint clean on all changed files.
- `npm audit`: the json-2-csv advisory is gone; remaining findings are exclusively the serverless-v3 chain (deferred — fix requires serverless 4, a semver-major with a commercial licensing change, so that is an owner decision rather than a mechanical bump).

## Risk
- Level: Low-Medium
- Why: touches CSV generation used by API download endpoints and several upload loops; mitigated by output-equivalence verification and the full test suite. The sync API change is absorbed at the call sites; error propagation inside existing try/catch blocks is unchanged.
- Rollback: revert the commit and redeploy affected services.

## Deployment
- `api`, `dbDumpsDaily`, `rememesLoop`, `royaltiesLoop`, `subscriptionsDaily`, `tdhLoop` (each bundles a changed file or the bumped dependency). Order-independent; staging `api` + `tdhLoop` serve as the primary validation pair. Undeployed loops keep running the old bundled v3 harmlessly until their next regular deploy.

## Review Notes
- v5 returns synchronously; `await` was removed rather than kept to avoid await-of-non-promise smell. Behavior inside callers is identical.