### PR TITLE
perf(api): scope eligibility cache invalidation to affected profiles

### DIFF
--- a/src/api-serverless/src/community-members/user-groups-service-cache-invalidation.test.ts
+++ b/src/api-serverless/src/community-members/user-groups-service-cache-invalidation.test.ts
@@ -1,0 +1,458 @@
+import { NewUserGroupEntity, UserGroupsService } from './user-groups.service';
+import { UserGroupsDb } from '@/user-groups/user-groups.db';
+import {
+  GroupTdhInclusionStrategy,
+  UserGroupEntity
+} from '@/entities/IUserGroup';
+import {
+  clearWaveGroupsCache,
+  evictWaveGroupsEntityCache,
+  getRedisClient
+} from '@/redis';
+import { AbusivenessCheckService } from '@/profiles/abusiveness-check.service';
+import { MetricsRecorder } from '@/metrics/MetricsRecorder';
+import { ApiGroupFull } from '@/api/generated/models/ApiGroupFull';
+import { ApiGroupTdhInclusionStrategy } from '@/api/generated/models/ApiGroupTdhInclusionStrategy';
+import { RequestContext } from '@/request.context';
+import * as mcache from 'memory-cache';
+
+jest.mock('@/redis', () => ({
+  ...jest.requireActual('@/redis'),
+  getRedisClient: jest.fn(),
+  clearWaveGroupsCache: jest.fn(),
+  evictWaveGroupsEntityCache: jest.fn()
+}));
+
+const CREATOR_ID = 'creator-profile-1';
+const GROUP_ID = 'group-1';
+const OLD_GROUP_ID = 'group-0';
+const IDENTITY_GROUP_ID = 'identity-group-1';
+
+type NewGroupInput = Omit<
+  NewUserGroupEntity,
+  'profile_group_id' | 'excluded_profile_group_id'
+> & {
+  addresses: string[];
+  excluded_addresses: string[];
+};
+
+function aNewGroup(overrides: Partial<NewGroupInput> = {}): NewGroupInput {
+  return {
+    name: 'Test Group',
+    cic_min: null,
+    cic_max: null,
+    cic_user: null,
+    cic_direction: null,
+    rep_min: null,
+    rep_max: null,
+    rep_user: null,
+    rep_direction: null,
+    rep_category: null,
+    tdh_min: null,
+    tdh_max: null,
+    tdh_inclusion_strategy: GroupTdhInclusionStrategy.TDH,
+    level_min: null,
+    level_max: null,
+    owns_meme: false,
+    owns_meme_tokens: null,
+    owns_gradient: false,
+    owns_gradient_tokens: null,
+    owns_nextgen: false,
+    owns_nextgen_tokens: null,
+    owns_lab: false,
+    owns_lab_tokens: null,
+    visible: true,
+    is_private: false,
+    is_direct_message: false,
+    is_beneficiary_of_grant_id: null,
+    addresses: ['0x1', '0x2'],
+    excluded_addresses: [],
+    ...overrides
+  };
+}
+
+function aGroupEntity(
+  overrides: Partial<UserGroupEntity> = {}
+): UserGroupEntity {
+  return {
+    id: GROUP_ID,
+    name: 'Group 1',
+    cic_min: null,
+    cic_max: null,
+    cic_user: null,
+    cic_direction: null,
+    rep_min: null,
+    rep_max: null,
+    rep_user: null,
+    rep_direction: null,
+    rep_category: null,
+    tdh_min: null,
+    tdh_max: null,
+    tdh_inclusion_strategy: GroupTdhInclusionStrategy.TDH,
+    level_min: null,
+    level_max: null,
+    created_at: new Date(),
+    created_by: CREATOR_ID,
+    visible: true,
+    owns_meme: false,
+    owns_meme_tokens: null,
+    owns_gradient: false,
+    owns_gradient_tokens: null,
+    owns_nextgen: false,
+    owns_nextgen_tokens: null,
+    owns_lab: false,
+    owns_lab_tokens: null,
+    profile_group_id: IDENTITY_GROUP_ID,
+    excluded_profile_group_id: null,
+    is_pure_profile_group: true,
+    is_private: false,
+    is_direct_message: false,
+    is_beneficiary_of_grant_id: null,
+    ...overrides
+  } as UserGroupEntity;
+}
+
+function anApiGroupFull(
+  groupOverrides: Partial<ApiGroupFull['group']> = {},
+  overrides: Partial<ApiGroupFull> = {}
+): ApiGroupFull {
+  return {
+    id: GROUP_ID,
+    name: 'Group 1',
+    visible: true,
+    is_private: false,
+    created_at: 1_000,
+    created_by: { id: CREATOR_ID } as unknown as ApiGroupFull['created_by'],
+    group: {
+      cic: { min: null, max: null, direction: null, user_identity: null },
+      rep: {
+        min: null,
+        max: null,
+        direction: null,
+        user_identity: null,
+        category: null
+      },
+      level: { min: null, max: null },
+      tdh: {
+        min: null,
+        max: null,
+        inclusion_strategy: ApiGroupTdhInclusionStrategy.Tdh
+      },
+      owns_nfts: [],
+      identity_group_id: IDENTITY_GROUP_ID,
+      identity_group_identities_count: 2,
+      excluded_identity_group_id: null,
+      excluded_identity_group_identities_count: 0,
+      is_beneficiary_of_grant_id: null,
+      is_beneficiary_of_grant: null,
+      ...groupOverrides
+    },
+    ...overrides
+  };
+}
+
+function buildUserGroupsDbMock() {
+  return {
+    executeNativeQueriesInTransaction: jest
+      .fn()
+      .mockImplementation(async (callback: any) => callback({})),
+    insertGroupEntriesAndGetGroupIds: jest
+      .fn()
+      .mockResolvedValue({ profile_group_id: IDENTITY_GROUP_ID }),
+    save: jest.fn().mockResolvedValue(undefined),
+    deleteById: jest.fn().mockResolvedValue(undefined),
+    changeVisibilityAndSetId: jest.fn().mockResolvedValue(undefined),
+    getByIds: jest.fn().mockResolvedValue([]),
+    findUserGroupsIdentityGroupProfileIds: jest.fn().mockResolvedValue({}),
+    insertGroupChanges: jest.fn().mockResolvedValue(undefined)
+  };
+}
+
+type UserGroupsDbMock = ReturnType<typeof buildUserGroupsDbMock>;
+
+function buildService(userGroupsDb: UserGroupsDbMock) {
+  return new UserGroupsService(
+    userGroupsDb as unknown as UserGroupsDb,
+    {
+      checkFilterName: jest.fn().mockResolvedValue({ status: 'ALLOWED' })
+    } as unknown as AbusivenessCheckService,
+    {
+      recordActiveIdentity: jest.fn().mockResolvedValue(undefined)
+    } as unknown as MetricsRecorder
+  );
+}
+
+function buildRedisMock() {
+  return {
+    get: jest.fn().mockResolvedValue(null),
+    set: jest.fn().mockResolvedValue('OK'),
+    del: jest.fn().mockResolvedValue(1)
+  };
+}
+
+const ctx: RequestContext = { timer: undefined };
+
+describe('UserGroupsService eligibility cache invalidation scoping', () => {
+  let redis: ReturnType<typeof buildRedisMock>;
+
+  beforeAll(() => {
+    process.env.REPLICA_CATCHUP_DELAY_AFTER_WRITE = '0';
+  });
+
+  afterAll(() => {
+    delete process.env.REPLICA_CATCHUP_DELAY_AFTER_WRITE;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mcache.clear();
+    redis = buildRedisMock();
+    (getRedisClient as jest.Mock).mockReturnValue(redis);
+  });
+
+  describe('save', () => {
+    async function saveGroup(group: NewGroupInput) {
+      const userGroupsDb = buildUserGroupsDbMock();
+      const service = buildService(userGroupsDb);
+      jest.spyOn(service, 'getByIdOrThrow').mockResolvedValue(anApiGroupFull());
+      await service.save(group, CREATOR_ID, ctx);
+      return userGroupsDb;
+    }
+
+    it('skips the global version bump for a pure inclusion-list group but evicts the blob and invalidates the creator', async () => {
+      await saveGroup(aNewGroup());
+      expect(clearWaveGroupsCache).not.toHaveBeenCalled();
+      expect(evictWaveGroupsEntityCache).toHaveBeenCalledTimes(1);
+      expect(redis.del).toHaveBeenCalledWith(
+        `cache_6529_eligible_groups:${CREATOR_ID}`
+      );
+    });
+
+    it('skips the global version bump for an inclusion-list group with exclusions and no criteria', async () => {
+      await saveGroup(aNewGroup({ excluded_addresses: ['0x3'] }));
+      expect(clearWaveGroupsCache).not.toHaveBeenCalled();
+      expect(evictWaveGroupsEntityCache).toHaveBeenCalledTimes(1);
+    });
+
+    it('bumps the global version for a group with non-identity criteria', async () => {
+      await saveGroup(aNewGroup({ tdh_min: 10 }));
+      expect(clearWaveGroupsCache).toHaveBeenCalledTimes(1);
+      expect(evictWaveGroupsEntityCache).not.toHaveBeenCalled();
+      expect(redis.del).toHaveBeenCalledWith(
+        `cache_6529_eligible_groups:${CREATOR_ID}`
+      );
+    });
+
+    it('bumps the global version for an exclusions-only group without an inclusion list', async () => {
+      await saveGroup(
+        aNewGroup({ addresses: [], excluded_addresses: ['0x3'] })
+      );
+      expect(clearWaveGroupsCache).toHaveBeenCalledTimes(1);
+      expect(evictWaveGroupsEntityCache).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('changeVisibility', () => {
+    it('bumps only the members of a pure inclusion-list group instead of the global version', async () => {
+      const userGroupsDb = buildUserGroupsDbMock();
+      userGroupsDb.findUserGroupsIdentityGroupProfileIds.mockResolvedValue({
+        [IDENTITY_GROUP_ID]: ['member-1', 'member-2']
+      });
+      const service = buildService(userGroupsDb);
+      jest.spyOn(service, 'getByIdOrThrow').mockResolvedValue(anApiGroupFull());
+
+      await service.changeVisibility(
+        {
+          group_id: GROUP_ID,
+          old_version_id: null,
+          visible: true,
+          profile_id: CREATOR_ID
+        },
+        ctx
+      );
+
+      expect(clearWaveGroupsCache).not.toHaveBeenCalled();
+      expect(evictWaveGroupsEntityCache).toHaveBeenCalledTimes(1);
+      expect(
+        userGroupsDb.findUserGroupsIdentityGroupProfileIds
+      ).toHaveBeenCalledWith([IDENTITY_GROUP_ID]);
+      expect(userGroupsDb.insertGroupChanges).toHaveBeenCalledWith([
+        'member-1',
+        'member-2'
+      ]);
+    });
+
+    it('bumps the global version for a group with non-identity criteria', async () => {
+      const userGroupsDb = buildUserGroupsDbMock();
+      const service = buildService(userGroupsDb);
+      jest.spyOn(service, 'getByIdOrThrow').mockResolvedValue(
+        anApiGroupFull({
+          tdh: {
+            min: 10,
+            max: null,
+            inclusion_strategy: ApiGroupTdhInclusionStrategy.Tdh
+          }
+        })
+      );
+
+      await service.changeVisibility(
+        {
+          group_id: GROUP_ID,
+          old_version_id: null,
+          visible: true,
+          profile_id: CREATOR_ID
+        },
+        ctx
+      );
+
+      expect(clearWaveGroupsCache).toHaveBeenCalledTimes(1);
+      expect(evictWaveGroupsEntityCache).not.toHaveBeenCalled();
+      expect(userGroupsDb.insertGroupChanges).not.toHaveBeenCalled();
+    });
+
+    it('bumps members of both new and replaced pure list groups when publishing a new version', async () => {
+      const userGroupsDb = buildUserGroupsDbMock();
+      userGroupsDb.findUserGroupsIdentityGroupProfileIds.mockResolvedValue({
+        'identity-group-new': ['member-1', 'member-2'],
+        'identity-group-old': ['member-2', 'member-3']
+      });
+      const service = buildService(userGroupsDb);
+      const newGroupInitial = anApiGroupFull({
+        identity_group_id: 'identity-group-new'
+      });
+      const oldGroup = anApiGroupFull(
+        { identity_group_id: 'identity-group-old' },
+        { id: OLD_GROUP_ID }
+      );
+      const updatedGroupAfterSwap = anApiGroupFull(
+        { identity_group_id: 'identity-group-new' },
+        { id: OLD_GROUP_ID }
+      );
+      jest
+        .spyOn(service, 'getByIdOrThrow')
+        .mockResolvedValueOnce(newGroupInitial)
+        .mockResolvedValueOnce(oldGroup)
+        .mockResolvedValueOnce(updatedGroupAfterSwap);
+
+      await service.changeVisibility(
+        {
+          group_id: GROUP_ID,
+          old_version_id: OLD_GROUP_ID,
+          visible: true,
+          profile_id: CREATOR_ID
+        },
+        ctx
+      );
+
+      expect(clearWaveGroupsCache).not.toHaveBeenCalled();
+      expect(evictWaveGroupsEntityCache).toHaveBeenCalledTimes(1);
+      expect(
+        userGroupsDb.findUserGroupsIdentityGroupProfileIds
+      ).toHaveBeenCalledWith(['identity-group-new', 'identity-group-old']);
+      expect(userGroupsDb.insertGroupChanges).toHaveBeenCalledWith([
+        'member-1',
+        'member-2',
+        'member-3'
+      ]);
+    });
+  });
+
+  describe('onWaveRelatedGroupsChanged', () => {
+    it('only evicts the entity blob when no group ids are given', async () => {
+      const userGroupsDb = buildUserGroupsDbMock();
+      const service = buildService(userGroupsDb);
+
+      await service.onWaveRelatedGroupsChanged([null, undefined], ctx);
+
+      expect(evictWaveGroupsEntityCache).toHaveBeenCalledTimes(1);
+      expect(clearWaveGroupsCache).not.toHaveBeenCalled();
+      expect(userGroupsDb.getByIds).not.toHaveBeenCalled();
+      expect(userGroupsDb.insertGroupChanges).not.toHaveBeenCalled();
+    });
+
+    it('bumps only the distinct members when all groups are pure inclusion-list groups', async () => {
+      const userGroupsDb = buildUserGroupsDbMock();
+      userGroupsDb.getByIds.mockResolvedValue([
+        aGroupEntity({ id: 'group-a', profile_group_id: 'identity-group-a' }),
+        aGroupEntity({ id: 'group-b', profile_group_id: 'identity-group-b' })
+      ]);
+      userGroupsDb.findUserGroupsIdentityGroupProfileIds.mockResolvedValue({
+        'identity-group-a': ['member-1', 'member-2'],
+        'identity-group-b': ['member-2', 'member-3']
+      });
+      const service = buildService(userGroupsDb);
+
+      await service.onWaveRelatedGroupsChanged(
+        ['group-a', 'group-b', 'group-a', null, undefined],
+        ctx
+      );
+
+      expect(clearWaveGroupsCache).not.toHaveBeenCalled();
+      expect(evictWaveGroupsEntityCache).toHaveBeenCalledTimes(1);
+      expect(userGroupsDb.getByIds).toHaveBeenCalledWith(
+        ['group-a', 'group-b'],
+        ctx
+      );
+      expect(
+        userGroupsDb.findUserGroupsIdentityGroupProfileIds
+      ).toHaveBeenCalledWith(['identity-group-a', 'identity-group-b']);
+      expect(userGroupsDb.insertGroupChanges).toHaveBeenCalledWith([
+        'member-1',
+        'member-2',
+        'member-3'
+      ]);
+    });
+
+    it('bumps the global version when any group has non-identity criteria', async () => {
+      const userGroupsDb = buildUserGroupsDbMock();
+      userGroupsDb.getByIds.mockResolvedValue([
+        aGroupEntity({ id: 'group-a', profile_group_id: 'identity-group-a' }),
+        aGroupEntity({
+          id: 'group-b',
+          profile_group_id: 'identity-group-b',
+          tdh_min: 5
+        })
+      ]);
+      const service = buildService(userGroupsDb);
+
+      await service.onWaveRelatedGroupsChanged(['group-a', 'group-b'], ctx);
+
+      expect(clearWaveGroupsCache).toHaveBeenCalledTimes(1);
+      expect(evictWaveGroupsEntityCache).not.toHaveBeenCalled();
+      expect(userGroupsDb.insertGroupChanges).not.toHaveBeenCalled();
+    });
+
+    it('bumps the global version when any group has no inclusion list', async () => {
+      const userGroupsDb = buildUserGroupsDbMock();
+      userGroupsDb.getByIds.mockResolvedValue([
+        aGroupEntity({ id: 'group-a', profile_group_id: 'identity-group-a' }),
+        aGroupEntity({
+          id: 'group-b',
+          profile_group_id: null,
+          excluded_profile_group_id: 'identity-group-x'
+        })
+      ]);
+      const service = buildService(userGroupsDb);
+
+      await service.onWaveRelatedGroupsChanged(['group-a', 'group-b'], ctx);
+
+      expect(clearWaveGroupsCache).toHaveBeenCalledTimes(1);
+      expect(evictWaveGroupsEntityCache).not.toHaveBeenCalled();
+      expect(userGroupsDb.insertGroupChanges).not.toHaveBeenCalled();
+    });
+
+    it('bumps the global version when any group id cannot be loaded', async () => {
+      const userGroupsDb = buildUserGroupsDbMock();
+      userGroupsDb.getByIds.mockResolvedValue([
+        aGroupEntity({ id: 'group-a', profile_group_id: 'identity-group-a' })
+      ]);
+      const service = buildService(userGroupsDb);
+
+      await service.onWaveRelatedGroupsChanged(['group-a', 'group-gone'], ctx);
+
+      expect(clearWaveGroupsCache).toHaveBeenCalledTimes(1);
+      expect(evictWaveGroupsEntityCache).not.toHaveBeenCalled();
+      expect(userGroupsDb.insertGroupChanges).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/api-serverless/src/community-members/user-groups.service.ts
+++ b/src/api-serverless/src/community-members/user-groups.service.ts
@@ -64,6 +64,7 @@ import { ids } from '@/ids';
 import { collections } from '@/collections';
 import {
   clearWaveGroupsCache,
+  evictWaveGroupsEntityCache,
   getRedisClient,
   WAVE_GROUPS_CACHE_KEY,
   WAVE_GROUPS_VERSION_CACHE_KEY
@@ -211,9 +212,45 @@ export class UserGroupsService {
         }
       );
     await giveReadReplicaTimeToCatchUp();
-    await clearWaveGroupsCache();
+    if (this.isNewGroupEligibilityScopedToItsMembers(group)) {
+      // Inclusion-list-only group: every listed (and excluded) member already
+      // got an individual profile_group_changes bump when the list rows were
+      // inserted, and nobody outside the list can be affected. Skip the global
+      // version bump which would invalidate all profiles' eligibility caches.
+      await evictWaveGroupsEntityCache();
+    } else {
+      await clearWaveGroupsCache();
+    }
     await this.invalidateGroupsUserIsEligibleFor(createdBy);
     return savedEntity;
+  }
+
+  /**
+   * True if the new group's eligibility is fully determined by an explicit
+   * inclusion list (has addresses, no criteria conditions). An exclusions-only
+   * group means "everyone except X" and a criteria group can match anyone, so
+   * both of those can affect profiles outside any member list.
+   */
+  private isNewGroupEligibilityScopedToItsMembers(
+    group: Omit<
+      NewUserGroupEntity,
+      'profile_group_id' | 'excluded_profile_group_id'
+    > & {
+      addresses: string[];
+    }
+  ): boolean {
+    return (
+      group.addresses.length > 0 &&
+      !hasGroupGotAnyNonIdentityConditions({
+        ...group,
+        id: '',
+        created_at: new Date(),
+        created_by: '',
+        profile_group_id: null,
+        excluded_profile_group_id: null,
+        is_pure_profile_group: false
+      })
+    );
   }
 
   public async findOrCreateDirectMessageGroup(
@@ -1150,7 +1187,7 @@ export class UserGroupsService {
     },
     ctx: RequestContext
   ): Promise<ApiGroupFull> {
-    const updatedGroupEntity =
+    const { updatedGroup, replacedGroup } =
       await this.userGroupsDb.executeNativeQueriesInTransaction(
         async (connection) => {
           const ctxWithConnection = { ...ctx, connection };
@@ -1158,13 +1195,14 @@ export class UserGroupsService {
             group_id,
             ctxWithConnection
           );
+          let oldGroupEntity: ApiGroupFull | null = null;
           if (old_version_id) {
             if (old_version_id === groupEntity.id) {
               throw new BadRequestException(
                 'Old version id should not be the same as the current'
               );
             }
-            const oldGroupEntity = await this.getByIdOrThrow(
+            oldGroupEntity = await this.getByIdOrThrow(
               old_version_id,
               ctxWithConnection
             );
@@ -1200,15 +1238,143 @@ export class UserGroupsService {
             { identityId: profile_id },
             ctxWithConnection
           );
-          return await this.getByIdOrThrow(
-            old_version_id ?? group_id,
-            ctxWithConnection
-          );
+          return {
+            updatedGroup: await this.getByIdOrThrow(
+              old_version_id ?? group_id,
+              ctxWithConnection
+            ),
+            replacedGroup: oldGroupEntity
+          };
         }
       );
     await giveReadReplicaTimeToCatchUp();
-    await clearWaveGroupsCache();
-    return updatedGroupEntity;
+    await this.invalidateEligibilityCachesAfterVisibilityChange(
+      updatedGroup,
+      replacedGroup
+    );
+    return updatedGroup;
+  }
+
+  /**
+   * With old_version_id the updated group takes over the replaced group's id,
+   * so waves referencing that id switch to the new membership. When both the
+   * updated and the replaced group are plain inclusion-list groups, only
+   * their listed members can gain or lose eligibility - bump exactly those
+   * members instead of doing the global version bump which would invalidate
+   * every profile's eligibility cache at once.
+   */
+  private async invalidateEligibilityCachesAfterVisibilityChange(
+    updatedGroup: ApiGroupFull,
+    replacedGroup: ApiGroupFull | null
+  ): Promise<void> {
+    const affectedGroups = [updatedGroup, replacedGroup].filter(
+      (it): it is ApiGroupFull => it !== null
+    );
+    const allScopedToMembers = affectedGroups.every((it) =>
+      this.isGroupEligibilityScopedToItsMembers(it)
+    );
+    if (!allScopedToMembers) {
+      await clearWaveGroupsCache();
+      return;
+    }
+    await evictWaveGroupsEntityCache();
+    await this.invalidateGroupMembersEligibility(
+      affectedGroups
+        .map((it) => it.group.identity_group_id)
+        .filter((it): it is string => it !== null)
+    );
+  }
+
+  /**
+   * True if the group's eligibility is fully determined by an explicit
+   * inclusion list: changes around such a group cannot affect any profile
+   * outside that list. Criteria groups, exclusion-only ("everyone except X")
+   * groups and no-condition ("everyone") groups can affect anyone, so they
+   * still require the global version bump.
+   */
+  private isGroupEligibilityScopedToItsMembers(group: ApiGroupFull): boolean {
+    const description = group.group;
+    return (
+      description.identity_group_id !== null &&
+      description.owns_nfts.length === 0 &&
+      description.tdh.min === null &&
+      description.tdh.max === null &&
+      description.level.min === null &&
+      description.level.max === null &&
+      description.rep.min === null &&
+      description.rep.max === null &&
+      description.rep.user_identity === null &&
+      description.rep.category === null &&
+      description.cic.min === null &&
+      description.cic.max === null &&
+      description.cic.user_identity === null &&
+      description.is_beneficiary_of_grant_id === null
+    );
+  }
+
+  private async invalidateGroupMembersEligibility(
+    identityGroupIds: string[]
+  ): Promise<void> {
+    const distinctIdentityGroupIds = collections.distinct(identityGroupIds);
+    if (!distinctIdentityGroupIds.length) {
+      return;
+    }
+    const memberProfileIdsByIdentityGroupId =
+      await this.userGroupsDb.findUserGroupsIdentityGroupProfileIds(
+        distinctIdentityGroupIds
+      );
+    const memberProfileIds = collections.distinct(
+      Object.values(memberProfileIdsByIdentityGroupId).flat()
+    );
+    if (memberProfileIds.length) {
+      await this.userGroupsDb.insertGroupChanges(memberProfileIds);
+    }
+  }
+
+  /**
+   * Call after a wave has been created or updated with the given group ids.
+   * Groups REMOVED from a wave need no invalidation at all: eligibility
+   * filters read the wave row fresh, and a group id lingering in someone's
+   * cached eligible-groups list simply stops matching anything.
+   */
+  public async onWaveRelatedGroupsChanged(
+    groupIds: (string | null | undefined)[],
+    ctx: RequestContext
+  ): Promise<void> {
+    const distinctGroupIds = collections.distinct(
+      groupIds.filter((it): it is string => !!it)
+    );
+    if (!distinctGroupIds.length) {
+      await evictWaveGroupsEntityCache();
+      return;
+    }
+    const groupEntities = await this.userGroupsDb.getByIds(
+      distinctGroupIds,
+      ctx
+    );
+    const allScopedToMembers =
+      groupEntities.length === distinctGroupIds.length &&
+      groupEntities.every(
+        (it) =>
+          it.profile_group_id !== null &&
+          !hasGroupGotAnyNonIdentityConditions(it)
+      );
+    if (!allScopedToMembers) {
+      // Unknown, criteria-based or exclusion-only group in play: profiles
+      // outside any inclusion list may be affected, so keep the global bump.
+      await clearWaveGroupsCache();
+      return;
+    }
+    // Pure inclusion-list groups: non-members' eligibility is unchanged by a
+    // wave (re)using them, while members need these group ids to show up in
+    // their cached eligible-groups lists - a per-member bump achieves that
+    // without invalidating every other profile's cache.
+    await evictWaveGroupsEntityCache();
+    await this.invalidateGroupMembersEligibility(
+      groupEntities
+        .map((it) => it.profile_group_id)
+        .filter((it): it is string => it !== null)
+    );
   }
 
   private async doNameAbusivenessCheck(groupEntity: ApiGroupFull) {

--- a/src/api-serverless/src/waves/wave.api.service.ts
+++ b/src/api-serverless/src/waves/wave.api.service.ts
@@ -76,7 +76,6 @@ import {
 } from '../identity-subscriptions/identity-subscriptions.db';
 import { SearchWavesParams, wavesApiDb, WavesApiDb } from './waves.api.db';
 import { wavesMappers, WavesMappers } from './waves.mappers';
-import { clearWaveGroupsCache } from '../../../redis';
 import {
   metricsRecorder,
   MetricsRecorder
@@ -579,7 +578,16 @@ export class WaveApiService {
     );
     await invalidateWaveUnreadCacheForWave(createdWave.id);
     await giveReadReplicaTimeToCatchUp();
-    await clearWaveGroupsCache();
+    await this.userGroupsService.onWaveRelatedGroupsChanged(
+      [
+        createWaveRequest.visibility.scope.group_id,
+        createWaveRequest.participation.scope.group_id,
+        createWaveRequest.chat.scope.group_id,
+        createWaveRequest.voting.scope.group_id,
+        createWaveRequest.wave.admin_group?.group_id
+      ],
+      ctx
+    );
     await sendIdentityPushNotifications(pendingPushNotificationIds);
     timer.stop(`${this.constructor.name}->createWave`);
     return createdWave;

--- a/src/api-serverless/src/waves/waves.routes.ts
+++ b/src/api-serverless/src/waves/waves.routes.ts
@@ -18,7 +18,6 @@ import {
   NotFoundException
 } from '../../../exceptions';
 import { numbers } from '../../../numbers';
-import { clearWaveGroupsCache } from '../../../redis';
 import { RequestContext } from '../../../request.context';
 import { Time, Timer } from '../../../time';
 import { giveReadReplicaTimeToCatchUp } from '../api-helpers';
@@ -276,7 +275,16 @@ router.post(
       requestContext
     );
     await giveReadReplicaTimeToCatchUp();
-    await clearWaveGroupsCache();
+    await userGroupsService.onWaveRelatedGroupsChanged(
+      [
+        request.visibility.scope.group_id,
+        request.participation.scope.group_id,
+        request.chat.scope.group_id,
+        request.voting.scope.group_id,
+        request.wave.admin_group?.group_id
+      ],
+      requestContext
+    );
     res.send(wave);
   }
 );

--- a/src/evict-wave-groups-entity-cache.test.ts
+++ b/src/evict-wave-groups-entity-cache.test.ts
@@ -1,0 +1,58 @@
+jest.mock('redis', () => ({ createClient: jest.fn() }));
+
+import { createClient } from 'redis';
+import {
+  clearWaveGroupsCache,
+  evictWaveGroupsEntityCache,
+  initRedis,
+  WAVE_GROUPS_CACHE_KEY,
+  WAVE_GROUPS_VERSION_CACHE_KEY
+} from '@/redis';
+
+describe('wave groups cache eviction helpers', () => {
+  const redisMock = {
+    on: jest.fn(),
+    connect: jest.fn().mockResolvedValue(undefined),
+    del: jest.fn().mockResolvedValue(1),
+    incr: jest.fn().mockResolvedValue(1)
+  };
+  const originalForceAvoidRedis = process.env.FORCE_AVOID_REDIS;
+  const originalRedisUrl = process.env.REDIS_URL;
+
+  beforeAll(async () => {
+    delete process.env.FORCE_AVOID_REDIS;
+    process.env.REDIS_URL = 'localhost';
+    (createClient as jest.Mock).mockReturnValue(redisMock);
+    await initRedis();
+  });
+
+  afterAll(() => {
+    if (originalForceAvoidRedis === undefined) {
+      delete process.env.FORCE_AVOID_REDIS;
+    } else {
+      process.env.FORCE_AVOID_REDIS = originalForceAvoidRedis;
+    }
+    if (originalRedisUrl === undefined) {
+      delete process.env.REDIS_URL;
+    } else {
+      process.env.REDIS_URL = originalRedisUrl;
+    }
+  });
+
+  beforeEach(() => {
+    redisMock.del.mockClear();
+    redisMock.incr.mockClear();
+  });
+
+  it('evictWaveGroupsEntityCache deletes only the entity blob and never bumps the version', async () => {
+    await evictWaveGroupsEntityCache();
+    expect(redisMock.del).toHaveBeenCalledWith(WAVE_GROUPS_CACHE_KEY);
+    expect(redisMock.incr).not.toHaveBeenCalled();
+  });
+
+  it('clearWaveGroupsCache deletes the entity blob and bumps the version', async () => {
+    await clearWaveGroupsCache();
+    expect(redisMock.del).toHaveBeenCalledWith(WAVE_GROUPS_CACHE_KEY);
+    expect(redisMock.incr).toHaveBeenCalledWith(WAVE_GROUPS_VERSION_CACHE_KEY);
+  });
+});

--- a/src/redis.ts
+++ b/src/redis.ts
@@ -223,6 +223,21 @@ export async function clearWaveGroupsCache() {
   ]);
 }
 
+/**
+ * Evicts only the shared wave-groups entity blob. Unlike
+ * clearWaveGroupsCache, this does NOT bump WAVE_GROUPS_VERSION_CACHE_KEY,
+ * which would invalidate every profile's cached eligible-groups entry at
+ * once. Use this when everyone whose eligibility could have changed has
+ * already been (or will be) invalidated individually via
+ * profile_group_changes.
+ */
+export async function evictWaveGroupsEntityCache() {
+  if (!redis) {
+    return;
+  }
+  await redis.del(WAVE_GROUPS_CACHE_KEY);
+}
+
 export function getRedisClient(): Redis | null {
   return redis || null;
 }

--- a/src/user-groups/insert-group-changes.test.ts
+++ b/src/user-groups/insert-group-changes.test.ts
@@ -1,0 +1,51 @@
+import 'reflect-metadata';
+import { UserGroupsDb } from '@/user-groups/user-groups.db';
+import { SqlExecutor } from '@/sql-executor';
+
+function buildDb() {
+  const execute = jest.fn().mockResolvedValue([]);
+  const db = new UserGroupsDb(() => ({ execute }) as unknown as SqlExecutor);
+  return { db, execute };
+}
+
+function countInsertedRows(statements: string[]): number {
+  return statements.join(' ').match(/\('profile-\d+'/g)?.length ?? 0;
+}
+
+describe('UserGroupsDb insertGroupChanges', () => {
+  it('does nothing for an empty profile id list', async () => {
+    const { db, execute } = buildDb();
+    await db.insertGroupChanges([]);
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('inserts small lists in a single statement', async () => {
+    const { db, execute } = buildDb();
+    await db.insertGroupChanges(['profile-1', 'profile-2']);
+    expect(execute).toHaveBeenCalledTimes(1);
+    const sql = execute.mock.calls[0][0] as string;
+    expect(sql).toContain("('profile-1'");
+    expect(sql).toContain("('profile-2'");
+  });
+
+  it('chunks large lists into multiple statements of at most 1000 rows', async () => {
+    const { db, execute } = buildDb();
+    const profileIds = Array.from(
+      { length: 2500 },
+      (_, index) => `profile-${index}`
+    );
+
+    await db.insertGroupChanges(profileIds);
+
+    expect(execute).toHaveBeenCalledTimes(3);
+    const statements = execute.mock.calls.map((call) => call[0] as string);
+    expect(statements[0]).toContain("('profile-0'");
+    expect(statements[0]).toContain("('profile-999'");
+    expect(statements[0]).not.toContain("('profile-1000'");
+    expect(statements[1]).toContain("('profile-1000'");
+    expect(statements[1]).toContain("('profile-1999'");
+    expect(statements[2]).toContain("('profile-2000'");
+    expect(statements[2]).toContain("('profile-2499'");
+    expect(countInsertedRows(statements)).toBe(2500);
+  });
+});

--- a/src/user-groups/user-groups.db.ts
+++ b/src/user-groups/user-groups.db.ts
@@ -889,8 +889,12 @@ export class UserGroupsDb extends LazyDbAccessCompatibleService {
   async insertGroupChanges(profileIds: string[]) {
     if (!profileIds.length) return null;
     const currentMillis = Time.currentMillis();
-    const sql = `INSERT INTO ${PROFILE_GROUP_CHANGES} (profile_id, chg_time) values ${profileIds.map((profileId) => `(${mysql.escape(profileId)}, ${currentMillis})`).join(', ')}`;
-    await this.db.execute(sql);
+    const chunkSize = 1000;
+    for (let i = 0; i < profileIds.length; i += chunkSize) {
+      const chunk = profileIds.slice(i, i + chunkSize);
+      const sql = `INSERT INTO ${PROFILE_GROUP_CHANGES} (profile_id, chg_time) values ${chunk.map((profileId) => `(${mysql.escape(profileId)}, ${currentMillis})`).join(', ')}`;
+      await this.db.execute(sql);
+    }
   }
 
   async inWhichOfGrantsIsProfileBeneficiary(


### PR DESCRIPTION
## What

Stops the community-wide eligibility-cache stampede. Today, `clearWaveGroupsCache()` INCRs the global wave-groups version on every group create (including **every new DM group**), group publish/visibility change, wave create and wave update. Every profile's cached eligible-groups entry embeds that version, so one INCR invalidates the eligibility cache of **all profiles at once** — the whole community then recomputes simultaneously through the (10-connection) API read pool. This is the main driver of the 6+ second p99 on eligibility "total cache miss".

The change scopes invalidation to the profiles that can actually be affected:

**Decision rule** — surgical (evict the shared entity blob, no version INCR) **iff every involved group has an explicit inclusion list AND zero non-identity criteria** (no tdh/level/rep/cic bounds or user/category, no owns_*, no grant). Everything else — criteria groups, exclusions-only ("everyone except X") groups, no-condition groups, unloadable/hidden group ids — keeps today's global bump.

Why this is safe: for an inclusion-list-only group, nobody outside the list can gain or lose eligibility, and every listed (and excluded) member already gets an individual `profile_group_changes` bump written transactionally when the list rows are inserted — which the cache validity check already consults on every read.

Per call site:
- **Group save**: pure list group (every DM) → blob evict only; members were pgc-bumped in the same transaction. Otherwise global bump.
- **Group visibility change**: considers **both** the updated group and, when `old_version_id` is used, the replaced group (the new group takes over the old id, so waves referencing it swap membership). Both pure lists → bump members of both lists via `profile_group_changes`; otherwise global bump.
- **Wave create/update**: new `userGroupsService.onWaveRelatedGroupsChanged(groupIds, ctx)` — all referenced groups pure lists → blob evict + bump those groups' members; any criteria/unknown group → global bump. Groups *removed* from a wave need no invalidation: queries read the wave row fresh, and a stale group id lingering in someone's cached list simply stops matching anything.
- `insertGroupChanges` now chunks its VALUES list (1000/statement) so large member lists are safe.

## Behavior notes

- DM flow end to end (create DM group → create DM wave) no longer bumps the global version at all; the DM's members see it immediately via their pgc bumps, everyone else's caches stay warm.
- Pre-existing gap (not introduced or changed here, flagging for awareness): wave-curation group writes (`wave_curations.community_group_id`) never invalidated these caches before either — they ride the 60s TTL. Unchanged.
- Conservative fallbacks everywhere: unknown/missing/hidden groups ⇒ global bump.

## Tests

17 new tests (plus 8 pre-existing, all green — 25 total): save pure-list / list+exclusions / criteria / exclusions-only; changeVisibility pure / criteria / old-version union; onWaveRelatedGroupsChanged empty / all-pure / criteria / no-inclusion / missing-entity; insertGroupChanges chunking; DEL-vs-INCR redis semantics. Lint (`--max-warnings=0`) and `tsc --noEmit` clean.

## Notes

- docs/architecture.md not updated: no change to system shape.
- Help-bot knowledge not updated: no user-visible behavior change (eligibility semantics unchanged; only invalidation scope).

## Deployment

- `api` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
