### PR TITLE
perf(subscriptions): batch consolidation and TDH lookups in consolidateSubscriptions

### DIFF
--- a/src/subscriptionsDaily/consolidate-subscriptions.test.ts
+++ b/src/subscriptionsDaily/consolidate-subscriptions.test.ts
@@ -1,0 +1,187 @@
+import { fetchWalletConsolidationKeysViewForWallet, getDataSource } from '@/db';
+import { DbQueryOptions } from '@/db-query.options';
+import { setSqlExecutor, SqlExecutor } from '@/sql-executor';
+import { consolidateSubscriptions } from './subscriptions';
+
+jest.mock('@/db', () => ({
+  fetchAllProfiles: jest.fn(),
+  fetchWalletConsolidationKeysViewForWallet: jest.fn(),
+  getDataSource: jest.fn()
+}));
+
+jest.mock('../delegationsLoop/db.delegations', () => ({
+  fetchAirdropAddressForConsolidationKey: jest.fn()
+}));
+
+jest.mock('../nftsLoop/db.nfts', () => ({
+  getMaxMemeId: jest.fn()
+}));
+
+jest.mock('../notifier-discord', () => ({
+  sendDiscordUpdate: jest.fn()
+}));
+
+jest.mock('../arweave', () => ({
+  arweaveFileUploader: { uploadFile: jest.fn() }
+}));
+
+jest.mock('./db.subscriptions', () => ({
+  fetchAllAutoSubscriptions: jest.fn(),
+  fetchAllNftSubscriptions: jest.fn(),
+  fetchAllNftSubscriptionBalances: jest.fn(),
+  fetchSubscriptionEligibilityForKeys: jest.fn(),
+  fetchSubscriptionEligibility: jest.fn(),
+  persistNFTFinalSubscriptions: jest.fn(),
+  persistSubscriptions: jest.fn()
+}));
+
+const mockedFetchWalletConsolidationKeysViewForWallet =
+  fetchWalletConsolidationKeysViewForWallet as jest.MockedFunction<
+    typeof fetchWalletConsolidationKeysViewForWallet
+  >;
+const mockedGetDataSource = getDataSource as jest.MockedFunction<
+  typeof getDataSource
+>;
+
+type ExecutedQuery = { sql: string; params?: Record<string, any> };
+
+class MockSqlExecutor extends SqlExecutor {
+  public readonly queries: ExecutedQuery[] = [];
+
+  constructor(
+    private readonly affectedSubscriptions: {
+      consolidation_key: string;
+      balance: number;
+    }[],
+    private readonly tdhByKey: Record<string, number>
+  ) {
+    super();
+  }
+
+  async execute<T = any>(
+    sql: string,
+    params?: Record<string, any>,
+    _options?: DbQueryOptions
+  ): Promise<T[]> {
+    this.queries.push({ sql, params });
+    if (sql.includes('LIKE')) {
+      return this.affectedSubscriptions as T[];
+    }
+    if (sql.includes('boosted_tdh')) {
+      const chunk: string[] = params?.chunk ?? [];
+      return chunk
+        .filter((key) => this.tdhByKey[key] !== undefined)
+        .map((key) => ({
+          consolidation_key: key,
+          boosted_tdh: this.tdhByKey[key]
+        })) as T[];
+    }
+    throw new Error(`Unexpected query: ${sql}`);
+  }
+
+  async executeNativeQueriesInTransaction<T>(): Promise<T> {
+    throw new Error('Not supported in this test');
+  }
+}
+
+describe('consolidateSubscriptions', () => {
+  const managerQueries: { sql: string; params?: any[] }[] = [];
+  const balancesByKey: Record<string, number> = {
+    '0xa-0xb': 3,
+    '0xc': 7
+  };
+
+  const fakeManager = {
+    query: jest.fn(async (sql: string, params?: any[]) => {
+      managerQueries.push({ sql, params });
+      if (sql.includes('SUM(balance)')) {
+        const total = (params ?? []).reduce(
+          (acc: number, key: string) => acc + (balancesByKey[key] ?? 0),
+          0
+        );
+        return [{ total_balance: total }];
+      }
+      if (sql.includes('automatic_count')) {
+        return [{ automatic_count: 0 }];
+      }
+      return [];
+    })
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    managerQueries.length = 0;
+    mockedGetDataSource.mockReturnValue({
+      transaction: async (fn: any) => fn(fakeManager)
+    } as any);
+    // 0xa moved into a new consolidation with 0xd; 0xb and 0xc are unchanged
+    mockedFetchWalletConsolidationKeysViewForWallet.mockImplementation(
+      async (addresses) =>
+        addresses
+          .filter((a) => a.toLowerCase() === '0xa')
+          .map(
+            (a) =>
+              ({
+                address: a.toLowerCase(),
+                consolidation_key: '0xa-0xd'
+              }) as any
+          )
+    );
+  });
+
+  it('migrates subscription keys using batched lookups with identical decision logic', async () => {
+    const executor = new MockSqlExecutor(
+      [
+        { consolidation_key: '0xa-0xb', balance: 3 },
+        { consolidation_key: '0xc', balance: 7 }
+      ],
+      { '0xa-0xd': 100, '0xb': 50 }
+    );
+    setSqlExecutor(executor);
+
+    await consolidateSubscriptions(new Set(['0xd']));
+
+    // affected-subscriptions query is parameterized, not string-concatenated
+    const likeQuery = executor.queries.find((q) => q.sql.includes('LIKE'));
+    expect(likeQuery?.sql).toContain(':addressPattern0');
+    expect(likeQuery?.sql).not.toContain('%0xd%');
+    expect(likeQuery?.params?.addressPattern0).toBe('%0xd%');
+
+    // one batched view lookup for all wallet parts, one TDH lookup for all candidates
+    expect(
+      mockedFetchWalletConsolidationKeysViewForWallet
+    ).toHaveBeenCalledTimes(1);
+    expect(
+      [
+        ...mockedFetchWalletConsolidationKeysViewForWallet.mock.calls[0][0]
+      ].sort((a, b) => a.localeCompare(b))
+    ).toEqual(['0xa', '0xb', '0xc']);
+    const tdhQueries = executor.queries.filter((q) =>
+      q.sql.includes('boosted_tdh')
+    );
+    expect(tdhQueries).toHaveLength(1);
+    expect(
+      [...(tdhQueries[0].params?.chunk ?? [])].sort((a, b) =>
+        a.localeCompare(b)
+      )
+    ).toEqual(['0xa-0xd', '0xb', '0xc']);
+
+    // 0xa-0xb migrates to 0xa-0xd (TDH 100 beats 0xb's 50); 0xc stays
+    const updates = managerQueries.filter((q) => q.sql.includes('UPDATE'));
+    const migrationPairs = new Set(updates.map((u) => u.params?.join('<-')));
+    expect(migrationPairs).toEqual(new Set(['0xa-0xd<-0xa-0xb', '0xc<-0xc']));
+    // 4 tables per old key
+    expect(updates).toHaveLength(8);
+
+    // balances re-inserted under the new keys with summed balances
+    const balanceInserts = managerQueries.filter(
+      (q) =>
+        q.sql.includes('INSERT INTO') && q.sql.includes('balance') && q.params
+    );
+    const inserted = new Map(
+      balanceInserts.map((q) => [q.params?.[0], q.params?.[1]])
+    );
+    expect(inserted.get('0xa-0xd')).toBe(3);
+    expect(inserted.get('0xc')).toBe(7);
+  });
+});

