### PR TITLE
Split xTdhLoop universe and stats phases

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -84,6 +84,7 @@ flowchart TD
     SeizeAPI --> WaveScoreDirtyQueue["SQS: wave-score-refresh-dirty.fifo"] --> WaveScoreRefreshLoop
     TdhLoop --> TdhDoneTopic["SNS: tdh-calculation-done.fifo"]
     TdhDoneTopic --> XTdhQueue["SQS: xtdh-start.fifo"] --> XTdhLoop["xTdhLoop"]
+    XTdhLoop --> XTdhQueue
     TdhDoneTopic --> OverRatesQueue["SQS: over-rates-revocation-start.fifo"] --> OverRatesRevocationLoop["overRatesRevocationLoop"]
     TdhDoneTopic --> WaveScoreRefreshQueue["SQS: wave-score-refresh-start.fifo"] --> WaveScoreRefreshLoop["waveScoreRefreshLoop"]
   end
@@ -174,7 +175,7 @@ flowchart TD
 | `pushNotificationsHandler`       | SQS `firebase-push-notifications`                                                                                                  | Deliver Firebase push notifications.                                                                                        |
 | `helpBotReplyLoop`               | SQS `help-bot-replies`                                                                                                             | Answer `@help6529` mentions and direct follow-ups to bot replies.                                                           |
 | `waveDropMetricsRefreshLoop`      | SQS `wave-drop-metrics-refresh-dirty.fifo`; EventBridge fallback                                                                   | Repair materialized wave/dropper drop counts and latest-drop timestamps after drop deletes.                                |
-| `xTdhLoop`                       | SNS `tdh-calculation-done.fifo` via SQS `xtdh-start.fifo`                                                                          | Recalculate xTDH after TDH finishes.                                                                                        |
+| `xTdhLoop`                       | SNS `tdh-calculation-done.fifo` via SQS `xtdh-start.fifo`; self-queued stats phase                                                  | Recalculate the xTDH universe after TDH finishes, then rebuild and publish xTDH stats in a follow-up queue message.         |
 | `overRatesRevocationLoop`        | SNS `tdh-calculation-done.fifo` via SQS `over-rates-revocation-start.fifo`                                                         | Revoke over-rates after TDH changes.                                                                                        |
 | `waveScoreRefreshLoop`           | SNS `tdh-calculation-done.fifo` via SQS `wave-score-refresh-start.fifo`; SQS `wave-score-refresh-dirty.fifo`; EventBridge fallback | Refresh materialized wave REP and Wave Score discovery fields after TDH changes or wave/drop/rating/subscription mutations. |
 | `mediaResizerLoop`               | CloudFront/request path                                                                                                            | Resize images on demand.                                                                                                    |
@@ -328,6 +329,17 @@ Most long-running scheduled jobs have reserved concurrency set low, usually `1`,
 Wave Score refreshes use a hybrid DB-backed/SQS pattern. Request-path mutations write `wave_score_refresh_requests` rows inside the same primary-DB transaction as the drop, rating, or subscription change, then publish a small wakeup message to `wave-score-refresh-dirty.fifo` after commit. `waveScoreRefreshLoop` drains dirty rows from the write pool, recalculates scores, and deletes a row only if its selected `(wave_id, dirty_at)` version still matches, so a wave dirtied again during processing remains queued. A one-minute EventBridge fallback invokes the same dirty drain in case enqueueing fails after the transaction commits.
 
 Wave drop metric repairs use the same DB-backed/SQS pattern. Drop deletes apply a bounded in-transaction counter decrement, write `wave_drop_metrics_refresh_requests`, and publish to `wave-drop-metrics-refresh-dirty.fifo` after commit. `waveDropMetricsRefreshLoop` drains from the write pool and runs the full wave/dropper metric reconciliation outside the API path, with an EventBridge fallback for missed wakeups.
+
+`xTdhLoop` uses a two-phase FIFO queue flow. The TDH completion SNS topic
+delivers the universe phase through `xtdh-start.fifo`; after the universe
+transaction commits, the same Lambda enqueues a stats phase back to that FIFO
+queue, using the same FIFO message group as the universe message when one is
+available and the queue's default FIFO group otherwise. That shared message
+group is what orders each universe phase before its stats phase; the SQS event
+source batch size stays at `1` and Lambda reserved concurrency stays at `1` to
+avoid parallel xTDH work across groups. The stats phase rebuilds the inactive
+xTDH stats slot and activates it only after the rebuild succeeds; a redelivered
+stats message truncates and refills the inactive slot again before activation.
 
 ## 6529 Help Bot Flow
 

