### PR TITLE
perf(consolidations): batch consolidation-key lookups in activity and nft-owners loops

### DIFF
--- a/src/aggregatedActivityLoop/aggregated_activity.ts
+++ b/src/aggregatedActivityLoop/aggregated_activity.ts
@@ -11,9 +11,9 @@ import {
 import { Transaction } from '../entities/ITransaction';
 import {
   fetchAllSeasons,
+  fetchConsolidationGroupsForAddresses,
   fetchMaxTransactionsBlockNumber,
   fetchTransactionsAfterBlock,
-  fetchWalletConsolidationKeysViewForWallet,
   fetchWalletTransactions
 } from '../db';
 import { Logger } from '../logging';
@@ -285,39 +285,33 @@ export async function consolidateActivity(
   >();
   const deleteDelta = new Set<string>();
 
+  // one batched lookup for all addresses, then one computation per unique
+  // consolidation instead of one per member address
+  const consolidationGroups = await fetchConsolidationGroupsForAddresses(
+    Array.from(addresses)
+  );
+
   await Promise.all(
-    Array.from(addresses).map(async (address) => {
-      const consolidation = (
-        await fetchWalletConsolidationKeysViewForWallet([address])
-      )[0];
+    Array.from(consolidationGroups.entries()).map(
+      async ([consolidationKey, consolidationAddresses]) => {
+        const cActivity = await getConsolidatedActivity(
+          consolidationKey,
+          consolidationAddresses
+        );
+        consolidatedActivityMap.set(consolidationKey, cActivity);
 
-      let consolidationKey: string;
-      let consolidationAddresses: string[] = [];
-      if (!consolidation) {
-        consolidationKey = address.toLowerCase();
-        consolidationAddresses.push(address.toLowerCase());
-      } else {
-        consolidationKey = consolidation.consolidation_key;
-        consolidationAddresses = consolidation.consolidation_key.split('-');
+        const cMemesActivity = await getConsolidatedMemesActivity(
+          seasons,
+          consolidationKey,
+          consolidationAddresses
+        );
+        consolidatedMemesActivityMap.set(consolidationKey, cMemesActivity);
+
+        consolidationAddresses.forEach((address) => {
+          deleteDelta.add(address);
+        });
       }
-
-      const cActivity = await getConsolidatedActivity(
-        consolidationKey,
-        consolidationAddresses
-      );
-      consolidatedActivityMap.set(consolidationKey, cActivity);
-
-      const cMemesActivity = await getConsolidatedMemesActivity(
-        seasons,
-        consolidationKey,
-        consolidationAddresses
-      );
-      consolidatedMemesActivityMap.set(consolidationKey, cMemesActivity);
-
-      consolidationAddresses.forEach((address) => {
-        deleteDelta.add(address);
-      });
-    })
+    )
   );
 
   const consolidatedActivity = Array.from(consolidatedActivityMap.values());

--- a/src/db.ts
+++ b/src/db.ts
@@ -1703,3 +1703,62 @@ export async function fetchWalletConsolidationKeysViewForWallet(
   const sql = `SELECT * FROM ${ADDRESS_CONSOLIDATION_KEY} WHERE address IN (:addresses)`;
   return await sqlExecutor.execute(sql, { addresses });
 }
+
+const CONSOLIDATION_KEY_ADDRESSES_CHUNK_SIZE = 5000;
+
+/**
+ * Resolves consolidations for all given addresses through the
+ * address_consolidation_keys view using chunked batch queries (instead of one
+ * query per address) and dedupes the result to one entry per consolidation:
+ * consolidation key -> member addresses (key.split('-')). Addresses missing
+ * from the view fall back to a singleton group keyed by the lowercased
+ * address, mirroring the per-address [0]-or-fallback logic used before.
+ * Group order follows the first appearance of a member in the input.
+ */
+export async function fetchConsolidationGroupsForAddresses(
+  addresses: string[]
+): Promise<Map<string, string[]>> {
+  const consolidationKeyByAddress = new Map<string, string>();
+  for (
+    let i = 0;
+    i < addresses.length;
+    i += CONSOLIDATION_KEY_ADDRESSES_CHUNK_SIZE
+  ) {
+    const chunk = addresses.slice(
+      i,
+      i + CONSOLIDATION_KEY_ADDRESSES_CHUNK_SIZE
+    );
+    const rows = await fetchWalletConsolidationKeysViewForWallet(chunk);
+    rows.forEach((row) => {
+      // the view's row shape is { address, consolidation_key }
+      const rowAddress = (row as unknown as { address: string }).address;
+      if (
+        rowAddress &&
+        !consolidationKeyByAddress.has(rowAddress.toLowerCase())
+      ) {
+        consolidationKeyByAddress.set(
+          rowAddress.toLowerCase(),
+          row.consolidation_key
+        );
+      }
+    });
+  }
+
+  const consolidationAddressesByKey = new Map<string, string[]>();
+  addresses.forEach((address) => {
+    const consolidationKey = consolidationKeyByAddress.get(
+      address.toLowerCase()
+    );
+    if (consolidationKey === undefined) {
+      consolidationAddressesByKey.set(address.toLowerCase(), [
+        address.toLowerCase()
+      ]);
+    } else if (!consolidationAddressesByKey.has(consolidationKey)) {
+      consolidationAddressesByKey.set(
+        consolidationKey,
+        consolidationKey.split('-')
+      );
+    }
+  });
+  return consolidationAddressesByKey;
+}

--- a/src/fetch-consolidation-groups-for-addresses.test.ts
+++ b/src/fetch-consolidation-groups-for-addresses.test.ts
@@ -1,0 +1,96 @@
+import { fetchConsolidationGroupsForAddresses } from './db';
+import { DbQueryOptions } from './db-query.options';
+import { setSqlExecutor, SqlExecutor } from './sql-executor';
+
+type ExecutedQuery = { sql: string; params?: Record<string, any> };
+
+class MockSqlExecutor extends SqlExecutor {
+  public readonly queries: ExecutedQuery[] = [];
+
+  constructor(
+    private readonly consolidationKeyByAddress: Record<string, string>
+  ) {
+    super();
+  }
+
+  async execute<T = any>(
+    sql: string,
+    params?: Record<string, any>,
+    _options?: DbQueryOptions
+  ): Promise<T[]> {
+    this.queries.push({ sql, params });
+    if (sql.includes('address IN')) {
+      const addresses: string[] = params?.addresses ?? [];
+      return addresses
+        .filter(
+          (address) =>
+            this.consolidationKeyByAddress[address.toLowerCase()] !== undefined
+        )
+        .map((address) => ({
+          address: address.toLowerCase(),
+          consolidation_key:
+            this.consolidationKeyByAddress[address.toLowerCase()]
+        })) as T[];
+    }
+    throw new Error(`Unexpected query: ${sql}`);
+  }
+
+  async executeNativeQueriesInTransaction<T>(): Promise<T> {
+    throw new Error('Not supported in this test');
+  }
+}
+
+describe('fetchConsolidationGroupsForAddresses', () => {
+  it('dedupes members into one group per consolidation and falls back to singleton groups', async () => {
+    const executor = new MockSqlExecutor({
+      '0xalice': '0xalice-0xbob',
+      '0xbob': '0xalice-0xbob'
+    });
+    setSqlExecutor(executor);
+
+    const groups = await fetchConsolidationGroupsForAddresses([
+      '0xAlice',
+      '0xbob',
+      '0xLoner'
+    ]);
+
+    expect(groups.size).toBe(2);
+    expect(groups.get('0xalice-0xbob')).toEqual(['0xalice', '0xbob']);
+    expect(groups.get('0xloner')).toEqual(['0xloner']);
+    expect(executor.queries).toHaveLength(1);
+  });
+
+  it('keeps first-appearance group order from the input', async () => {
+    const executor = new MockSqlExecutor({
+      '0xalice': '0xalice-0xbob',
+      '0xbob': '0xalice-0xbob'
+    });
+    setSqlExecutor(executor);
+
+    const groups = await fetchConsolidationGroupsForAddresses([
+      '0xLoner',
+      '0xbob',
+      '0xAlice'
+    ]);
+
+    expect(Array.from(groups.keys())).toEqual(['0xloner', '0xalice-0xbob']);
+  });
+
+  it('chunks the view lookup above 5000 addresses and never queries with an empty list', async () => {
+    const executor = new MockSqlExecutor({});
+    setSqlExecutor(executor);
+
+    const addresses = Array.from({ length: 5001 }, (_, i) => `0xw${i}`);
+    const groups = await fetchConsolidationGroupsForAddresses(addresses);
+
+    expect(executor.queries).toHaveLength(2);
+    expect(executor.queries[0].params?.addresses).toHaveLength(5000);
+    expect(executor.queries[1].params?.addresses).toHaveLength(1);
+    expect(groups.size).toBe(5001);
+
+    executor.queries.length = 0;
+    const empty = await fetchConsolidationGroupsForAddresses([]);
+    expect(empty.size).toBe(0);
+    expect(executor.queries).toHaveLength(0);
+  });
+});

--- a/src/nftOwnersLoop/consolidate-nft-owners.test.ts
+++ b/src/nftOwnersLoop/consolidate-nft-owners.test.ts
@@ -1,0 +1,92 @@
+import { fetchConsolidationGroupsForAddresses } from '@/db';
+import { NFTOwner } from '@/entities/INFTOwner';
+import {
+  fetchAllNftOwners,
+  persistConsolidatedNftOwners
+} from './db.nft_owners';
+import { consolidateNftOwners } from './nft_owners';
+
+jest.mock('@/db', () => ({
+  fetchConsolidationGroupsForAddresses: jest.fn(),
+  fetchMaxTransactionsBlockNumber: jest.fn(),
+  fetchTransactionsAfterBlock: jest.fn()
+}));
+
+jest.mock('./db.nft_owners', () => ({
+  fetchAllNftOwners: jest.fn(),
+  getMaxNftOwnersBlockReference: jest.fn(),
+  getNftOwnersSyncBlock: jest.fn(),
+  persistConsolidatedNftOwners: jest.fn(),
+  persistNftOwners: jest.fn(),
+  setNftOwnersSyncBlock: jest.fn()
+}));
+
+const mockedFetchConsolidationGroupsForAddresses =
+  fetchConsolidationGroupsForAddresses as jest.MockedFunction<
+    typeof fetchConsolidationGroupsForAddresses
+  >;
+const mockedFetchAllNftOwners = fetchAllNftOwners as jest.MockedFunction<
+  typeof fetchAllNftOwners
+>;
+const mockedPersistConsolidatedNftOwners =
+  persistConsolidatedNftOwners as jest.MockedFunction<
+    typeof persistConsolidatedNftOwners
+  >;
+
+const MEMES = '0xmemes';
+
+function owner(wallet: string, tokenId: number, balance: number): NFTOwner {
+  return {
+    wallet,
+    contract: MEMES,
+    token_id: tokenId,
+    balance,
+    block_reference: 1
+  } as NFTOwner;
+}
+
+describe('consolidateNftOwners', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedPersistConsolidatedNftOwners.mockResolvedValue(undefined);
+  });
+
+  it('fetches owners once per unique consolidation and sums member balances', async () => {
+    mockedFetchConsolidationGroupsForAddresses.mockResolvedValue(
+      new Map([
+        ['0xalice-0xbob', ['0xalice', '0xbob']],
+        ['0xloner', ['0xloner']]
+      ])
+    );
+    const ownersByWallet: Record<string, NFTOwner[]> = {
+      '0xalice': [owner('0xalice', 1, 2)],
+      '0xbob': [owner('0xbob', 1, 3), owner('0xbob', 2, 1)],
+      '0xloner': []
+    };
+    mockedFetchAllNftOwners.mockImplementation(async (_contracts, pk) =>
+      (pk ?? []).flatMap((p) => ownersByWallet[p.toLowerCase()] ?? [])
+    );
+
+    await consolidateNftOwners(new Set(['0xalice', '0xbob', '0xloner']));
+
+    // one owners fetch per unique consolidation, not per member address
+    expect(mockedFetchAllNftOwners).toHaveBeenCalledTimes(2);
+
+    const [upsertDelta, deleteDelta] =
+      mockedPersistConsolidatedNftOwners.mock.calls[0];
+    expect(deleteDelta).toEqual(new Set(['0xalice', '0xbob', '0xloner']));
+
+    const byToken = new Map(
+      upsertDelta.map((o: any) => [`${o.consolidation_key}_${o.token_id}`, o])
+    );
+    expect((byToken.get('0xalice-0xbob_1') as any).balance).toBe(5);
+    expect((byToken.get('0xalice-0xbob_2') as any).balance).toBe(1);
+    expect(byToken.has('0xloner_1')).toBe(false);
+  });
+
+  it('does nothing for an empty address set', async () => {
+    await consolidateNftOwners(new Set());
+    expect(mockedFetchConsolidationGroupsForAddresses).not.toHaveBeenCalled();
+    expect(mockedPersistConsolidatedNftOwners).not.toHaveBeenCalled();
+  });
+});

