### PR TITLE
perf(db): add indexes for eligibility hot-path queries

### DIFF
--- a/src/entities/IRating.ts
+++ b/src/entities/IRating.ts
@@ -29,6 +29,7 @@ import { RATINGS_TABLE } from '@/constants';
   'rater_profile_id',
   'rating'
 ])
+@Index('idx_ratings_6', ['rater_profile_id', 'matter', 'rating'])
 export class Rating {
   @PrimaryColumn({ type: 'varchar', length: 50, collation: 'utf8_bin' })
   rater_profile_id!: string;

--- a/src/entities/IWave.ts
+++ b/src/entities/IWave.ts
@@ -198,6 +198,11 @@ export class WaveBase implements WaveBaseType {
 @Entity(WAVES_TABLE)
 @Index('idx_wave_serialno_id', ['serial_no', 'id'])
 @Index('idx_wave_parent_wave_id', ['parent_wave_id'])
+@Index('idx_wave_visibility_group_id', ['visibility_group_id'])
+@Index('idx_wave_admin_group_id', ['admin_group_id'])
+@Index('idx_wave_chat_group_id', ['chat_group_id'])
+@Index('idx_wave_participation_group_id', ['participation_group_id'])
+@Index('idx_wave_voting_group_id', ['voting_group_id'])
 export class WaveEntity extends WaveBase {
   @Column({ type: 'varchar', length: 100, unique: true, nullable: false })
   readonly id!: string;

--- a/src/entities/IXTdhGrant.ts
+++ b/src/entities/IXTdhGrant.ts
@@ -4,6 +4,7 @@ import { XTDH_GRANTS_TABLE } from '@/constants';
 @Entity(XTDH_GRANTS_TABLE)
 @Index(['target_chain', 'target_contract'])
 @Index(['status', 'valid_from', 'target_partition'])
+@Index('idx_status_target_partition', ['status', 'target_partition'])
 export class XTdhGrantEntity {
   @PrimaryColumn({ type: 'varchar', length: 100, nullable: false })
   readonly id: string;


### PR DESCRIPTION
## What

Adds index coverage for three eligibility hot-path queries, via TypeORM entity definitions only (the dbMigrations loop runs with `sync=true` and applies entity changes; no migration files, per AGENTS.md):

- **waves**: `idx_wave_visibility_group_id`, `idx_wave_admin_group_id`, `idx_wave_chat_group_id`, `idx_wave_participation_group_id`, `idx_wave_voting_group_id` — serve `userGroupsDb.getAllWaveRelatedGroups`, whose five UNION ALL branches each select a single group-id column from `waves` and previously required full table scans (one per branch, on every eligibility compute whose wave-groups cache is cold). Each branch becomes an index-only scan. Declared on `WaveEntity` only (not `WaveBase`), so `waves_archive` is not affected.
- **ratings**: `idx_ratings_6 (rater_profile_id, matter, rating)` — serves `userGroupsDb.getGivenCicAndRep` (`select matter, sum(rating) ... where rater_profile_id = :p group by 1`). None of the existing `idx_ratings_1..5` lead with `rater_profile_id`. The new index is covering: equality seek on `rater_profile_id`, `matter` for the GROUP BY, `rating` summed straight from the index.
- **xtdh_grants**: `idx_status_target_partition (status, target_partition)` — serves `userGroupsDb.inWhichOfGrantsIsProfileBeneficiary` (`status = 'GRANTED'` + join on `target_partition`). The existing `(status, valid_from, target_partition)` composite is not usable past `valid_from` for this access path.

## Why

These queries sit inside the eligibility compute that backs visibility/rights on every Brain endpoint; on total cache miss they run per profile. This is part of the eligibility hot-path work discussed with @gelatogenesis (companion PRs: read-attribution logging, surgical cache invalidation, compute parallelization).

## Operational note (please confirm before prod deploy)

`ratings` is a large table — TypeORM sync will run `ALTER TABLE ADD INDEX` when dbMigrationsLoop next runs after deploy. Index build duration and impact on `ratings` should be sized/confirmed first. `waves` and `xtdh_grants` are small by comparison.

## Notes

- Additive `@Index` decorators only; no column/type/existing-index changes, no new entities, no migrations.
- docs/architecture.md not updated: no change to system shape.

## Deployment

- `dbMigrationsLoop` applies the schema sync (indexes build on its next run after deploy). No API code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
