### PR TITLE
Bump remaining lambda runtimes to nodejs22.x

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -219,7 +219,7 @@ jobs:
           VERSION_DESCRIPTION="$(git rev-parse --short HEAD) - $(date) - $(git rev-parse --abbrev-ref HEAD) - $(git show -s --format=%s)"
           aws lambda update-function-code --function-name  mediaResizerLoop --zip-file fileb://src/mediaResizerLoop/dist/index.zip
           sleep 10
-          aws lambda update-function-configuration --function-name mediaResizerLoop --description "$VERSION_DESCRIPTION"
+          aws lambda update-function-configuration --function-name mediaResizerLoop --runtime nodejs22.x --description "$VERSION_DESCRIPTION"
       - name: Deploy nextgenMediaProxyInterceptor
         if: github.event.inputs.service == 'nextgenMediaProxyInterceptor'
         run: |

--- a/scripts/generate-deploy-config.mjs
+++ b/scripts/generate-deploy-config.mjs
@@ -214,7 +214,7 @@ jobs:
           VERSION_DESCRIPTION="$(git rev-parse --short HEAD) - $(date) - $(git rev-parse --abbrev-ref HEAD) - $(git show -s --format=%s)"
           aws lambda update-function-code --function-name  mediaResizerLoop --zip-file fileb://src/mediaResizerLoop/dist/index.zip
           sleep 10
-          aws lambda update-function-configuration --function-name mediaResizerLoop --description "$VERSION_DESCRIPTION"
+          aws lambda update-function-configuration --function-name mediaResizerLoop --runtime nodejs22.x --description "$VERSION_DESCRIPTION"
       - name: Deploy nextgenMediaProxyInterceptor
         if: github.event.inputs.service == 'nextgenMediaProxyInterceptor'
         run: |

--- a/src/dropMediaIngestStorage/serverless.yaml
+++ b/src/dropMediaIngestStorage/serverless.yaml
@@ -2,7 +2,7 @@ service: dropMediaIngestStorage
 
 provider:
   name: aws
-  runtime: nodejs20.x
+  runtime: nodejs22.x
   stage: ${opt:stage, 'staging'}
   logRetentionInDays: 60
 

--- a/src/nextgenMediaProxyInterceptor/deploy.sh
+++ b/src/nextgenMediaProxyInterceptor/deploy.sh
@@ -10,6 +10,10 @@ echo "Uploading new code to $function_name"
 aws lambda update-function-code --function-name "${function_name}" --zip-file fileb://dist/index.zip --region="${region}" > /dev/null
 sleep 10
 echo "New code uploaded to $function_name"
+echo "Setting runtime of $function_name to nodejs22.x"
+aws lambda update-function-configuration --function-name "${function_name}" --runtime nodejs22.x --region="${region}" > /dev/null
+sleep 10
+echo "Runtime of $function_name set to nodejs22.x"
 echo "Publishing new version of $function_name"
 aws lambda publish-version --function-name "${function_name}" --description "$(date) - $(git rev-parse --abbrev-ref HEAD) - $(git show -s --format=%s)" --region="${region}" > /dev/null
 sleep 10


### PR DESCRIPTION
## Issue
- After the @aws-sdk v3 bump (#1712), every `mediaResizerLoop` invocation logs `NodeVersionSupportWarning`: AWS SDK v3 releases after early January 2027 will require Node >= 22, but the lambda still runs on `nodejs18.x`.
- A repo-wide runtime audit found two more stragglers below `nodejs22.x` (all other 53 serverless-managed loops are already on `nodejs22.x`, and `seizeAPI` is on `nodejs22.x` in both regions):
  - `nextgenMediaProxyInterceptor` (Lambda@Edge): `nodejs20.x`
  - `dropMediaIngestStorage`: `nodejs20.x` in its `serverless.yaml` (resources-only stack, no functions — cosmetic, but bumped for a clean audit)

## Fix
- `mediaResizerLoop` and `nextgenMediaProxyInterceptor` have no `serverless.yaml`; their runtime lives only in the AWS function configuration because they are deployed via `aws lambda update-function-code`. The fix pins `--runtime nodejs22.x` in their deploy paths so the next deploy upgrades and keeps them on `nodejs22.x`:
  - `mediaResizerLoop`: added `--runtime nodejs22.x` to the existing `update-function-configuration` call in the deploy workflow (edited in `scripts/generate-deploy-config.mjs`, regenerated `.github/workflows/deploy.yml`).
  - `nextgenMediaProxyInterceptor`: added an `update-function-configuration --runtime nodejs22.x` step to `src/nextgenMediaProxyInterceptor/deploy.sh` before `publish-version`, so the published Edge version carries the new runtime.
- `dropMediaIngestStorage`: `runtime: nodejs20.x` → `nodejs22.x` in `serverless.yaml`.

## Changes
- `scripts/generate-deploy-config.mjs` + regenerated `.github/workflows/deploy.yml` (one-line runtime pin for mediaResizerLoop).
- `src/nextgenMediaProxyInterceptor/deploy.sh` (runtime pin + wait before publish-version).
- `src/dropMediaIngestStorage/serverless.yaml` (runtime bump).
- No application code changes; no architecture-doc update needed (no system-shape change).

## Validation
- `npm run generate:deploy-config` — regenerated `deploy.yml` matches the generator (PR CI verifies this too).
- `mediaResizerLoop`: `npm i && npm run build` in its directory (after root `npm i`, as the deploy workflow does) — full build succeeds, `dist/index.zip` produced.
- `nextgenMediaProxyInterceptor`: `npm i && npm run build` in its directory — full build succeeds, `dist/index.zip` produced.
- `dropMediaIngestStorage`: `npm run build` succeeds (dist scaffold only).
- Verified live runtimes via read-only `aws lambda get-function-configuration`: mediaResizerLoop `nodejs18.x`, nextgenMediaProxyInterceptor `nodejs20.x`, seizeAPI `nodejs22.x` (both regions).
- Not tested: an actual deploy run of the modified workflow steps (exercised on next deploy; both flags are additive to existing, known-working CLI calls).

## Risk
- Level: Low
- Why: no code changes; runtime bumps are config-only. Node 18 → 22 is compatible with everything these lambdas use (sharp ^0.34, @aws-sdk v3, esbuild `es2020` target). `nodejs22.x` is supported for Lambda@Edge. The runtime change only takes effect at the next deploy of each service.
- Rollback: redeploy with the flag reverted (or `aws lambda update-function-configuration --runtime nodejs18.x/nodejs20.x`); function code is unchanged.

## Deployment
- `mediaResizerLoop` (prod-only) — deploy once after merge to apply `nodejs22.x` and silence the SDK warning.
- `nextgenMediaProxyInterceptor` (prod-only, Lambda@Edge) — deploy at next convenient opportunity; CloudFront association is republished by the existing script flow.
- `dropMediaIngestStorage` (staging-only, resources-only stack) — no urgency; picks up on next deploy.
- No other services affected; no dbMigrationsLoop or api deploy needed.

## Review Notes
- `deploy.yml` is generated — review `scripts/generate-deploy-config.mjs` and confirm the regenerated file matches.
- In `deploy.sh`, the runtime update happens before `publish-version` so the published Edge version snapshots the new runtime; the `sleep 10` mirrors the script's existing pattern of waiting for the previous update to settle.
