### PR TITLE
perf(api): add structured eligibility read attribution log

### DIFF
--- a/src/api-serverless/src/community-members/user-groups.service.ts
+++ b/src/api-serverless/src/community-members/user-groups.service.ts
@@ -852,6 +852,11 @@ export class UserGroupsService {
       )
     ) {
       this.putEligibleGroupsMemoryCache(profileId, redisCacheEntry, ttlSec);
+      this.logEligibilityRead({
+        profileId,
+        level: 'redis',
+        resultCount: redisCacheEntry.eligibleGroupIds.length
+      });
       return redisCacheEntry.eligibleGroupIds;
     }
 
@@ -868,10 +873,16 @@ export class UserGroupsService {
         timer
       });
       if (waitedCacheEntry) {
+        this.logEligibilityRead({
+          profileId,
+          level: 'lock_wait',
+          resultCount: waitedCacheEntry.eligibleGroupIds.length
+        });
         return waitedCacheEntry.eligibleGroupIds;
       }
     }
 
+    const computeStartMillis = Time.currentMillis();
     const results = await this.computeGroupsUserIsEligibleFor(profileId, timer);
     const computedAtMillis = Time.currentMillis();
     const latestProfileGroupChangeMillisAfterCompute = await this.timeAsync(
@@ -885,6 +896,13 @@ export class UserGroupsService {
         latestProfileGroupChangeMillisAfterCompute
       )
     ) {
+      this.logEligibilityRead({
+        profileId,
+        level: 'computed',
+        computeMs: computedAtMillis - computeStartMillis,
+        resultCount: results.length,
+        cached: false
+      });
       return results;
     }
 
@@ -900,7 +918,26 @@ export class UserGroupsService {
       ttlSec,
       timer
     );
+    this.logEligibilityRead({
+      profileId,
+      level: 'computed',
+      computeMs: computedAtMillis - computeStartMillis,
+      resultCount: results.length,
+      cached: true
+    });
     return results;
+  }
+
+  private logEligibilityRead(param: {
+    readonly profileId: string;
+    readonly level: 'redis' | 'lock_wait' | 'computed';
+    readonly computeMs?: number;
+    readonly resultCount: number;
+    readonly cached?: boolean;
+  }) {
+    // Memory-cache hits are deliberately not logged: they are the dominant
+    // path and would flood the logs without adding attribution value.
+    logger.info(`[ELIGIBILITY_READ] ${JSON.stringify(param)}`);
   }
 
   private hasProfileGroupChangeAdvanced(


### PR DESCRIPTION
## What

Adds a single structured log line, `[ELIGIBILITY_READ] {...}`, to `UserGroupsService.getGroupsUserIsEligibleForWithCache`, emitted on the three non-memory resolution paths:

- `level: "redis"` — served from the shared redis cache
- `level: "lock_wait"` — served from redis after waiting on another instance's compute lock
- `level: "computed"` — full recompute, with `computeMs`, `resultCount`, and `cached: true|false` (`false` = result was not cached because the profile's group membership advanced during compute)

Memory-cache hits are deliberately not logged — they are the dominant path and would flood logs without adding attribution value.

## Why

The eligibility check backs visibility/rights on effectively every Brain endpoint, and its total-cache-miss tail is 6+ seconds at p99. The existing slow-request timer reports show per-step spans but not which cache level served a request or how often full recomputes happen (and whether they cluster after wave/group-creation invalidations). This line makes the miss rate, the compute duration distribution, and invalidation stampedes directly measurable in CloudWatch, so the follow-up eligibility PRs (surgical invalidation, compute parallelization, indexes) can be validated with before/after data.

## Notes

- No behavior change; log-only.
- docs/architecture.md not updated: no change to system shape.
- Help-bot knowledge not updated: no user-visible behavior change.

## Deployment

- `api` (redeploy to pick up the log line). No other services affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