--- a/src/sqs.ts
+++ b/src/sqs.ts
@@ -7,7 +7,7 @@ import {
 import { env } from './env';
 import { Logger } from './logging';
 
-const DEFAULT_MESSAGE_GROUP_ID = 'default';
+export const DEFAULT_MESSAGE_GROUP_ID = 'default';
 
 export class SQS {
   private readonly logger = Logger.get(this.constructor.name);

--- a/src/xTdhLoop/index.test.ts
+++ b/src/xTdhLoop/index.test.ts
@@ -1,0 +1,139 @@
+const mockDoInDbContext = jest.fn();
+const mockLoggerInfo = jest.fn();
+const mockLoggerWarn = jest.fn();
+const mockHandleUniversePhase = jest.fn();
+const mockHandleStatsPhase = jest.fn();
+
+jest.mock('../secrets', () => ({
+  doInDbContext: mockDoInDbContext
+}));
+
+jest.mock('../sentry.context', () => ({
+  wrapLambdaHandler: jest.fn((handler) => handler)
+}));
+
+jest.mock('../logging', () => ({
+  Logger: {
+    get: jest.fn(() => ({
+      info: mockLoggerInfo,
+      warn: mockLoggerWarn
+    }))
+  }
+}));
+
+jest.mock('../xtdh/recalculate-xtdh.use-case', () => ({
+  recalculateXTdhUseCase: {
+    handleUniversePhase: mockHandleUniversePhase,
+    handleStatsPhase: mockHandleStatsPhase
+  }
+}));
+
+import { handler, resolveXTdhLoopPhase, resolveXTdhLoopWork } from './index';
+import { XTDH_LOOP_PHASE } from '../xtdh/xtdh-loop-phase';
+
+describe('xTdhLoop handler', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDoInDbContext.mockImplementation(async (fn) => fn());
+    mockHandleUniversePhase.mockResolvedValue(undefined);
+    mockHandleStatsPhase.mockResolvedValue(undefined);
+  });
+
+  it('treats empty and legacy messages as universe phase', () => {
+    expect(resolveXTdhLoopPhase({})).toBe(XTDH_LOOP_PHASE.UNIVERSE);
+    expect(
+      resolveXTdhLoopPhase({
+        Records: [{ body: JSON.stringify({}) }]
+      })
+    ).toBe(XTDH_LOOP_PHASE.UNIVERSE);
+  });
+
+  it('resolves stats messages to stats phase', () => {
+    expect(resolveXTdhLoopPhase({ phase: XTDH_LOOP_PHASE.STATS })).toBe(
+      XTDH_LOOP_PHASE.STATS
+    );
+    expect(
+      resolveXTdhLoopPhase({
+        Records: [{ body: JSON.stringify({ phase: XTDH_LOOP_PHASE.STATS }) }]
+      })
+    ).toBe(XTDH_LOOP_PHASE.STATS);
+  });
+
+  it('extracts FIFO message group id from universe messages', () => {
+    expect(
+      resolveXTdhLoopWork({
+        Records: [
+          {
+            attributes: { MessageGroupId: 'tdh-fifo-group' },
+            body: JSON.stringify({ type: 'tdh-complete' })
+          }
+        ]
+      })
+    ).toEqual({
+      phase: XTDH_LOOP_PHASE.UNIVERSE,
+      messageGroupId: 'tdh-fifo-group'
+    });
+    expect(
+      resolveXTdhLoopWork({
+        Records: [{ body: JSON.stringify({ randomId: 'sns-body-id' }) }]
+      })
+    ).toEqual({
+      phase: XTDH_LOOP_PHASE.UNIVERSE,
+      messageGroupId: 'sns-body-id'
+    });
+  });
+
+  it('warns when a mixed SQS batch is observed', () => {
+    expect(
+      resolveXTdhLoopWork({
+        Records: [
+          { body: JSON.stringify({ phase: XTDH_LOOP_PHASE.STATS }) },
+          {
+            attributes: { MessageGroupId: 'tdh-fifo-group' },
+            body: JSON.stringify({ type: 'tdh-complete' })
+          }
+        ]
+      })
+    ).toEqual({
+      phase: XTDH_LOOP_PHASE.UNIVERSE,
+      messageGroupId: 'tdh-fifo-group'
+    });
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      'Mixed xTDH loop SQS batch observed; processing universe phase and relying on batchSize: 1 to avoid dropping stats work.'
+    );
+  });
+
+  it('runs the universe phase for non-stats SQS messages', async () => {
+    await handler(
+      {
+        Records: [
+          {
+            attributes: { MessageGroupId: 'tdh-fifo-group' },
+            body: JSON.stringify({ type: 'tdh-complete' })
+          }
+        ]
+      },
+      {} as any,
+      jest.fn()
+    );
+
+    expect(mockHandleUniversePhase).toHaveBeenCalledWith(
+      expect.objectContaining({ timer: expect.any(Object) }),
+      { messageGroupId: 'tdh-fifo-group' }
+    );
+    expect(mockHandleStatsPhase).not.toHaveBeenCalled();
+  });
+
+  it('runs only the stats phase for stats SQS messages', async () => {
+    await handler(
+      {
+        Records: [{ body: JSON.stringify({ phase: XTDH_LOOP_PHASE.STATS }) }]
+      },
+      {} as any,
+      jest.fn()
+    );
+
+    expect(mockHandleStatsPhase).toHaveBeenCalledTimes(1);
+    expect(mockHandleUniversePhase).not.toHaveBeenCalled();
+  });
+});

