### PR TITLE
Fix external snapshot ownerOf multicall target

### DIFF
--- a/src/external-indexing/external-collection-snapshotting.service.ts
+++ b/src/external-indexing/external-collection-snapshotting.service.ts
@@ -157,6 +157,7 @@ export class ExternalCollectionSnapshottingService {
               );
               ids = await this.enumerateByOwnerOf(
                 erc721,
+                contract,
                 atBlock,
                 tokenByIndexZero,
                 log
@@ -165,6 +166,7 @@ export class ExternalCollectionSnapshottingService {
           } else {
             ids = await this.enumerateByOwnerOf(
               erc721,
+              contract,
               atBlock,
               tokenByIndexZero,
               log
@@ -298,6 +300,7 @@ export class ExternalCollectionSnapshottingService {
 
   private async enumerateByOwnerOf(
     erc721: Contract,
+    contractAddr: string,
     atBlock: number,
     startHint: bigint | null,
     log: Logger
@@ -334,6 +337,7 @@ export class ExternalCollectionSnapshottingService {
 
       const owners = await this.ownerOfProbeBatch(
         erc721,
+        contractAddr,
         chunkIds,
         atBlock,
         log
@@ -381,6 +385,7 @@ export class ExternalCollectionSnapshottingService {
 
   private async ownerOfProbeBatch(
     erc721: Contract,
+    contractAddr: string,
     tokenIds: bigint[],
     atBlock: number,
     log: Logger
@@ -397,7 +402,7 @@ export class ExternalCollectionSnapshottingService {
     const erc721Iface = new ethers.Interface(ERC721_ABI);
 
     const calls = tokenIds.map((tid) => ({
-      target: erc721.address,
+      target: contractAddr,
       callData: erc721Iface.encodeFunctionData('ownerOf', [tid])
     }));
 


### PR DESCRIPTION
## Summary
- Pass the known ERC-721 contract address into ownerOf probing multicalls instead of reading `erc721.address`.
- Prevent ethers v6 from producing null multicall targets and forcing slow single-call fallback during external collection snapshotting.

## Cause
CloudWatch for `externalCollectionSnapshottingLoop` showed contract `1:0x036721e5a769cc48b3189efbb9cce4471e8a48b1` repeatedly logging `unsupported addressable value (argument="target", value=null, code=INVALID_ARGUMENT, version=6.16.0)` before Lambda hit `Status: timeout` at `900000 ms`. The batching helper was still using the v5-style `Contract.address` field after ethers v6.

## Verification
- `npm run lint`
- `npm run build` (Jest: 208 passed suites, 1857 passed tests, 1 skipped; TypeScript compile passed)

## Deployment
Backend-only. Deploy `externalCollectionSnapshottingLoop`. No architecture docs update required: implementation-only fix, no Lambda/API/DB boundary change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ERC-721 ownership lookups during collection snapshotting, helping ensure NFT ownership data is indexed against the correct contract.
  * Increased reliability of ownership checks when processing snapshots, reducing the chance of mismatched results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->