### PR TITLE
perf(indexing-loops): batch per-item queries and remove quadratic rank/count scans

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -873,15 +873,17 @@ export async function persistMemesExtendedData(data: MemesExtendedData[]) {
   await AppDataSource.getRepository(MemesExtendedData).save(data);
 }
 
-export async function findVolume(
-  nft_id: number,
-  contract: string
-): Promise<{
+export interface NftVolumes {
   total_volume_last_24_hours: number;
   total_volume_last_7_days: number;
   total_volume_last_1_month: number;
   total_volume: number;
-}> {
+}
+
+export async function findVolume(
+  nft_id: number,
+  contract: string
+): Promise<NftVolumes> {
   const sql = `SELECT
       SUM(CASE WHEN created_at >= DATE_SUB(NOW(), INTERVAL 24 HOUR) THEN value ELSE 0 END) AS total_volume_last_24_hours,
       SUM(CASE WHEN created_at >= DATE_SUB(NOW(), INTERVAL 7 DAY) THEN value ELSE 0 END) AS total_volume_last_7_days,
@@ -894,6 +896,34 @@ export async function findVolume(
     contract: contract
   });
   return results[0];
+}
+
+export async function findVolumesForContract(
+  contract: string
+): Promise<Map<number, NftVolumes>> {
+  const sql = `SELECT
+      token_id,
+      SUM(CASE WHEN created_at >= DATE_SUB(NOW(), INTERVAL 24 HOUR) THEN value ELSE 0 END) AS total_volume_last_24_hours,
+      SUM(CASE WHEN created_at >= DATE_SUB(NOW(), INTERVAL 7 DAY) THEN value ELSE 0 END) AS total_volume_last_7_days,
+      SUM(CASE WHEN created_at >= DATE_SUB(NOW(), INTERVAL 1 MONTH) THEN value ELSE 0 END) AS total_volume_last_1_month,
+      SUM(value) AS total_volume
+    FROM ${TRANSACTIONS_TABLE}
+    WHERE contract =:contract
+    GROUP BY token_id;`;
+  const results: ({ token_id: number } & NftVolumes)[] =
+    await sqlExecutor.execute(sql, {
+      contract: contract
+    });
+  const volumesByTokenId = new Map<number, NftVolumes>();
+  results.forEach((row) => {
+    volumesByTokenId.set(Number(row.token_id), {
+      total_volume_last_24_hours: row.total_volume_last_24_hours,
+      total_volume_last_7_days: row.total_volume_last_7_days,
+      total_volume_last_1_month: row.total_volume_last_1_month,
+      total_volume: row.total_volume
+    });
+  });
+  return volumesByTokenId;
 }
 
 export async function persistNFTs(nfts: NFT[]) {

--- a/src/marketStatsLoop/nft_market_stats.ts
+++ b/src/marketStatsLoop/nft_market_stats.ts
@@ -6,7 +6,7 @@ import {
 import {
   fetchAllMemeLabNFTs,
   fetchNftsForContract,
-  findVolume,
+  findVolumesForContract,
   persistLabNFTS,
   persistNFTs
 } from '../db';
@@ -51,6 +51,7 @@ export const findNftMarketStats = async (contract: string) => {
   );
 
   const nfts = await getNFTsForContract(contract);
+  const volumesByTokenId = await findVolumesForContract(contract);
   const BATCH_SIZE = 50;
   const totalBatches = Math.ceil(nfts.length / BATCH_SIZE);
 
@@ -76,7 +77,7 @@ export const findNftMarketStats = async (contract: string) => {
           maker: null
         };
 
-        const volumes = await findVolume(nft.id, contract);
+        const volumes = volumesByTokenId.get(nft.id);
         updateNftVolumeStats(nft, volumes);
         updateNftMarketStats(nft, bestListing, bestOffer);
 

--- a/src/nextgen/nextgen_tokens.ts
+++ b/src/nextgen/nextgen_tokens.ts
@@ -13,13 +13,15 @@ import {
   NextGenTokenTrait
 } from '../entities/INextGen';
 import { Logger } from '../logging';
-import { EntityManager } from 'typeorm';
+import { EntityManager, In } from 'typeorm';
 import { NFTS_TABLE } from '@/constants';
 import { MINT_TYPE_TRAIT } from './nextgen_constants';
 
 const logger = Logger.get('NEXTGEN_TOKENS');
 
 const mintTypeTraitLower = MINT_TYPE_TRAIT.toLowerCase();
+
+const TOKEN_TRAITS_CHUNK_SIZE = 5000;
 
 export async function refreshNextgenTokens(entityManager: EntityManager) {
   logger.info(`[REFRESHING NEXTGEN TOKENS]`);
@@ -141,14 +143,32 @@ async function processTokens(
 
   const traitCategories = new Set<string>();
   const traitCategoriesWithNone = new Set<string>();
-  for (const token of tokens) {
-    const tokenTraits = await entityManager
+
+  const tokenIds = tokens.map((token) => token.id);
+  const allTokenTraits: NextGenTokenTrait[] = [];
+  for (let i = 0; i < tokenIds.length; i += TOKEN_TRAITS_CHUNK_SIZE) {
+    const chunk = tokenIds.slice(i, i + TOKEN_TRAITS_CHUNK_SIZE);
+    const chunkTraits = await entityManager
       .getRepository(NextGenTokenTrait)
       .find({
         where: {
-          token_id: token.id
+          token_id: In(chunk)
         }
       });
+    allTokenTraits.push(...chunkTraits);
+  }
+  const dbTraitsPerToken = new Map<number, NextGenTokenTrait[]>();
+  allTokenTraits.forEach((tt) => {
+    const tokenTraitList = dbTraitsPerToken.get(tt.token_id);
+    if (tokenTraitList) {
+      tokenTraitList.push(tt);
+    } else {
+      dbTraitsPerToken.set(tt.token_id, [tt]);
+    }
+  });
+
+  for (const token of tokens) {
+    const tokenTraits = dbTraitsPerToken.get(token.id) ?? [];
 
     const filteredTokenTraits = tokenTraits.filter((tt) => {
       const traitLower = tt.trait.toLowerCase();
@@ -171,6 +191,11 @@ async function processTokens(
     traitCountPerToken.set(token.id, traitCount);
     traitsPerToken.set(token.id, filteredTokenTraits);
   }
+
+  const traitCountFrequencies = new Map<number, number>();
+  traitCountPerToken.forEach((tc) => {
+    traitCountFrequencies.set(tc, (traitCountFrequencies.get(tc) ?? 0) + 1);
+  });
 
   for (const token of tokens) {
     const filteredTokenTraits = traitsPerToken.get(token.id) || [];
@@ -213,9 +238,7 @@ async function processTokens(
     }
 
     const traitCount = traitCountPerToken.get(token.id) ?? 0;
-    const denominator = Array.from(traitCountPerToken.values()).filter(
-      (tc) => tc === traitCount
-    ).length;
+    const denominator = traitCountFrequencies.get(traitCount) ?? 0;
     const rarityScoreTraitCount = tokens.length / denominator + rarityScore;
 
     const rarityScoreTraitCountNormalisedAdjustement =

--- a/src/nftsLoop/assign-ranks-by-value.test.ts
+++ b/src/nftsLoop/assign-ranks-by-value.test.ts
@@ -1,0 +1,85 @@
+import fc from 'fast-check';
+import { assignRanksByValue } from './nft-extended-data';
+
+type Item = { id: number; value: number; rank?: number };
+
+/**
+ * The pre-optimization O(n^2) implementation, kept verbatim as a reference:
+ * rank = 1 + count of items strictly better by (value per direction, id asc).
+ */
+function referenceAssignRanks(
+  arr: Item[],
+  direction: 'asc' | 'desc'
+): Map<number, number> {
+  const ranks = new Map<number, number>();
+  arr.forEach((item) => {
+    const itemValue = item.value;
+    const rank =
+      arr.filter((other) => {
+        const otherValue = other.value;
+        if (direction === 'asc') {
+          return (
+            otherValue < itemValue ||
+            (otherValue === itemValue && other.id < item.id)
+          );
+        } else {
+          return (
+            otherValue > itemValue ||
+            (otherValue === itemValue && other.id < item.id)
+          );
+        }
+      }).length + 1;
+    ranks.set(item.id, rank);
+  });
+  return ranks;
+}
+
+const itemsArb: fc.Arbitrary<Item[]> = fc
+  .uniqueArray(fc.integer({ min: 1, max: 1000 }), { maxLength: 40 })
+  .chain((ids) =>
+    fc.tuple(
+      fc.constant(ids),
+      fc.array(fc.integer({ min: -5, max: 5 }), {
+        minLength: ids.length,
+        maxLength: ids.length
+      })
+    )
+  )
+  .map(([ids, values]) =>
+    ids.map((id, i) => ({ id, value: values[i] }) as Item)
+  );
+
+describe('assignRanksByValue', () => {
+  it('assigns exactly the ranks of the pre-optimization counting implementation', () => {
+    fc.assert(
+      fc.property(
+        itemsArb,
+        fc.constantFrom<'asc' | 'desc'>('asc', 'desc'),
+        (items, direction) => {
+          const expected = referenceAssignRanks(items, direction);
+
+          const actual = items.map((i) => ({ ...i }));
+          assignRanksByValue(actual, 'rank', (i) => i.value, direction);
+
+          actual.forEach((item) => {
+            expect(item.rank).toBe(expected.get(item.id));
+          });
+        }
+      ),
+      { numRuns: 200 }
+    );
+  });
+
+  it('gives duplicate values distinct ranks broken by ascending id', () => {
+    const items: Item[] = [
+      { id: 3, value: 10 },
+      { id: 1, value: 10 },
+      { id: 2, value: 7 }
+    ];
+    assignRanksByValue(items, 'rank', (i) => i.value, 'desc');
+    const rankById = new Map(items.map((i) => [i.id, i.rank]));
+    expect(rankById.get(1)).toBe(1);
+    expect(rankById.get(3)).toBe(2);
+    expect(rankById.get(2)).toBe(3);
+  });
+});

--- a/src/nftsLoop/nft-extended-data.ts
+++ b/src/nftsLoop/nft-extended-data.ts
@@ -200,32 +200,25 @@ function assignRanks<T extends { id: number }>(
   );
 }
 
-function assignRanksByValue<T extends { id: number }>(
+export function assignRanksByValue<T extends { id: number }>(
   arr: T[],
   rankField: string,
   valueGetter: (item: T) => number,
   direction: 'asc' | 'desc' = 'desc'
 ) {
-  arr.forEach((item) => {
-    const itemValue = valueGetter(item);
-    const rank =
-      arr.filter((other) => {
-        const otherValue = valueGetter(other);
-
-        if (direction === 'asc') {
-          return (
-            otherValue < itemValue ||
-            (otherValue === itemValue && other.id < item.id)
-          );
-        } else {
-          return (
-            otherValue > itemValue ||
-            (otherValue === itemValue && other.id < item.id)
-          );
-        }
-      }).length + 1;
-
-    (item as any)[rankField] = rank;
+  // rank = 1 + number of strictly-better items, where "better" is
+  // (value per direction, then lower id). (value, id) is a total order, so
+  // sorting by it and assigning positions yields the same ranks as counting.
+  const sorted = [...arr].sort((a, b) => {
+    const aValue = valueGetter(a);
+    const bValue = valueGetter(b);
+    if (aValue !== bValue) {
+      return direction === 'asc' ? aValue - bValue : bValue - aValue;
+    }
+    return a.id - b.id;
+  });
+  sorted.forEach((item, index) => {
+    (item as any)[rankField] = index + 1;
   });
 }
 

--- a/src/nftsLoop/nfts.ts
+++ b/src/nftsLoop/nfts.ts
@@ -957,42 +957,74 @@ async function updateSupply(
   nftMap: Map<string, NftProcessingEntry>
 ): Promise<number> {
   let maxSupply = 0;
+  const entries = Array.from(nftMap.values());
 
-  await Promise.all(
-    Array.from(nftMap.values()).map(async (entry) => {
-      const nft = entry.nft;
-      let supply: number;
-
-      if (nft.token_type === TokenType.ERC1155) {
-        const raw = await getDataSource()
-          .getRepository(NFTOwner)
-          .createQueryBuilder('owner')
-          .select('SUM(owner.balance)', 'sum')
-          .where('owner.contract = :contract', { contract: nft.contract })
-          .andWhere('owner.token_id = :token_id', { token_id: nft.id })
-          .getRawOne();
-        supply = Number(raw?.sum ?? 0);
-
-        if (equalIgnoreCase(nft.contract, MEMES_CONTRACT) && nft.id === 8) {
-          supply += MEME_8_EDITION_BURN_ADJUSTMENT;
-        }
-      } else {
-        supply = Array.from(nftMap.values()).filter((e) =>
-          equalIgnoreCase(e.nft.contract, nft.contract)
-        ).length;
-      }
-
-      if (supply !== nft.supply) {
-        logInfo(
-          `♻️ ${nft.contract} #${nft.id} updating supply from ${nft.supply} to ${supply}`
-        );
-        nft.supply = supply;
-        entry.changed = true;
-      }
-
-      maxSupply = Math.max(maxSupply, supply);
-    })
+  const erc1155Contracts = Array.from(
+    new Set(
+      entries
+        .filter((e) => e.nft.token_type === TokenType.ERC1155)
+        .map((e) => e.nft.contract.toLowerCase())
+    )
   );