--- a/src/nftOwnersLoop/nft_owners.ts
+++ b/src/nftOwnersLoop/nft_owners.ts
@@ -20,9 +20,9 @@ import {
   NULL_ADDRESS
 } from '@/constants';
 import {
+  fetchConsolidationGroupsForAddresses,
   fetchMaxTransactionsBlockNumber,
-  fetchTransactionsAfterBlock,
-  fetchWalletConsolidationKeysViewForWallet
+  fetchTransactionsAfterBlock
 } from '../db';
 
 function normalizeAddress(addr: string): string {
@@ -260,36 +260,30 @@ export async function consolidateNftOwners(
   const upsertDeltaMap = new Map<string, ConsolidatedNFTOwner[]>();
   const deleteDelta = new Set<string>();
 
+  // one batched lookup for all addresses, then one owners fetch per unique
+  // consolidation instead of one per member address
+  const consolidationGroups = await fetchConsolidationGroupsForAddresses(
+    Array.from(addresses)
+  );
+
   await Promise.all(
-    Array.from(addresses).map(async (address) => {
-      const consolidation = (
-        await fetchWalletConsolidationKeysViewForWallet([address])
-      )[0];
+    Array.from(consolidationGroups.entries()).map(
+      async ([consolidationKey, consolidationAddresses]) => {
+        const owners = await fetchAllNftOwners(
+          undefined,
+          Array.from(consolidationAddresses)
+        );
 
-      let consolidationKey: string;
-      let consolidationAddresses: string[] = [];
-      if (!consolidation) {
-        consolidationKey = address.toLowerCase();
-        consolidationAddresses.push(address.toLowerCase());
-      } else {
-        consolidationKey = consolidation.consolidation_key;
-        consolidationAddresses = consolidation.consolidation_key.split('-');
+        const consolidatedOwners = getConsolidatedOwners(
+          consolidationKey,
+          owners
+        );
+
+        upsertDeltaMap.set(consolidationKey, consolidatedOwners);
+
+        consolidationAddresses.forEach((addr) => deleteDelta.add(addr));
       }
-
-      const owners = await fetchAllNftOwners(
-        undefined,
-        Array.from(consolidationAddresses)
-      );
-
-      const consolidatedOwners = getConsolidatedOwners(
-        consolidationKey,
-        owners
-      );
-
-      upsertDeltaMap.set(consolidationKey, consolidatedOwners);
-
-      consolidationAddresses.forEach((addr) => deleteDelta.add(addr));
-    })
+    )
   );
 
   const upsertDelta = Array.from(upsertDeltaMap.values()).flat();


### PR DESCRIPTION
## Issue

Tier-1 follow-up to the perf batch under review. `consolidateActivity` (aggregatedActivityLoop) and `consolidateNftOwners` (nftOwnersLoop) contain the **exact same pattern** fixed for ownersBalancesLoop in #1701:

- one `address_consolidation_keys` view query **per address** inside an unbounded `Promise.all`, and
- the consolidated aggregate recomputed **once per member address** of the same consolidation (members overwrite each other's identical results).

Both functions also run inside `delegationsLoop` on every consolidation change, so the win applies to three services.

## Fix

New shared helper `fetchConsolidationGroupsForAddresses(addresses)` in `src/db.ts`:

- resolves all addresses through the view in **5000-address chunked queries**;
- returns one entry per unique consolidation: `Map<consolidation key, member addresses>`;
- preserves the old per-address semantics exactly: address missing from the view → singleton group keyed by the lowercased address (the old `[0]`-or-fallback branch); first row wins per address; group order follows first appearance in the input.

Both call sites now iterate unique groups and compute each consolidation's aggregate **once**. Equivalence: same-group members previously invoked the aggregate with identical `(key, key.split('-'))` arguments and overwrote the same map entries with identical values, and the delete-delta was already the union of group members — so map contents and delta are unchanged.

## Changes

- `src/db.ts` — `fetchConsolidationGroupsForAddresses` (+ chunk-size constant).
- `src/aggregatedActivityLoop/aggregated_activity.ts` — `consolidateActivity` uses the helper; per-group activity + memes-activity computed once.
- `src/nftOwnersLoop/nft_owners.ts` — `consolidateNftOwners` uses the helper; one owners fetch per unique group.
- `src/fetch-consolidation-groups-for-addresses.test.ts` — **new**: dedup + fallback, first-appearance ordering, 5000-chunking, empty-input no-query.
- `src/nftOwnersLoop/consolidate-nft-owners.test.ts` — **new**: one owners fetch per unique group, member balance summing, delete-delta union, empty-set no-op.

## Validation

- New tests: 5/5 pass.
- `npx tsc --noEmit` clean for touched files; `eslint --max-warnings=0` + `prettier` clean.
- Not tested live: full loop runs against production data.

## Risk

- Level: **Low**
- Why: mechanical application of the already-reviewed #1701 pattern, now via one shared, unit-tested helper.
- Rollback: revert the single commit.

## Deployment

Not to be deployed yet — same review gate as the open perf batch (@gelatogenesis). When approved: `aggregatedActivityLoop`, `nftOwnersLoop`, `delegationsLoop` (calls both functions).

## Review Notes

- The helper reads the view row's `address` column through a local cast because `WalletConsolidationKey` still declares the misnamed `wallet` field on `main`; open PR #1701 fixes that interface, after which the cast can be dropped in a tiny follow-up. Kept the cast here so the two PRs don't both edit `IDelegation.ts`.
- ownersBalancesLoop keeps its own inline copy of this logic from #1701 for now; once both PRs land, pointing it at the shared helper is a two-line cleanup (happy to do as a follow-up).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Consolidation now performs batched grouping of addresses before computing consolidated activity, reducing per-address lookups.
  - NFT owner consolidation now runs per unique consolidation group to improve performance on large address sets.

- **Bug Fixes**
  - Addresses without a consolidation mapping are now handled as singleton groups.
  - Ensures stable group ordering based on first appearance and correctly skips work for empty inputs.

- **Tests**
  - Added Jest coverage for batched, chunked grouping behavior (including 5,000-item batches) and ordering.
  - Updated NFT owner consolidation tests to validate grouped fetch and persistence behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->