### PR TITLE
Allow GIPHY chat GIF links

### DIFF
--- a/src/drops/create-or-update-drop-use-case.test.ts
+++ b/src/drops/create-or-update-drop-use-case.test.ts
@@ -600,7 +600,7 @@ describe('CreateOrUpdateDropUseCase', () => {
     ).not.toThrow();
   });
 
-  it('allows Tenor media links when chat links are disabled', () => {
+  it('allows GIF provider media links when chat links are disabled', () => {
     const useCase = createUseCaseWithMocks();
 
     expect(() =>
@@ -619,15 +619,38 @@ describe('CreateOrUpdateDropUseCase', () => {
         groupIdsUserIsEligibleFor: []
       })
     ).not.toThrow();
+
+    expect(() =>
+      (useCase as any).verifyChatLinksAreAllowed({
+        isDescriptionDrop: false,
+        wave: createSlowModeWave({ chat_links_disabled: true }),
+        model: createChatDropModel({
+          parts: [
+            {
+              content:
+                'reaction https://media1.giphy.com/media/abc123/giphy.gif',
+              quoted_drop: null,
+              media: []
+            }
+          ]
+        }),
+        groupIdsUserIsEligibleFor: []
+      })
+    ).not.toThrow();
   });
 
-  it('allows only configured Tenor file extensions in chat link allowlist', () => {
+  it('allows only configured GIF provider file extensions in chat link allowlist', () => {
     const useCase = createUseCaseWithMocks();
 
     for (const extension of ['gif', 'mp4', 'jpg', 'webp']) {
       expect(
         (useCase as any).isAllowedChatLink(
           `https://media.tenor.com/abc123/tenor.${extension}?item=1`
+        )
+      ).toBe(true);
+      expect(
+        (useCase as any).isAllowedChatLink(
+          `https://media1.giphy.com/media/abc123/giphy.${extension}?cid=1`
         )
       ).toBe(true);
     }
@@ -637,9 +660,19 @@ describe('CreateOrUpdateDropUseCase', () => {
           `https://media.tenor.com/abc123/tenor.${extension}`
         )
       ).toBe(false);
+      expect(
+        (useCase as any).isAllowedChatLink(
+          `https://media.giphy.com/media/abc123/giphy.${extension}`
+        )
+      ).toBe(false);
     }
     expect(
       (useCase as any).isAllowedChatLink('https://media.tenor.com/abc123/tenor')
+    ).toBe(false);
+    expect(
+      (useCase as any).isAllowedChatLink(
+        'https://media.giphy.com/media/abc/giphy'
+      )
     ).toBe(false);
   });
 
@@ -770,7 +803,7 @@ describe('CreateOrUpdateDropUseCase', () => {
     expect(wavesApiDb.insertMissingWaveReaderMetrics).not.toHaveBeenCalled();
   });
 
-  it('allows scheme-less Tenor candidates in chat link allowlist', () => {
+  it('allows scheme-less GIF provider candidates in chat link allowlist', () => {
     const useCase = createUseCaseWithMocks();
 
     expect(
@@ -781,12 +814,27 @@ describe('CreateOrUpdateDropUseCase', () => {
     ).toBe(true);
     expect(
       (useCase as any).isAllowedChatLink(
+        'media1.giphy.com/media/abc123/giphy.gif'
+      )
+    ).toBe(true);
+    expect(
+      (useCase as any).isAllowedChatLink(
+        '//media.giphy.com/media/abc123/giphy.gif'
+      )
+    ).toBe(true);
+    expect(
+      (useCase as any).isAllowedChatLink(
         'media.tenor.com.evil/abc123/tenor.gif'
+      )
+    ).toBe(false);
+    expect(
+      (useCase as any).isAllowedChatLink(
+        'media.giphy.com.evil/media/abc123/giphy.gif'
       )
     ).toBe(false);
   });
 
-  it('rejects mixed Tenor and non-Tenor links when chat links are disabled', () => {
+  it('rejects mixed GIF provider and non-provider links when chat links are disabled', () => {
     const useCase = createUseCaseWithMocks();
 
     expect(() =>
@@ -808,7 +856,7 @@ describe('CreateOrUpdateDropUseCase', () => {
     ).toThrow(`Chat drops with links are not allowed in this wave`);
   });
 
-  it('rejects Tenor lookalike links when chat links are disabled', () => {
+  it('rejects GIF provider lookalike links when chat links are disabled', () => {
     const useCase = createUseCaseWithMocks();
 
     expect(() =>
@@ -819,6 +867,24 @@ describe('CreateOrUpdateDropUseCase', () => {
           parts: [
             {
               content: 'fake https://media.tenor.com.evil/abc123/tenor.gif',
+              quoted_drop: null,
+              media: []
+            }
+          ]
+        }),
+        groupIdsUserIsEligibleFor: []
+      })
+    ).toThrow(`Chat drops with links are not allowed in this wave`);
+
+    expect(() =>
+      (useCase as any).verifyChatLinksAreAllowed({
+        isDescriptionDrop: false,
+        wave: createSlowModeWave({ chat_links_disabled: true }),
+        model: createChatDropModel({
+          parts: [
+            {
+              content:
+                'fake https://media.giphy.com.evil/media/abc123/giphy.gif',
               quoted_drop: null,
               media: []
             }

--- a/src/drops/create-or-update-drop.use-case.ts
+++ b/src/drops/create-or-update-drop.use-case.ts
@@ -100,7 +100,8 @@ import { isWaveCreatorOrAdmin } from '@/waves/wave-admin.helpers';
 import { parseDecentralizedMediaRef } from '@/decentralized-media/decentralized-media';
 
 const TENOR_CHAT_LINK_ORIGIN = 'https://media.tenor.com';
-const ALLOWED_TENOR_CHAT_LINK_EXTENSION_REGEX = /\.(?:gif|mp4|jpg|webp)$/i;
+const GIPHY_CHAT_LINK_HOST_REGEX = /^media\d*\.giphy\.com$/;
+const ALLOWED_GIF_CHAT_LINK_EXTENSION_REGEX = /\.(?:gif|mp4|jpg|webp)$/i;
 const ALL_GROUP_MENTION_REGEX = /(^|[^a-z0-9_@])@all(?![a-z0-9_@])/i;
 
 export function normalizeDropGroupMentions({
@@ -818,13 +819,22 @@ export class CreateOrUpdateDropUseCase {
       if (url.origin === CLOUDFRONT_LINK) {
         return true;
       }
-      return (
-        url.origin === TENOR_CHAT_LINK_ORIGIN &&
-        ALLOWED_TENOR_CHAT_LINK_EXTENSION_REGEX.test(url.pathname)
-      );
+      return this.isAllowedGifProviderChatLink(url);
     } catch {
       return false;
     }
+  }
+
+  private isAllowedGifProviderChatLink(url: URL): boolean {
+    const hostname = url.hostname.toLowerCase();
+    const isAllowedGifProvider =
+      url.origin === TENOR_CHAT_LINK_ORIGIN ||
+      GIPHY_CHAT_LINK_HOST_REGEX.test(hostname);
+
+    return (
+      isAllowedGifProvider &&
+      ALLOWED_GIF_CHAT_LINK_EXTENSION_REGEX.test(url.pathname)
+    );
   }
 
   private normalizeChatLinkCandidate(candidate: string): string {


### PR DESCRIPTION
## Summary
- Add GIPHY media hosts to the chat-link allowlist for waves with chat links disabled.
- Preserve legacy Tenor media URL handling so old Tenor GIF drops continue to work.
- Cover GIPHY extensions, scheme-less candidates, and lookalike host rejection in the drop use-case tests.