--- a/src/xTdhLoop/index.ts
+++ b/src/xTdhLoop/index.ts
@@ -4,20 +4,144 @@ import { doInDbContext } from '../secrets';
 import { RequestContext } from '../request.context';
 import { Timer } from '../time';
 import { recalculateXTdhUseCase } from '../xtdh/recalculate-xtdh.use-case';
+import {
+  isXTdhLoopPhase,
+  XTDH_LOOP_PHASE,
+  XTdhLoopPhase
+} from '../xtdh/xtdh-loop-phase';
 
 const logger = Logger.get('XTDH_LOOP');
 
-export const handler = sentryContext.wrapLambdaHandler(async () => {
-  await doInDbContext(
-    async () => {
-      const ctx: RequestContext = {
-        timer: new Timer('XTDH_LOOP')
-      };
-      await recalculateXTdhUseCase.handle(ctx);
-      logger.info(`Loop finished ${JSON.stringify(ctx?.timer)}`);
-    },
-    {
-      logger
-    }
+type SqsRecord = Record<string, unknown>;
+
+interface XTdhLoopWork {
+  readonly phase: XTdhLoopPhase;
+  readonly messageGroupId?: string;
+}
+
+export function resolveXTdhLoopPhase(event: unknown): XTdhLoopPhase {
+  return resolveXTdhLoopWork(event).phase;
+}
+
+export function resolveXTdhLoopWork(event: unknown): XTdhLoopWork {
+  const records = getSqsRecords(event);
+  if (!records.length) {
+    return {
+      phase: getPhaseFromMessage(event),
+      messageGroupId: getMessageGroupIdFromMessage(event)
+    };
+  }
+  // The event source is configured with batchSize: 1. If that changes and a
+  // mixed batch arrives, prefer the universe phase so it can enqueue fresh stats.
+  const hasUniverseMessage = records.some(
+    (record) => getPhaseFromRecord(record) !== XTDH_LOOP_PHASE.STATS
   );
-});
+  if (hasUniverseMessage) {
+    const hasStatsMessage = records.some(
+      (record) => getPhaseFromRecord(record) === XTDH_LOOP_PHASE.STATS
+    );
+    if (hasStatsMessage) {
+      logger.warn(
+        `Mixed xTDH loop SQS batch observed; processing universe phase and relying on batchSize: 1 to avoid dropping stats work.`
+      );
+    }
+    const universeRecord = records.find(
+      (record) => getPhaseFromRecord(record) !== XTDH_LOOP_PHASE.STATS
+    );
+    return {
+      phase: XTDH_LOOP_PHASE.UNIVERSE,
+      messageGroupId: universeRecord
+        ? getMessageGroupIdFromRecord(universeRecord)
+        : undefined
+    };
+  }
+  return {
+    phase: XTDH_LOOP_PHASE.STATS
+  };
+}
+
+function getSqsRecords(event: unknown): SqsRecord[] {
+  if (!isRecord(event) || !Array.isArray(event.Records)) {
+    return [];
+  }
+  return event.Records.filter(isRecord);
+}
+
+function getPhaseFromRecord(record: SqsRecord): XTdhLoopPhase {
+  return getPhaseFromMessage(getMessageFromRecord(record));
+}
+
+function getMessageFromRecord(record: SqsRecord): unknown {
+  return typeof record.body === 'string' ? parseJsonOrNull(record.body) : null;
+}
+
+function getMessageGroupIdFromRecord(record: SqsRecord): string | undefined {
+  const attributes = record.attributes;
+  if (isRecord(attributes) && typeof attributes.MessageGroupId === 'string') {
+    return attributes.MessageGroupId;
+  }
+  return getMessageGroupIdFromMessage(getMessageFromRecord(record));
+}
+
+function parseJsonOrNull(value: string): unknown {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
+}
+
+function getPhaseFromMessage(message: unknown): XTdhLoopPhase {
+  if (!isRecord(message)) {
+    return XTDH_LOOP_PHASE.UNIVERSE;
+  }
+  return isXTdhLoopPhase(message.phase)
+    ? message.phase
+    : XTDH_LOOP_PHASE.UNIVERSE;
+}
+
+function getMessageGroupIdFromMessage(message: unknown): string | undefined {
+  if (!isRecord(message)) {
+    return undefined;
+  }
+  if (typeof message.message_group_id === 'string') {
+    return message.message_group_id;
+  }
+  return typeof message.randomId === 'string' ? message.randomId : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+export const handler = sentryContext.wrapLambdaHandler(
+  async (event, lambdaContext) => {
+    await doInDbContext(
+      async () => {
+        const work = resolveXTdhLoopWork(event);
+        const getRemainingTimeInMillis =
+          typeof lambdaContext?.getRemainingTimeInMillis === 'function'
+            ? () => lambdaContext.getRemainingTimeInMillis()
+            : undefined;
+        const ctx: RequestContext = {
+          timer: new Timer('XTDH_LOOP')
+        };
+        logger.info(`Loop phase ${work.phase} started`);
+        if (work.phase === XTDH_LOOP_PHASE.STATS) {
+          await recalculateXTdhUseCase.handleStatsPhase(ctx);
+        } else {
+          await recalculateXTdhUseCase.handleUniversePhase(ctx, {
+            messageGroupId: work.messageGroupId,
+            ...(getRemainingTimeInMillis ? { getRemainingTimeInMillis } : {})
+          });
+        }
+        logger.info(
+          `Loop phase ${work.phase} finished ${JSON.stringify(ctx?.timer)}`
+        );
+      },
+      {
+        logger
+      }
+    );
+  }
+);

--- a/src/xTdhLoop/serverless.yaml
+++ b/src/xTdhLoop/serverless.yaml
@@ -26,6 +26,7 @@ functions:
             Fn::GetAtt:
               - XTdhStartQueue
               - Arn
+          batchSize: 1
     role: arn:aws:iam::987989283142:role/lambda-vpc-role
     vpc:
       securityGroupIds: ${file(../../serverless-config/${opt:stage, self:provider.stage}/vpc.js):security}
@@ -33,6 +34,8 @@ functions:
     environment:
       SENTRY_DSN: ${env:SENTRY_DSN}
       SENTRY_ENVIRONMENT: "xTdhLoop_${opt:stage, self:provider.stage}"
+      XTDH_LOOP_QUEUE_URL:
+        Ref: XTdhStartQueue
 
 resources:
   Resources:

--- a/src/xtdh/recalculate-xtdh-stats.use-case.test.ts
+++ b/src/xtdh/recalculate-xtdh-stats.use-case.test.ts
@@ -1,0 +1,88 @@
+const mockRecordXtdhGranted = jest.fn();
+
+jest.mock('../metrics/MetricsRecorder', () => ({
+  metricsRecorder: {
+    recordXtdhGranted: mockRecordXtdhGranted
+  }
+}));
+
+import { RequestContext } from '../request.context';
+import { RecalculateXTdhStatsUseCase } from './recalculate-xtdh-stats.use-case';
+
+describe('RecalculateXTdhStatsUseCase', () => {
+  const makeRepository = () => ({
+    getStatsMetaOrNull: jest.fn().mockResolvedValue({ active_slot: 'a' }),
+    refillXTdhGrantStats: jest.fn().mockResolvedValue(undefined),
+    refillXTdhTokenStats: jest.fn().mockResolvedValue(undefined),
+    getTotalGrantedXTdh: jest.fn().mockResolvedValue(6529),
+    markStatsJustReindexed: jest.fn().mockResolvedValue(undefined)
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRecordXtdhGranted.mockResolvedValue(undefined);
+  });
+
+  it('rebuilds the inactive slot before activating it', async () => {
+    const order: string[] = [];
+    const repository = makeRepository();
+    repository.getStatsMetaOrNull.mockImplementationOnce(async () => {
+      order.push('meta');
+      return { active_slot: 'a' };
+    });
+    repository.refillXTdhGrantStats.mockImplementationOnce(async ({ slot }) => {
+      order.push(`grant:${slot}`);
+    });
+    repository.refillXTdhTokenStats.mockImplementationOnce(async ({ slot }) => {
+      order.push(`token:${slot}`);
+    });
+    repository.getTotalGrantedXTdh.mockImplementationOnce(async ({ slot }) => {
+      order.push(`total:${slot}`);
+      return 6529;
+    });
+    repository.markStatsJustReindexed.mockImplementationOnce(
+      async ({ slot }) => {
+        order.push(`activate:${slot}`);
+      }
+    );
+
+    await new RecalculateXTdhStatsUseCase(repository as any).handle(
+      {} as RequestContext
+    );
+
+    expect(repository.refillXTdhGrantStats).toHaveBeenCalledWith(
+      { slot: 'b' },
+      expect.any(Object)
+    );
+    expect(repository.refillXTdhTokenStats).toHaveBeenCalledWith(
+      { slot: 'b' },
+      expect.any(Object)
+    );
+    expect(repository.markStatsJustReindexed).toHaveBeenCalledWith(
+      { slot: 'b' },
+      expect.any(Object)
+    );
+    expect(order).toEqual([
+      'meta',
+      'grant:b',
+      'token:b',
+      'total:b',
+      'activate:b'
+    ]);
+  });
+
+  it('does not activate a slot when rebuilding token stats fails', async () => {
+    const repository = makeRepository();
+    repository.refillXTdhTokenStats.mockRejectedValueOnce(
+      new Error('token rebuild failed')
+    );
+
+    await expect(
+      new RecalculateXTdhStatsUseCase(repository as any).handle(
+        {} as RequestContext
+      )
+    ).rejects.toThrow('token rebuild failed');
+
+    expect(repository.markStatsJustReindexed).not.toHaveBeenCalled();
+  });
+});

--- a/src/xtdh/recalculate-xtdh-stats.use-case.ts
+++ b/src/xtdh/recalculate-xtdh-stats.use-case.ts
@@ -15,6 +15,9 @@ export class RecalculateXTdhStatsUseCase {
       const meta = await this.xtdhRepository.getStatsMetaOrNull(ctx);
       const slot = meta?.active_slot === 'a' ? 'b' : 'a';
       this.logger.info(`Indexing XTDH stats to slot ${slot}`);
+      // Rebuild the inactive slot from scratch before activating it. If SQS
+      // redelivers after a partial rebuild, the next run truncates/refills the
+      // same inactive slot again while readers remain on the prior active slot.
       this.logger.info(`Indexing grant stats`);
       await this.xtdhRepository.refillXTdhGrantStats(
         {

--- a/src/xtdh/recalculate-xtdh.use-case.test.ts
+++ b/src/xtdh/recalculate-xtdh.use-case.test.ts
@@ -1,0 +1,212 @@
+const mockSqsSend = jest.fn();
+const mockGetStringOrNull = jest.fn();
+const mockIsXTdhEnabled = jest.fn();
+const mockBulkCreateIdentities = jest.fn();
+const mockUpdateAllIdentitiesLevels = jest.fn();
+
+jest.mock('../sqs', () => ({
+  DEFAULT_MESSAGE_GROUP_ID: 'default',
+  sqs: {
+    send: mockSqsSend
+  }
+}));
+
+jest.mock('../env', () => ({
+  env: {
+    getStringOrNull: mockGetStringOrNull
+  }
+}));
+
+jest.mock('../app-features', () => ({
+  appFeatures: {
+    isXTdhEnabled: mockIsXTdhEnabled
+  }
+}));
+
+jest.mock('../api-serverless/src/identities/identities.service', () => ({
+  identitiesService: {
+    bulkCreateIdentities: mockBulkCreateIdentities
+  }
+}));
+
+jest.mock('../identity', () => ({
+  identityConsolidationEffects: {
+    updateAllIdentitiesLevels: mockUpdateAllIdentitiesLevels
+  }
+}));
+
+import { RequestContext } from '../request.context';
+import { RecalculateXTdhUseCase } from './recalculate-xtdh.use-case';
+import { XTDH_LOOP_PHASE } from './xtdh-loop-phase';
+
+describe('RecalculateXTdhUseCase phase handling', () => {
+  const connection = { connection: {} };
+
+  const makeRepository = () => ({
+    executeNativeQueriesInTransaction: jest.fn(
+      async (callback: (connection: unknown) => Promise<void>) => {
+        await callback(connection);
+      }
+    ),
+    getWalletsWithoutIdentities: jest.fn().mockResolvedValue([]),
+    updateProducedXTDH: jest.fn().mockResolvedValue(undefined),
+    updateAllGrantedXTdhs: jest.fn().mockResolvedValue(undefined),
+    deleteXTdhState: jest.fn().mockResolvedValue(undefined),
+    updateAllXTdhsWithGrantedPart: jest.fn().mockResolvedValue(undefined),
+    giveOutUngrantedXTdh: jest.fn().mockResolvedValue(undefined),
+    updateXtdhRate: jest.fn().mockResolvedValue(undefined)
+  });
+
+  const makeUseCase = () => {
+    const repository = makeRepository();
+    const reReviewRates = { handle: jest.fn().mockResolvedValue(undefined) };
+    const stats = { handle: jest.fn().mockResolvedValue(undefined) };
+    const useCase = new RecalculateXTdhUseCase(
+      repository as any,
+      reReviewRates as any,
+      stats as any
+    );
+    return { repository, reReviewRates, stats, useCase };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetStringOrNull.mockReturnValue(
+      'https://sqs.us-east-1.amazonaws.com/123/xtdh-start.fifo'
+    );
+    mockIsXTdhEnabled.mockReturnValue(true);
+    mockSqsSend.mockResolvedValue({});
+    mockUpdateAllIdentitiesLevels.mockResolvedValue(undefined);
+  });
+
+  it('enqueues stats phase after the universe transaction commits', async () => {
+    const order: string[] = [];
+    const { repository, stats, useCase } = makeUseCase();
+    repository.executeNativeQueriesInTransaction.mockImplementationOnce(
+      async (callback: (connection: unknown) => Promise<void>) => {
+        order.push('transaction-start');
+        await callback(connection);
+        order.push('transaction-commit');
+      }
+    );
+    mockSqsSend.mockImplementationOnce(async () => {
+      order.push('stats-enqueued');
+      return {};
+    });
+
+    await useCase.handleUniversePhase({} as RequestContext, {
+      messageGroupId: 'tdh-fifo-group'
+    });
+
+    expect(stats.handle).not.toHaveBeenCalled();
+    expect(mockSqsSend).toHaveBeenCalledWith({
+      queue: 'https://sqs.us-east-1.amazonaws.com/123/xtdh-start.fifo',
+      messageGroupId: 'tdh-fifo-group',
+      message: {
+        phase: XTDH_LOOP_PHASE.STATS,
+        queued_at_ms: expect.any(Number)
+      }
+    });
+    expect(order).toEqual([
+      'transaction-start',
+      'transaction-commit',
+      'stats-enqueued'
+    ]);
+  });
+
+  it('uses the default FIFO message group for stats when no source group resolves', async () => {
+    const { useCase } = makeUseCase();
+
+    await useCase.handleUniversePhase({} as RequestContext);
+
+    expect(mockSqsSend).toHaveBeenCalledWith({
+      queue: 'https://sqs.us-east-1.amazonaws.com/123/xtdh-start.fifo',
+      messageGroupId: 'default',
+      message: {
+        phase: XTDH_LOOP_PHASE.STATS,
+        queued_at_ms: expect.any(Number)
+      }
+    });
+  });
+
+  it('does not enqueue stats when the universe transaction fails', async () => {
+    const { repository, useCase } = makeUseCase();
+    repository.executeNativeQueriesInTransaction.mockRejectedValueOnce(
+      new Error('transaction failed')
+    );
+
+    await expect(
+      useCase.handleUniversePhase({} as RequestContext)
+    ).rejects.toThrow('transaction failed');
+
+    expect(mockSqsSend).not.toHaveBeenCalled();
+  });
+
+  it('fails before the universe transaction when stats phase queue url is missing', async () => {
+    const { repository, useCase } = makeUseCase();
+    mockGetStringOrNull.mockReturnValue(null);
+
+    await expect(
+      useCase.handleUniversePhase({} as RequestContext)
+    ).rejects.toThrow(
+      'XTDH_LOOP_QUEUE_URL not configured. Can not enqueue xTDH stats phase.'
+    );
+
+    expect(repository.executeNativeQueriesInTransaction).not.toHaveBeenCalled();
+    expect(mockSqsSend).not.toHaveBeenCalled();
+  });
+
+  it('does not enqueue stats when too little lambda time remains', async () => {
+    const { repository, useCase } = makeUseCase();
+
+    await expect(
+      useCase.handleUniversePhase({} as RequestContext, {
+        getRemainingTimeInMillis: () => 1_000
+      })
+    ).rejects.toThrow(
+      'Not enough Lambda time remaining to enqueue xTDH stats phase after universe phase.'
+    );
+
+    expect(repository.executeNativeQueriesInTransaction).toHaveBeenCalledTimes(
+      1
+    );
+    expect(mockSqsSend).not.toHaveBeenCalled();
+  });
+
+  it('rejects universe phase when a caller-managed transaction is open', async () => {
+    const { repository, useCase } = makeUseCase();
+
+    await expect(
+      useCase.handleUniversePhase({ connection } as RequestContext)
+    ).rejects.toThrow(
+      'handleUniversePhase must own the transaction before enqueueing xTDH stats phase'
+    );
+
+    expect(repository.executeNativeQueriesInTransaction).not.toHaveBeenCalled();
+    expect(mockSqsSend).not.toHaveBeenCalled();
+  });
+
+  it('enqueues direct universe wakeups with a unique FIFO body', async () => {
+    const { useCase } = makeUseCase();
+
+    await useCase.activateLoop({} as RequestContext);
+
+    expect(mockSqsSend).toHaveBeenCalledWith({
+      queue: 'https://sqs.us-east-1.amazonaws.com/123/xtdh-start.fifo',
+      message: {
+        phase: XTDH_LOOP_PHASE.UNIVERSE,
+        queued_at_ms: expect.any(Number)
+      }
+    });
+  });
+
+  it('runs stats phase without recalculating the universe', async () => {
+    const { repository, stats, useCase } = makeUseCase();
+
+    await useCase.handleStatsPhase({} as RequestContext);
+
+    expect(stats.handle).toHaveBeenCalledTimes(1);
+    expect(repository.executeNativeQueriesInTransaction).not.toHaveBeenCalled();
+    expect(mockSqsSend).not.toHaveBeenCalled();
+  });
+});

--- a/src/xtdh/recalculate-xtdh.use-case.ts
+++ b/src/xtdh/recalculate-xtdh.use-case.ts
@@ -10,10 +10,26 @@ import {
   recalculateXTdhStatsUseCase,
   RecalculateXTdhStatsUseCase
 } from './recalculate-xtdh-stats.use-case';
-import { sqs } from '../sqs';
+import { DEFAULT_MESSAGE_GROUP_ID, sqs } from '../sqs';
 import { env } from '../env';
 import { appFeatures } from '../app-features';
 import { identityConsolidationEffects } from '../identity';
+import {
+  XTDH_LOOP_PHASE,
+  XTdhLoopMessage,
+  XTdhLoopPhase
+} from './xtdh-loop-phase';
+
+const MIN_STATS_ENQUEUE_REMAINING_MS = 15_000;
+
+interface HandleUniversePhaseOptions {
+  readonly messageGroupId?: string;
+  readonly getRemainingTimeInMillis?: () => number;
+}
+
+interface ActivateLoopOptions {
+  readonly messageGroupId?: string;
+}
 
 export class RecalculateXTdhUseCase {
   private readonly logger = Logger.get(this.constructor.name);
@@ -24,7 +40,26 @@ export class RecalculateXTdhUseCase {
     private readonly recalculateXTdhStats: RecalculateXTdhStatsUseCase
   ) {}
 
-  public async handle(ctx: RequestContext) {
+  public async handleUniversePhase(
+    ctx: RequestContext,
+    options: HandleUniversePhaseOptions = {}
+  ) {
+    if (ctx.connection) {
+      throw new Error(
+        `handleUniversePhase must own the transaction before enqueueing xTDH stats phase`
+      );
+    }
+    this.getRequiredXTdhLoopQueueUrl();
+    await this.recalculateXTdhUniverse(ctx);
+    this.assertEnoughTimeToEnqueueStats(options.getRemainingTimeInMillis);
+    await this.activateLoop(ctx, XTDH_LOOP_PHASE.STATS, options);
+  }
+
+  public async handleStatsPhase(ctx: RequestContext) {
+    await this.recalculateXTdhStats.handle(ctx);
+  }
+
+  private async recalculateXTdhUniverse(ctx: RequestContext) {
     if (ctx.connection) {
       await this.recalculateXTdh(ctx);
     } else {
@@ -33,7 +68,6 @@ export class RecalculateXTdhUseCase {
           await this.recalculateXTdh({ ...ctx, connection });
         }
       );
-      await this.recalculateXTdhStats.handle(ctx);
     }
   }
 
@@ -97,22 +131,65 @@ export class RecalculateXTdhUseCase {
     }
   }
 
-  public async activateLoop(ctx: RequestContext) {
+  public async activateLoop(
+    ctx: RequestContext,
+    phase: XTdhLoopPhase = XTDH_LOOP_PHASE.UNIVERSE,
+    options: ActivateLoopOptions = {}
+  ) {
     try {
       ctx.timer?.start(`${this.constructor.name}->activateLoop`);
-      const xtdhLoopQueueUrl = env.getStringOrNull('XTDH_LOOP_QUEUE_URL');
+      const xtdhLoopQueueUrl =
+        phase === XTDH_LOOP_PHASE.STATS
+          ? this.getRequiredXTdhLoopQueueUrl()
+          : env.getStringOrNull('XTDH_LOOP_QUEUE_URL');
       if (!xtdhLoopQueueUrl) {
         this.logger.warn(
           `XTDH_LOOP_QUEUE_URL not configured. Skipping loop call.`
         );
       } else {
+        const messageGroupId =
+          options.messageGroupId ??
+          (phase === XTDH_LOOP_PHASE.STATS ? DEFAULT_MESSAGE_GROUP_ID : null);
         await sqs.send({
-          message: {},
-          queue: xtdhLoopQueueUrl
+          message: this.buildLoopMessage(phase),
+          queue: xtdhLoopQueueUrl,
+          ...(messageGroupId ? { messageGroupId } : {})
         });
       }
     } finally {
       ctx.timer?.stop(`${this.constructor.name}->activateLoop`);
+    }
+  }
+
+  private buildLoopMessage(phase: XTdhLoopPhase): XTdhLoopMessage {
+    return {
+      phase,
+      // Keep same-phase FIFO message bodies unique under content-based dedupe.
+      queued_at_ms: Date.now()
+    };
+  }
+
+  private getRequiredXTdhLoopQueueUrl(): string {
+    const xtdhLoopQueueUrl = env.getStringOrNull('XTDH_LOOP_QUEUE_URL');
+    if (!xtdhLoopQueueUrl) {
+      throw new Error(
+        `XTDH_LOOP_QUEUE_URL not configured. Can not enqueue xTDH stats phase.`
+      );
+    }
+    return xtdhLoopQueueUrl;
+  }
+
+  private assertEnoughTimeToEnqueueStats(
+    getRemainingTimeInMillis?: () => number
+  ) {
+    const remainingMs = getRemainingTimeInMillis?.();
+    if (
+      typeof remainingMs === 'number' &&
+      remainingMs < MIN_STATS_ENQUEUE_REMAINING_MS
+    ) {
+      throw new Error(
+        `Not enough Lambda time remaining to enqueue xTDH stats phase after universe phase.`
+      );
     }
   }
 }

--- a/src/xtdh/xtdh-loop-phase.ts
+++ b/src/xtdh/xtdh-loop-phase.ts
@@ -1,0 +1,16 @@
+export const XTDH_LOOP_PHASE = {
+  UNIVERSE: 'universe',
+  STATS: 'stats'
+} as const;
+
+export type XTdhLoopPhase =
+  (typeof XTDH_LOOP_PHASE)[keyof typeof XTDH_LOOP_PHASE];
+
+export interface XTdhLoopMessage {
+  readonly phase?: XTdhLoopPhase;
+  readonly queued_at_ms?: number;
+}
+
+export function isXTdhLoopPhase(value: unknown): value is XTdhLoopPhase {
+  return value === XTDH_LOOP_PHASE.UNIVERSE || value === XTDH_LOOP_PHASE.STATS;
+}


### PR DESCRIPTION
## Summary
- split `xTdhLoop` into explicit `universe` and `stats` phases on the existing FIFO queue
- keep legacy/TDH-completion messages mapped to the universe phase, then enqueue a follow-up stats phase after the universe DB transaction commits
- force SQS event `batchSize: 1` and expose `XTDH_LOOP_QUEUE_URL` to let the loop enqueue its own stats phase
- update architecture docs and add focused unit coverage for phase dispatch and post-commit stats enqueueing

## Why
The loop is currently timing out after completing most of the universe recalculation and entering stats indexing. Splitting the phases gives the stats rebuild its own Lambda timeout window without changing the math or adding a new service.

## Validation
- `npm test -- src/xTdhLoop/index.test.ts src/xtdh/recalculate-xtdh.use-case.test.ts --runInBand`
- `npm run lint`
- `npm run build`

## Deployment
Backend only. Deploy service order:
1. `xTdhLoop`

No frontend dependency. No migrations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a two-step xTDH processing flow, with separate universe and stats phases.
  * The loop now recognizes incoming phase information and routes work accordingly.
  * Queue processing is now serialized with a single-message batch setting.

* **Bug Fixes**
  * Stats processing now runs only after the earlier phase completes successfully.
  * Improved handling for missing or invalid phase data by falling back to the default flow.

* **Documentation**
  * Clarified the architecture docs to reflect the updated queueing and activation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->