### PR TITLE
perf(nextgen): remove quadratic trait-score scans in collection processing

### DIFF
--- a/src/nextgen/nextgen-token-trait-scores.test.ts
+++ b/src/nextgen/nextgen-token-trait-scores.test.ts
@@ -1,0 +1,247 @@
+import fc from 'fast-check';
+import { NextGenCollection, NextGenTokenTrait } from '@/entities/INextGen';
+import {
+  fetchNextGenCollections,
+  fetchNextGenTokensForCollection,
+  fetchNextGenTokenTraits,
+  persistNextGenCollection,
+  persistNextGenCollectionHodlRate,
+  persistNextGenTraits,
+  persistNextGenTraitScores
+} from './nextgen.db';
+import { MINT_TYPE_TRAIT } from './nextgen_constants';
+import { refreshNextgenTokens } from './nextgen_tokens';
+
+jest.mock('./nextgen.db', () => ({
+  fetchNextGenCollections: jest.fn(),
+  fetchNextGenTokensForCollection: jest.fn(),
+  fetchNextGenTokenTraits: jest.fn(),
+  persistNextGenCollection: jest.fn(),
+  persistNextGenCollectionHodlRate: jest.fn(),
+  persistNextGenTraits: jest.fn(),
+  persistNextGenTraitScores: jest.fn()
+}));
+
+const mockedFetchNextGenCollections =
+  fetchNextGenCollections as jest.MockedFunction<
+    typeof fetchNextGenCollections
+  >;
+const mockedFetchNextGenTokensForCollection =
+  fetchNextGenTokensForCollection as jest.MockedFunction<
+    typeof fetchNextGenTokensForCollection
+  >;
+const mockedFetchNextGenTokenTraits =
+  fetchNextGenTokenTraits as jest.MockedFunction<
+    typeof fetchNextGenTokenTraits
+  >;
+const mockedPersistNextGenTraits = persistNextGenTraits as jest.MockedFunction<
+  typeof persistNextGenTraits
+>;
+const mockedPersistNextGenCollectionHodlRate =
+  persistNextGenCollectionHodlRate as jest.MockedFunction<
+    typeof persistNextGenCollectionHodlRate
+  >;
+const mockedPersistNextGenTraitScores =
+  persistNextGenTraitScores as jest.MockedFunction<
+    typeof persistNextGenTraitScores
+  >;
+const mockedPersistNextGenCollection =
+  persistNextGenCollection as jest.MockedFunction<
+    typeof persistNextGenCollection
+  >;
+
+const mintTypeTraitLower = MINT_TYPE_TRAIT.toLowerCase();
+
+const fakeEntityManager = {
+  query: jest.fn().mockResolvedValue([{ maxSupply: 1000 }]),
+  getRepository: jest.fn()
+} as any;
+
+/**
+ * Verbatim pre-optimization pipeline: the O(T^2) per-row score computation of
+ * processCollectionTraitScores plus the per-category-refiltering
+ * calulateTokenRanks chain, kept as the reference implementation.
+ */
+function referenceTraitScorePipeline(tokenTraits: any[]): any[] {
+  const tokenCount = new Set(tokenTraits.map((item) => item.token_id)).size;
+  const traitsCount = new Set(
+    tokenTraits
+      .filter((t) => !t.trait.toLowerCase().startsWith(mintTypeTraitLower))
+      .map((item) => item.trait)
+  ).size;
+
+  tokenTraits.forEach((tt) => {
+    const name = tt.trait;
+    const value = tt.value;
+
+    tt.token_count = tokenCount;
+
+    const sharedKey = tokenTraits.filter((other) => other.trait === name);
+    tt.trait_count = new Set(sharedKey.map((item) => item.value)).size;
+
+    tt.value_count = sharedKey.filter((other) => other.value === value).length;
+
+    if (name.toLowerCase().startsWith(mintTypeTraitLower)) {
+      tt.statistical_rarity = -1;
+      tt.rarity_score = -1;
+      tt.rarity_score_normalised = -1;
+      tt.rarity_score_trait_count_normalised = -1;
+      tt.statistical_rarity_normalised = -1;
+      tt.single_trait_rarity_score_normalised = -1;
+    } else {
+      const sharedKeyValue = sharedKey.filter(
+        (other) => other.value === value
+      ).length;
+      const valuesCountForTrait = new Set(sharedKey.map((item) => item.value))
+        .size;
+
+      const statisticalScore = sharedKeyValue / tokenCount;
+      tt.statistical_rarity = statisticalScore;
+      tt.single_trait_rarity_score_normalised =
+        statisticalScore * valuesCountForTrait;
+      tt.statistical_rarity_normalised =
+        statisticalScore ** (1 / valuesCountForTrait);
+      tt.rarity_score = tokenCount / sharedKeyValue;
+      tt.rarity_score_normalised =
+        ((1 / sharedKeyValue) * 1000000) / (traitsCount * valuesCountForTrait);
+      tt.rarity_score_trait_count_normalised =
+        ((1 / sharedKeyValue) * 1000000) /
+        ((traitsCount + 1) * valuesCountForTrait);
+    }
+  });
+
+  let rankedTraits = referenceCalulateTokenRanks(tokenTraits, 'rarity_score');
+  rankedTraits = referenceCalulateTokenRanks(
+    rankedTraits,
+    'rarity_score_normalised'
+  );
+  rankedTraits = referenceCalulateTokenRanks(
+    rankedTraits,
+    'statistical_rarity'
+  );
+  rankedTraits = referenceCalulateTokenRanks(
+    rankedTraits,
+    'statistical_rarity_normalised'
+  );
+  rankedTraits = referenceCalulateTokenRanks(
+    rankedTraits,
+    'single_trait_rarity_score_normalised'
+  );
+  rankedTraits = referenceCalulateTokenRanks(
+    rankedTraits,
+    'rarity_score_trait_count_normalised'
+  );
+  return rankedTraits;
+}
+
+function referenceCalulateTokenRanks(startingTraits: any[], field: string) {
+  const categories = new Set<string>(startingTraits.map((tt) => tt.trait));
+  const rankedTokens = Array.from(categories).map((category) => {
+    const traits = startingTraits.filter((tt) => tt.trait === category);
+    return referenceRanksForCategory(traits, field);
+  });
+  return rankedTokens.flat();
+}
+
+function referenceRanksForCategory(startingTraits: any[], field: string) {
+  const tokenTraits = [...startingTraits] as any[];
+  const sortedTraits = tokenTraits.sort((a, b) => b[field] - a[field]);
+
+  let currentRank = 1;
+  let previousValue = sortedTraits[0][field];
+
+  sortedTraits.forEach((tt) => {
+    if (tt[field] !== previousValue) {
+      currentRank += 1;
+      previousValue = tt[field];
+    }
+    tt[`${field}_rank`] = currentRank;
+  });
+
+  return sortedTraits;
+}
+
+const TRAITS = ['Background', 'Palette', MINT_TYPE_TRAIT, 'Size'];
+const VALUES = ['Alpha', 'Beta', 'Gamma', 'None Big', 'Delta'];
+
+const traitRowArb: fc.Arbitrary<any> = fc.record({
+  token_id: fc.integer({ min: 1, max: 25 }),
+  trait: fc.constantFrom(...TRAITS),
+  value: fc.constantFrom(...VALUES)
+});
+
+describe('refreshNextgenTokens trait scores', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    fakeEntityManager.query.mockResolvedValue([{ maxSupply: 1000 }]);
+    mockedFetchNextGenCollections.mockResolvedValue([
+      { id: 1, name: 'Test Collection' } as NextGenCollection
+    ]);
+    // empty token list keeps processTokens inert; this suite targets the
+    // trait-score pipeline feeding persistNextGenTraits
+    mockedFetchNextGenTokensForCollection.mockResolvedValue([]);
+    mockedPersistNextGenTraits.mockResolvedValue(undefined);
+    mockedPersistNextGenCollectionHodlRate.mockResolvedValue(undefined);
+    mockedPersistNextGenTraitScores.mockResolvedValue(undefined);
+    mockedPersistNextGenCollection.mockResolvedValue(undefined);
+  });
+
+  it('persists exactly the rows (content and order) of the pre-optimization pipeline', async () => {
+    await fc.assert(
+      fc.asyncProperty(
+        fc.array(traitRowArb, { minLength: 1, maxLength: 60 }),
+        async (rows) => {
+          const actualInput = rows.map((r) => ({ ...r, collection_id: 1 }));
+          const referenceInput = rows.map((r) => ({ ...r, collection_id: 1 }));
+
+          mockedPersistNextGenTraits.mockClear();
+          mockedFetchNextGenTokenTraits.mockResolvedValue(
+            actualInput as NextGenTokenTrait[]
+          );
+
+          await refreshNextgenTokens(fakeEntityManager);
+
+          const expected = referenceTraitScorePipeline(referenceInput);
+          expect(mockedPersistNextGenTraits).toHaveBeenCalledTimes(1);
+          const persisted = mockedPersistNextGenTraits.mock.calls[0][1];
+          expect(persisted).toEqual(expected);
+        }
+      ),
+      { numRuns: 40 }
+    );
+  });
+
+  it('marks mint-type traits with -1 scores while still counting their values', async () => {
+    const rows = [
+      {
+        token_id: 1,
+        trait: MINT_TYPE_TRAIT,
+        value: 'Airdrop',
+        collection_id: 1
+      },
+      { token_id: 2, trait: MINT_TYPE_TRAIT, value: 'Mint', collection_id: 1 },
+      { token_id: 1, trait: 'Background', value: 'Alpha', collection_id: 1 },
+      { token_id: 2, trait: 'Background', value: 'Alpha', collection_id: 1 }
+    ];
+    mockedFetchNextGenTokenTraits.mockResolvedValue(
+      rows as unknown as NextGenTokenTrait[]
+    );
+
+    await refreshNextgenTokens(fakeEntityManager);
+
+    const persisted = mockedPersistNextGenTraits.mock.calls[0][1] as any[];
+    const mintRows = persisted.filter((r) => r.trait === MINT_TYPE_TRAIT);
+    expect(mintRows).toHaveLength(2);
+    mintRows.forEach((r) => {
+      expect(r.rarity_score).toBe(-1);
+      expect(r.trait_count).toBe(2);
+      expect(r.value_count).toBe(1);
+    });
+    const backgroundRows = persisted.filter((r) => r.trait === 'Background');
+    backgroundRows.forEach((r) => {
+      expect(r.value_count).toBe(2);
+      expect(r.trait_count).toBe(1);
+      expect(r.statistical_rarity).toBe(1);
+    });
+  });
+});