+  const erc1155SupplyByContractAndToken = new Map<string, number>();
+  if (erc1155Contracts.length) {
+    const raws: { contract: string; token_id: number; sum: any }[] =
+      await getDataSource()
+        .getRepository(NFTOwner)
+        .createQueryBuilder('owner')
+        .select('owner.contract', 'contract')
+        .addSelect('owner.token_id', 'token_id')
+        .addSelect('SUM(owner.balance)', 'sum')
+        .where('owner.contract IN (:...contracts)', {
+          contracts: erc1155Contracts
+        })
+        .groupBy('owner.contract')
+        .addGroupBy('owner.token_id')
+        .getRawMany();
+    raws.forEach((raw) => {
+      erc1155SupplyByContractAndToken.set(
+        `${raw.contract.toLowerCase()}_${raw.token_id}`,
+        Number(raw.sum ?? 0)
+      );
+    });
+  }
+
+  const entryCountByContract = new Map<string, number>();
+  entries.forEach((e) => {
+    const contractKey = e.nft.contract.toLowerCase();
+    entryCountByContract.set(
+      contractKey,
+      (entryCountByContract.get(contractKey) ?? 0) + 1
+    );
+  });
+
+  entries.forEach((entry) => {
+    const nft = entry.nft;
+    let supply: number;
+
+    if (nft.token_type === TokenType.ERC1155) {
+      supply =
+        erc1155SupplyByContractAndToken.get(
+          `${nft.contract.toLowerCase()}_${nft.id}`
+        ) ?? 0;
+
+      if (equalIgnoreCase(nft.contract, MEMES_CONTRACT) && nft.id === 8) {
+        supply += MEME_8_EDITION_BURN_ADJUSTMENT;
+      }
+    } else {
+      supply = entryCountByContract.get(nft.contract.toLowerCase()) ?? 0;
+    }
+
+    if (supply !== nft.supply) {
+      logInfo(
+        `♻️ ${nft.contract} #${nft.id} updating supply from ${nft.supply} to ${supply}`
+      );
+      nft.supply = supply;
+      entry.changed = true;
+    }
+
+    maxSupply = Math.max(maxSupply, supply);
+  });
 
   return maxSupply;
 }


