### PR TITLE
Avoid DB context in drop video conversion invoker

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -102,9 +102,11 @@ flowchart TD
   end
 
   BackgroundWorkers["background Lambda runtime"] --> LambdaRuntime["doInDbContext runtime"]
+  DropVideoConversionInvokerLoop --> EnvOnlyRuntime["environment-only runtime"]
   LambdaRuntime --> MySQL
   LambdaRuntime --> Redis
   LambdaRuntime --> Ops["Sentry / CloudWatch / Discord"]
+  EnvOnlyRuntime --> Ops
 
   S3Uploader --> S3
   AttachmentsProcessor --> S3
@@ -193,7 +195,7 @@ flowchart TD
 
 The API Lambda is the public synchronous boundary. It initializes local config or AWS secrets, opens MySQL read/write pools, initializes Redis, configures Passport JWT authentication, registers all routers, and then serves HTTP through `serverless-http`. The same handler also branches on API Gateway WebSocket route keys for `$connect`, `$disconnect`, and `$default` messages.
 
-Background Lambdas use a shared `doInDbContext` wrapper. That wrapper prepares environment/secrets, initializes TypeORM-backed DB access, initializes Redis, runs the job, then disconnects. This gives loop jobs a consistent lifecycle and keeps each worker independently deployable.
+Background Lambdas that read or write application state use a shared `doInDbContext` wrapper. That wrapper prepares environment/secrets, initializes TypeORM-backed DB access, initializes Redis, runs the job, then disconnects. The `dropVideoConversionInvokerLoop` is intentionally environment-only: it loads config/secrets, filters the S3 object key, and invokes MediaConvert without opening MySQL or Redis connections.
 
 MySQL is the integration contract between nearly all modules. API routes, scheduled pollers, queue workers, and derived-data loops all read and write shared tables. Redis is secondary and mostly disposable: API request cache, rate limiting, webhook dedupe, locks, and selected feature caches can fail open or be repopulated from MySQL.
 

--- a/src/dropVideoConversionInvokerLoop/index.test.ts
+++ b/src/dropVideoConversionInvokerLoop/index.test.ts
@@ -1,0 +1,118 @@
+const mockSend = jest.fn();
+const mockPrepEnvironment = jest.fn();
+const mockDoInDbContext = jest.fn();
+const mockLoggerInfo = jest.fn();
+const mockGetStringOrThrow = jest.fn((name: string) => {
+  const values: Record<string, string> = {
+    MC_ENDPOINT: 'https://mediaconvert.example.com',
+    MC_ROLE_ARN: 'arn:aws:iam::123456789012:role/media-convert',
+    MC_DROPS_VIDEO_TEMPLATE_NAME: 'drop-video-template',
+    S3_BUCKET: '6529-test-bucket',
+    BUCKET_REGION: 'eu-west-1'
+  };
+  return values[name];
+});
+
+jest.mock('@aws-sdk/client-mediaconvert', () => ({
+  CreateJobCommand: jest.fn((input) => ({ input })),
+  MediaConvertClient: jest.fn(() => ({ send: mockSend }))
+}));
+
+jest.mock('../env', () => ({
+  env: {
+    getStringOrThrow: mockGetStringOrThrow
+  },
+  prepEnvironment: mockPrepEnvironment
+}));
+
+jest.mock('../logging', () => ({
+  Logger: {
+    get: jest.fn(() => ({
+      info: mockLoggerInfo
+    }))
+  }
+}));
+
+jest.mock('../secrets', () => ({
+  doInDbContext: mockDoInDbContext
+}));
+
+jest.mock('../sentry.context', () => ({
+  wrapLambdaHandler: jest.fn((handler) => handler)
+}));
+
+jest.mock('../time', () => ({
+  Time: {
+    now: jest.fn(() => ({
+      diffFromNow: () => ({
+        formatAsDuration: () => '1ms'
+      })
+    }))
+  }
+}));
+
+import {
+  CreateJobCommand,
+  MediaConvertClient
+} from '@aws-sdk/client-mediaconvert';
+import { handler } from './index';
+
+describe('dropVideoConversionInvokerLoop', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPrepEnvironment.mockResolvedValue(undefined);
+    mockSend.mockResolvedValue(undefined);
+  });
+
+  it('invokes MediaConvert without opening a DB context', async () => {
+    await handler(
+      {
+        detail: {
+          object: {
+            key: 'drops/example-video.mp4'
+          }
+        }
+      },
+      {} as any,
+      jest.fn()
+    );
+
+    expect(mockPrepEnvironment).toHaveBeenCalledTimes(1);
+    expect(mockDoInDbContext).not.toHaveBeenCalled();
+    expect(MediaConvertClient).toHaveBeenCalledWith({
+      region: 'eu-west-1',
+      endpoint: 'https://mediaconvert.example.com'
+    });
+    expect(CreateJobCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        Role: 'arn:aws:iam::123456789012:role/media-convert',
+        JobTemplate: 'drop-video-template'
+      })
+    );
+    expect(mockSend).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    'drops/example-video/hls/playlist.m3u8',
+    'drops/example-video/mp4/output.mp4',
+    'drops/example-image.png'
+  ])('does not invoke MediaConvert for skipped key %s', async (key) => {
+    await handler(
+      {
+        detail: {
+          object: {
+            key
+          }
+        }
+      },
+      {} as any,
+      jest.fn()
+    );
+
+    expect(mockPrepEnvironment).toHaveBeenCalledTimes(1);
+    expect(mockDoInDbContext).not.toHaveBeenCalled();
+    expect(MediaConvertClient).not.toHaveBeenCalled();
+    expect(CreateJobCommand).not.toHaveBeenCalled();
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+});