--- a/src/nextgen/nextgen_tokens.ts
+++ b/src/nextgen/nextgen_tokens.ts
@@ -60,16 +60,27 @@ async function processCollectionTraitScores(
   logger.info(
     `[PROCESSING TRAIT SCORES] : [COLLECTION ${collection.id}] : [TOKEN COUNT ${tokenCount}]`
   );
+  // per trait: how often each value occurs (map size = distinct value count)
+  const traitValueCounts = new Map<string, Map<string, number>>();
+  tokenTraits.forEach((tt) => {
+    let valueCounts = traitValueCounts.get(tt.trait);
+    if (!valueCounts) {
+      valueCounts = new Map<string, number>();
+      traitValueCounts.set(tt.trait, valueCounts);
+    }
+    valueCounts.set(tt.value, (valueCounts.get(tt.value) ?? 0) + 1);
+  });
+
   tokenTraits.forEach((tt) => {
     const name = tt.trait;
     const value = tt.value;
 
     tt.token_count = tokenCount;
 
-    const sharedKey = tokenTraits.filter((tt) => tt.trait === name);
-    tt.trait_count = new Set(sharedKey.map((item) => item.value)).size;
+    const valueCounts = traitValueCounts.get(name)!;
+    tt.trait_count = valueCounts.size;
 
-    tt.value_count = sharedKey.filter((tt) => tt.value === value).length;
+    tt.value_count = valueCounts.get(value) ?? 0;
 
     if (name.toLowerCase().startsWith(mintTypeTraitLower)) {
       tt.statistical_rarity = -1;
@@ -79,12 +90,9 @@ async function processCollectionTraitScores(
       tt.statistical_rarity_normalised = -1;
       tt.single_trait_rarity_score_normalised = -1;
     } else {
-      const sharedKeyValue = sharedKey.filter(
-        (tt) => tt.value === value
-      ).length;
+      const sharedKeyValue = tt.value_count;
 
-      const valuesCountForTrait = new Set(sharedKey.map((item) => item.value))
-        .size;
+      const valuesCountForTrait = valueCounts.size;
 
       const statisticalScore = sharedKeyValue / tokenCount;
       tt.statistical_rarity = statisticalScore;
@@ -395,12 +403,21 @@ function calulateTokenRanks(
   startingTraits: NextGenTokenTrait[],
   field: string
 ) {
-  const categories = new Set<string>(startingTraits.map((tt) => tt.trait));
-
-  const rankedTokens = Array.from(categories).map((category) => {
-    const traits = startingTraits.filter((tt) => tt.trait === category);
-    return calculateTokenRanksForCategory(traits, field);
+  // group rows by trait in one pass; map insertion order matches the previous
+  // Set-of-categories first-appearance order, and rows keep array order
+  const traitsByCategory = new Map<string, NextGenTokenTrait[]>();
+  startingTraits.forEach((tt) => {
+    const categoryTraits = traitsByCategory.get(tt.trait);
+    if (categoryTraits) {
+      categoryTraits.push(tt);
+    } else {
+      traitsByCategory.set(tt.trait, [tt]);
+    }
   });
+
+  const rankedTokens = Array.from(traitsByCategory.values()).map((traits) =>
+    calculateTokenRanksForCategory(traits, field)
+  );
   return rankedTokens.flat();
 }
 


### PR DESCRIPTION
## Issue

Tier-1 follow-up to the perf batch under review (#1699, #1701, #1703, #1705, #1706) — this one is likely the **largest remaining single win** in the codebase.

`processCollectionTraitScores` in `src/nextgen/nextgen_tokens.ts` runs on every NextGen contract/metadata loop pass and, for **every trait row**, re-filters the entire trait-row list of the collection (then scans that subset twice more). With T = tokens × trait categories ≈ 150k rows for a 10k-token collection, that's on the order of 10⁹–10¹⁰ operations per run. `calulateTokenRanks` adds a full-list filter per trait category per rank field (6 fields × ~dozens of categories × 150k).

## Fix

- **Per-trait value-count map built once** (`Map<trait, Map<value, count>>`). Per row, `trait_count` (= distinct values for the trait), `value_count` / `sharedKeyValue` (= rows with the same trait+value) and `valuesCountForTrait` are O(1) lookups. Equivalence: the old code used strict `===` on `trait` and `value`; `Map`/`Set` keying is SameValueZero, which is identical to `===` for the string (and even null) values involved. The old code also recomputed `sharedKeyValue`/`valuesCountForTrait` redundantly per row — they are by definition `value_count`/`trait_count`, which the old code had already computed from the same subset.
- **`calulateTokenRanks` groups rows by category in one pass** per call instead of `Set` + per-category `filter`. Map insertion order ≡ the previous first-appearance category order, and per-category rows keep array order — so the inputs to the (untouched) `calculateTokenRanksForCategory` sorts are byte-identical, and therefore the ranks **and the output array order** are unchanged. This matters because the six chained calls deliberately reorder the array; the property test asserts order equality, not just content.

## Changes

- `src/nextgen/nextgen_tokens.ts` — the two rewrites above; `calculateTokenRanksForCategory` untouched.
- `src/nextgen/nextgen-token-trait-scores.test.ts` — **new**: fast-check property through the public `refreshNextgenTokens` entry proving the rows handed to `persistNextGenTraits` are deep-equal **including order** to the verbatim pre-optimization pipeline (kept in the test as a reference implementation), across randomized token/trait/value combinations including mint-type traits; plus an explicit mint-type case (−1 scores, counts still populated).

## Validation

- New tests: 2/2 pass (property runs 40 randomized collections).
- `npx tsc --noEmit` clean for touched files; `eslint --max-warnings=0` + `prettier` clean.
- Not tested live: a full nextgen loop run against a production-size collection.

## Risk

- Level: **Low**
- Why: batch loop only; pure-computation rewrite property-tested for exact output equality including array order.
- Rollback: revert the single commit.

## Deployment

Not to be deployed yet — same review gate as the open perf batch (@gelatogenesis). When approved: `nextgenContractLoop`, `nextgenMetadataLoop`.

## Review Notes

- This file is also touched by open PR #1705, but in a **different function** (`processTokens`) — the hunks don't overlap, so either merge order is clean.
- The interesting equivalence detail is the array-order preservation through the six chained `calulateTokenRanks` calls (explained above; asserted by the test).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token collection trait score calculations with more consistent rarity values.
  * Enhanced handling for mint-type trait rows so rarity-related scores are correctly set, while counts remain accurate.
  * Improved ranking stability by preserving category ordering based on first appearance.

* **Tests**
  * Added property-based and deterministic tests to verify trait-score persistence matches expected pipeline output (including correct row ordering).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->