### PR DESCRIPTION
## Issue

Four indexing/stats jobs issue one query (or one full-array scan) **per item** where one grouped query (or one precomputed map) serves the whole run:

- `nextgen_tokens.processTokens`: one `NextGenTokenTrait` query **per token** — ~10k queries per collection per metadata refresh — plus an O(tokens²) trait-count "denominator" rescan per token.
- `nftsLoop/nfts.updateSupply`: one `SUM(balance)` query **per ERC1155 NFT** per refresh, and a full-map rescan per ERC721 NFT to count same-contract entries.
- `nftsLoop/nft-extended-data.assignRanksByValue`: O(n²) rank assignment (count strictly-better per element), executed for ~6 rank fields per run.
- `marketStatsLoop`: one 4-window volume aggregation query **per NFT** per hourly stats run.

Part of a batch of performance-only PRs from a full backend audit; all changes intended to be **output-identical**.

## Fix

- **NextGen traits**: chunked `In(tokenIds)` fetch (5000/chunk) grouped into `Map<token_id, traits[]>`. Trait usage is order-independent (sums, products, `Math.min`, `Set` membership), so no `ORDER BY` dependency exists. Denominator = frequency map over per-token trait counts, built once — same counts as the old per-token filter. Queries still run on the same `entityManager` (transaction) connection, just ~10k× fewer round trips.
- **updateSupply**: one `GROUP BY contract, token_id` SUM over the ERC1155 contracts present, looked up per NFT (`?? 0` matches the old `Number(raw?.sum ?? 0)` for tokens with no owner rows); meme #8 burn adjustment unchanged. ERC721 branch reads a per-contract entry count computed once (the old filter counted **all** entries of the contract regardless of token type — the new count does exactly the same). Case-insensitivity of the old SQL `=` comparisons is preserved by lowercased map keys.
- **assignRanksByValue**: sort by `(value per direction, id asc)` and assign `index + 1`. Since ids are unique this is a total order, so "1 + number of strictly better items" is exactly the sorted position. **Property-tested against the verbatim old implementation** (200 randomized runs incl. duplicate values, both directions).
- **Market stats volumes**: one `GROUP BY token_id` query per contract with the same four conditional SUM windows. Tokens with no transactions are absent from the map → `volumes` is `undefined` → the existing `volumes?.x ?? 0` defaults produce the same zeros the old all-NULL single-row result did. Windows are now evaluated against a single `NOW()` per contract instead of a `NOW()` per NFT milliseconds apart — same-run consistency, no semantic change.

