### PR TITLE
fix(nftOwnersLoop): apply both filters in fetchAllNftOwners instead of dropping the contract filter

### DIFF
--- a/src/nftOwnersLoop/db.nft_owners.ts
+++ b/src/nftOwnersLoop/db.nft_owners.ts
@@ -48,12 +48,12 @@ export async function fetchAllNftOwners(
     .createQueryBuilder('nftowner');
 
   if (contracts) {
-    queryBuilder.where('nftowner.contract IN (:...contracts)', {
+    queryBuilder.andWhere('nftowner.contract IN (:...contracts)', {
       contracts
     });
   }
   if (pk) {
-    queryBuilder.where(`nftowner.wallet IN (:...pk)`, {
+    queryBuilder.andWhere(`nftowner.wallet IN (:...pk)`, {
       pk
     });
   }

--- a/src/nftOwnersLoop/fetch-all-nft-owners.db.test.ts
+++ b/src/nftOwnersLoop/fetch-all-nft-owners.db.test.ts
@@ -1,6 +1,6 @@
 import 'reflect-metadata';
-import { connect, disconnect, getDataSource } from '../db';
-import { NFTOwner } from '../entities/INFTOwner';
+import { connect, disconnect, getDataSource } from '@/db';
+import { NFTOwner } from '@/entities/INFTOwner';
 import { fetchAllNftOwners } from './db.nft_owners';
 
 const MEMES = '0xmemescontract';

--- a/src/nftOwnersLoop/fetch-all-nft-owners.db.test.ts
+++ b/src/nftOwnersLoop/fetch-all-nft-owners.db.test.ts
@@ -1,0 +1,89 @@
+import 'reflect-metadata';
+import { connect, disconnect, getDataSource } from '../db';
+import { NFTOwner } from '../entities/INFTOwner';
+import { fetchAllNftOwners } from './db.nft_owners';
+
+const MEMES = '0xmemescontract';
+const OTHER = '0xothercontract';
+
+function owner(
+  wallet: string,
+  contract: string,
+  tokenId: number,
+  balance: number
+): NFTOwner {
+  const o = new NFTOwner();
+  o.wallet = wallet;
+  o.contract = contract;
+  o.token_id = tokenId;
+  o.balance = balance;
+  o.block_reference = 100;
+  return o;
+}
+
+function rowKey(o: NFTOwner): string {
+  return `${o.wallet.toLowerCase()}|${o.contract.toLowerCase()}|${Number(
+    o.token_id
+  )}|${o.balance}`;
+}
+
+function sortedKeys(owners: NFTOwner[]): string[] {
+  return owners.map(rowKey).sort((a, b) => a.localeCompare(b));
+}
+
+describe('fetchAllNftOwners', () => {
+  beforeAll(async () => {
+    // the nft_owners table is entity-synced (no migration creates it), so let
+    // TypeORM create it in this worker's test database
+    await connect([NFTOwner], true);
+  });
+
+  afterAll(async () => {
+    await disconnect();
+  });
+
+  beforeEach(async () => {
+    const repo = getDataSource().getRepository(NFTOwner);
+    await repo.clear();
+    await repo.insert([
+      owner('0xalice', MEMES, 1, 2),
+      owner('0xalice', OTHER, 1, 5),
+      owner('0xbob', MEMES, 2, 1),
+      owner('0xbob', OTHER, 3, 4),
+      owner('0xcarol', MEMES, 1, 7)
+    ]);
+  });
+
+  it('returns everything when no filters are given', async () => {
+    const result = await fetchAllNftOwners();
+    expect(result).toHaveLength(5);
+  });
+
+  it('filters by contract only', async () => {
+    const result = await fetchAllNftOwners([MEMES]);
+    expect(sortedKeys(result)).toEqual([
+      `0xalice|${MEMES}|1|2`,
+      `0xbob|${MEMES}|2|1`,
+      `0xcarol|${MEMES}|1|7`
+    ]);
+  });
+
+  it('filters by wallet only', async () => {
+    const result = await fetchAllNftOwners(undefined, ['0xalice']);
+    expect(sortedKeys(result)).toEqual([
+      `0xalice|${MEMES}|1|2`,
+      `0xalice|${OTHER}|1|5`
+    ]);
+  });
+
+  it('applies BOTH filters when contracts and wallets are given (regression: the contract filter used to be silently dropped)', async () => {
+    const result = await fetchAllNftOwners([MEMES], ['0xalice', '0xbob']);
+
+    // pre-fix behavior returned 0xalice/0xbob rows of ALL contracts (4 rows,
+    // including the two OTHER-contract rows); the intersection is 2 rows
+    expect(sortedKeys(result)).toEqual([
+      `0xalice|${MEMES}|1|2`,
+      `0xbob|${MEMES}|2|1`
+    ]);
+  });
+});


### PR DESCRIPTION
## Issue

`fetchAllNftOwners(contracts?, pk?)` in `src/nftOwnersLoop/db.nft_owners.ts` calls `.where()` twice. In TypeORM the second `.where()` **replaces** the first, so when a caller passes both arguments the contract filter is silently dropped and the query returns the wallets' rows across **every** contract in `nft_owners`.

This was spotted during the performance audit and flagged in #1701's review notes as needing a separate human-approved fix, since — unlike the perf batch — **this PR intentionally changes behavior**. That's why it ships alone: green-lighting it is a one-decision review.

## Fix

Both conditions now compose with `.andWhere(...)` — the same pattern `fetchDistinctNftOwnerWallets` in the same file already uses correctly (which is also good evidence the double-`.where` was a slip, not intent).

## Behavior change, precisely

Callers passing **both** arguments (the only affected shape):

- `updateOwnerBalances` incremental path (`src/ownersBalancesLoop/owners_balances.ts`) — `fetchAllNftOwners(allContracts, addresses)`
- `getConsolidatedBalances` (same file) — `fetchAllNftOwners(contracts, addresses)`

All other callers pass one argument or none and are unaffected (`nextgen_metadata_refresh.ts` contracts-only; `nft_owners.ts` ×2 wallets-only; `owners_balances.ts:103` contracts-only).

**Expected production impact:** the `nft_owners` table is written by `nftOwnersLoop` for exactly the tracked contracts (Memes, MemeLab, Gradient, current-network NextGen), so if the table only contains those, the result set is byte-identical and nothing changes. If the table ever holds rows for anything else — e.g. a different-network NextGen contract from a previous configuration, or a formerly-tracked contract — those rows were **wrongly included in owner balances** before and are excluded after this fix, which is what the call sites were always asking for. A quick production sanity check before/after deploy: `SELECT DISTINCT contract FROM nft_owners;` — if that returns only the four tracked contracts, this fix is a no-op at runtime.

## Changes

- `src/nftOwnersLoop/db.nft_owners.ts` — `.where`→`.andWhere` (two lines).
- `src/nftOwnersLoop/fetch-all-nft-owners.db.test.ts` — **new** real-database regression test (testcontainers MySQL, per the repo's db-test pattern) covering all four filter combinations. Red-green verified: the both-filters case **fails against the pre-fix implementation** (returns 4 rows including other-contract ones instead of the 2-row intersection) and passes with the fix.

## Validation

- New db test: 4/4 pass; red-green check performed by stashing the fix (1 failed / 3 passed on old code).
- `npx tsc --noEmit` clean for touched files; `eslint --max-warnings=0` + `prettier` clean.
- Not tested live: production `nft_owners` contents (see the sanity-check query above).

## Risk

- Level: **Low–Medium** (it is a deliberate behavior change in the balances pipeline, though almost certainly a runtime no-op today)
- Why: two-line fix restoring the obvious intent of the function signature; the only scenario where output changes is one where the old output was wrong.
- Rollback: revert the single commit.

## Deployment

Not to be deployed yet — awaiting human review (@gelatogenesis), same gate as the open perf batch. When approved: `ownersBalancesLoop` (both affected callers live there), plus `nftOwnersLoop`, `aggregatedActivityLoop`, `nextgenContractLoop`, `nextgenMetadataLoop`, `delegationsLoop` if you prefer redeploying every service that links the changed module (their call sites are single-argument and behaviorally unaffected).

## Review Notes

- No file overlap with any of the 8 open perf PRs (#1699–#1709 touch other files; #1708's helper calls the *view*, not this function).
- The one thing to decide is the behavior change itself — the "Behavior change, precisely" section above is the whole story.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected NFT owner retrieval so contract and wallet filters are applied together, returning the intersection instead of overriding one another.

* **Tests**
  * Added integration tests covering unfiltered results, single-filter behavior (contract-only and wallet-only), and the combined filter case to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->