### PR TITLE
Fix Mobula rate limit handling in eth price loop

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -147,7 +147,7 @@ flowchart TD
 | `subscriptionsTopUpLoop`             | Process subscription top-ups.                                     |
 | `discoverEnsLoop`                    | Discover ENS names.                                               |
 | `refreshEnsLoop`                     | Refresh known ENS names.                                          |
-| `ethPriceLoop`                       | Snapshot ETH price.                                               |
+| `ethPriceLoop`                       | Snapshot ETH price every five minutes.                            |
 | `mintAnnouncementsLoop`              | Publish mint announcements.                                       |
 | `artCurationNftWatchLoop`            | Watch curated NFT state.                                          |
 | `rememesLoop`                        | Refresh rememes S3 files and metadata.                            |

--- a/src/ethPriceLoop/eth-usd-price.test.ts
+++ b/src/ethPriceLoop/eth-usd-price.test.ts
@@ -1,0 +1,196 @@
+import type { AxiosError } from 'axios';
+
+const mockGet = jest.fn();
+const mockCreate = jest.fn(() => ({ get: mockGet }));
+const mockIsAxiosError = jest.fn(
+  (error: unknown) => !!(error as { isAxiosError?: boolean })?.isAxiosError
+);
+
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: {
+    create: mockCreate,
+    isAxiosError: mockIsAxiosError
+  }
+}));
+
+const mockExponentialDelay = jest.fn(() => 1234);
+const mockIsNetworkError = jest.fn(() => false);
+const mockIsRetryableError = jest.fn(() => false);
+const mockAxiosRetry = jest.fn();
+
+jest.mock('axios-retry', () => ({
+  __esModule: true,
+  default: Object.assign(mockAxiosRetry, {
+    exponentialDelay: mockExponentialDelay,
+    isNetworkError: mockIsNetworkError,
+    isRetryableError: mockIsRetryableError
+  })
+}));
+
+jest.mock('./db.eth_price', () => ({
+  getEthPriceCount: jest.fn(),
+  persistEthPrices: jest.fn()
+}));
+
+const mockInfo = jest.fn();
+const mockWarn = jest.fn();
+
+jest.mock('../logging', () => ({
+  Logger: {
+    get: jest.fn(() => ({
+      info: mockInfo,
+      warn: mockWarn
+    }))
+  }
+}));
+
+import { getEthPriceCount, persistEthPrices } from './db.eth_price';
+import { syncEthUsdPrice } from './eth_usd_price';
+
+const MOBULA_CURRENT_URL =
+  'https://api.mobula.io/api/1/market/data?asset=Ethereum';
+
+type RetryConfig = {
+  retries: number;
+  retryDelay: (retryCount: number, error: AxiosError) => number;
+  retryCondition: (error: AxiosError) => boolean;
+  shouldResetTimeout: boolean;
+};
+
+function getRetryConfig(): RetryConfig {
+  return mockAxiosRetry.mock.calls[0][1] as RetryConfig;
+}
+
+function buildAxiosError(
+  status: number,
+  headers: Record<string, unknown> = {}
+): AxiosError {
+  return {
+    isAxiosError: true,
+    response: {
+      status,
+      headers
+    }
+  } as AxiosError;
+}
+
+describe('syncEthUsdPrice', () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+    mockIsAxiosError.mockClear();
+    mockExponentialDelay.mockClear();
+    mockIsNetworkError.mockReturnValue(false);
+    mockIsRetryableError.mockReturnValue(false);
+    mockInfo.mockClear();
+    mockWarn.mockClear();
+    (getEthPriceCount as jest.Mock).mockReset();
+    (persistEthPrices as jest.Mock).mockReset();
+    process.env.MOBULA_API_KEY = 'mobula-key';
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    delete process.env.MOBULA_API_KEY;
+  });
+
+  it('persists the latest Mobula ETH price', async () => {
+    const nowMs = 1710000000000;
+    jest.spyOn(Date, 'now').mockReturnValue(nowMs);
+    (getEthPriceCount as jest.Mock).mockResolvedValue(1);
+    mockGet.mockResolvedValue({
+      data: {
+        data: {
+          price: 3133.12
+        }
+      }
+    });
+
+    await syncEthUsdPrice(false);
+
+    expect(mockGet).toHaveBeenCalledWith(MOBULA_CURRENT_URL, {
+      headers: {
+        Authorization: 'Bearer mobula-key'
+      }
+    });
+    expect(persistEthPrices).toHaveBeenCalledWith([
+      {
+        timestamp_ms: nowMs,
+        date: new Date(nowMs),
+        usd_price: 3133.12
+      }
+    ]);
+  });
+
+  it('omits authorization when Mobula API key is absent', async () => {
+    delete process.env.MOBULA_API_KEY;
+    (getEthPriceCount as jest.Mock).mockResolvedValue(1);
+    mockGet.mockResolvedValue({
+      data: {
+        data: {
+          price: 3133.12
+        }
+      }
+    });
+
+    await syncEthUsdPrice(false);
+
+    expect(mockGet).toHaveBeenCalledWith(MOBULA_CURRENT_URL, {
+      headers: undefined
+    });
+  });
+
+  it('skips the latest sample when Mobula remains rate limited', async () => {
+    (getEthPriceCount as jest.Mock).mockResolvedValue(1);
+    mockGet.mockRejectedValue(buildAxiosError(429, { 'retry-after': '120' }));
+
+    await expect(syncEthUsdPrice(false)).resolves.toBeUndefined();
+
+    expect(persistEthPrices).not.toHaveBeenCalled();
+    expect(mockWarn).toHaveBeenCalledWith(
+      '[CURRENT DATA SKIPPED] : [MOBULA HTTP 429] [RETRY_AFTER_MS 120000]'
+    );
+  });
+
+  it('skips the historic reset sample when Mobula remains rate limited', async () => {
+    (getEthPriceCount as jest.Mock).mockResolvedValue(0);
+    mockGet.mockRejectedValue(buildAxiosError(429));
+
+    await expect(syncEthUsdPrice(false)).resolves.toBeUndefined();
+
+    expect(persistEthPrices).not.toHaveBeenCalled();
+    expect(mockWarn).toHaveBeenCalledWith(
+      '[HISTORIC DATA SKIPPED] : [MOBULA HTTP 429] [RETRY_AFTER_MS -1]'
+    );
+  });
+
+  it('rethrows non-rate-limit Mobula failures', async () => {
+    const error = buildAxiosError(500);
+    (getEthPriceCount as jest.Mock).mockResolvedValue(1);
+    mockGet.mockRejectedValue(error);
+
+    await expect(syncEthUsdPrice(false)).rejects.toBe(error);
+  });
+
+  it('configures bounded retries for transient Mobula responses', () => {
+    const retryConfig = getRetryConfig();
+
+    expect(retryConfig.retries).toBe(3);
+    expect(retryConfig.shouldResetTimeout).toBe(true);
+    expect(retryConfig.retryCondition(buildAxiosError(500))).toBe(true);
+    expect(retryConfig.retryCondition(buildAxiosError(429))).toBe(true);
+    expect(
+      retryConfig.retryCondition(buildAxiosError(429, { 'retry-after': '31' }))
+    ).toBe(false);
+    expect(
+      retryConfig.retryDelay(1, buildAxiosError(429, { 'retry-after': '5' }))
+    ).toBe(5000);
+    expect(retryConfig.retryDelay(1, buildAxiosError(503))).toBe(1234);
+    expect(mockExponentialDelay).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({
+        response: expect.objectContaining({ status: 503 })
+      })
+    );
+  });
+});

