### PR TITLE
perf(api): overlap independent drop-mapping reads and reuse the PFP S3 client

### DIFF
--- a/src/api-serverless/src/drops/drops.mappers.ts
+++ b/src/api-serverless/src/drops/drops.mappers.ts
@@ -240,18 +240,20 @@ export class DropsMappers {
     const readContextProfileId = getWaveReadContextProfileId(
       effectiveAuthenticationContext
     );
-    const dWoW = await this.convertToDropsWithoutWaves(dropEntities, {
-      connection,
-      authenticationContext: effectiveAuthenticationContext
-    });
     const dropIds = dropEntities.map((it) => it.id);
     const waveIds = collections.distinct(dropEntities.map((it) => it.wave_id));
     const [
+      dWoW,
       waveOverviews,
       waveVotingCreditNftsByWaveId,
       pinnedWaveIds,
-      identityWaveIds
+      identityWaveIds,
+      group_ids_user_is_eligible_for
     ] = await Promise.all([
+      this.convertToDropsWithoutWaves(dropEntities, {
+        connection,
+        authenticationContext: effectiveAuthenticationContext
+      }),
       this.wavesApiDb.getWavesByDropIds(dropIds, connection),
       this.wavesApiDb.findWaveVotingCreditNftsByWaveIds(waveIds, connection),
       this.wavesApiDb.whichOfWavesArePinnedByGivenProfile(
@@ -261,7 +263,10 @@ export class DropsMappers {
         },
         { connection }
       ),
-      profileWavesDb.findSelectedWaveIdsByWaveIds(waveIds, { connection })
+      profileWavesDb.findSelectedWaveIdsByWaveIds(waveIds, { connection }),
+      this.userGroupsService.getGroupsUserIsEligibleFor(
+        readContextProfileId ?? null
+      )
     ]);
     const waveDisplayByWaveId =
       await directMessageWaveDisplayService.resolveWaveDisplayByWaveIdForContext(
@@ -273,10 +278,6 @@ export class DropsMappers {
           contextProfileId: readContextProfileId ?? null
         },
         connection
-      );
-    const group_ids_user_is_eligible_for =
-      await this.userGroupsService.getGroupsUserIsEligibleFor(
-        readContextProfileId ?? null
       );
     const { noRightToVote, noRightToParticipate } = getWaveMinPermissionMask(
       effectiveAuthenticationContext

--- a/src/api-serverless/src/identities/identities.service.ts
+++ b/src/api-serverless/src/identities/identities.service.ts
@@ -51,6 +51,13 @@ import { findEnsForAddress } from '@/ens-lookup';
 import { helpBotCreditsService } from '@/help-bot/help-bot-credits.service';
 import { Logger } from '@/logging';
 
+let pfpS3Client: S3Client | undefined;
+
+function getPfpS3Client(): S3Client {
+  pfpS3Client ??= new S3Client({ region: 'eu-west-1' });
+  return pfpS3Client;
+}
+
 export class IdentitiesService {
   private readonly logger = Logger.get(this.constructor.name);
 
@@ -283,7 +290,7 @@ export class IdentitiesService {
   }
 
   private async uploadPfpToS3(file: any, fileExtension: string) {
-    const s3 = new S3Client({ region: 'eu-west-1' });
+    const s3 = getPfpS3Client();
 
     const myBucket = process.env.AWS_6529_IMAGES_BUCKET_NAME!;
 


### PR DESCRIPTION
## Issue

Two small request-path inefficiencies in the API:

1. `DropsMappers.convertToDrops` (behind the highest-traffic drop/feed endpoints) awaited `convertToDropsWithoutWaves` **before** starting the wave-related `Promise.all`, and awaited `getGroupsUserIsEligibleFor` **after** it — even though neither has any data dependency on the queries in between. Endpoint latency = sum of the three stages instead of the max of one.
2. `uploadPfpToS3` constructed a fresh `S3Client` on every profile-picture upload.

Part of a batch of performance-only PRs from a full backend audit; changes intended to be **output-identical**.

## Fix

- All six independent reads (`convertToDropsWithoutWaves`, wave overviews, voting-credit NFTs, pinned wave ids, selected wave ids, eligible group ids) now run in a single `Promise.all`. The wave-display resolution that genuinely depends on `waveOverviews` remains sequential after it. Correctness notes:
  - No result of any of the six depends on another; all are reads.
  - When a wrapped transaction `connection` is passed, the MySQL driver serializes queries on that connection exactly as it already did for the existing 4-way `Promise.all` — no concurrency semantics change; on the pool path the reads genuinely overlap.
  - Error behavior: any failing read still rejects the whole call; the only difference is that sibling reads may have started (they are side-effect-free selects).
- The PFP `S3Client` is now a lazily-initialized module-level singleton (same hardcoded `eu-west-1` region), matching the module-scope client pattern used elsewhere in the codebase (e.g. the push-notifications SQS client).

## Changes

- `src/api-serverless/src/drops/drops.mappers.ts` — `Promise.all` consolidation in `convertToDrops`.
- `src/api-serverless/src/identities/identities.service.ts` — `getPfpS3Client()` lazy singleton.

## Validation

- Existing drops + identities suites: 184/184 tests across 15 suites pass unchanged.
- `npx tsc --noEmit` clean for touched files; `eslint --max-warnings=0` + `prettier` clean.
- Not tested live: endpoint latency measurement.

## Risk

- Level: **Low**
- Why: smallest PR of the batch; pure read-reordering with no data dependencies, plus a client singleton.
- Rollback: revert the single commit.

## Deployment

Not to be deployed yet — awaiting human review (@gelatogenesis). When approved: `api` only.

## Review Notes

- The thing to check is the no-data-dependency claim in `convertToDrops` — the six calls and their inputs are all derived from `dropEntities` / `readContextProfileId`, both available before the block.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the speed of loading drop details and related eligibility information.
  * Made profile picture uploads more efficient by reusing an existing connection, which can reduce delays during upload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->