## Changes

- `src/nextgen/nextgen_tokens.ts` — chunked trait fetch + grouping; trait-count frequency map.
- `src/nftsLoop/nfts.ts` — grouped supply query + per-contract counts in `updateSupply`.
- `src/nftsLoop/nft-extended-data.ts` — sort-based `assignRanksByValue` (now exported for the test).
- `src/marketStatsLoop/nft_market_stats.ts` + `src/db.ts` — `findVolumesForContract` (grouped) replaces per-NFT `findVolume` in the loop; `findVolume` itself is kept (no other callers removed).
- `src/nftsLoop/assign-ranks-by-value.test.ts` — **new**: fast-check equivalence property vs the old counting implementation + explicit tie-break case.

## Validation

- New property test: 2/2 pass (200 randomized cases).
- Existing `src/nftsLoop/nft-extended-data.test.ts` (rank behavior through the public API): 5/5 pass unchanged.
- `npx tsc --noEmit` clean for touched files; `eslint --max-warnings=0` + `prettier` clean.
- Not tested live: full nextgen/nfts/marketStats loop runs against production data.

## Risk

- Level: **Low**
- Why: batch jobs only; every rewrite mechanically preserves the old per-item semantics, with the only behaviorally-subtle one (rank assignment) property-tested against the old algorithm.
- Rollback: revert the single commit.

## Deployment

Not to be deployed yet — awaiting human review (@gelatogenesis). When approved: `nextgenContractLoop`, `nextgenMetadataLoop` (both import the nextgen module), `nftsLoop`, `marketStatsLoop`.

## Review Notes

- `assignRanksByValue` assumes rank-field values are real numbers (they're computed unconditionally upstream). If a value were ever `NaN`, the old counting code produced degenerate all-rank-1-ish results and the new sort produces engine-order-dependent results — both garbage; flagged only for completeness.
- In `updateSupply`, the ERC1155 supply map intentionally keys by `contract_tokenId` because MemeLab and Memes share token id ranges.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * NFT stats, trait processing, and supply updates now use batched lookups, which should make large collections load and process faster.
* **Bug Fixes**
  * Improved rank calculations and tie handling for NFT sorting, making displayed rankings more consistent.
  * Volume and supply values are now computed more reliably across token batches.
* **New Features**
  * Expanded support for reusable NFT volume data handling behind the scenes, improving consistency in results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->