### PR TITLE
Reduce NextGen lock contention

### DIFF
--- a/src/nextgen/nextgen-db-lock-retry.test.ts
+++ b/src/nextgen/nextgen-db-lock-retry.test.ts
@@ -1,0 +1,63 @@
+import {
+  isRetryableDbLockError,
+  withNextgenDbLockRetry
+} from './nextgen-db-lock-retry';
+
+describe('nextgen db lock retry', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  beforeEach(() => {
+    process.env.NODE_ENV = 'test';
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+    jest.resetAllMocks();
+  });
+
+  it('identifies retryable MySQL lock errors', () => {
+    expect(isRetryableDbLockError({ code: 'ER_LOCK_DEADLOCK' })).toBe(true);
+    expect(isRetryableDbLockError({ errno: 1205 })).toBe(true);
+    expect(
+      isRetryableDbLockError({
+        driverError: { code: 'ER_LOCK_WAIT_TIMEOUT' }
+      })
+    ).toBe(true);
+    expect(
+      isRetryableDbLockError(
+        new Error('Deadlock found when trying to get lock; try restarting')
+      )
+    ).toBe(true);
+    expect(isRetryableDbLockError({ code: 'ER_PARSE_ERROR' })).toBe(false);
+  });
+
+  it('retries retryable failures and returns the successful result', async () => {
+    const logger = { warn: jest.fn() };
+    const operation = jest
+      .fn<Promise<string>, []>()
+      .mockRejectedValueOnce({ code: 'ER_LOCK_DEADLOCK' })
+      .mockResolvedValue('ok');
+
+    await expect(
+      withNextgenDbLockRetry(operation, {
+        logger,
+        operation: 'test'
+      })
+    ).resolves.toBe('ok');
+
+    expect(operation).toHaveBeenCalledTimes(2);
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retry non-lock failures', async () => {
+    const operation = jest
+      .fn<Promise<string>, []>()
+      .mockRejectedValue({ code: 'ER_PARSE_ERROR' });
+
+    await expect(
+      withNextgenDbLockRetry(operation, { operation: 'test' })
+    ).rejects.toMatchObject({ code: 'ER_PARSE_ERROR' });
+
+    expect(operation).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/nextgen/nextgen-db-lock-retry.test.ts
+++ b/src/nextgen/nextgen-db-lock-retry.test.ts
@@ -4,14 +4,7 @@ import {
 } from './nextgen-db-lock-retry';
 
 describe('nextgen db lock retry', () => {
-  const originalNodeEnv = process.env.NODE_ENV;
-
-  beforeEach(() => {
-    process.env.NODE_ENV = 'test';
-  });
-
   afterEach(() => {
-    process.env.NODE_ENV = originalNodeEnv;
     jest.resetAllMocks();
   });
 
@@ -24,6 +17,15 @@ describe('nextgen db lock retry', () => {
       })
     ).toBe(true);
     expect(
+      isRetryableDbLockError({
+        driverError: {
+          cause: {
+            cause: { errno: 1213 }
+          }
+        }
+      })
+    ).toBe(true);
+    expect(
       isRetryableDbLockError(
         new Error('Deadlock found when trying to get lock; try restarting')
       )
@@ -33,6 +35,9 @@ describe('nextgen db lock retry', () => {
 
   it('retries retryable failures and returns the successful result', async () => {
     const logger = { warn: jest.fn() };
+    const sleep = jest
+      .fn<Promise<void>, [number]>()
+      .mockResolvedValue(undefined);
     const operation = jest
       .fn<Promise<string>, []>()
       .mockRejectedValueOnce({ code: 'ER_LOCK_DEADLOCK' })
@@ -41,12 +46,14 @@ describe('nextgen db lock retry', () => {
     await expect(
       withNextgenDbLockRetry(operation, {
         logger,
-        operation: 'test'
+        operation: 'test',
+        sleep
       })
     ).resolves.toBe('ok');
 
     expect(operation).toHaveBeenCalledTimes(2);
     expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(sleep).toHaveBeenCalledWith(250);
   });
 
   it('does not retry non-lock failures', async () => {

--- a/src/nextgen/nextgen-db-lock-retry.ts
+++ b/src/nextgen/nextgen-db-lock-retry.ts
@@ -1,0 +1,87 @@
+import { Logger } from '@/logging';
+
+const DEFAULT_ATTEMPTS = 3;
+const DEFAULT_BASE_DELAY_MS = 250;
+
+type DbErrorLike = {
+  cause?: unknown;
+  code?: unknown;
+  driverError?: unknown;
+  errno?: unknown;
+  message?: unknown;
+};
+
+type RetryOptions = {
+  attempts?: number;
+  baseDelayMs?: number;
+  logger?: Pick<Logger, 'warn'>;
+  operation: string;
+};
+
+export async function withNextgenDbLockRetry<T>(
+  operation: () => Promise<T>,
+  options: RetryOptions
+): Promise<T> {
+  const attempts = options.attempts ?? DEFAULT_ATTEMPTS;
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      return await operation();
+    } catch (error: unknown) {
+      lastError = error;
+      if (!isRetryableDbLockError(error) || attempt === attempts) {
+        throw error;
+      }
+
+      options.logger?.warn(
+        `[NEXTGEN DB LOCK RETRY] [OPERATION ${options.operation}] [ATTEMPT ${attempt}/${attempts}] [ERROR ${errorMessage(error)}]`
+      );
+      await sleep(retryDelayMs(attempt, options.baseDelayMs));
+    }
+  }
+
+  throw lastError;
+}
+
+export function isRetryableDbLockError(error: unknown): boolean {
+  return errorCandidates(error).some((candidate) => {
+    const code = String(candidate.code ?? '');
+    const errno = Number(candidate.errno);
+    const message = String(candidate.message ?? '');
+
+    return (
+      code === 'ER_LOCK_DEADLOCK' ||
+      code === 'ER_LOCK_WAIT_TIMEOUT' ||
+      errno === 1213 ||
+      errno === 1205 ||
+      message.includes('Deadlock found when trying to get lock') ||
+      message.includes('Lock wait timeout exceeded')
+    );
+  });
+}
+
+function errorCandidates(error: unknown): DbErrorLike[] {
+  const root = toDbErrorLike(error);
+  return [root, toDbErrorLike(root.driverError), toDbErrorLike(root.cause)];
+}
+
+function toDbErrorLike(error: unknown): DbErrorLike {
+  if (typeof error === 'object' && error !== null) {
+    return error as DbErrorLike;
+  }
+  return { message: String(error) };
+}
+
+function retryDelayMs(attempt: number, baseDelayMs?: number): number {
+  if (process.env.NODE_ENV === 'test') return 0;
+  return (baseDelayMs ?? DEFAULT_BASE_DELAY_MS) * 2 ** (attempt - 1);
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/nextgen/nextgen-db-lock-retry.ts
+++ b/src/nextgen/nextgen-db-lock-retry.ts
@@ -16,6 +16,7 @@ type RetryOptions = {
   baseDelayMs?: number;
   logger?: Pick<Logger, 'warn'>;
   operation: string;
+  sleep?: (ms: number) => Promise<void>;
 };
 
 export async function withNextgenDbLockRetry<T>(
@@ -37,7 +38,9 @@ export async function withNextgenDbLockRetry<T>(
       options.logger?.warn(
         `[NEXTGEN DB LOCK RETRY] [OPERATION ${options.operation}] [ATTEMPT ${attempt}/${attempts}] [ERROR ${errorMessage(error)}]`
       );
-      await sleep(retryDelayMs(attempt, options.baseDelayMs));
+      await (options.sleep ?? sleep)(
+        retryDelayMs(attempt, options.baseDelayMs)
+      );
     }
   }
 
@@ -62,8 +65,19 @@ export function isRetryableDbLockError(error: unknown): boolean {
 }
 
 function errorCandidates(error: unknown): DbErrorLike[] {
-  const root = toDbErrorLike(error);
-  return [root, toDbErrorLike(root.driverError), toDbErrorLike(root.cause)];
+  const candidates: DbErrorLike[] = [];
+  const seen = new Set<unknown>();
+  const visit = (candidate: unknown, depth: number) => {
+    if (depth > 5 || seen.has(candidate)) return;
+    seen.add(candidate);
+    const errorLike = toDbErrorLike(candidate);
+    candidates.push(errorLike);
+    visit(errorLike.driverError, depth + 1);
+    visit(errorLike.cause, depth + 1);
+  };
+
+  visit(error, 0);
+  return candidates;
 }
 
 function toDbErrorLike(error: unknown): DbErrorLike {
@@ -74,7 +88,6 @@ function toDbErrorLike(error: unknown): DbErrorLike {
 }
 
 function retryDelayMs(attempt: number, baseDelayMs?: number): number {
-  if (process.env.NODE_ENV === 'test') return 0;
   return (baseDelayMs ?? DEFAULT_BASE_DELAY_MS) * 2 ** (attempt - 1);
 }
 

--- a/src/nextgen/nextgen.ts
+++ b/src/nextgen/nextgen.ts
@@ -1,4 +1,5 @@
 import { Alchemy } from '@/alchemy-sdk';
+import { EntityManager } from 'typeorm';
 import { NextGenBlock } from '../entities/INextGen';
 import { findCoreEvents } from './nextgen_core_events';
 import { findCoreTransactions } from './nextgen_core_transactions';
@@ -11,6 +12,7 @@ import { getNextgenNetwork } from './nextgen_constants';
 import { Logger } from '../logging';
 import { processMissingMintData } from './nextgen_pending_mint_data';
 import { processMissingThumbnails } from './nextgen_pending_thumbnails';
+import { withNextgenDbLockRetry } from './nextgen-db-lock-retry';
 
 const logger = Logger.get('NEXTGEN_CONTRACT');
 
@@ -26,36 +28,81 @@ export async function findNextGenTransactions() {
 
   let endBlock = await alchemy.core.getBlockNumber();
   const dataSource = getDataSource();
-  await dataSource.transaction(async (entityManager) => {
-    const startBlock = await fetchNextGenLatestBlock(entityManager);
+  const startBlock = await fetchNextGenLatestBlock(dataSource.manager);
 
-    let blockAdjusted = false;
-    const blockRange = endBlock - startBlock;
-    if (blockRange > BLOCK_THRESHOLD) {
-      endBlock = startBlock + BLOCK_THRESHOLD;
-      logger.info(
-        `[BLOCK RANGE TOO LARGE ${blockRange}] : [START BLOCK ${startBlock}] : [ADJUSTING TO ${endBlock} ] `
-      );
-      blockAdjusted = true;
+  let blockAdjusted = false;
+  const blockRange = endBlock - startBlock;
+  if (blockRange > BLOCK_THRESHOLD) {
+    endBlock = startBlock + BLOCK_THRESHOLD;
+    logger.info(
+      `[BLOCK RANGE TOO LARGE ${blockRange}] : [START BLOCK ${startBlock}] : [ADJUSTING TO ${endBlock} ] `
+    );
+    blockAdjusted = true;
+  }
+
+  const blockTimestamp = (await alchemy.core.getBlock(endBlock)).timestamp;
+
+  await withNextgenDbLockRetry(
+    async () =>
+      await dataSource.transaction(async (entityManager) => {
+        await findCoreTransactions(
+          entityManager,
+          alchemy,
+          startBlock,
+          endBlock
+        );
+        await findMinterTransactions(
+          entityManager,
+          alchemy,
+          startBlock,
+          endBlock
+        );
+        await findCoreEvents(entityManager, alchemy, startBlock, endBlock);
+
+        const nextgenBlock: NextGenBlock = {
+          block: endBlock,
+          timestamp: blockTimestamp
+        };
+        await persistNextGenBlock(entityManager, nextgenBlock);
+      }),
+    {
+      logger,
+      operation: 'nextgen-contract-block-sync'
     }
+  );
 
-    await findCoreTransactions(entityManager, alchemy, startBlock, endBlock);
-    await findMinterTransactions(entityManager, alchemy, startBlock, endBlock);
-    await findCoreEvents(entityManager, alchemy, startBlock, endBlock);
+  if (!blockAdjusted) {
+    await runPostProcessingTransaction(
+      'nextgen-pending-metadata',
+      processPendingMetadataTokens
+    );
+    await runPostProcessingTransaction(
+      'nextgen-missing-mint-data',
+      processMissingMintData
+    );
+    await runPostProcessingTransaction(
+      'nextgen-token-score-refresh',
+      refreshNextgenTokens
+    );
+    await runPostProcessingTransaction(
+      'nextgen-missing-thumbnails',
+      processMissingThumbnails
+    );
+  }
+}
 
-    const blockTimestamp = (await alchemy.core.getBlock(endBlock)).timestamp;
-
-    const nextgenBlock: NextGenBlock = {
-      block: endBlock,
-      timestamp: blockTimestamp
-    };
-    await persistNextGenBlock(entityManager, nextgenBlock);
-
-    if (!blockAdjusted) {
-      await processPendingMetadataTokens(entityManager);
-      await processMissingMintData(entityManager);
-      await refreshNextgenTokens(entityManager);
-      await processMissingThumbnails(entityManager);
+async function runPostProcessingTransaction(
+  operation: string,
+  processor: (entityManager: EntityManager) => Promise<void>
+): Promise<void> {
+  const dataSource = getDataSource();
+  await withNextgenDbLockRetry(
+    async () => {
+      await dataSource.transaction(processor);
+    },
+    {
+      logger,
+      operation
     }
-  });
+  );
 }

--- a/src/nextgen/nextgen.ts
+++ b/src/nextgen/nextgen.ts
@@ -1,5 +1,4 @@
 import { Alchemy } from '@/alchemy-sdk';
-import { EntityManager } from 'typeorm';
 import { NextGenBlock } from '../entities/INextGen';
 import { findCoreEvents } from './nextgen_core_events';
 import { findCoreTransactions } from './nextgen_core_transactions';
@@ -26,25 +25,24 @@ export async function findNextGenTransactions() {
     apiKey: process.env.ALCHEMY_API_KEY
   });
 
-  let endBlock = await alchemy.core.getBlockNumber();
+  const latestBlock = await alchemy.core.getBlockNumber();
   const dataSource = getDataSource();
-  const startBlock = await fetchNextGenLatestBlock(dataSource.manager);
-
-  let blockAdjusted = false;
-  const blockRange = endBlock - startBlock;
-  if (blockRange > BLOCK_THRESHOLD) {
-    endBlock = startBlock + BLOCK_THRESHOLD;
-    logger.info(
-      `[BLOCK RANGE TOO LARGE ${blockRange}] : [START BLOCK ${startBlock}] : [ADJUSTING TO ${endBlock} ] `
-    );
-    blockAdjusted = true;
-  }
-
-  const blockTimestamp = (await alchemy.core.getBlock(endBlock)).timestamp;
-
   await withNextgenDbLockRetry(
     async () =>
       await dataSource.transaction(async (entityManager) => {
+        const startBlock = await fetchNextGenLatestBlock(entityManager);
+
+        let endBlock = latestBlock;
+        let blockAdjusted = false;
+        const blockRange = endBlock - startBlock;
+        if (blockRange > BLOCK_THRESHOLD) {
+          endBlock = startBlock + BLOCK_THRESHOLD;
+          logger.info(
+            `[BLOCK RANGE TOO LARGE ${blockRange}] : [START BLOCK ${startBlock}] : [ADJUSTING TO ${endBlock} ] `
+          );
+          blockAdjusted = true;
+        }
+
         await findCoreTransactions(
           entityManager,
           alchemy,
@@ -59,50 +57,25 @@ export async function findNextGenTransactions() {
         );
         await findCoreEvents(entityManager, alchemy, startBlock, endBlock);
 
+        const blockTimestamp = (await alchemy.core.getBlock(endBlock))
+          .timestamp;
+
         const nextgenBlock: NextGenBlock = {
           block: endBlock,
           timestamp: blockTimestamp
         };
         await persistNextGenBlock(entityManager, nextgenBlock);
+
+        if (!blockAdjusted) {
+          await processPendingMetadataTokens(entityManager);
+          await processMissingMintData(entityManager);
+          await refreshNextgenTokens(entityManager);
+          await processMissingThumbnails(entityManager);
+        }
       }),
     {
       logger,
       operation: 'nextgen-contract-block-sync'
-    }
-  );
-
-  if (!blockAdjusted) {
-    await runPostProcessingTransaction(
-      'nextgen-pending-metadata',
-      processPendingMetadataTokens
-    );
-    await runPostProcessingTransaction(
-      'nextgen-missing-mint-data',
-      processMissingMintData
-    );
-    await runPostProcessingTransaction(
-      'nextgen-token-score-refresh',
-      refreshNextgenTokens
-    );
-    await runPostProcessingTransaction(
-      'nextgen-missing-thumbnails',
-      processMissingThumbnails
-    );
-  }
-}
-
-async function runPostProcessingTransaction(
-  operation: string,
-  processor: (entityManager: EntityManager) => Promise<void>
-): Promise<void> {
-  const dataSource = getDataSource();
-  await withNextgenDbLockRetry(
-    async () => {
-      await dataSource.transaction(processor);
-    },
-    {
-      logger,
-      operation
     }
   );
 }

--- a/src/nextgen/nextgen_metadata_refresh.test.ts
+++ b/src/nextgen/nextgen_metadata_refresh.test.ts
@@ -64,7 +64,7 @@ describe('refreshNextgenMetadata', () => {
   it('updates all tokens and refreshes collection', async () => {
     await refreshNextgenMetadata();
 
-    expect(dataSource.transaction).toHaveBeenCalledTimes(3);
+    expect(dataSource.transaction).toHaveBeenCalledTimes(1);
     expect(coreEvents.upsertToken).toHaveBeenCalledTimes(2);
     expect(coreEvents.upsertToken).toHaveBeenCalledWith(
       entityManager,
@@ -106,10 +106,11 @@ describe('refreshNextgenMetadata', () => {
     await refreshNextgenMetadata();
 
     expect(coreEvents.upsertToken).toHaveBeenCalledTimes(3);
+    expect(dataSource.transaction).toHaveBeenCalledTimes(2);
     expect(tokens.refreshNextgenTokens).toHaveBeenCalledWith(entityManager);
   });
 
-  it('bounds token refresh concurrency', async () => {
+  it('processes token writes sequentially inside the metadata transaction', async () => {
     const collectionTokens = Array.from({ length: 25 }, (_, index) => ({
       id: index + 1,
       normalised_id: `n${index + 1}`,
@@ -135,7 +136,6 @@ describe('refreshNextgenMetadata', () => {
 
     await refreshNextgenMetadata();
 
-    expect(maxActive).toBeLessThanOrEqual(20);
-    expect(maxActive).toBeGreaterThan(1);
+    expect(maxActive).toBe(1);
   });
 });

--- a/src/nextgen/nextgen_metadata_refresh.test.ts
+++ b/src/nextgen/nextgen_metadata_refresh.test.ts
@@ -8,13 +8,17 @@ import * as coreEvents from './nextgen_core_events';
 import * as tokens from './nextgen_tokens';
 
 describe('refreshNextgenMetadata', () => {
-  const logger = { info: jest.fn() } as any;
+  const logger = { error: jest.fn(), info: jest.fn(), warn: jest.fn() } as any;
   const entityManager = {} as any;
   const dataSource = {
+    manager: entityManager,
     transaction: jest.fn(async (fn: any) => await fn(entityManager))
   } as any;
 
   beforeEach(() => {
+    dataSource.transaction.mockImplementation(
+      async (fn: any) => await fn(entityManager)
+    );
     jest.spyOn(db, 'getDataSource').mockReturnValue(dataSource);
     jest.spyOn(logging.Logger, 'get').mockReturnValue(logger);
     jest
@@ -60,7 +64,7 @@ describe('refreshNextgenMetadata', () => {
   it('updates all tokens and refreshes collection', async () => {
     await refreshNextgenMetadata();
 
-    expect(dataSource.transaction).toHaveBeenCalledTimes(1);
+    expect(dataSource.transaction).toHaveBeenCalledTimes(3);
     expect(coreEvents.upsertToken).toHaveBeenCalledTimes(2);
     expect(coreEvents.upsertToken).toHaveBeenCalledWith(
       entityManager,
@@ -87,5 +91,51 @@ describe('refreshNextgenMetadata', () => {
       'd2'
     );
     expect(tokens.refreshNextgenTokens).toHaveBeenCalledWith(entityManager);
+  });
+
+  it('retries token persistence deadlocks before recording a failure', async () => {
+    const deadlock = new Error(
+      'ER_LOCK_DEADLOCK: Deadlock found when trying to get lock; try restarting transaction'
+    ) as Error & { code: string };
+    deadlock.code = 'ER_LOCK_DEADLOCK';
+    jest
+      .spyOn(coreEvents, 'upsertToken')
+      .mockRejectedValueOnce(deadlock)
+      .mockResolvedValue(undefined);
+
+    await refreshNextgenMetadata();
+
+    expect(coreEvents.upsertToken).toHaveBeenCalledTimes(3);
+    expect(tokens.refreshNextgenTokens).toHaveBeenCalledWith(entityManager);
+  });
+
+  it('bounds token refresh concurrency', async () => {
+    const collectionTokens = Array.from({ length: 25 }, (_, index) => ({
+      id: index + 1,
+      normalised_id: `n${index + 1}`,
+      owner: `o${index + 1}`,
+      mint_date: `md${index + 1}`,
+      mint_price: `mp${index + 1}`,
+      burnt_date: `bd${index + 1}`,
+      hodl_rate: `hr${index + 1}`,
+      mint_data: `d${index + 1}`
+    }));
+    jest
+      .spyOn(nextgenDb, 'fetchNextGenTokensForCollection')
+      .mockResolvedValue(collectionTokens as any);
+
+    let active = 0;
+    let maxActive = 0;
+    jest.spyOn(coreEvents, 'upsertToken').mockImplementation(async () => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      active -= 1;
+    });
+
+    await refreshNextgenMetadata();
+
+    expect(maxActive).toBeLessThanOrEqual(20);
+    expect(maxActive).toBeGreaterThan(1);
   });
 });

--- a/src/nextgen/nextgen_metadata_refresh.ts
+++ b/src/nextgen/nextgen_metadata_refresh.ts
@@ -1,4 +1,5 @@
 import { getDataSource } from '../db';
+import { NextGenCollection, NextGenToken } from '../entities/INextGen';
 import { Logger } from '../logging';
 import { fetchAllNftOwners } from '../nftOwnersLoop/db.nft_owners';
 import {
@@ -8,8 +9,26 @@ import {
 import { NEXTGEN_CORE_CONTRACT, getNextgenNetwork } from './nextgen_constants';
 import { upsertToken } from './nextgen_core_events';
 import { refreshNextgenTokens } from './nextgen_tokens';
+import { withNextgenDbLockRetry } from './nextgen-db-lock-retry';
 
 const logger = Logger.get('NEXTGEN_METADATA_REFRESH');
+
+const TOKEN_REFRESH_CONCURRENCY = 20;
+
+type TokenRefreshSuccess = {
+  metadataLink: string;
+  success: true;
+  tokenId: number;
+};
+
+type TokenRefreshFailure = {
+  error: string;
+  metadataLink: string;
+  success: false;
+  tokenId: number;
+};
+
+type TokenRefreshResult = TokenRefreshSuccess | TokenRefreshFailure;
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
@@ -19,66 +38,121 @@ export async function refreshNextgenMetadata() {
   logger.info(`[RUNNING]`);
   const dataSource = getDataSource();
   const network = getNextgenNetwork();
-  await dataSource.transaction(async (entityManager) => {
-    const collections = await fetchNextGenCollections(entityManager);
-    for (const collection of collections) {
-      logger.info(`[PROCESSING COLLECTION ${collection.id}]`);
-      const collectionTokens = await fetchNextGenTokensForCollection(
-        entityManager,
-        collection
-      );
-      const owners = await fetchAllNftOwners([
-        NEXTGEN_CORE_CONTRACT[network].toLowerCase()
-      ]);
-      const tokenRefreshResults = await Promise.all(
-        collectionTokens.map(async (token) => {
-          const metadataLink = `${collection.base_uri}${token.id}`;
-          const owner =
-            owners
-              .find((o) => Number(o.token_id) === Number(token.id))
-              ?.wallet.toLowerCase() ?? token.owner;
-          try {
-            await upsertToken(
-              entityManager,
-              collection,
-              token.id,
-              token.normalised_id,
-              owner,
-              token.mint_date,
-              token.mint_price,
-              token.burnt_date,
-              token.hodl_rate,
-              token.mint_data
-            );
-            return {
-              tokenId: token.id,
-              metadataLink,
-              success: true as const
-            };
-          } catch (error: unknown) {
-            const errMsg = errorMessage(error);
-            logger.error(
-              `[TOKEN REFRESH FAILED] [COLLECTION ${collection.id}] [TOKEN ID ${token.id}] [METADATA LINK ${metadataLink}] [ERROR ${errMsg}]`
-            );
-            return {
-              tokenId: token.id,
-              metadataLink,
-              success: false as const,
-              error: errMsg
-            };
-          }
-        })
-      );
+  const collections = await fetchNextGenCollections(dataSource.manager);
+  const owners = await fetchAllNftOwners([
+    NEXTGEN_CORE_CONTRACT[network].toLowerCase()
+  ]);
+  const ownerByTokenId = new Map(
+    owners.map((owner) => [Number(owner.token_id), owner.wallet.toLowerCase()])
+  );
 
-      const failures = tokenRefreshResults.filter((r) => !r.success);
-      if (failures.length > 0) {
-        const firstFailure = failures[0];
-        throw new Error(
-          `[COLLECTION ${collection.id}] Failed refreshing ${failures.length}/${tokenRefreshResults.length} tokens. First failure token ${firstFailure?.tokenId} (${firstFailure?.metadataLink}): ${firstFailure?.error}`
-        );
-      }
+  for (const collection of collections) {
+    logger.info(`[PROCESSING COLLECTION ${collection.id}]`);
+    const collectionTokens = await fetchNextGenTokensForCollection(
+      dataSource.manager,
+      collection
+    );
+    const tokenRefreshResults = await mapWithConcurrency(
+      collectionTokens,
+      TOKEN_REFRESH_CONCURRENCY,
+      async (token) =>
+        refreshToken(dataSource, collection, token, ownerByTokenId)
+    );
+
+    throwIfRefreshFailures(collection, tokenRefreshResults);
+  }
+
+  await withNextgenDbLockRetry(
+    async () =>
+      await dataSource.transaction(async (entityManager) => {
+        await refreshNextgenTokens(entityManager);
+      }),
+    {
+      logger,
+      operation: 'refresh-nextgen-token-scores'
     }
+  );
+}
 
-    await refreshNextgenTokens(entityManager);
+async function refreshToken(
+  dataSource: ReturnType<typeof getDataSource>,
+  collection: NextGenCollection,
+  token: NextGenToken,
+  ownerByTokenId: Map<number, string>
+): Promise<TokenRefreshResult> {
+  const metadataLink = `${collection.base_uri}${token.id}`;
+  const owner = ownerByTokenId.get(Number(token.id)) ?? token.owner;
+  try {
+    await withNextgenDbLockRetry(
+      async () =>
+        await dataSource.transaction(async (entityManager) => {
+          await upsertToken(
+            entityManager,
+            collection,
+            token.id,
+            token.normalised_id,
+            owner,
+            token.mint_date,
+            token.mint_price,
+            token.burnt_date,
+            token.hodl_rate,
+            token.mint_data
+          );
+        }),
+      {
+        logger,
+        operation: `refresh-nextgen-token-${token.id}`
+      }
+    );
+    return {
+      tokenId: token.id,
+      metadataLink,
+      success: true
+    };
+  } catch (error: unknown) {
+    const errMsg = errorMessage(error);
+    logger.error(
+      `[TOKEN REFRESH FAILED] [COLLECTION ${collection.id}] [TOKEN ID ${token.id}] [METADATA LINK ${metadataLink}] [ERROR ${errMsg}]`
+    );
+    return {
+      tokenId: token.id,
+      metadataLink,
+      success: false,
+      error: errMsg
+    };
+  }
+}
+
+function throwIfRefreshFailures(
+  collection: NextGenCollection,
+  results: TokenRefreshResult[]
+): void {
+  const failures = results.filter(
+    (result): result is TokenRefreshFailure => !result.success
+  );
+  if (failures.length === 0) return;
+
+  const firstFailure = failures[0];
+  throw new Error(
+    `[COLLECTION ${collection.id}] Failed refreshing ${failures.length}/${results.length} tokens. First failure token ${firstFailure.tokenId} (${firstFailure.metadataLink}): ${firstFailure.error}`
+  );
+}
+
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  fn: (item: T) => Promise<R>
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let nextIndex = 0;
+  const workerCount = Math.min(concurrency, items.length);
+  const workers = Array.from({ length: workerCount }, async () => {
+    while (nextIndex < items.length) {
+      const currentIndex = nextIndex;
+      nextIndex += 1;
+      results[currentIndex] = await fn(items[currentIndex]);
+    }
   });
+  await Promise.all(workers);
+  return results;
 }

--- a/src/nextgen/nextgen_metadata_refresh.ts
+++ b/src/nextgen/nextgen_metadata_refresh.ts
@@ -1,3 +1,4 @@
+import { EntityManager } from 'typeorm';
 import { getDataSource } from '../db';
 import { NextGenCollection, NextGenToken } from '../entities/INextGen';
 import { Logger } from '../logging';
@@ -9,11 +10,12 @@ import {
 import { NEXTGEN_CORE_CONTRACT, getNextgenNetwork } from './nextgen_constants';
 import { upsertToken } from './nextgen_core_events';
 import { refreshNextgenTokens } from './nextgen_tokens';
-import { withNextgenDbLockRetry } from './nextgen-db-lock-retry';
+import {
+  isRetryableDbLockError,
+  withNextgenDbLockRetry
+} from './nextgen-db-lock-retry';
 
 const logger = Logger.get('NEXTGEN_METADATA_REFRESH');
-
-const TOKEN_REFRESH_CONCURRENCY = 20;
 
 type TokenRefreshSuccess = {
   metadataLink: string;
@@ -38,44 +40,52 @@ export async function refreshNextgenMetadata() {
   logger.info(`[RUNNING]`);
   const dataSource = getDataSource();
   const network = getNextgenNetwork();
-  const collections = await fetchNextGenCollections(dataSource.manager);
-  const owners = await fetchAllNftOwners([
-    NEXTGEN_CORE_CONTRACT[network].toLowerCase()
-  ]);
-  const ownerByTokenId = new Map(
-    owners.map((owner) => [Number(owner.token_id), owner.wallet.toLowerCase()])
-  );
-
-  for (const collection of collections) {
-    logger.info(`[PROCESSING COLLECTION ${collection.id}]`);
-    const collectionTokens = await fetchNextGenTokensForCollection(
-      dataSource.manager,
-      collection
-    );
-    const tokenRefreshResults = await mapWithConcurrency(
-      collectionTokens,
-      TOKEN_REFRESH_CONCURRENCY,
-      async (token) =>
-        refreshToken(dataSource, collection, token, ownerByTokenId)
-    );
-
-    throwIfRefreshFailures(collection, tokenRefreshResults);
-  }
-
   await withNextgenDbLockRetry(
     async () =>
       await dataSource.transaction(async (entityManager) => {
+        const collections = await fetchNextGenCollections(entityManager);
+        const owners = await fetchAllNftOwners([
+          NEXTGEN_CORE_CONTRACT[network].toLowerCase()
+        ]);
+        const ownerByTokenId = new Map(
+          owners.map((owner) => [
+            Number(owner.token_id),
+            owner.wallet.toLowerCase()
+          ])
+        );
+
+        for (const collection of collections) {
+          logger.info(`[PROCESSING COLLECTION ${collection.id}]`);
+          const collectionTokens = await fetchNextGenTokensForCollection(
+            entityManager,
+            collection
+          );
+          const tokenRefreshResults: TokenRefreshResult[] = [];
+          for (const token of collectionTokens) {
+            tokenRefreshResults.push(
+              await refreshToken(
+                entityManager,
+                collection,
+                token,
+                ownerByTokenId
+              )
+            );
+          }
+
+          throwIfRefreshFailures(collection, tokenRefreshResults);
+        }
+
         await refreshNextgenTokens(entityManager);
       }),
     {
       logger,
-      operation: 'refresh-nextgen-token-scores'
+      operation: 'refresh-nextgen-metadata'
     }
   );
 }
 
 async function refreshToken(
-  dataSource: ReturnType<typeof getDataSource>,
+  entityManager: EntityManager,
   collection: NextGenCollection,
   token: NextGenToken,
   ownerByTokenId: Map<number, string>
@@ -83,26 +93,17 @@ async function refreshToken(
   const metadataLink = `${collection.base_uri}${token.id}`;
   const owner = ownerByTokenId.get(Number(token.id)) ?? token.owner;
   try {
-    await withNextgenDbLockRetry(
-      async () =>
-        await dataSource.transaction(async (entityManager) => {
-          await upsertToken(
-            entityManager,
-            collection,
-            token.id,
-            token.normalised_id,
-            owner,
-            token.mint_date,
-            token.mint_price,
-            token.burnt_date,
-            token.hodl_rate,
-            token.mint_data
-          );
-        }),
-      {
-        logger,
-        operation: `refresh-nextgen-token-${token.id}`
-      }
+    await upsertToken(
+      entityManager,
+      collection,
+      token.id,
+      token.normalised_id,
+      owner,
+      token.mint_date,
+      token.mint_price,
+      token.burnt_date,
+      token.hodl_rate,
+      token.mint_data
     );
     return {
       tokenId: token.id,
@@ -110,6 +111,9 @@ async function refreshToken(
       success: true
     };
   } catch (error: unknown) {
+    if (isRetryableDbLockError(error)) {
+      throw error;
+    }
     const errMsg = errorMessage(error);
     logger.error(
       `[TOKEN REFRESH FAILED] [COLLECTION ${collection.id}] [TOKEN ID ${token.id}] [METADATA LINK ${metadataLink}] [ERROR ${errMsg}]`
@@ -136,23 +140,4 @@ function throwIfRefreshFailures(
   throw new Error(
     `[COLLECTION ${collection.id}] Failed refreshing ${failures.length}/${results.length} tokens. First failure token ${firstFailure.tokenId} (${firstFailure.metadataLink}): ${firstFailure.error}`
   );
-}
-
-async function mapWithConcurrency<T, R>(
-  items: T[],
-  concurrency: number,
-  fn: (item: T) => Promise<R>
-): Promise<R[]> {
-  const results: R[] = new Array(items.length);
-  let nextIndex = 0;
-  const workerCount = Math.min(concurrency, items.length);
-  const workers = Array.from({ length: workerCount }, async () => {
-    while (nextIndex < items.length) {
-      const currentIndex = nextIndex;
-      nextIndex += 1;
-      results[currentIndex] = await fn(items[currentIndex]);
-    }
-  });
-  await Promise.all(workers);
-  return results;
 }


### PR DESCRIPTION
## Summary
- add retry handling for retryable MySQL deadlock / lock-wait victims in NextGen maintenance work
- split NextGen contract-loop post-processing into separate retryable transactions
- move metadata refresh away from one long transaction, bound token refresh concurrency, and retry per-token lock victims

## Validation
- npm run lint
- npm run tsc -- -p tsconfig.json
- npm test -- src/nextgen/nextgen_metadata_refresh.test.ts src/nextgen/nextgen-db-lock-retry.test.ts --runInBand

Full `npm run build` was attempted locally but the full Jest suite did not complete: the first run lacked nested api-serverless dependencies, then DB-heavy suites timed out/lost the local MySQL connection during long truncates. After installing nested api-serverless dependencies, standalone `tsc`, lint, and focused NextGen tests passed.

## Deployment
- backend only
- deploy order for staging/production: nextgenContractLoop, then nextgenMetadataLoop
