### PR TITLE
Increase xTdhLoop memory

### DIFF
--- a/src/xTdhLoop/serverless.yaml
+++ b/src/xTdhLoop/serverless.yaml
@@ -9,7 +9,7 @@ plugins:
 provider:
   name: aws
   runtime: nodejs22.x
-  memorySize: 512
+  memorySize: 3072
   timeout: 900
   architecture: arm64
   logRetentionInDays: 60


### PR DESCRIPTION
## Issue
- `xTdhLoop` is timing out near the 15-minute Lambda ceiling while recalculating xTDH and rebuilding xTDH stats.

## Fix
- Increase the `xTdhLoop` Lambda memory from 512 MB to 3072 MB to give the function materially more CPU and network headroom without changing xTDH behavior.

## Changes
- Updated `src/xTdhLoop/serverless.yaml` provider memory size only.
- No API, entity, migration, queue, or workflow changes.
- No architecture-doc update needed because this only changes Lambda sizing, not system shape.

## Validation
- `npm run lint` passed.
- `npm run build` passed after installing both root and nested `src/api-serverless` dependencies in the fresh worktree.
- First `npm run build` attempt failed because nested API dependencies were not installed in the new worktree; no code changes were made for that failure.

## Risk
- Level: Low
- Why: Deployment-only Lambda sizing change; behavior and data shape are unchanged. Cost per invocation can increase, but timeout/retry churn should decrease.
- Rollback: Revert the memory size to 512 MB and redeploy `xTdhLoop`.

## Deployment
- Redeploy backend service: `xTdhLoop`.
- Order: `xTdhLoop` only.

## Review Notes
- Please focus on whether 3072 MB is the desired emergency headroom for the current production timeout loop.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the app’s default compute memory allocation, which may improve stability and reduce failures under heavier workloads.
  * Updated an alerting action to keep monitoring behavior aligned with the current environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->