--- a/src/subscriptionsDaily/subscriptions.ts
+++ b/src/subscriptionsDaily/subscriptions.ts
@@ -348,8 +348,9 @@ async function uploadFinalSubscriptions(
 
 const CONSOLIDATION_LOOKUP_CHUNK_SIZE = 5000;
 
-export async function consolidateSubscriptions(addresses: Set<string>) {
-  const addressList = Array.from(addresses);
+async function fetchAffectedSubscriptions(
+  addressList: string[]
+): Promise<SubscriptionBalance[]> {
   const addressesFilter = addressList
     .map(
       (_, i) =>
@@ -364,28 +365,16 @@ export async function consolidateSubscriptions(addresses: Set<string>) {
     {} as Record<string, string>
   );
 
-  const affectedSubscriptions: SubscriptionBalance[] =
-    await sqlExecutor.execute(
-      `SELECT * FROM ${SUBSCRIPTIONS_BALANCES_TABLE}
+  return await sqlExecutor.execute(
+    `SELECT * FROM ${SUBSCRIPTIONS_BALANCES_TABLE}
     WHERE (${addressesFilter})`,
-      addressesFilterParams
-    );
-
-  logger.info(
-    `[CONSOLIDATING SUBSCRIPTIONS] : [FOUND ${affectedSubscriptions.length} AFFECTED SUBSCRIPTIONS]`
+    addressesFilterParams
   );
+}
 
-  // prefetch view keys for every wallet part and TDH for every candidate key,
-  // instead of querying per wallet part inside the loop below
-  const allWalletParts = new Set<string>();
-  affectedSubscriptions.forEach((sub) => {
-    sub.consolidation_key.split('-').forEach((wallet) => {
-      if (wallet) {
-        allWalletParts.add(wallet);
-      }
-    });
-  });
-  const walletPartsList = Array.from(allWalletParts);
+async function buildViewKeyByWallet(
+  walletPartsList: string[]
+): Promise<Map<string, string>> {
   const viewKeyByWallet = new Map<string, string>();
   for (
     let i = 0;
@@ -402,12 +391,12 @@ export async function consolidateSubscriptions(addresses: Set<string>) {
       }
     });
   }
+  return viewKeyByWallet;
+}
 
-  const candidateKeys = new Set<string>();
-  walletPartsList.forEach((wallet) => {
-    candidateKeys.add(viewKeyByWallet.get(wallet.toLowerCase()) ?? wallet);
-  });
-  const candidateKeysList = Array.from(candidateKeys);
+async function buildTdhByKey(
+  candidateKeysList: string[]
+): Promise<Map<string, number>> {
   const tdhByKey = new Map<string, number>();
   for (
     let i = 0;
@@ -430,6 +419,36 @@ export async function consolidateSubscriptions(addresses: Set<string>) {
       }
     });
   }
+  return tdhByKey;
+}
+
+export async function consolidateSubscriptions(addresses: Set<string>) {
+  const affectedSubscriptions = await fetchAffectedSubscriptions(
+    Array.from(addresses)
+  );
+
+  logger.info(
+    `[CONSOLIDATING SUBSCRIPTIONS] : [FOUND ${affectedSubscriptions.length} AFFECTED SUBSCRIPTIONS]`
+  );
+
+  // prefetch view keys for every wallet part and TDH for every candidate key,
+  // instead of querying per wallet part inside the loop below
+  const allWalletParts = new Set<string>();
+  affectedSubscriptions.forEach((sub) => {
+    sub.consolidation_key.split('-').forEach((wallet) => {
+      if (wallet) {
+        allWalletParts.add(wallet);
+      }
+    });
+  });
+  const walletPartsList = Array.from(allWalletParts);
+  const viewKeyByWallet = await buildViewKeyByWallet(walletPartsList);
+
+  const candidateKeys = new Set<string>();
+  walletPartsList.forEach((wallet) => {
+    candidateKeys.add(viewKeyByWallet.get(wallet.toLowerCase()) ?? wallet);
+  });
+  const tdhByKey = await buildTdhByKey(Array.from(candidateKeys));
 
   const replaceConsolidations = new Map<string, string>();
 

--- a/src/subscriptionsDaily/subscriptions.ts
+++ b/src/subscriptionsDaily/subscriptions.ts
@@ -346,58 +346,107 @@ async function uploadFinalSubscriptions(
   };
 }
 
+const CONSOLIDATION_LOOKUP_CHUNK_SIZE = 5000;
+
 export async function consolidateSubscriptions(addresses: Set<string>) {
-  const addressesFilter = Array.from(addresses)
+  const addressList = Array.from(addresses);
+  const addressesFilter = addressList
     .map(
-      (address) =>
-        `${SUBSCRIPTIONS_BALANCES_TABLE}.consolidation_key LIKE '%${address}%'`
+      (_, i) =>
+        `${SUBSCRIPTIONS_BALANCES_TABLE}.consolidation_key LIKE :addressPattern${i}`
     )
     .join(' OR ');
+  const addressesFilterParams = addressList.reduce(
+    (acc, address, i) => {
+      acc[`addressPattern${i}`] = `%${address}%`;
+      return acc;
+    },
+    {} as Record<string, string>
+  );
 
   const affectedSubscriptions: SubscriptionBalance[] =
     await sqlExecutor.execute(
       `SELECT * FROM ${SUBSCRIPTIONS_BALANCES_TABLE}
-    WHERE (${addressesFilter})`
+    WHERE (${addressesFilter})`,
+      addressesFilterParams
     );
 
   logger.info(
     `[CONSOLIDATING SUBSCRIPTIONS] : [FOUND ${affectedSubscriptions.length} AFFECTED SUBSCRIPTIONS]`
   );
 
+  // prefetch view keys for every wallet part and TDH for every candidate key,
+  // instead of querying per wallet part inside the loop below
+  const allWalletParts = new Set<string>();
+  affectedSubscriptions.forEach((sub) => {
+    sub.consolidation_key.split('-').forEach((wallet) => {
+      if (wallet) {
+        allWalletParts.add(wallet);
+      }
+    });
+  });
+  const walletPartsList = Array.from(allWalletParts);
+  const viewKeyByWallet = new Map<string, string>();
+  for (
+    let i = 0;
+    i < walletPartsList.length;
+    i += CONSOLIDATION_LOOKUP_CHUNK_SIZE
+  ) {
+    const chunk = walletPartsList.slice(i, i + CONSOLIDATION_LOOKUP_CHUNK_SIZE);
+    const rows = await fetchWalletConsolidationKeysViewForWallet(chunk);
+    rows.forEach((row) => {
+      // the view's row shape is { address, consolidation_key }
+      const rowAddress = (row as unknown as { address: string }).address;
+      if (rowAddress && !viewKeyByWallet.has(rowAddress.toLowerCase())) {
+        viewKeyByWallet.set(rowAddress.toLowerCase(), row.consolidation_key);
+      }
+    });
+  }
+
+  const candidateKeys = new Set<string>();
+  walletPartsList.forEach((wallet) => {
+    candidateKeys.add(viewKeyByWallet.get(wallet.toLowerCase()) ?? wallet);
+  });
+  const candidateKeysList = Array.from(candidateKeys);
+  const tdhByKey = new Map<string, number>();
+  for (
+    let i = 0;
+    i < candidateKeysList.length;
+    i += CONSOLIDATION_LOOKUP_CHUNK_SIZE
+  ) {
+    const chunk = candidateKeysList.slice(
+      i,
+      i + CONSOLIDATION_LOOKUP_CHUNK_SIZE
+    );
+    const rows: { consolidation_key: string; boosted_tdh: number }[] =
+      await sqlExecutor.execute(
+        `SELECT consolidation_key, boosted_tdh FROM ${CONSOLIDATED_WALLETS_TDH_TABLE}
+        WHERE consolidation_key IN (:chunk)`,
+        { chunk }
+      );
+    rows.forEach((row) => {
+      if (row.consolidation_key && !tdhByKey.has(row.consolidation_key)) {
+        tdhByKey.set(row.consolidation_key, row.boosted_tdh ?? 0);
+      }
+    });
+  }
+
   const replaceConsolidations = new Map<string, string>();
 
   for (const sub of affectedSubscriptions) {
     const walletParts = sub.consolidation_key.split('-');
     for (const wallet of walletParts) {
-      let newConsolidationKey = wallet;
-      const consolidation = (
-        await fetchWalletConsolidationKeysViewForWallet([wallet])
-      )[0];
-      if (consolidation) {
-        newConsolidationKey = consolidation.consolidation_key;
-      }
+      const newConsolidationKey = wallet
+        ? (viewKeyByWallet.get(wallet.toLowerCase()) ?? wallet)
+        : wallet;
 
       const replaceConsolidation = replaceConsolidations.get(
         sub.consolidation_key
       );
 
       if (replaceConsolidation) {
-        const replaceTdh =
-          (
-            await sqlExecutor.execute(
-              `SELECT boosted_tdh FROM ${CONSOLIDATED_WALLETS_TDH_TABLE}
-              WHERE consolidation_key = :replaceConsolidation`,
-              { replaceConsolidation }
-            )
-          )[0]?.boosted_tdh ?? 0;
-        const newTdh =
-          (
-            await sqlExecutor.execute(
-              `SELECT boosted_tdh FROM ${CONSOLIDATED_WALLETS_TDH_TABLE}
-              WHERE consolidation_key = :newConsolidationKey`,
-              { newConsolidationKey }
-            )
-          )[0]?.boosted_tdh ?? 0;
+        const replaceTdh = tdhByKey.get(replaceConsolidation) ?? 0;
+        const newTdh = tdhByKey.get(newConsolidationKey) ?? 0;
         if (newTdh > replaceTdh) {
           replaceConsolidations.set(sub.consolidation_key, newConsolidationKey);
         } else {


### PR DESCRIPTION
## Issue

Tier-1 follow-up to the perf batch under review. `consolidateSubscriptions` (runs from `delegationsLoop` whenever consolidations change) does per-item queries inside a nested loop:

- one `address_consolidation_keys` view query **per wallet part** of every affected subscription;
- up to **two consolidated-TDH queries per wallet part** while deciding which consolidation key wins a migration.

It also builds its `LIKE '%address%'` filter by string concatenation — functionally fine for hex wallets, but hand-rolled SQL interpolation worth removing while touching the function.

## Fix

- **Prefetch both lookup sets in chunked batch queries** before the loop: view keys for every distinct wallet part, and `boosted_tdh` for every candidate key (candidates = each part's view key, or the part itself as fallback — a set fully derivable up front). The decision loop is byte-identical except that it reads the two maps instead of querying; replacement choices (highest boosted TDH wins, first candidate otherwise) are unchanged. `[0]?.boosted_tdh ?? 0` missing-row semantics are preserved via `?? 0` map defaults, and first-row-wins map seeding mirrors the old `[0]` picks.
- **Parameterized LIKE filter**: `LIKE :addressPattern{i}` with `%address%` bound values — the SQL layer escapes them exactly as the old inline literals behaved for hex addresses, so the result set is identical.

The write phase (the key-migration transaction) is untouched.

## Changes

- `src/subscriptionsDaily/subscriptions.ts` — prefetch maps + parameterized filter in `consolidateSubscriptions` only.
- `src/subscriptionsDaily/consolidate-subscriptions.test.ts` — **new**: asserts the parameterized filter (pattern reaches params, not the SQL string), the batched lookup shapes (one view call for all parts, one TDH `IN` for all candidates), and the end-to-end migration decisions — a consolidation change migrates `0xa-0xb` to the higher-TDH `0xa-0xd` across all four key-bearing tables while an unaffected key is preserved, with balances re-inserted under the surviving keys.

## Validation

- New test: 1/1 pass; full `src/subscriptionsDaily/` suite (incl. pre-existing tests): 7/7 pass.
- `npx tsc --noEmit` clean for touched files; `eslint --max-warnings=0` + `prettier` clean.
- Not tested live: a real consolidation-change run via delegationsLoop.

## Risk

- Level: **Low–Medium** (subscription key migration is money-adjacent, hence the end-to-end decision test)
- Why: the decision loop logic is untouched — only its data access moved from per-iteration queries to prefetched snapshots. The one theoretical difference: the old code re-read TDH per iteration, so a concurrent TDH write mid-loop could have produced torn reads; the snapshot is consistent for the whole run. No ordering or output changes otherwise.
- Rollback: revert the single commit.

## Deployment

Not to be deployed yet — same review gate as the open perf batch (@gelatogenesis). When approved: `subscriptionsDaily` and `delegationsLoop` (the caller).

## Review Notes

- This file is also touched by open PR #1703, but in **different functions** (`createFinalSubscriptions` / `populateAutoSubscriptionsForMemeId` vs `consolidateSubscriptions`) — hunks don't overlap.
- The view-row `address` cast matches the approach in #1708 pending #1701's `WalletConsolidationKey` interface fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subscription consolidation performance and reliability by batching and caching consolidation lookups, reducing repetitive database/view queries.
  * Ensured affected-subscription matching uses safer, parameterized filtering instead of string-based queries.
* **Tests**
  * Added Jest coverage for subscription consolidation, including lookup chunking behavior, TDH mapping, generated migration/update operations, and correct balance reinsertion under consolidated keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->