### PR TITLE
Stabilize NextGen metadata refresh

### DIFF
--- a/src/nextgen/nextgen-metadata.test.ts
+++ b/src/nextgen/nextgen-metadata.test.ts
@@ -1,0 +1,64 @@
+import {
+  fetchNextGenMetadata,
+  NextGenMetadataFetchError
+} from './nextgen-metadata';
+
+function metadataResponse({
+  body = '{"name":"Token"}',
+  status = 200,
+  contentType = 'application/json'
+}: {
+  body?: string;
+  contentType?: string;
+  status?: number;
+}) {
+  return {
+    ok: status < 400,
+    status,
+    text: jest.fn().mockResolvedValue(body),
+    headers: {
+      get: jest.fn((header: string) =>
+        header.toLowerCase() === 'content-type' ? contentType : null
+      )
+    }
+  };
+}
+
+describe('fetchNextGenMetadata', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.resetAllMocks();
+  });
+
+  it('retries retryable HTTP failures before returning metadata', async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce(metadataResponse({ status: 500 }))
+      .mockResolvedValueOnce(metadataResponse({}));
+    global.fetch = fetchMock as any;
+
+    await expect(
+      fetchNextGenMetadata('https://metadata.example/token/1')
+    ).resolves.toEqual({ name: 'Token' });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry invalid metadata payloads', async () => {
+    const fetchMock = jest.fn().mockResolvedValue(
+      metadataResponse({
+        body: '<html>bad</html>',
+        contentType: 'text/html'
+      })
+    );
+    global.fetch = fetchMock as any;
+
+    await expect(
+      fetchNextGenMetadata('https://metadata.example/token/1')
+    ).rejects.toMatchObject({
+      retryable: false
+    } as Partial<NextGenMetadataFetchError>);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/nextgen/nextgen-metadata.ts
+++ b/src/nextgen/nextgen-metadata.ts
@@ -4,8 +4,45 @@ import {
 } from '@/metadata-payload';
 
 const METADATA_FETCH_TIMEOUT_MS = 30000;
+const METADATA_FETCH_ATTEMPTS = 3;
+const METADATA_FETCH_RETRY_BASE_DELAY_MS = 500;
+
+const RETRYABLE_STATUS_CODES = new Set([408, 429]);
+
+export class NextGenMetadataFetchError extends Error {
+  constructor(
+    message: string,
+    public readonly retryable: boolean,
+    public readonly status?: number
+  ) {
+    super(message);
+    Object.setPrototypeOf(this, NextGenMetadataFetchError.prototype);
+  }
+}
 
 export async function fetchNextGenMetadata(
+  metadataLink: string
+): Promise<Record<string, unknown>> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= METADATA_FETCH_ATTEMPTS; attempt++) {
+    try {
+      return await fetchNextGenMetadataOnce(metadataLink);
+    } catch (error: unknown) {
+      lastError = error;
+      if (
+        !isRetryableMetadataFetchError(error) ||
+        attempt === METADATA_FETCH_ATTEMPTS
+      ) {
+        throw error;
+      }
+      await sleep(retryDelayMs(attempt));
+    }
+  }
+
+  throw lastError;
+}
+
+async function fetchNextGenMetadataOnce(
   metadataLink: string
 ): Promise<Record<string, unknown>> {
   const controller = new AbortController();
@@ -19,19 +56,25 @@ export async function fetchNextGenMetadata(
     res = await fetch(metadataLink, { signal: controller.signal });
   } catch (error: unknown) {
     if (error instanceof Error && error.name === 'AbortError') {
-      throw new Error(
-        `Metadata fetch timed out for ${metadataLink} after ${METADATA_FETCH_TIMEOUT_MS}ms`
+      throw new NextGenMetadataFetchError(
+        `Metadata fetch timed out for ${metadataLink} after ${METADATA_FETCH_TIMEOUT_MS}ms`,
+        true
       );
     }
-    throw error;
+    throw new NextGenMetadataFetchError(
+      `Metadata fetch failed for ${metadataLink}: ${errorMessage(error)}`,
+      true
+    );
   } finally {
     clearTimeout(timeoutId);
   }
 
   const body = await res.text();
   if (res.ok === false || res.status >= 400) {
-    throw new Error(
-      `Metadata fetch failed for ${metadataLink} with status ${res.status}`
+    throw new NextGenMetadataFetchError(
+      `Metadata fetch failed for ${metadataLink} with status ${res.status}`,
+      isRetryableStatus(res.status),
+      res.status
     );
   }
 
@@ -39,11 +82,33 @@ export async function fetchNextGenMetadata(
   if (!metadata) {
     const contentType = res.headers.get('content-type') ?? 'unknown';
     const preview = getPayloadPreview(body);
-    throw new Error(
-      `Invalid metadata payload for ${metadataLink} (content-type: ${contentType}, preview: ${preview})`
+    throw new NextGenMetadataFetchError(
+      `Invalid metadata payload for ${metadataLink} (content-type: ${contentType}, preview: ${preview})`,
+      false
     );
   }
   return metadata;
+}
+
+export function isRetryableMetadataFetchError(error: unknown): boolean {
+  return error instanceof NextGenMetadataFetchError && error.retryable;
+}
+
+function isRetryableStatus(status: number): boolean {
+  return RETRYABLE_STATUS_CODES.has(status) || status >= 500;
+}
+
+function retryDelayMs(attempt: number): number {
+  if (process.env.NODE_ENV === 'test') return 0;
+  return METADATA_FETCH_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1);
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 export function getRequiredMetadataName(

--- a/src/nextgen/nextgen-metadata.ts
+++ b/src/nextgen/nextgen-metadata.ts
@@ -23,12 +23,11 @@ export class NextGenMetadataFetchError extends Error {
 export async function fetchNextGenMetadata(
   metadataLink: string
 ): Promise<Record<string, unknown>> {
-  let lastError: unknown;
-  for (let attempt = 1; attempt <= METADATA_FETCH_ATTEMPTS; attempt++) {
+  let attempt = 1;
+  while (true) {
     try {
       return await fetchNextGenMetadataOnce(metadataLink);
     } catch (error: unknown) {
-      lastError = error;
       if (
         !isRetryableMetadataFetchError(error) ||
         attempt === METADATA_FETCH_ATTEMPTS
@@ -36,10 +35,9 @@ export async function fetchNextGenMetadata(
         throw error;
       }
       await sleep(retryDelayMs(attempt));
+      attempt += 1;
     }
   }
-
-  throw lastError;
 }
 
 async function fetchNextGenMetadataOnce(
@@ -99,7 +97,6 @@ function isRetryableStatus(status: number): boolean {
 }
 
 function retryDelayMs(attempt: number): number {
-  if (process.env.NODE_ENV === 'test') return 0;
   return METADATA_FETCH_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1);
 }
 

--- a/src/nextgen/nextgen_core_events.ts
+++ b/src/nextgen/nextgen_core_events.ts
@@ -35,6 +35,13 @@ import {
 
 const logger = Logger.get('NEXTGEN_CORE_EVENTS');
 
+export type NextGenTokenMetadata = {
+  metadataLink: string;
+  metadataResponse: any;
+  name: string;
+  pending: boolean;
+};
+
 let alchemy: Alchemy;
 
 export async function findCoreEvents(
@@ -266,30 +273,68 @@ export async function upsertToken(
   hodlRate: number,
   mintData: string | undefined
 ) {
-  const metadataLink = `${collection.base_uri}${tokenId}`;
+  const metadata = await fetchNextGenTokenMetadata(collection, tokenId);
+  await persistTokenWithMetadata(
+    entityManager,
+    collection,
+    tokenId,
+    normalisedTokenId,
+    owner,
+    mintDate,
+    mintPrice,
+    burnDate,
+    hodlRate,
+    mintData,
+    metadata
+  );
+}
 
+export async function fetchNextGenTokenMetadata(
+  collection: NextGenCollection,
+  tokenId: number
+): Promise<NextGenTokenMetadata> {
+  const metadataLink = `${collection.base_uri}${tokenId}`;
   const metadataResponse: any = await fetchNextGenMetadata(metadataLink);
   const name = getRequiredMetadataName(metadataResponse, metadataLink);
-  const pending = name.toLowerCase().startsWith('pending');
+  return {
+    metadataLink,
+    metadataResponse,
+    name,
+    pending: name.toLowerCase().startsWith('pending')
+  };
+}
 
+export async function persistTokenWithMetadata(
+  entityManager: EntityManager,
+  collection: NextGenCollection,
+  tokenId: number,
+  normalisedTokenId: number,
+  owner: string,
+  mintDate: Date,
+  mintPrice: number,
+  burnDate: Date | undefined,
+  hodlRate: number,
+  mintData: string | undefined,
+  metadata: NextGenTokenMetadata
+) {
   const nextGenToken: NextGenToken = {
     id: tokenId,
     normalised_id: normalisedTokenId,
-    name,
+    name: metadata.name,
     collection_id: collection.id,
     collection_name: collection.name,
     mint_date: mintDate,
     mint_price: mintPrice,
-    metadata_url: metadataLink,
-    image_url: metadataResponse.image,
+    metadata_url: metadata.metadataLink,
+    image_url: metadata.metadataResponse.image,
     animation_url:
-      metadataResponse.image?.replace('/png/', '/html/') ??
-      metadataResponse.animation_url ??
-      metadataResponse.generator?.html ??
+      metadata.metadataResponse.image?.replace('/png/', '/html/') ??
+      metadata.metadataResponse.animation_url ??
+      metadata.metadataResponse.generator?.html ??
       null,
-    generator: metadataResponse.generator,
+    generator: metadata.metadataResponse.generator,
     owner: owner.toLowerCase(),
-    pending: pending,
+    pending: metadata.pending,
     burnt: !!burnDate,
     burnt_date: burnDate,
     hodl_rate: hodlRate,
@@ -298,12 +343,12 @@ export async function upsertToken(
 
   await persistNextGenToken(entityManager, nextGenToken);
 
-  if (metadataResponse.attributes) {
+  if (metadata.metadataResponse.attributes) {
     await processTraits(
       entityManager,
       tokenId,
       collection.id,
-      metadataResponse.attributes
+      metadata.metadataResponse.attributes
     );
   }
 }

--- a/src/nextgen/nextgen_metadata_refresh.test.ts
+++ b/src/nextgen/nextgen_metadata_refresh.test.ts
@@ -192,6 +192,19 @@ describe('refreshNextgenMetadata', () => {
     expect(tokens.refreshNextgenTokens).not.toHaveBeenCalled();
   });
 
+  it('treats primitive thrown values as non-retryable failures', async () => {
+    jest
+      .spyOn(coreEvents, 'fetchNextGenTokenMetadata')
+      .mockRejectedValueOnce('plain failure')
+      .mockImplementation(async (collection, tokenId) =>
+        tokenMetadata(collection, tokenId)
+      );
+
+    await expect(refreshNextgenMetadata()).rejects.toThrow('plain failure');
+    expect(dataSource.transaction).not.toHaveBeenCalled();
+    expect(tokens.refreshNextgenTokens).not.toHaveBeenCalled();
+  });
+
   it('bounds token refresh concurrency', async () => {
     const collectionTokens = Array.from({ length: 25 }, (_, index) =>
       nextgenToken(index + 1)

--- a/src/nextgen/nextgen_metadata_refresh.test.ts
+++ b/src/nextgen/nextgen_metadata_refresh.test.ts
@@ -6,6 +6,20 @@ import * as nextgenDb from './nextgen.db';
 import * as constants from './nextgen_constants';
 import * as coreEvents from './nextgen_core_events';
 import * as tokens from './nextgen_tokens';
+import { NextGenMetadataFetchError } from './nextgen-metadata';
+
+function nextgenToken(id: number) {
+  return {
+    id,
+    normalised_id: `n${id}`,
+    owner: `o${id}`,
+    mint_date: `md${id}`,
+    mint_price: `mp${id}`,
+    burnt_date: `bd${id}`,
+    hodl_rate: `hr${id}`,
+    mint_data: `d${id}`
+  } as any;
+}
 
 describe('refreshNextgenMetadata', () => {
   const logger = { error: jest.fn(), info: jest.fn(), warn: jest.fn() } as any;
@@ -28,28 +42,9 @@ describe('refreshNextgenMetadata', () => {
     jest
       .spyOn(nextgenDb, 'fetchNextGenCollections')
       .mockResolvedValue([{ id: 1 } as any]);
-    jest.spyOn(nextgenDb, 'fetchNextGenTokensForCollection').mockResolvedValue([
-      {
-        id: 1,
-        normalised_id: 'n1',
-        owner: 'o1',
-        mint_date: 'md1',
-        mint_price: 'mp1',
-        burnt_date: 'bd1',
-        hodl_rate: 'hr1',
-        mint_data: 'd1'
-      },
-      {
-        id: 2,
-        normalised_id: 'n2',
-        owner: 'o2',
-        mint_date: 'md2',
-        mint_price: 'mp2',
-        burnt_date: 'bd2',
-        hodl_rate: 'hr2',
-        mint_data: 'd2'
-      }
-    ] as any);
+    jest
+      .spyOn(nextgenDb, 'fetchNextGenTokensForCollection')
+      .mockResolvedValue([nextgenToken(1), nextgenToken(2)] as any);
     jest
       .spyOn(nftOwnersDb, 'fetchAllNftOwners')
       .mockResolvedValue([{ token_id: 1, wallet: 'NEW' }] as any);
@@ -64,7 +59,7 @@ describe('refreshNextgenMetadata', () => {
   it('updates all tokens and refreshes collection', async () => {
     await refreshNextgenMetadata();
 
-    expect(dataSource.transaction).toHaveBeenCalledTimes(1);
+    expect(dataSource.transaction).toHaveBeenCalledTimes(3);
     expect(coreEvents.upsertToken).toHaveBeenCalledTimes(2);
     expect(coreEvents.upsertToken).toHaveBeenCalledWith(
       entityManager,
@@ -106,24 +101,51 @@ describe('refreshNextgenMetadata', () => {
     await refreshNextgenMetadata();
 
     expect(coreEvents.upsertToken).toHaveBeenCalledTimes(3);
-    expect(dataSource.transaction).toHaveBeenCalledTimes(2);
     expect(tokens.refreshNextgenTokens).toHaveBeenCalledWith(entityManager);
   });
 
-  it('processes token writes sequentially inside the metadata transaction', async () => {
-    const collectionTokens = Array.from({ length: 25 }, (_, index) => ({
-      id: index + 1,
-      normalised_id: `n${index + 1}`,
-      owner: `o${index + 1}`,
-      mint_date: `md${index + 1}`,
-      mint_price: `mp${index + 1}`,
-      burnt_date: `bd${index + 1}`,
-      hodl_rate: `hr${index + 1}`,
-      mint_data: `d${index + 1}`
-    }));
+  it('skips tiny exhausted transient metadata failures and refreshes scores', async () => {
+    const collectionTokens = Array.from({ length: 100 }, (_, index) =>
+      nextgenToken(index + 1)
+    );
     jest
       .spyOn(nextgenDb, 'fetchNextGenTokensForCollection')
-      .mockResolvedValue(collectionTokens as any);
+      .mockResolvedValue(collectionTokens);
+    jest
+      .spyOn(coreEvents, 'upsertToken')
+      .mockImplementation(async (_manager, _collection, tokenId) => {
+        if (tokenId === 100) {
+          throw new NextGenMetadataFetchError('fetch failed', true);
+        }
+      });
+
+    await refreshNextgenMetadata();
+
+    expect(coreEvents.upsertToken).toHaveBeenCalledTimes(100);
+    expect(tokens.refreshNextgenTokens).toHaveBeenCalledWith(entityManager);
+  });
+
+  it('throws permanent metadata failures instead of skipping them', async () => {
+    jest
+      .spyOn(coreEvents, 'upsertToken')
+      .mockRejectedValueOnce(
+        new NextGenMetadataFetchError('Invalid metadata payload', false)
+      )
+      .mockResolvedValue(undefined);
+
+    await expect(refreshNextgenMetadata()).rejects.toThrow(
+      'Failed refreshing 1/2 tokens'
+    );
+    expect(tokens.refreshNextgenTokens).not.toHaveBeenCalled();
+  });
+
+  it('bounds token refresh concurrency', async () => {
+    const collectionTokens = Array.from({ length: 25 }, (_, index) =>
+      nextgenToken(index + 1)
+    );
+    jest
+      .spyOn(nextgenDb, 'fetchNextGenTokensForCollection')
+      .mockResolvedValue(collectionTokens);
 
     let active = 0;
     let maxActive = 0;
@@ -136,6 +158,7 @@ describe('refreshNextgenMetadata', () => {
 
     await refreshNextgenMetadata();
 
-    expect(maxActive).toBe(1);
+    expect(maxActive).toBeLessThanOrEqual(20);
+    expect(maxActive).toBeGreaterThan(1);
   });
 });

--- a/src/nextgen/nextgen_metadata_refresh.test.ts
+++ b/src/nextgen/nextgen_metadata_refresh.test.ts
@@ -21,6 +21,20 @@ function nextgenToken(id: number) {
   } as any;
 }
 
+function nextgenCollection(id: number) {
+  return { base_uri: `metadata/${id}/`, id, name: `Collection ${id}` } as any;
+}
+
+function tokenMetadata(collection: { base_uri: string }, tokenId: number) {
+  const metadataLink = `${collection.base_uri}${tokenId}`;
+  return {
+    metadataLink,
+    metadataResponse: { image: `image-${tokenId}` },
+    name: `Token ${tokenId}`,
+    pending: false
+  };
+}
+
 describe('refreshNextgenMetadata', () => {
   const logger = { error: jest.fn(), info: jest.fn(), warn: jest.fn() } as any;
   const entityManager = {} as any;
@@ -41,14 +55,21 @@ describe('refreshNextgenMetadata', () => {
     (constants as any).NEXTGEN_CORE_CONTRACT = { testnet: '0xabc' } as any;
     jest
       .spyOn(nextgenDb, 'fetchNextGenCollections')
-      .mockResolvedValue([{ id: 1 } as any]);
+      .mockResolvedValue([nextgenCollection(1)]);
     jest
       .spyOn(nextgenDb, 'fetchNextGenTokensForCollection')
       .mockResolvedValue([nextgenToken(1), nextgenToken(2)] as any);
     jest
       .spyOn(nftOwnersDb, 'fetchAllNftOwners')
       .mockResolvedValue([{ token_id: 1, wallet: 'NEW' }] as any);
-    jest.spyOn(coreEvents, 'upsertToken').mockResolvedValue(undefined);
+    jest
+      .spyOn(coreEvents, 'fetchNextGenTokenMetadata')
+      .mockImplementation(async (collection, tokenId) =>
+        tokenMetadata(collection, tokenId)
+      );
+    jest
+      .spyOn(coreEvents, 'persistTokenWithMetadata')
+      .mockResolvedValue(undefined);
     jest.spyOn(tokens, 'refreshNextgenTokens').mockResolvedValue(undefined);
   });
 
@@ -59,11 +80,12 @@ describe('refreshNextgenMetadata', () => {
   it('updates all tokens and refreshes collection', async () => {
     await refreshNextgenMetadata();
 
-    expect(dataSource.transaction).toHaveBeenCalledTimes(3);
-    expect(coreEvents.upsertToken).toHaveBeenCalledTimes(2);
-    expect(coreEvents.upsertToken).toHaveBeenCalledWith(
+    expect(dataSource.transaction).toHaveBeenCalledTimes(1);
+    expect(coreEvents.fetchNextGenTokenMetadata).toHaveBeenCalledTimes(2);
+    expect(coreEvents.persistTokenWithMetadata).toHaveBeenCalledTimes(2);
+    expect(coreEvents.persistTokenWithMetadata).toHaveBeenCalledWith(
       entityManager,
-      { id: 1 },
+      nextgenCollection(1),
       1,
       'n1',
       'new',
@@ -71,11 +93,12 @@ describe('refreshNextgenMetadata', () => {
       'mp1',
       'bd1',
       'hr1',
-      'd1'
+      'd1',
+      tokenMetadata(nextgenCollection(1), 1)
     );
-    expect(coreEvents.upsertToken).toHaveBeenCalledWith(
+    expect(coreEvents.persistTokenWithMetadata).toHaveBeenCalledWith(
       entityManager,
-      { id: 1 },
+      nextgenCollection(1),
       2,
       'n2',
       'o2',
@@ -83,24 +106,25 @@ describe('refreshNextgenMetadata', () => {
       'mp2',
       'bd2',
       'hr2',
-      'd2'
+      'd2',
+      tokenMetadata(nextgenCollection(1), 2)
     );
     expect(tokens.refreshNextgenTokens).toHaveBeenCalledWith(entityManager);
   });
 
-  it('retries token persistence deadlocks before recording a failure', async () => {
+  it('retries the atomic refresh transaction on deadlock', async () => {
     const deadlock = new Error(
       'ER_LOCK_DEADLOCK: Deadlock found when trying to get lock; try restarting transaction'
     ) as Error & { code: string };
     deadlock.code = 'ER_LOCK_DEADLOCK';
-    jest
-      .spyOn(coreEvents, 'upsertToken')
+    dataSource.transaction
       .mockRejectedValueOnce(deadlock)
-      .mockResolvedValue(undefined);
+      .mockImplementation(async (fn: any) => await fn(entityManager));
 
     await refreshNextgenMetadata();
 
-    expect(coreEvents.upsertToken).toHaveBeenCalledTimes(3);
+    expect(dataSource.transaction).toHaveBeenCalledTimes(2);
+    expect(coreEvents.persistTokenWithMetadata).toHaveBeenCalledTimes(2);
     expect(tokens.refreshNextgenTokens).toHaveBeenCalledWith(entityManager);
   });
 
@@ -112,30 +136,59 @@ describe('refreshNextgenMetadata', () => {
       .spyOn(nextgenDb, 'fetchNextGenTokensForCollection')
       .mockResolvedValue(collectionTokens);
     jest
-      .spyOn(coreEvents, 'upsertToken')
-      .mockImplementation(async (_manager, _collection, tokenId) => {
+      .spyOn(coreEvents, 'fetchNextGenTokenMetadata')
+      .mockImplementation(async (collection, tokenId) => {
         if (tokenId === 100) {
           throw new NextGenMetadataFetchError('fetch failed', true);
         }
+        return tokenMetadata(collection, tokenId);
       });
 
     await refreshNextgenMetadata();
 
-    expect(coreEvents.upsertToken).toHaveBeenCalledTimes(100);
+    expect(coreEvents.fetchNextGenTokenMetadata).toHaveBeenCalledTimes(100);
+    expect(coreEvents.persistTokenWithMetadata).toHaveBeenCalledTimes(99);
     expect(tokens.refreshNextgenTokens).toHaveBeenCalledWith(entityManager);
+  });
+
+  it('applies the transient skip limit globally across collections', async () => {
+    jest
+      .spyOn(nextgenDb, 'fetchNextGenCollections')
+      .mockResolvedValue([nextgenCollection(1), nextgenCollection(2)]);
+    jest
+      .spyOn(nextgenDb, 'fetchNextGenTokensForCollection')
+      .mockImplementation(async () =>
+        Array.from({ length: 300 }, (_, index) => nextgenToken(index + 1))
+      );
+    jest
+      .spyOn(coreEvents, 'fetchNextGenTokenMetadata')
+      .mockImplementation(async (collection, tokenId) => {
+        if (tokenId <= 3) {
+          throw new NextGenMetadataFetchError('fetch failed', true);
+        }
+        return tokenMetadata(collection, tokenId);
+      });
+
+    await expect(refreshNextgenMetadata()).rejects.toThrow(
+      'Failed refreshing 6/600 tokens'
+    );
+    expect(dataSource.transaction).not.toHaveBeenCalled();
   });
 
   it('throws permanent metadata failures instead of skipping them', async () => {
     jest
-      .spyOn(coreEvents, 'upsertToken')
+      .spyOn(coreEvents, 'fetchNextGenTokenMetadata')
       .mockRejectedValueOnce(
         new NextGenMetadataFetchError('Invalid metadata payload', false)
       )
-      .mockResolvedValue(undefined);
+      .mockImplementation(async (collection, tokenId) =>
+        tokenMetadata(collection, tokenId)
+      );
 
     await expect(refreshNextgenMetadata()).rejects.toThrow(
       'Failed refreshing 1/2 tokens'
     );
+    expect(dataSource.transaction).not.toHaveBeenCalled();
     expect(tokens.refreshNextgenTokens).not.toHaveBeenCalled();
   });
 
@@ -149,12 +202,15 @@ describe('refreshNextgenMetadata', () => {
 
     let active = 0;
     let maxActive = 0;
-    jest.spyOn(coreEvents, 'upsertToken').mockImplementation(async () => {
-      active += 1;
-      maxActive = Math.max(maxActive, active);
-      await new Promise((resolve) => setTimeout(resolve, 5));
-      active -= 1;
-    });
+    jest
+      .spyOn(coreEvents, 'fetchNextGenTokenMetadata')
+      .mockImplementation(async (collection, tokenId) => {
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        active -= 1;
+        return tokenMetadata(collection, tokenId);
+      });
 
     await refreshNextgenMetadata();
 

--- a/src/nextgen/nextgen_metadata_refresh.ts
+++ b/src/nextgen/nextgen_metadata_refresh.ts
@@ -1,21 +1,21 @@
-import { EntityManager } from 'typeorm';
 import { getDataSource } from '../db';
-import { NextGenCollection, NextGenToken } from '../entities/INextGen';
 import { Logger } from '../logging';
 import { fetchAllNftOwners } from '../nftOwnersLoop/db.nft_owners';
-import {
-  fetchNextGenCollections,
-  fetchNextGenTokensForCollection
-} from './nextgen.db';
+import { NextGenCollection, NextGenToken } from '../entities/INextGen';
+import { DataSource } from 'typeorm';
+import * as nextgenDb from './nextgen.db';
 import { NEXTGEN_CORE_CONTRACT, getNextgenNetwork } from './nextgen_constants';
-import { upsertToken } from './nextgen_core_events';
-import { refreshNextgenTokens } from './nextgen_tokens';
-import {
-  isRetryableDbLockError,
-  withNextgenDbLockRetry
-} from './nextgen-db-lock-retry';
+import * as nextgenCoreEvents from './nextgen_core_events';
+import { isRetryableMetadataFetchError } from './nextgen-metadata';
+import * as nextgenTokens from './nextgen_tokens';
 
 const logger = Logger.get('NEXTGEN_METADATA_REFRESH');
+
+const TOKEN_REFRESH_CONCURRENCY = 20;
+const TOKEN_REFRESH_DB_ATTEMPTS = 3;
+const TOKEN_REFRESH_RETRY_BASE_DELAY_MS = 250;
+const MAX_TRANSIENT_FAILURES_TO_SKIP = 5;
+const MAX_TRANSIENT_FAILURE_RATIO_TO_SKIP = 0.01;
 
 type TokenRefreshSuccess = {
   metadataLink: string;
@@ -26,6 +26,7 @@ type TokenRefreshSuccess = {
 type TokenRefreshFailure = {
   error: string;
   metadataLink: string;
+  retryable: boolean;
   success: false;
   tokenId: number;
 };
@@ -40,52 +41,39 @@ export async function refreshNextgenMetadata() {
   logger.info(`[RUNNING]`);
   const dataSource = getDataSource();
   const network = getNextgenNetwork();
-  await withNextgenDbLockRetry(
-    async () =>
-      await dataSource.transaction(async (entityManager) => {
-        const collections = await fetchNextGenCollections(entityManager);
-        const owners = await fetchAllNftOwners([
-          NEXTGEN_CORE_CONTRACT[network].toLowerCase()
-        ]);
-        const ownerByTokenId = new Map(
-          owners.map((owner) => [
-            Number(owner.token_id),
-            owner.wallet.toLowerCase()
-          ])
-        );
-
-        for (const collection of collections) {
-          logger.info(`[PROCESSING COLLECTION ${collection.id}]`);
-          const collectionTokens = await fetchNextGenTokensForCollection(
-            entityManager,
-            collection
-          );
-          const tokenRefreshResults: TokenRefreshResult[] = [];
-          for (const token of collectionTokens) {
-            tokenRefreshResults.push(
-              await refreshToken(
-                entityManager,
-                collection,
-                token,
-                ownerByTokenId
-              )
-            );
-          }
-
-          throwIfRefreshFailures(collection, tokenRefreshResults);
-        }
-
-        await refreshNextgenTokens(entityManager);
-      }),
-    {
-      logger,
-      operation: 'refresh-nextgen-metadata'
-    }
+  const collections = await nextgenDb.fetchNextGenCollections(
+    dataSource.manager
   );
+  const owners = await fetchAllNftOwners([
+    NEXTGEN_CORE_CONTRACT[network].toLowerCase()
+  ]);
+  const ownerByTokenId = new Map(
+    owners.map((owner) => [Number(owner.token_id), owner.wallet.toLowerCase()])
+  );
+
+  for (const collection of collections) {
+    logger.info(`[PROCESSING COLLECTION ${collection.id}]`);
+    const collectionTokens = await nextgenDb.fetchNextGenTokensForCollection(
+      dataSource.manager,
+      collection
+    );
+    const tokenRefreshResults = await mapWithConcurrency(
+      collectionTokens,
+      TOKEN_REFRESH_CONCURRENCY,
+      async (token) =>
+        refreshToken(dataSource, collection, token, ownerByTokenId)
+    );
+
+    handleRefreshFailures(collection, tokenRefreshResults);
+  }
+
+  await dataSource.transaction(async (entityManager) => {
+    await nextgenTokens.refreshNextgenTokens(entityManager);
+  });
 }
 
 async function refreshToken(
-  entityManager: EntityManager,
+  dataSource: DataSource,
   collection: NextGenCollection,
   token: NextGenToken,
   ownerByTokenId: Map<number, string>
@@ -93,27 +81,13 @@ async function refreshToken(
   const metadataLink = `${collection.base_uri}${token.id}`;
   const owner = ownerByTokenId.get(Number(token.id)) ?? token.owner;
   try {
-    await upsertToken(
-      entityManager,
-      collection,
-      token.id,
-      token.normalised_id,
-      owner,
-      token.mint_date,
-      token.mint_price,
-      token.burnt_date,
-      token.hodl_rate,
-      token.mint_data
-    );
+    await refreshTokenWithDbRetries(dataSource, collection, token, owner);
     return {
       tokenId: token.id,
       metadataLink,
       success: true
     };
   } catch (error: unknown) {
-    if (isRetryableDbLockError(error)) {
-      throw error;
-    }
     const errMsg = errorMessage(error);
     logger.error(
       `[TOKEN REFRESH FAILED] [COLLECTION ${collection.id}] [TOKEN ID ${token.id}] [METADATA LINK ${metadataLink}] [ERROR ${errMsg}]`
@@ -122,12 +96,48 @@ async function refreshToken(
       tokenId: token.id,
       metadataLink,
       success: false,
+      retryable: isTransientTokenFailure(error),
       error: errMsg
     };
   }
 }
 
-function throwIfRefreshFailures(
+async function refreshTokenWithDbRetries(
+  dataSource: DataSource,
+  collection: NextGenCollection,
+  token: NextGenToken,
+  owner: string
+): Promise<void> {
+  for (let attempt = 1; attempt <= TOKEN_REFRESH_DB_ATTEMPTS; attempt++) {
+    try {
+      await dataSource.transaction(async (entityManager) => {
+        await nextgenCoreEvents.upsertToken(
+          entityManager,
+          collection,
+          token.id,
+          token.normalised_id,
+          owner,
+          token.mint_date,
+          token.mint_price,
+          token.burnt_date,
+          token.hodl_rate,
+          token.mint_data
+        );
+      });
+      return;
+    } catch (error: unknown) {
+      if (!isRetryableDbError(error) || attempt === TOKEN_REFRESH_DB_ATTEMPTS) {
+        throw error;
+      }
+      logger.warn(
+        `[TOKEN REFRESH RETRY] [COLLECTION ${collection.id}] [TOKEN ID ${token.id}] [ATTEMPT ${attempt}/${TOKEN_REFRESH_DB_ATTEMPTS}] [ERROR ${errorMessage(error)}]`
+      );
+      await sleep(tokenRefreshRetryDelayMs(attempt));
+    }
+  }
+}
+
+function handleRefreshFailures(
   collection: NextGenCollection,
   results: TokenRefreshResult[]
 ): void {
@@ -136,8 +146,78 @@ function throwIfRefreshFailures(
   );
   if (failures.length === 0) return;
 
-  const firstFailure = failures[0];
+  if (shouldSkipTransientFailures(failures, results.length)) {
+    logger.warn(
+      `[COLLECTION ${collection.id}] Skipping ${failures.length}/${results.length} transient token refresh failures`
+    );
+    return;
+  }
+
+  const firstFailure =
+    failures.find((failure) => !failure.retryable) ?? failures[0];
   throw new Error(
     `[COLLECTION ${collection.id}] Failed refreshing ${failures.length}/${results.length} tokens. First failure token ${firstFailure.tokenId} (${firstFailure.metadataLink}): ${firstFailure.error}`
   );
+}
+
+function shouldSkipTransientFailures(
+  failures: TokenRefreshFailure[],
+  tokenCount: number
+): boolean {
+  if (failures.length === 0 || tokenCount === 0) return false;
+  if (failures.some((failure) => !failure.retryable)) return false;
+  return (
+    failures.length <= MAX_TRANSIENT_FAILURES_TO_SKIP &&
+    failures.length / tokenCount <= MAX_TRANSIENT_FAILURE_RATIO_TO_SKIP
+  );
+}
+
+function isTransientTokenFailure(error: unknown): boolean {
+  return isRetryableMetadataFetchError(error) || isRetryableDbError(error);
+}
+
+function isRetryableDbError(error: unknown): boolean {
+  const dbError = error as {
+    code?: unknown;
+    errno?: unknown;
+    message?: unknown;
+  };
+  const code = String(dbError.code ?? '');
+  const errno = Number(dbError.errno);
+  const message = String(dbError.message ?? '');
+  return (
+    code === 'ER_LOCK_DEADLOCK' ||
+    code === 'ER_LOCK_WAIT_TIMEOUT' ||
+    errno === 1213 ||
+    errno === 1205 ||
+    message.includes('Deadlock found when trying to get lock')
+  );
+}
+
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  fn: (item: T) => Promise<R>
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let nextIndex = 0;
+  const workerCount = Math.min(concurrency, items.length);
+  const workers = Array.from({ length: workerCount }, async () => {
+    while (nextIndex < items.length) {
+      const currentIndex = nextIndex;
+      nextIndex += 1;
+      results[currentIndex] = await fn(items[currentIndex]);
+    }
+  });
+  await Promise.all(workers);
+  return results;
+}
+
+function tokenRefreshRetryDelayMs(attempt: number): number {
+  if (process.env.NODE_ENV === 'test') return 0;
+  return TOKEN_REFRESH_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1);
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/src/nextgen/nextgen_metadata_refresh.ts
+++ b/src/nextgen/nextgen_metadata_refresh.ts
@@ -2,7 +2,7 @@ import { getDataSource } from '../db';
 import { Logger } from '../logging';
 import { fetchAllNftOwners } from '../nftOwnersLoop/db.nft_owners';
 import { NextGenCollection, NextGenToken } from '../entities/INextGen';
-import { DataSource } from 'typeorm';
+import { DataSource, EntityManager } from 'typeorm';
 import * as nextgenDb from './nextgen.db';
 import { NEXTGEN_CORE_CONTRACT, getNextgenNetwork } from './nextgen_constants';
 import * as nextgenCoreEvents from './nextgen_core_events';
@@ -18,8 +18,12 @@ const MAX_TRANSIENT_FAILURES_TO_SKIP = 5;
 const MAX_TRANSIENT_FAILURE_RATIO_TO_SKIP = 0.01;
 
 type TokenRefreshSuccess = {
+  collection: NextGenCollection;
+  metadata: nextgenCoreEvents.NextGenTokenMetadata;
   metadataLink: string;
+  owner: string;
   success: true;
+  token: NextGenToken;
   tokenId: number;
 };
 
@@ -32,6 +36,11 @@ type TokenRefreshFailure = {
 };
 
 type TokenRefreshResult = TokenRefreshSuccess | TokenRefreshFailure;
+
+type CollectionRefreshPlan = {
+  collection: NextGenCollection;
+  tokens: TokenRefreshSuccess[];
+};
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
@@ -51,29 +60,49 @@ export async function refreshNextgenMetadata() {
     owners.map((owner) => [Number(owner.token_id), owner.wallet.toLowerCase()])
   );
 
+  const refreshPlans: CollectionRefreshPlan[] = [];
+  const transientFailures: TokenRefreshFailure[] = [];
+  let totalTokenCount = 0;
+
   for (const collection of collections) {
     logger.info(`[PROCESSING COLLECTION ${collection.id}]`);
     const collectionTokens = await nextgenDb.fetchNextGenTokensForCollection(
       dataSource.manager,
       collection
     );
+    totalTokenCount += collectionTokens.length;
     const tokenRefreshResults = await mapWithConcurrency(
       collectionTokens,
       TOKEN_REFRESH_CONCURRENCY,
-      async (token) =>
-        refreshToken(dataSource, collection, token, ownerByTokenId)
+      async (token) => fetchTokenMetadata(collection, token, ownerByTokenId)
     );
 
-    handleRefreshFailures(collection, tokenRefreshResults);
+    const failures = tokenRefreshResults.filter(
+      (result): result is TokenRefreshFailure => !result.success
+    );
+    const permanentFailure = failures.find((failure) => !failure.retryable);
+    if (permanentFailure) {
+      throw refreshFailureError(
+        collection,
+        failures,
+        tokenRefreshResults.length
+      );
+    }
+
+    transientFailures.push(...failures);
+    refreshPlans.push({
+      collection,
+      tokens: tokenRefreshResults.filter(
+        (result): result is TokenRefreshSuccess => result.success
+      )
+    });
   }
 
-  await dataSource.transaction(async (entityManager) => {
-    await nextgenTokens.refreshNextgenTokens(entityManager);
-  });
+  handleTransientFailures(transientFailures, totalTokenCount);
+  await runRefreshTransactionWithDbRetries(dataSource, refreshPlans);
 }
 
-async function refreshToken(
-  dataSource: DataSource,
+async function fetchTokenMetadata(
   collection: NextGenCollection,
   token: NextGenToken,
   ownerByTokenId: Map<number, string>
@@ -81,10 +110,17 @@ async function refreshToken(
   const metadataLink = `${collection.base_uri}${token.id}`;
   const owner = ownerByTokenId.get(Number(token.id)) ?? token.owner;
   try {
-    await refreshTokenWithDbRetries(dataSource, collection, token, owner);
+    const metadata = await nextgenCoreEvents.fetchNextGenTokenMetadata(
+      collection,
+      token.id
+    );
     return {
+      collection,
+      metadata,
+      metadataLink: metadata.metadataLink,
+      owner,
       tokenId: token.id,
-      metadataLink,
+      token,
       success: true
     };
   } catch (error: unknown) {
@@ -102,27 +138,14 @@ async function refreshToken(
   }
 }
 
-async function refreshTokenWithDbRetries(
+async function runRefreshTransactionWithDbRetries(
   dataSource: DataSource,
-  collection: NextGenCollection,
-  token: NextGenToken,
-  owner: string
+  refreshPlans: CollectionRefreshPlan[]
 ): Promise<void> {
   for (let attempt = 1; attempt <= TOKEN_REFRESH_DB_ATTEMPTS; attempt++) {
     try {
       await dataSource.transaction(async (entityManager) => {
-        await nextgenCoreEvents.upsertToken(
-          entityManager,
-          collection,
-          token.id,
-          token.normalised_id,
-          owner,
-          token.mint_date,
-          token.mint_price,
-          token.burnt_date,
-          token.hodl_rate,
-          token.mint_data
-        );
+        await persistRefreshPlans(entityManager, refreshPlans);
       });
       return;
     } catch (error: unknown) {
@@ -130,33 +153,77 @@ async function refreshTokenWithDbRetries(
         throw error;
       }
       logger.warn(
-        `[TOKEN REFRESH RETRY] [COLLECTION ${collection.id}] [TOKEN ID ${token.id}] [ATTEMPT ${attempt}/${TOKEN_REFRESH_DB_ATTEMPTS}] [ERROR ${errorMessage(error)}]`
+        `[REFRESH TRANSACTION RETRY] [ATTEMPT ${attempt}/${TOKEN_REFRESH_DB_ATTEMPTS}] [ERROR ${errorMessage(error)}]`
       );
       await sleep(tokenRefreshRetryDelayMs(attempt));
     }
   }
 }
 
-function handleRefreshFailures(
-  collection: NextGenCollection,
-  results: TokenRefreshResult[]
+async function persistRefreshPlans(
+  entityManager: EntityManager,
+  refreshPlans: CollectionRefreshPlan[]
+): Promise<void> {
+  for (const refreshPlan of refreshPlans) {
+    for (const tokenRefresh of refreshPlan.tokens) {
+      await nextgenCoreEvents.persistTokenWithMetadata(
+        entityManager,
+        tokenRefresh.collection,
+        tokenRefresh.token.id,
+        tokenRefresh.token.normalised_id,
+        tokenRefresh.owner,
+        tokenRefresh.token.mint_date,
+        tokenRefresh.token.mint_price,
+        tokenRefresh.token.burnt_date,
+        tokenRefresh.token.hodl_rate,
+        tokenRefresh.token.mint_data,
+        tokenRefresh.metadata
+      );
+    }
+  }
+  await nextgenTokens.refreshNextgenTokens(entityManager);
+}
+
+function handleTransientFailures(
+  failures: TokenRefreshFailure[],
+  tokenCount: number
 ): void {
-  const failures = results.filter(
-    (result): result is TokenRefreshFailure => !result.success
-  );
   if (failures.length === 0) return;
 
-  if (shouldSkipTransientFailures(failures, results.length)) {
-    logger.warn(
-      `[COLLECTION ${collection.id}] Skipping ${failures.length}/${results.length} transient token refresh failures`
+  if (shouldSkipTransientFailures(failures, tokenCount)) {
+    const skippedTokens = failures
+      .slice(0, 20)
+      .map((failure) => `${failure.tokenId}:${failure.metadataLink}`)
+      .join(',');
+    logger.error(
+      `[SKIPPING TRANSIENT TOKEN REFRESH FAILURES] [COUNT ${failures.length}/${tokenCount}] [TOKENS ${skippedTokens}]`
     );
     return;
   }
 
+  throw refreshFailureErrorForFailures(failures, tokenCount);
+}
+
+function refreshFailureError(
+  collection: NextGenCollection,
+  failures: TokenRefreshFailure[],
+  tokenCount: number
+): Error {
   const firstFailure =
     failures.find((failure) => !failure.retryable) ?? failures[0];
-  throw new Error(
-    `[COLLECTION ${collection.id}] Failed refreshing ${failures.length}/${results.length} tokens. First failure token ${firstFailure.tokenId} (${firstFailure.metadataLink}): ${firstFailure.error}`
+  return new Error(
+    `[COLLECTION ${collection.id}] Failed refreshing ${failures.length}/${tokenCount} tokens. First failure token ${firstFailure.tokenId} (${firstFailure.metadataLink}): ${firstFailure.error}`
+  );
+}
+
+function refreshFailureErrorForFailures(
+  failures: TokenRefreshFailure[],
+  tokenCount: number
+): Error {
+  const firstFailure =
+    failures.find((failure) => !failure.retryable) ?? failures[0];
+  return new Error(
+    `Failed refreshing ${failures.length}/${tokenCount} tokens. First failure token ${firstFailure.tokenId} (${firstFailure.metadataLink}): ${firstFailure.error}`
   );
 }
 
@@ -214,7 +281,6 @@ async function mapWithConcurrency<T, R>(
 }
 
 function tokenRefreshRetryDelayMs(attempt: number): number {
-  if (process.env.NODE_ENV === 'test') return 0;
   return TOKEN_REFRESH_RETRY_BASE_DELAY_MS * 2 ** (attempt - 1);
 }
 

--- a/src/nextgen/nextgen_metadata_refresh.ts
+++ b/src/nextgen/nextgen_metadata_refresh.ts
@@ -83,9 +83,9 @@ export async function refreshNextgenMetadata() {
     const permanentFailure = failures.find((failure) => !failure.retryable);
     if (permanentFailure) {
       throw refreshFailureError(
-        collection,
         failures,
-        tokenRefreshResults.length
+        tokenRefreshResults.length,
+        collection
       );
     }
 
@@ -201,29 +201,19 @@ function handleTransientFailures(
     return;
   }
 
-  throw refreshFailureErrorForFailures(failures, tokenCount);
+  throw refreshFailureError(failures, tokenCount);
 }
 
 function refreshFailureError(
-  collection: NextGenCollection,
   failures: TokenRefreshFailure[],
-  tokenCount: number
+  tokenCount: number,
+  collection?: NextGenCollection
 ): Error {
   const firstFailure =
     failures.find((failure) => !failure.retryable) ?? failures[0];
+  const collectionPrefix = collection ? `[COLLECTION ${collection.id}] ` : '';
   return new Error(
-    `[COLLECTION ${collection.id}] Failed refreshing ${failures.length}/${tokenCount} tokens. First failure token ${firstFailure.tokenId} (${firstFailure.metadataLink}): ${firstFailure.error}`
-  );
-}
-
-function refreshFailureErrorForFailures(
-  failures: TokenRefreshFailure[],
-  tokenCount: number
-): Error {
-  const firstFailure =
-    failures.find((failure) => !failure.retryable) ?? failures[0];
-  return new Error(
-    `Failed refreshing ${failures.length}/${tokenCount} tokens. First failure token ${firstFailure.tokenId} (${firstFailure.metadataLink}): ${firstFailure.error}`
+    `${collectionPrefix}Failed refreshing ${failures.length}/${tokenCount} tokens. First failure token ${firstFailure.tokenId} (${firstFailure.metadataLink}): ${firstFailure.error}`
   );
 }
 
@@ -244,6 +234,12 @@ function isTransientTokenFailure(error: unknown): boolean {
 }
 
 function isRetryableDbError(error: unknown): boolean {
+  if (
+    error == null ||
+    (typeof error !== 'object' && typeof error !== 'function')
+  ) {
+    return false;
+  }
   const dbError = error as {
     code?: unknown;
     errno?: unknown;


### PR DESCRIPTION
## Issue

Sentry `SEIZE-BACKEND-VX` shows `nextgenMetadataLoop` failing when a tiny number of NextGen token metadata refreshes fail out of a 1000-token batch. Recent events include transient `fetch failed` metadata fetches and `ER_LOCK_DEADLOCK` DB write failures.

## Fix

- Add retry/backoff and retryability classification to NextGen metadata fetches.
- Bound metadata refresh concurrency to 20 token workers instead of refreshing an entire collection at once.
- Move token refresh writes to per-token transactions and retry DB deadlocks/lock waits before counting a token as failed.
- Skip only tiny exhausted transient failures (up to 5 and up to 1% of a collection) so stale tokens can retry on the next loop run.
- Keep permanent metadata failures, such as invalid payloads or invalid names, fatal.

## Validation

- `npm test -- src/nextgen/nextgen_metadata_refresh.test.ts src/nextgen/nextgen-metadata.test.ts`
- `npm run lint`
- `npm run build`

## Risk / Deploy

No schema, API, or frontend changes. Deploy only the backend `nextgenMetadataLoop` lambda.

Deployment order:
1. `nextgenMetadataLoop`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved NextGen token metadata refresh with bounded concurrent fetching, consolidated refresh planning, and a persistence flow that reuses fetched metadata.
  * Added targeted retry behavior for metadata fetches with exponential backoff on retryable failures.

* **Bug Fixes**
  * Temporary metadata failures are now handled more reliably, including smarter transient-skip logic and immediate stop on permanent invalid payloads.
  * Refresh transactions now better tolerate retryable database deadlocks with backoff.

* **Tests**
  * Expanded refresh and metadata fetch unit coverage, including retry, transient/permanent failure handling, and concurrency limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->