--- a/src/ethPriceLoop/eth_usd_price.ts
+++ b/src/ethPriceLoop/eth_usd_price.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios, { AxiosError, AxiosRequestConfig } from 'axios';
 import axiosRetry from 'axios-retry';
 import { EthPrice } from '../entities/IEthPrice';
 import { Logger } from '../logging';
@@ -11,16 +11,16 @@ const MOBULA_HISTORIC_URL =
 const MOBULA_CURRENT_URL =
   'https://api.mobula.io/api/1/market/data?asset=Ethereum';
 
-axiosRetry(axios, {
-  retries: 3,
-  retryDelay: axiosRetry.exponentialDelay,
-  retryCondition: (error) => {
-    return (
-      axiosRetry.isNetworkError(error) ??
-      axiosRetry.isRetryableError(error) ??
-      (error.response?.status ?? 0) >= 500
-    );
-  }
+const MOBULA_RETRIES = 3;
+const MAX_RETRY_AFTER_MS = Time.seconds(30).toMillis();
+
+const mobulaAxios = axios.create();
+
+axiosRetry(mobulaAxios, {
+  retries: MOBULA_RETRIES,
+  retryDelay: getRetryDelay,
+  retryCondition: isRetryableMobulaError,
+  shouldResetTimeout: true
 });
 
 interface HistoricResponse {
@@ -37,6 +37,116 @@ interface CurrentResponse {
 
 const logger = Logger.get('ETH_PRICE');
 
+function normalizeHeaderValue(value: unknown): string | undefined {
+  if (Array.isArray(value)) {
+    return normalizeHeaderValue(value[0]);
+  }
+
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (typeof value === 'number') {
+    return value.toString();
+  }
+
+  return undefined;
+}
+
+function getRetryAfterHeader(error: AxiosError): string | undefined {
+  const headers = error.response?.headers;
+  if (!headers) {
+    return undefined;
+  }
+
+  if ('get' in headers && typeof headers.get === 'function') {
+    return normalizeHeaderValue(headers.get('retry-after'));
+  }
+
+  const headerRecord = headers as Record<string, unknown>;
+  return normalizeHeaderValue(
+    headerRecord['retry-after'] ?? headerRecord['Retry-After']
+  );
+}
+
+function getRetryAfterMs(error: AxiosError): number | undefined {
+  const retryAfterHeader = getRetryAfterHeader(error);
+  if (!retryAfterHeader) {
+    return undefined;
+  }
+
+  const retryAfterSeconds = Number(retryAfterHeader);
+  if (Number.isFinite(retryAfterSeconds) && retryAfterSeconds >= 0) {
+    return retryAfterSeconds * Time.seconds(1).toMillis();
+  }
+
+  const retryAt = Date.parse(retryAfterHeader);
+  if (!Number.isFinite(retryAt)) {
+    return undefined;
+  }
+
+  return Math.max(0, retryAt - Date.now());
+}
+
+function isShortRateLimitRetry(error: AxiosError): boolean {
+  const retryAfterMs = getRetryAfterMs(error);
+  return retryAfterMs === undefined || retryAfterMs <= MAX_RETRY_AFTER_MS;
+}
+
+function isRateLimitError(error: unknown): error is AxiosError {
+  return axios.isAxiosError(error) && error.response?.status === 429;
+}
+
+function isRetryableMobulaError(error: AxiosError): boolean {
+  const status = error.response?.status ?? 0;
+  if (status === 429) {
+    return isShortRateLimitRetry(error);
+  }
+
+  return (
+    axiosRetry.isNetworkError(error) ||
+    axiosRetry.isRetryableError(error) ||
+    status >= 500
+  );
+}
+
+function getRetryDelay(retryCount: number, error: AxiosError): number {
+  if (error.response?.status === 429) {
+    const retryAfterMs = getRetryAfterMs(error);
+    if (retryAfterMs !== undefined && retryAfterMs <= MAX_RETRY_AFTER_MS) {
+      return retryAfterMs;
+    }
+  }
+
+  return axiosRetry.exponentialDelay(retryCount, error);
+}
+
+function getRetryAfterLogValue(error: AxiosError): number {
+  return getRetryAfterMs(error) ?? -1;
+}
+
+async function fetchMobulaData<T>(
+  url: string,
+  label: 'CURRENT' | 'HISTORIC',
+  config?: AxiosRequestConfig
+): Promise<T | undefined> {
+  try {
+    const response = await mobulaAxios.get<T>(url, config);
+    return response.data;
+  } catch (error) {
+    if (isRateLimitError(error)) {
+      logger.warn(
+        `[${label} DATA SKIPPED] : [MOBULA HTTP 429] [RETRY_AFTER_MS ${getRetryAfterLogValue(
+          error
+        )}]`
+      );
+      return undefined;
+    }
+
+    throw error;
+  }
+}
+
 export async function syncEthUsdPrice(reset: boolean) {
   const existingData = await getEthPriceCount();
   const isReset = reset || existingData === 0;
@@ -51,9 +161,13 @@ export async function syncEthUsdPrice(reset: boolean) {
 }
 
 async function syncHistoricEthUsdPriceData() {
-  const historicResponse =
-    await axios.get<HistoricResponse>(MOBULA_HISTORIC_URL);
-  const historicData = historicResponse.data;
+  const historicData = await fetchMobulaData<HistoricResponse>(
+    MOBULA_HISTORIC_URL,
+    'HISTORIC'
+  );
+  if (!historicData) {
+    return;
+  }
   logger.info(
     `[HISTORIC DATA  RESPONSE ${historicData.data.price_history.length}]`
   );
@@ -72,12 +186,20 @@ async function syncHistoricEthUsdPriceData() {
 
 async function syncLatestEthUsdPriceData() {
   const apiKey = process.env.MOBULA_API_KEY;
-  const currentResponse = await axios.get<CurrentResponse>(MOBULA_CURRENT_URL, {
-    headers: {
-      Authorization: `Bearer ${apiKey}`
+  const currentData = await fetchMobulaData<CurrentResponse>(
+    MOBULA_CURRENT_URL,
+    'CURRENT',
+    {
+      headers: apiKey
+        ? {
+            Authorization: `Bearer ${apiKey}`
+          }
+        : undefined
     }
-  });
-  const currentData = currentResponse.data;
+  );
+  if (!currentData) {
+    return;
+  }
   logger.info(`[CURRENT DATA RESPONSE]`);
   const ethPrice: EthPrice = {
     timestamp_ms: Time.now().toMillis(),

--- a/src/ethPriceLoop/serverless.yaml
+++ b/src/ethPriceLoop/serverless.yaml
@@ -21,7 +21,7 @@ functions:
     role: arn:aws:iam::987989283142:role/lambda-vpc-role
     reservedConcurrency: 1
     events:
-      - schedule: rate(2 minutes)
+      - schedule: rate(5 minutes)
     vpc:
       securityGroupIds: ${file(../../serverless-config/${opt:stage, self:provider.stage}/vpc.js):security}
       subnetIds: ${file(../../serverless-config/${opt:stage, self:provider.stage}/vpc.js):subnets}


### PR DESCRIPTION
## Summary
- use a dedicated Mobula axios client with correct retry predicates and bounded Retry-After handling
- skip exhausted Mobula 429 samples without throwing unhandled Lambda errors
- reduce ethPriceLoop schedule from 2 minutes to 5 minutes and update architecture docs

Fixes SEIZE-BACKEND-9Y

## Verification
- npm run lint
- npm test -- src/ethPriceLoop/eth-usd-price.test.ts
- npm run build

## Deployment
- Backend only
- Deploy ethPriceLoop to staging first, then production after merge to main
- No schema changes