--- a/src/dropVideoConversionInvokerLoop/index.ts
+++ b/src/dropVideoConversionInvokerLoop/index.ts
@@ -1,7 +1,7 @@
 import { Logger } from '../logging';
 import * as sentryContext from '../sentry.context';
-import { doInDbContext } from '../secrets';
-import { env } from '../env';
+import { env, prepEnvironment } from '../env';
+import { Time } from '../time';
 import {
   CreateJobCommand,
   MediaConvertClient
@@ -10,59 +10,61 @@ import {
 const logger = Logger.get('DROP_VIDEO_CONVERSION_INVOKER_LOOP');
 
 export const handler = sentryContext.wrapLambdaHandler(async (event) => {
-  await doInDbContext(
-    async () => {
-      const endpoint = env.getStringOrThrow('MC_ENDPOINT');
-      const roleArn = env.getStringOrThrow('MC_ROLE_ARN');
-      const template = env.getStringOrThrow('MC_DROPS_VIDEO_TEMPLATE_NAME');
-      const bucket = env.getStringOrThrow('S3_BUCKET');
-      const bucketRegion = env.getStringOrThrow('BUCKET_REGION');
-      const exts = ['mp4', 'mov', 'avi', 'webm'];
-      const key = event.detail.object.key;
-      if (key.includes('/hls/') || key.includes('/mp4/')) return;
-      const ext = key.split('.').pop()!.toLowerCase();
-      if (!exts.includes(ext)) return; // ignore pictures, etc.
-      const base = key.replace(/\.[^.]+$/i, '');
+  const start = Time.now();
+  logger.info(`[RUNNING]`);
+  try {
+    await prepEnvironment();
+    const endpoint = env.getStringOrThrow('MC_ENDPOINT');
+    const roleArn = env.getStringOrThrow('MC_ROLE_ARN');
+    const template = env.getStringOrThrow('MC_DROPS_VIDEO_TEMPLATE_NAME');
+    const bucket = env.getStringOrThrow('S3_BUCKET');
+    const bucketRegion = env.getStringOrThrow('BUCKET_REGION');
+    const exts = ['mp4', 'mov', 'avi', 'webm'];
+    const key = event.detail.object.key;
+    if (key.includes('/hls/') || key.includes('/mp4/')) return;
+    const ext = key.split('.').pop()!.toLowerCase();
+    if (!exts.includes(ext)) return; // ignore pictures, etc.
+    const base = key.replace(/\.[^.]+$/i, '');
 
-      const mc = new MediaConvertClient({ region: bucketRegion, endpoint });
-      const fileInput = `s3://${bucket}/${key}`;
-      logger.info(`Invoking video conversion for ${fileInput}`);
-      await mc.send(
-        new CreateJobCommand({
-          Role: roleArn,
-          JobTemplate: template,
-          Settings: {
-            Inputs: [
-              {
-                FileInput: fileInput,
-                VideoSelector: {
-                  Rotate: 'AUTO'
+    const mc = new MediaConvertClient({ region: bucketRegion, endpoint });
+    const fileInput = `s3://${bucket}/${key}`;
+    logger.info(`Invoking video conversion for ${fileInput}`);
+    await mc.send(
+      new CreateJobCommand({
+        Role: roleArn,
+        JobTemplate: template,
+        Settings: {
+          Inputs: [
+            {
+              FileInput: fileInput,
+              VideoSelector: {
+                Rotate: 'AUTO'
+              }
+            }
+          ],
+          OutputGroups: [
+            {
+              OutputGroupSettings: {
+                Type: 'HLS_GROUP_SETTINGS',
+                HlsGroupSettings: {
+                  Destination: `s3://${bucket}/renditions/${base}/hls/`
                 }
               }
-            ],
-            OutputGroups: [
-              {
-                OutputGroupSettings: {
-                  Type: 'HLS_GROUP_SETTINGS',
-                  HlsGroupSettings: {
-                    Destination: `s3://${bucket}/renditions/${base}/hls/`
-                  }
-                }
-              },
-              {
-                OutputGroupSettings: {
-                  Type: 'FILE_GROUP_SETTINGS',
-                  FileGroupSettings: {
-                    Destination: `s3://${bucket}/renditions/${base}/mp4/`
-                  }
+            },
+            {
+              OutputGroupSettings: {
+                Type: 'FILE_GROUP_SETTINGS',
+                FileGroupSettings: {
+                  Destination: `s3://${bucket}/renditions/${base}/mp4/`
                 }
               }
-            ]
-          }
-        })
-      );
-      logger.info(`Video conversion successfully invoked for ${fileInput}`);
-    },
-    { logger }
-  );
+            }
+          ]
+        }
+      })
+    );
+    logger.info(`Video conversion successfully invoked for ${fileInput}`);
+  } finally {
+    logger.info(`[FINISHED IN ${start.diffFromNow().formatAsDuration()}]`);
+  }
 });


### PR DESCRIPTION
## Summary
- load environment/secrets directly in dropVideoConversionInvokerLoop instead of using doInDbContext
- keep MediaConvert invocation behavior unchanged
- document dropVideoConversionInvokerLoop as an environment-only Lambda and add focused coverage that verifies no DB context is opened

## Validation
- npm run lint
- npm test -- src/dropVideoConversionInvokerLoop/index.test.ts --runInBand
- NODE_OPTIONS=--max-old-space-size=8192 ./node_modules/typescript/bin/tsc -p tsconfig.json --noEmit

## Deployment
- Backend only, no DB migration, no frontend changes
- Deploy order: dropVideoConversionInvokerLoop