### PR TITLE
perf(api): parallelize eligibility compute and skip redundant wave-group scans

### DIFF
--- a/src/api-serverless/src/community-members/user-groups-service-cache-invalidation.test.ts
+++ b/src/api-serverless/src/community-members/user-groups-service-cache-invalidation.test.ts
@@ -1,6 +1,8 @@
 import { NewUserGroupEntity, UserGroupsService } from './user-groups.service';
 import { UserGroupsDb } from '@/user-groups/user-groups.db';
 import {
+  GroupBeneficiaryGrantMatchMode,
+  GroupNftOwnershipMatchMode,
   GroupTdhInclusionStrategy,
   UserGroupEntity
 } from '@/entities/IUserGroup';
@@ -11,6 +13,7 @@ import {
 } from '@/redis';
 import { AbusivenessCheckService } from '@/profiles/abusiveness-check.service';
 import { MetricsRecorder } from '@/metrics/MetricsRecorder';
+import { ApiGroupBeneficiaryGrantMatchMode } from '@/api/generated/models/ApiGroupBeneficiaryGrantMatchMode';
 import { ApiGroupFull } from '@/api/generated/models/ApiGroupFull';
 import { ApiGroupTdhInclusionStrategy } from '@/api/generated/models/ApiGroupTdhInclusionStrategy';
 import { RequestContext } from '@/request.context';
@@ -55,16 +58,22 @@ function aNewGroup(overrides: Partial<NewGroupInput> = {}): NewGroupInput {
     level_max: null,
     owns_meme: false,
     owns_meme_tokens: null,
+    owns_meme_tokens_match_mode: GroupNftOwnershipMatchMode.ALL_TOKENS,
     owns_gradient: false,
     owns_gradient_tokens: null,
+    owns_gradient_tokens_match_mode: GroupNftOwnershipMatchMode.ALL_TOKENS,
     owns_nextgen: false,
     owns_nextgen_tokens: null,
+    owns_nextgen_tokens_match_mode: GroupNftOwnershipMatchMode.ALL_TOKENS,
     owns_lab: false,
     owns_lab_tokens: null,
+    owns_lab_tokens_match_mode: GroupNftOwnershipMatchMode.ALL_TOKENS,
     visible: true,
     is_private: false,
     is_direct_message: false,
     is_beneficiary_of_grant_id: null,
+    is_beneficiary_of_grant_match_mode:
+      GroupBeneficiaryGrantMatchMode.ANY_TOKEN,
     addresses: ['0x1', '0x2'],
     excluded_addresses: [],
     ...overrides
@@ -144,6 +153,8 @@ function anApiGroupFull(
       excluded_identity_group_id: null,
       excluded_identity_group_identities_count: 0,
       is_beneficiary_of_grant_id: null,
+      is_beneficiary_of_grant_match_mode:
+        ApiGroupBeneficiaryGrantMatchMode.AnyToken,
       is_beneficiary_of_grant: null,
       ...groupOverrides
     },

--- a/src/api-serverless/src/community-members/user-groups-service.test.ts
+++ b/src/api-serverless/src/community-members/user-groups-service.test.ts
@@ -1,13 +1,21 @@
 import { NewUserGroupEntity, UserGroupsService } from './user-groups.service';
 import { UserGroupsDb } from '@/user-groups/user-groups.db';
 import {
+  FilterDirection,
   GroupBeneficiaryGrantMatchMode,
   GroupNftOwnershipMatchMode,
   GroupTdhInclusionStrategy,
   UserGroupEntity
 } from '@/entities/IUserGroup';
 import { XTdhGrantTokenMode } from '@/entities/IXTdhGrant';
-import { getRedisClient, WAVE_GROUPS_VERSION_CACHE_KEY } from '@/redis';
+import { RateMatter } from '@/entities/IRating';
+import { MEMES_CONTRACT } from '@/constants';
+import {
+  getRedisClient,
+  WAVE_GROUPS_CACHE_KEY,
+  WAVE_GROUPS_VERSION_CACHE_KEY
+} from '@/redis';
+import { SqlExecutor } from '@/sql-executor';
 import { Time } from '@/time';
 import * as mcache from 'memory-cache';
 import { AbusivenessCheckService } from '@/profiles/abusiveness-check.service';
@@ -39,7 +47,9 @@ function buildRedisMock(): RedisMock {
   };
 }
 
-function buildUserGroup(): UserGroupEntity {
+function buildUserGroup(
+  overrides: Partial<UserGroupEntity> = {}
+): UserGroupEntity {
   return {
     id: GROUP_ID,
     name: 'Group 1',
@@ -78,7 +88,9 @@ function buildUserGroup(): UserGroupEntity {
     is_private: false,
     is_direct_message: false,
     is_beneficiary_of_grant_id: null,
-    is_beneficiary_of_grant_match_mode: GroupBeneficiaryGrantMatchMode.ANY_TOKEN
+    is_beneficiary_of_grant_match_mode:
+      GroupBeneficiaryGrantMatchMode.ANY_TOKEN,
+    ...overrides
   } as UserGroupEntity;
 }
 
@@ -147,7 +159,13 @@ function buildUserGroupsDbMock() {
     }),
     getByIds: jest.fn().mockResolvedValue([buildUserGroup()]),
     getGroupsUserIsEligibleByIdentity: jest.fn().mockResolvedValue([GROUP_ID]),
-    getGroupsUserIsExcludedFromByIdentity: jest.fn().mockResolvedValue([])
+    getGroupsUserIsExcludedFromByIdentity: jest.fn().mockResolvedValue([]),
+    getGivenCicAndRep: jest.fn().mockResolvedValue({ cic: 0, rep: 0 }),
+    getAllProfileOwnedTokensByProfileIdGroupedByContract: jest
+      .fn()
+      .mockResolvedValue({}),
+    getRatings: jest.fn().mockResolvedValue([]),
+    findBeneficiaryGrantGroupIdsForProfile: jest.fn().mockResolvedValue([])
   };
 }
 
@@ -471,5 +489,346 @@ describe('UserGroupsService eligibility cache', () => {
       [GROUP_ID]
     ]);
     expect(userGroupsDb.getAllWaveRelatedGroups).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips the wave-group id scan when the wave-group entity blob is warm', async () => {
+    const waveGroup = buildUserGroup();
+    const redis = buildRedisMock();
+    redis.get.mockImplementation((key: string) => {
+      if (key === WAVE_GROUPS_VERSION_CACHE_KEY) {
+        return Promise.resolve('7');
+      }
+      if (key === WAVE_GROUPS_CACHE_KEY) {
+        return Promise.resolve(JSON.stringify([waveGroup]));
+      }
+      return Promise.resolve(null);
+    });
+    (getRedisClient as jest.Mock).mockReturnValue(redis);
+
+    const userGroupsDb = buildUserGroupsDbMock();
+    const service = buildService(userGroupsDb);
+
+    await expect(
+      service.getGroupsUserIsEligibleFor(PROFILE_ID)
+    ).resolves.toEqual([GROUP_ID]);
+    expect(userGroupsDb.getAllWaveRelatedGroups).not.toHaveBeenCalled();
+    expect(userGroupsDb.getByIds).not.toHaveBeenCalled();
+    expect(redis.set).not.toHaveBeenCalledWith(
+      WAVE_GROUPS_CACHE_KEY,
+      expect.anything(),
+      expect.anything()
+    );
+  });
+
+  it('scans wave-group ids and caches the entity blob when the blob is cold', async () => {
+    const waveGroup = buildUserGroup();
+    const redis = buildRedisMock();
+    redis.get.mockImplementation((key: string) => {
+      if (key === WAVE_GROUPS_VERSION_CACHE_KEY) {
+        return Promise.resolve('7');
+      }
+      return Promise.resolve(null);
+    });
+    (getRedisClient as jest.Mock).mockReturnValue(redis);
+
+    const userGroupsDb = buildUserGroupsDbMock();
+    userGroupsDb.getAllWaveRelatedGroups.mockResolvedValue([GROUP_ID]);
+    userGroupsDb.getByIds.mockResolvedValue([waveGroup]);
+    const service = buildService(userGroupsDb);
+
+    await expect(
+      service.getGroupsUserIsEligibleFor(PROFILE_ID)
+    ).resolves.toEqual([GROUP_ID]);
+    expect(userGroupsDb.getAllWaveRelatedGroups).toHaveBeenCalledTimes(1);
+    expect(userGroupsDb.getByIds).toHaveBeenCalledWith(
+      [GROUP_ID],
+      expect.anything()
+    );
+    expect(redis.set).toHaveBeenCalledWith(
+      WAVE_GROUPS_CACHE_KEY,
+      JSON.stringify([waveGroup]),
+      { EX: 60 }
+    );
+  });
+
+  it('returns peer-produced cache entry without sleeping when it is already present', async () => {
+    const sleepSpy = jest.spyOn(Time.prototype, 'sleep');
+    const redis = buildRedisMock();
+    let eligibleGroupsCacheReads = 0;
+    redis.get.mockImplementation((key: string) => {
+      if (key === WAVE_GROUPS_VERSION_CACHE_KEY) {
+        return Promise.resolve('7');
+      }
+      if (key === ELIGIBLE_GROUPS_CACHE_KEY) {
+        eligibleGroupsCacheReads++;
+        if (eligibleGroupsCacheReads === 1) {
+          return Promise.resolve(null);
+        }
+        return Promise.resolve(
+          JSON.stringify({
+            eligibleGroupIds: [GROUP_ID],
+            computedAtMillis: 3_000,
+            waveGroupsVersion: 7
+          })
+        );
+      }
+      return Promise.resolve(null);
+    });
+    redis.set.mockResolvedValueOnce(null);
+    (getRedisClient as jest.Mock).mockReturnValue(redis);
+
+    const userGroupsDb = buildUserGroupsDbMock();
+    const service = buildService(userGroupsDb);
+
+    await expect(
+      service.getGroupsUserIsEligibleFor(PROFILE_ID)
+    ).resolves.toEqual([GROUP_ID]);
+    expect(sleepSpy).not.toHaveBeenCalled();
+    expect(eligibleGroupsCacheReads).toBe(2);
+    expect(userGroupsDb.getAllWaveRelatedGroups).not.toHaveBeenCalled();
+  });
+});
+
+describe('UserGroupsService eligibility computation semantics', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+    mcache.clear();
+    (getRedisClient as jest.Mock).mockReturnValue(null);
+  });
+
+  it('keeps the sequential elimination semantics across all criteria types', async () => {
+    // Sequential reference semantics: banned-by-identity split first, then
+    // simple metrics -> total sent cic/rep -> ownings -> granular ratings ->
+    // beneficiary grants; groups passing all checks come first, groups where
+    // the user is in by identity are appended last.
+    const tdhPass = buildUserGroup({
+      id: 'tdh-pass',
+      profile_group_id: null,
+      tdh_min: 10
+    });
+    const tdhFail = buildUserGroup({
+      id: 'tdh-fail',
+      profile_group_id: null,
+      tdh_min: 1000
+    });
+    const ownsPass = buildUserGroup({
+      id: 'owns-pass',
+      profile_group_id: null,
+      owns_meme: true,
+      owns_meme_tokens: JSON.stringify(['1'])
+    });
+    const ownsFail = buildUserGroup({
+      id: 'owns-fail',
+      profile_group_id: null,
+      owns_meme: true,
+      owns_meme_tokens: JSON.stringify(['999'])
+    });
+    const ownsAnyTokenPass = buildUserGroup({
+      id: 'owns-any-token-pass',
+      profile_group_id: null,
+      owns_meme: true,
+      owns_meme_tokens: JSON.stringify(['999', '1']),
+      owns_meme_tokens_match_mode: GroupNftOwnershipMatchMode.ANY_TOKEN
+    });
+    const sentRepPass = buildUserGroup({
+      id: 'sent-rep-pass',
+      profile_group_id: null,
+      rep_min: 5,
+      rep_direction: FilterDirection.Sent
+    });
+    const sentRepFail = buildUserGroup({
+      id: 'sent-rep-fail',
+      profile_group_id: null,
+      rep_min: 100,
+      rep_direction: FilterDirection.Sent
+    });
+    const repByUserPass = buildUserGroup({
+      id: 'rep-by-user-pass',
+      profile_group_id: null,
+      rep_min: 5,
+      rep_user: 'rater-x'
+    });
+    const repByUserFail = buildUserGroup({
+      id: 'rep-by-user-fail',
+      profile_group_id: null,
+      rep_min: 50,
+      rep_user: 'rater-x'
+    });
+    const grantPass = buildUserGroup({
+      id: 'grant-pass',
+      profile_group_id: null,
+      is_beneficiary_of_grant_id: 'grant-1'
+    });
+    const grantFail = buildUserGroup({
+      id: 'grant-fail',
+      profile_group_id: null,
+      is_beneficiary_of_grant_id: 'grant-2',
+      is_beneficiary_of_grant_match_mode:
+        GroupBeneficiaryGrantMatchMode.ALL_TOKENS
+    });
+    const bannedGroup = buildUserGroup({
+      id: 'banned-group',
+      profile_group_id: null,
+      excluded_profile_group_id: 'excluded-pg',
+      tdh_min: 10
+    });
+    const byIdentityGroup = buildUserGroup({ id: 'by-identity-group' });
+    const exclusionOnlyGroup = buildUserGroup({
+      id: 'exclusion-only-group',
+      profile_group_id: null,
+      excluded_profile_group_id: 'excluded-pg-2'
+    });
+    const allGroups = [
+      tdhPass,
+      tdhFail,
+      ownsPass,
+      ownsFail,
+      ownsAnyTokenPass,
+      sentRepPass,
+      sentRepFail,
+      repByUserPass,
+      repByUserFail,
+      grantPass,
+      grantFail,
+      bannedGroup,
+      byIdentityGroup,
+      exclusionOnlyGroup
+    ];
+
+    const userGroupsDb = buildUserGroupsDbMock();
+    userGroupsDb.getAllWaveRelatedGroups.mockResolvedValue(
+      allGroups.map((it) => it.id)
+    );
+    userGroupsDb.getByIds.mockResolvedValue(allGroups);
+    userGroupsDb.getIdentityByProfileId.mockResolvedValue({
+      profile_id: PROFILE_ID,
+      rep: 0,
+      cic: 0,
+      tdh: 50,
+      xtdh: 0,
+      level_raw: 0
+    });
+    userGroupsDb.getGroupsUserIsEligibleByIdentity.mockResolvedValue([
+      byIdentityGroup.id
+    ]);
+    userGroupsDb.getGroupsUserIsExcludedFromByIdentity.mockResolvedValue([
+      bannedGroup.id
+    ]);
+    userGroupsDb.getGivenCicAndRep.mockResolvedValue({ cic: 0, rep: 10 });
+    userGroupsDb.getAllProfileOwnedTokensByProfileIdGroupedByContract.mockResolvedValue(
+      { [MEMES_CONTRACT.toLowerCase()]: ['1', '2'] }
+    );
+    userGroupsDb.getRatings.mockResolvedValue([
+      {
+        rater_profile_id: 'rater-x',
+        matter_target_id: PROFILE_ID,
+        matter: RateMatter.REP,
+        matter_category: 'kindness',
+        rating: 10
+      }
+    ]);
+    userGroupsDb.findBeneficiaryGrantGroupIdsForProfile.mockResolvedValue([
+      'grant-pass'
+    ]);
+    const service = buildService(userGroupsDb);
+
+    await expect(
+      service.getGroupsUserIsEligibleFor(PROFILE_ID)
+    ).resolves.toEqual([
+      'tdh-pass',
+      'owns-pass',
+      'owns-any-token-pass',
+      'sent-rep-pass',
+      'rep-by-user-pass',
+      'grant-pass',
+      'exclusion-only-group',
+      'by-identity-group'
+    ]);
+
+    expect(userGroupsDb.getGivenCicAndRep).toHaveBeenCalledTimes(1);
+    expect(userGroupsDb.getGivenCicAndRep).toHaveBeenCalledWith(PROFILE_ID);
+    expect(
+      userGroupsDb.getAllProfileOwnedTokensByProfileIdGroupedByContract
+    ).toHaveBeenCalledTimes(1);
+    expect(
+      userGroupsDb.getAllProfileOwnedTokensByProfileIdGroupedByContract
+    ).toHaveBeenCalledWith(PROFILE_ID, expect.anything());
+    expect(userGroupsDb.getRatings).toHaveBeenCalledTimes(1);
+    expect(userGroupsDb.getRatings).toHaveBeenCalledWith(
+      PROFILE_ID,
+      ['rater-x'],
+      []
+    );
+    expect(
+      userGroupsDb.findBeneficiaryGrantGroupIdsForProfile
+    ).toHaveBeenCalledTimes(1);
+    expect(
+      userGroupsDb.findBeneficiaryGrantGroupIdsForProfile
+    ).toHaveBeenCalledWith(
+      {
+        beneficiaryGrantGroups: [
+          {
+            groupId: 'grant-pass',
+            grantId: 'grant-1',
+            matchMode: GroupBeneficiaryGrantMatchMode.ANY_TOKEN
+          },
+          {
+            groupId: 'grant-fail',
+            grantId: 'grant-2',
+            matchMode: GroupBeneficiaryGrantMatchMode.ALL_TOKENS
+          }
+        ],
+        profileId: PROFILE_ID
+      },
+      expect.anything()
+    );
+  });
+
+  it('skips conditional per-profile fetches when no candidate group needs them', async () => {
+    const userGroupsDb = buildUserGroupsDbMock();
+    const service = buildService(userGroupsDb);
+
+    await expect(
+      service.getGroupsUserIsEligibleFor(PROFILE_ID)
+    ).resolves.toEqual([GROUP_ID]);
+    expect(userGroupsDb.getGivenCicAndRep).not.toHaveBeenCalled();
+    expect(
+      userGroupsDb.getAllProfileOwnedTokensByProfileIdGroupedByContract
+    ).not.toHaveBeenCalled();
+    expect(userGroupsDb.getRatings).not.toHaveBeenCalled();
+    expect(
+      userGroupsDb.findBeneficiaryGrantGroupIdsForProfile
+    ).not.toHaveBeenCalled();
+  });
+});
+
+describe('UserGroupsDb getAllProfileOwnedTokensByProfileIdGroupedByContract', () => {
+  it('groups plain token rows by lowercased contract with token ids as lowercase strings', async () => {
+    const execute = jest.fn().mockResolvedValue([
+      { contract: '0xABC', token_id: 1 },
+      { contract: '0xabc', token_id: 'TOKEN-2' },
+      { contract: '0xDeF', token_id: 42 }
+    ]);
+    const db = new UserGroupsDb(() => ({ execute }) as unknown as SqlExecutor);
+
+    const result =
+      await db.getAllProfileOwnedTokensByProfileIdGroupedByContract(
+        PROFILE_ID,
+        {}
+      );
+
+    expect(result).toEqual({
+      '0xabc': ['1', 'token-2'],
+      '0xdef': ['42']
+    });
+    expect(execute).toHaveBeenCalledTimes(1);
+    const sql = execute.mock.calls[0][0] as string;
+    expect(sql.toLowerCase()).not.toContain('group_concat');
+    expect(execute).toHaveBeenCalledWith(
+      expect.any(String),
+      { profileId: PROFILE_ID },
+      { wrappedConnection: undefined }
+    );
   });
 });

--- a/src/api-serverless/src/community-members/user-groups.service.ts
+++ b/src/api-serverless/src/community-members/user-groups.service.ts
@@ -101,6 +101,32 @@ type EligibleGroupsCacheEntry = {
   readonly waveGroupsVersion: number;
 };
 
+type ProfileGroupRating = {
+  readonly other_side_id: string;
+  readonly matter: RateMatter;
+  readonly matter_category: string;
+  readonly rating: number;
+};
+
+type GroupedProfileRatings = {
+  readonly incomingRatings: ProfileGroupRating[];
+  readonly outgoingRatings: ProfileGroupRating[];
+};
+
+type DirectGroupInvolvement = {
+  readonly groupsIdsUserIsEligibleByIdentity: string[];
+  readonly groupIdsUserIsBannedFromByIdentity: string[];
+};
+
+type PrefetchedEligibilityCheckData = {
+  readonly profile: ProfileSimpleMetrics;
+  readonly directInvolvement: DirectGroupInvolvement;
+  readonly sentCicAndRep: { cic: number; rep: number } | undefined;
+  readonly ownings: Record<string, string[]> | undefined;
+  readonly groupedRatings: GroupedProfileRatings | undefined;
+  readonly groupIdsWhereProfileIsBeneficiary: string[] | undefined;
+};
+
 const DEFAULT_ELIGIBLE_GROUPS_CACHE_TTL_SEC = 60;
 const ELIGIBLE_GROUPS_MEMORY_CACHE_PREFIX = 'eligible-groups-v2';
 const ELIGIBLE_GROUPS_REDIS_CACHE_PREFIX = 'cache_6529_eligible_groups';
@@ -356,11 +382,11 @@ export class UserGroupsService {
     {
       profileId,
       givenGroups,
-      allWaveGroups
+      preloadedGroupEntities
     }: {
       profileId: string;
-      givenGroups: string[];
-      allWaveGroups: boolean;
+      givenGroups?: string[];
+      preloadedGroupEntities?: UserGroupEntity[];
     },
     timer?: Timer
   ): Promise<string[]> {
@@ -368,101 +394,197 @@ export class UserGroupsService {
       timer,
       'whichOfGivenGroupsIsUserEligibleFor',
       async () => {
-        if (!givenGroups.length) {
-          return [];
-        }
-        const identityEntity = await this.timeAsync(
-          timer,
-          'whichOfGivenGroupsIsUserEligibleFor->getIdentityByProfileId',
-          () => this.userGroupsDb.getIdentityByProfileId(profileId)
-        );
-        if (!identityEntity) {
-          return [];
-        }
-        const profile: ProfileSimpleMetrics = {
-          profile_id: identityEntity.profile_id!,
-          rep: identityEntity.rep,
-          cic: identityEntity.cic,
-          tdh: identityEntity.tdh,
-          xtdh: identityEntity.xtdh,
-          level: getLevelFromScore(identityEntity.level_raw)
-        };
-        const givenGroupEntities = await this.getGivenGroupEntities(
-          { givenGroups, allWaveGroups },
-          timer
-        );
+        const givenGroupEntities =
+          preloadedGroupEntities ??
+          (givenGroups?.length
+            ? await this.getGivenGroupEntities(givenGroups, timer)
+            : []);
         if (!givenGroupEntities.length) {
           return [];
         }
-        const { groupsWhereUserIsInByIdentity, groupsInNeedOfAdditionalCheck } =
-          await this.eliminateBannedGroupsAndGroupRestByInByIdentityAndNeedsAdditionalCheck(
-            givenGroupEntities,
-            profile,
-            timer
-          );
-
-        const groupEntitiesWhichPassedAllChecks =
-          await this.eliminateGroupsBySimpleMetricsViolations(
-            groupsInNeedOfAdditionalCheck,
-            profile,
-            timer
-          )
-            .then((groups) =>
-              this.eliminateGroupsByFullOutgoingCicAndRep(
-                groups,
-                profile,
-                timer
-              )
-            )
-            .then((groups) =>
-              this.eliminateGroupsByOwnings(groups, profile, timer)
-            )
-            .then((groups) =>
-              this.eliminateGroupsByGranularRatings(groups, profile, timer)
-            )
-            .then((groups) =>
-              this.eliminateGroupsByBeneficiaryGrants(groups, profile, {
-                timer
-              })
-            );
-        return [
-          ...groupEntitiesWhichPassedAllChecks.map((it) => it.id),
-          ...groupsWhereUserIsInByIdentity.map((it) => it.id)
-        ];
+        const prefetchedData = await this.prefetchEligibilityCheckData(
+          profileId,
+          givenGroupEntities,
+          timer
+        );
+        if (!prefetchedData) {
+          return [];
+        }
+        return this.applyEliminationChain(
+          givenGroupEntities,
+          prefetchedData,
+          timer
+        );
       }
     );
   }
 
+  private async prefetchEligibilityCheckData(
+    profileId: string,
+    candidateGroupEntities: UserGroupEntity[],
+    timer?: Timer
+  ): Promise<PrefetchedEligibilityCheckData | null> {
+    // The needed datasets are derived from the FULL candidate set, which is a
+    // superset of what the previous sequential flow fetched (it derived each
+    // stage's needs from the already-filtered group list). Results are
+    // identical because each eliminate filter only reads the rows matching its
+    // own group's criteria.
+    const needsSentCicAndRep = isAnyGroupByTotalSentCicOrRepCriteria(
+      candidateGroupEntities
+    );
+    const needsOwnings = isAnyGroupByOwningsCriteria(candidateGroupEntities);
+    const { users, categories } =
+      this.extractAllCicRepUsersAndCategoriesFromGroups(candidateGroupEntities);
+    const needsGranularRatings = users.length !== 0 || categories.length !== 0;
+    const beneficiaryGrantGroups = candidateGroupEntities
+      .filter((group) => !!group.is_beneficiary_of_grant_id)
+      .map((group) => ({
+        groupId: group.id,
+        grantId: group.is_beneficiary_of_grant_id!,
+        matchMode:
+          group.is_beneficiary_of_grant_match_mode ??
+          DEFAULT_BENEFICIARY_GRANT_MATCH_MODE
+      }));
+    const [
+      identityEntity,
+      directInvolvement,
+      sentCicAndRep,
+      ownings,
+      groupedRatings,
+      groupIdsWhereProfileIsBeneficiary
+    ] = await Promise.all([
+      this.timeAsync(
+        timer,
+        'whichOfGivenGroupsIsUserEligibleFor->getIdentityByProfileId',
+        () => this.userGroupsDb.getIdentityByProfileId(profileId)
+      ),
+      this.getGroupsUserIsDirectlyInvolvedIn(
+        {
+          profileId,
+          candidates: candidateGroupEntities.map((it) => it.id)
+        },
+        timer
+      ),
+      needsSentCicAndRep
+        ? this.timeAsync(
+            timer,
+            'whichOfGivenGroupsIsUserEligibleFor->getGivenCicAndRep',
+            () => this.userGroupsDb.getGivenCicAndRep(profileId)
+          )
+        : undefined,
+      needsOwnings
+        ? this.userGroupsDb.getAllProfileOwnedTokensByProfileIdGroupedByContract(
+            profileId,
+            { timer }
+          )
+        : undefined,
+      needsGranularRatings
+        ? this.timeAsync(
+            timer,
+            'whichOfGivenGroupsIsUserEligibleFor->getIncomingOutgoingGroupedRatings',
+            () =>
+              this.getIncomingOutgoingGroupedRatings(
+                profileId,
+                users,
+                categories
+              )
+          )
+        : undefined,
+      beneficiaryGrantGroups.length
+        ? this.userGroupsDb.findBeneficiaryGrantGroupIdsForProfile(
+            { beneficiaryGrantGroups, profileId },
+            { timer }
+          )
+        : undefined
+    ]);
+    if (!identityEntity) {
+      return null;
+    }
+    return {
+      profile: {
+        profile_id: identityEntity.profile_id!,
+        rep: identityEntity.rep,
+        cic: identityEntity.cic,
+        tdh: identityEntity.tdh,
+        xtdh: identityEntity.xtdh,
+        level: getLevelFromScore(identityEntity.level_raw)
+      },
+      directInvolvement,
+      sentCicAndRep,
+      ownings,
+      groupedRatings,
+      groupIdsWhereProfileIsBeneficiary
+    };
+  }
+
+  private applyEliminationChain(
+    givenGroupEntities: UserGroupEntity[],
+    prefetchedData: PrefetchedEligibilityCheckData,
+    timer?: Timer
+  ): string[] {
+    const { groupsWhereUserIsInByIdentity, groupsInNeedOfAdditionalCheck } =
+      this.eliminateBannedGroupsAndGroupRestByInByIdentityAndNeedsAdditionalCheck(
+        givenGroupEntities,
+        prefetchedData.directInvolvement,
+        timer
+      );
+    const groupsAfterSimpleMetricsCheck =
+      this.eliminateGroupsBySimpleMetricsViolations(
+        groupsInNeedOfAdditionalCheck,
+        prefetchedData.profile,
+        timer
+      );
+    const groupsAfterTotalSentCheck =
+      this.eliminateGroupsByFullOutgoingCicAndRep(
+        groupsAfterSimpleMetricsCheck,
+        prefetchedData.sentCicAndRep,
+        timer
+      );
+    const groupsAfterOwningsCheck = this.eliminateGroupsByOwnings(
+      groupsAfterTotalSentCheck,
+      prefetchedData.ownings,
+      timer
+    );
+    const groupsAfterGranularRatingsCheck =
+      this.eliminateGroupsByGranularRatings(
+        groupsAfterOwningsCheck,
+        prefetchedData.groupedRatings,
+        timer
+      );
+    const groupEntitiesWhichPassedAllChecks =
+      this.eliminateGroupsByBeneficiaryGrants(
+        groupsAfterGranularRatingsCheck,
+        prefetchedData.groupIdsWhereProfileIsBeneficiary,
+        timer
+      );
+    return [
+      ...groupEntitiesWhichPassedAllChecks.map((it) => it.id),
+      ...groupsWhereUserIsInByIdentity.map((it) => it.id)
+    ];
+  }
+
   private async getGivenGroupEntities(
-    {
-      givenGroups,
-      allWaveGroups
-    }: { givenGroups: string[]; allWaveGroups: boolean },
+    givenGroups: string[],
     timer?: Timer
   ): Promise<UserGroupEntity[]> {
     return this.timeAsync(
       timer,
       'whichOfGivenGroupsIsUserEligibleFor->getGivenGroupEntities',
-      async () => {
-        if (!allWaveGroups) {
-          return await this.userGroupsDb.getByIds(givenGroups, {
-            timer
-          });
-        }
-        return await this.getCachedWaveGroupEntities(givenGroups, timer);
-      }
+      () =>
+        this.userGroupsDb.getByIds(givenGroups, {
+          timer
+        })
     );
   }
 
-  private async getCachedWaveGroupEntities(
-    givenGroups: string[],
+  private async getAllWaveRelatedGroupEntities(
     timer?: Timer
   ): Promise<UserGroupEntity[]> {
     const timerPrefix =
       'whichOfGivenGroupsIsUserEligibleFor->getGivenGroupEntities';
-    const ttlSec = env.getIntOrNull('WAVE_GROUPS_CACHE_TTL_SEC') ?? 60;
     const redisClient = getRedisClient();
     if (!redisClient) {
+      const givenGroups = await this.getAllWaveRelatedGroupIds(timer);
       return await this.timeAsync(
         timer,
         `${timerPrefix}->redisUnavailableGetByIds`,
@@ -484,6 +606,11 @@ export class UserGroupsService {
       ) as UserGroupEntity[];
     }
 
+    // The waves + wave_curations scan only runs when the Redis entity blob
+    // misses. The cache key and the stored shape (array of UserGroupEntity)
+    // must stay unchanged for compatibility with other invalidation call
+    // sites and rolling deploys.
+    const givenGroups = await this.getAllWaveRelatedGroupIds(timer);
     const value = await this.timeAsync(
       timer,
       `${timerPrefix}->redisMissGetByIds`,
@@ -497,6 +624,7 @@ export class UserGroupsService {
       `${timerPrefix}->redisJsonStringify`,
       () => JSON.stringify(value)
     );
+    const ttlSec = env.getIntOrNull('WAVE_GROUPS_CACHE_TTL_SEC') ?? 60;
     await this.timeAsync(timer, `${timerPrefix}->redisSet`, () =>
       redisClient.set(WAVE_GROUPS_CACHE_KEY, payload, {
         EX: Time.seconds(ttlSec).toSeconds()
@@ -505,35 +633,26 @@ export class UserGroupsService {
     return value;
   }
 
-  private async eliminateGroupsByBeneficiaryGrants(
+  private async getAllWaveRelatedGroupIds(timer?: Timer): Promise<string[]> {
+    return await this.timeAsync(
+      timer,
+      'getGroupsUserIsEligibleFor->getAllWaveRelatedGroups',
+      () => this.userGroupsDb.getAllWaveRelatedGroups({ timer })
+    );
+  }
+
+  private eliminateGroupsByBeneficiaryGrants(
     groups: UserGroupEntity[],
-    profile: ProfileSimpleMetrics,
-    ctx: RequestContext
-  ): Promise<UserGroupEntity[]> {
-    return this.timeAsync(
-      ctx.timer,
+    groupIdsWhereProfileIsBeneficiary: string[] | undefined,
+    timer?: Timer
+  ): UserGroupEntity[] {
+    return this.timeSync(
+      timer,
       'whichOfGivenGroupsIsUserEligibleFor->eliminateGroupsByBeneficiaryGrants',
-      async () => {
-        const beneficiaryGrantGroups = groups
-          .filter((group) => !!group.is_beneficiary_of_grant_id)
-          .map((group) => ({
-            groupId: group.id,
-            grantId: group.is_beneficiary_of_grant_id!,
-            matchMode:
-              group.is_beneficiary_of_grant_match_mode ??
-              DEFAULT_BENEFICIARY_GRANT_MATCH_MODE
-          }));
-        if (!beneficiaryGrantGroups.length) {
+      () => {
+        if (groupIdsWhereProfileIsBeneficiary === undefined) {
           return groups;
         }
-        const groupIdsWhereProfileIsBeneficiary =
-          await this.userGroupsDb.findBeneficiaryGrantGroupIdsForProfile(
-            {
-              beneficiaryGrantGroups,
-              profileId: profile.profile_id
-            },
-            ctx
-          );
         return groups.filter(
           (group) =>
             !group.is_beneficiary_of_grant_id ||
@@ -543,56 +662,49 @@ export class UserGroupsService {
     );
   }
 
-  private async eliminateGroupsByGranularRatings(
+  private eliminateGroupsByGranularRatings(
     groups: UserGroupEntity[],
-    profile: ProfileSimpleMetrics,
+    groupedRatings: GroupedProfileRatings | undefined,
     timer?: Timer
-  ): Promise<UserGroupEntity[]> {
-    return this.timeAsync(
+  ): UserGroupEntity[] {
+    return this.timeSync(
       timer,
       'whichOfGivenGroupsIsUserEligibleFor->eliminateGroupsByGranularRatings',
-      async () => {
-        const { users, categories } =
-          this.extractAllCicRepUsersAndCategoriesFromGroups(groups);
-        if (users.length !== 0 || categories.length !== 0) {
-          const { outgoingRatings, incomingRatings } = await this.timeAsync(
-            timer,
-            'whichOfGivenGroupsIsUserEligibleFor->getIncomingOutgoingGroupedRatings',
-            () =>
-              this.getIncomingOutgoingGroupedRatings(profile, users, categories)
-          );
-          return groups.filter(
-            (entity) =>
-              !isGroupViolatingAnySpecificRepCriteria(
-                entity,
-                incomingRatings,
-                outgoingRatings
-              ) &&
-              !isGroupViolatingAnySpecificCicCriteria(
-                entity,
-                incomingRatings,
-                outgoingRatings
-              )
-          );
+      () => {
+        if (!groupedRatings) {
+          return groups;
         }
-        return groups;
+        const { outgoingRatings, incomingRatings } = groupedRatings;
+        return groups.filter(
+          (entity) =>
+            !isGroupViolatingAnySpecificRepCriteria(
+              entity,
+              incomingRatings,
+              outgoingRatings
+            ) &&
+            !isGroupViolatingAnySpecificCicCriteria(
+              entity,
+              incomingRatings,
+              outgoingRatings
+            )
+        );
       }
     );
   }
 
   private async getIncomingOutgoingGroupedRatings(
-    profile: ProfileSimpleMetrics,
+    profileId: string,
     users: string[],
     categories: string[]
-  ) {
+  ): Promise<GroupedProfileRatings> {
     const ratings = await this.userGroupsDb.getRatings(
-      profile.profile_id,
+      profileId,
       users,
       categories
     );
     const { outgoingRatings, incomingRatings } = ratings.reduce(
       (acc, rating) => {
-        if (rating.rater_profile_id === profile.profile_id) {
+        if (rating.rater_profile_id === profileId) {
           acc.outgoingRatings.push({
             matter: rating.matter,
             matter_category: rating.matter_category,
@@ -610,18 +722,8 @@ export class UserGroupsService {
         return acc;
       },
       { outgoingRatings: [], incomingRatings: [] } as {
-        incomingRatings: {
-          other_side_id: string;
-          matter: RateMatter;
-          matter_category: string;
-          rating: number;
-        }[];
-        outgoingRatings: {
-          other_side_id: string;
-          matter: RateMatter;
-          matter_category: string;
-          rating: number;
-        }[];
+        incomingRatings: ProfileGroupRating[];
+        outgoingRatings: ProfileGroupRating[];
       }
     );
     return {
@@ -656,61 +758,52 @@ export class UserGroupsService {
     return { users, categories };
   }
 
-  private async eliminateGroupsByOwnings(
+  private eliminateGroupsByOwnings(
     groups: UserGroupEntity[],
-    profile: ProfileSimpleMetrics,
+    ownings: Record<string, string[]> | undefined,
     timer?: Timer
-  ): Promise<UserGroupEntity[]> {
-    return this.timeAsync(
+  ): UserGroupEntity[] {
+    return this.timeSync(
       timer,
       'whichOfGivenGroupsIsUserEligibleFor->eliminateGroupsByOwnings',
-      async () => {
-        if (isAnyGroupByOwningsCriteria(groups)) {
-          const ownings =
-            await this.userGroupsDb.getAllProfileOwnedTokensByProfileIdGroupedByContract(
-              profile.profile_id,
-              { timer }
-            );
-          return groups.filter(
-            (entity) => !isProfileViolatingOwnsCriteria(entity, ownings)
-          );
+      () => {
+        if (!ownings) {
+          return groups;
         }
-        return groups;
+        return groups.filter(
+          (entity) => !isProfileViolatingOwnsCriteria(entity, ownings)
+        );
       }
     );
   }
 
-  private async eliminateGroupsByFullOutgoingCicAndRep(
+  private eliminateGroupsByFullOutgoingCicAndRep(
     groups: UserGroupEntity[],
-    profile: ProfileSimpleMetrics,
+    sentCicAndRep: { cic: number; rep: number } | undefined,
     timer?: Timer
-  ): Promise<UserGroupEntity[]> {
-    return this.timeAsync(
+  ): UserGroupEntity[] {
+    return this.timeSync(
       timer,
       'whichOfGivenGroupsIsUserEligibleFor->eliminateGroupsByFullOutgoingCicAndRep',
-      async () => {
-        if (isAnyGroupByTotalSentCicOrRepCriteria(groups)) {
-          const { cic, rep } = await this.timeAsync(
-            timer,
-            'whichOfGivenGroupsIsUserEligibleFor->getGivenCicAndRep',
-            () => this.userGroupsDb.getGivenCicAndRep(profile.profile_id)
-          );
-          return groups.filter(
-            (entity) =>
-              !isProfileViolatingTotalSentCicCriteria(cic, entity) &&
-              !isProfileViolatingTotalSentRepCriteria(rep, entity)
-          );
+      () => {
+        if (!sentCicAndRep) {
+          return groups;
         }
-        return groups;
+        const { cic, rep } = sentCicAndRep;
+        return groups.filter(
+          (entity) =>
+            !isProfileViolatingTotalSentCicCriteria(cic, entity) &&
+            !isProfileViolatingTotalSentRepCriteria(rep, entity)
+        );
       }
     );
   }
 
-  private async eliminateGroupsBySimpleMetricsViolations(
+  private eliminateGroupsBySimpleMetricsViolations(
     groups: UserGroupEntity[],
     profile: ProfileSimpleMetrics,
     timer?: Timer
-  ): Promise<UserGroupEntity[]> {
+  ): UserGroupEntity[] {
     return this.timeSync(
       timer,
       'whichOfGivenGroupsIsUserEligibleFor->eliminateGroupsBySimpleMetricsViolations',
@@ -725,34 +818,22 @@ export class UserGroupsService {
     );
   }
 
-  private async eliminateBannedGroupsAndGroupRestByInByIdentityAndNeedsAdditionalCheck(
+  private eliminateBannedGroupsAndGroupRestByInByIdentityAndNeedsAdditionalCheck(
     groups: UserGroupEntity[],
-    profile: {
-      profile_id: string;
-      tdh: number;
-      level: number;
-      cic: number;
-      rep: number;
-    },
+    directInvolvement: DirectGroupInvolvement,
     timer?: Timer
-  ): Promise<{
+  ): {
     groupsWhereUserIsInByIdentity: UserGroupEntity[];
     groupsInNeedOfAdditionalCheck: UserGroupEntity[];
-  }> {
-    return this.timeAsync(
+  } {
+    return this.timeSync(
       timer,
       'whichOfGivenGroupsIsUserEligibleFor->eliminateBannedGroupsAndDirectIdentityGroups',
-      async () => {
+      () => {
         const {
           groupsIdsUserIsEligibleByIdentity,
           groupIdsUserIsBannedFromByIdentity
-        } = await this.getGroupsUserIsDirectlyInvolvedIn(
-          {
-            profileId: profile.profile_id,
-            candidates: groups.map((it) => it.id)
-          },
-          timer
-        );
+        } = directInvolvement;
 
         const nonBannedGroups = groups.filter(
           (it) => !groupIdsUserIsBannedFromByIdentity.includes(it.id)
@@ -791,10 +872,7 @@ export class UserGroupsService {
       candidates: string[];
     },
     timer?: Timer
-  ): Promise<{
-    groupsIdsUserIsEligibleByIdentity: string[];
-    groupIdsUserIsBannedFromByIdentity: string[];
-  }> {
+  ): Promise<DirectGroupInvolvement> {
     return this.timeAsync(
       timer,
       'whichOfGivenGroupsIsUserEligibleFor->getGroupsUserIsDirectlyInvolvedIn',
@@ -1031,14 +1109,9 @@ export class UserGroupsService {
     profileId: string,
     timer?: Timer | undefined
   ): Promise<string[]> {
-    const timerKey = 'getGroupsUserIsEligibleFor';
-    const groups = await this.timeAsync(
-      timer,
-      `${timerKey}->getAllWaveRelatedGroups`,
-      () => this.userGroupsDb.getAllWaveRelatedGroups({ timer })
-    );
+    const groupEntities = await this.getAllWaveRelatedGroupEntities(timer);
     return await this.whichOfGivenGroupsIsUserEligibleFor(
-      { profileId, givenGroups: groups, allWaveGroups: true },
+      { profileId, preloadedGroupEntities: groupEntities },
       timer
     );
   }
@@ -1182,7 +1255,9 @@ export class UserGroupsService {
     timer?: Timer;
   }): Promise<EligibleGroupsCacheEntry | null> {
     for (let i = 0; i < ELIGIBLE_GROUPS_REDIS_LOCK_WAIT_RETRIES; i++) {
-      await Time.millis(ELIGIBLE_GROUPS_REDIS_LOCK_WAIT_MS).sleep();
+      if (i > 0) {
+        await Time.millis(ELIGIBLE_GROUPS_REDIS_LOCK_WAIT_MS).sleep();
+      }
       const cacheEntry = await this.getEligibleGroupsRedisCacheEntry(
         profileId,
         timer

--- a/src/user-groups/user-groups.db.ts
+++ b/src/user-groups/user-groups.db.ts
@@ -730,18 +730,19 @@ export class UserGroupsDb extends LazyDbAccessCompatibleService {
     ctx.timer?.start(
       'userGroupsDb->getAllProfileOwnedTokensByProfileIdGroupedByContract'
     );
+    // Plain row select grouped in JS instead of GROUP_CONCAT, which silently
+    // truncates at group_concat_max_len for identities with many tokens.
     const result = await this.db
       .execute<{
         contract: string;
-        token_ids: string;
+        token_id: string | number;
       }>(
         `
-        select o.contract as contract, group_concat(o.token_id separator ',') as token_ids
+        select o.contract as contract, o.token_id as token_id
         from ${IDENTITIES_TABLE} i
                  join ${ADDRESS_CONSOLIDATION_KEY} ack on ack.consolidation_key = i.consolidation_key
                  join ${NFT_OWNERS_TABLE} o on o.wallet = ack.address
         where i.profile_id = :profileId
-        group by 1
         `,
         { profileId },
         { wrappedConnection: ctx.connection }
@@ -749,9 +750,10 @@ export class UserGroupsDb extends LazyDbAccessCompatibleService {
       .then((res) =>
         res.reduce(
           (acc, it) => {
-            acc[it.contract.toLowerCase()] = it.token_ids
-              .split(',')
-              .map((k) => k.toLowerCase());
+            const contract = it.contract.toLowerCase();
+            const tokenIds = acc[contract] ?? [];
+            tokenIds.push(`${it.token_id}`.toLowerCase());
+            acc[contract] = tokenIds;
             return acc;
           },
           {} as Record<string, string[]>


### PR DESCRIPTION
## What

Cuts the eligibility total-cache-miss compute from a sequential waterfall to parallel fetches, and removes redundant work:

1. **One `Promise.all` for the per-profile fetches.** `whichOfGivenGroupsIsUserEligibleFor` used to await identity → group entities → by-identity pair → sent CIC/REP sums → NFT ownings → granular ratings → grant beneficiaries in sequence (each stage fetching only after the previous filter ran). Now the needed datasets are derived upfront from the full candidate set and fetched concurrently; the eliminate chain runs as pure in-memory filters in the **exact original order** (banned/by-identity split → simple metrics → total sent CIC/REP → ownings → granular ratings → grants). The upfront derivation is a superset of what the sequential flow fetched; results are provably identical because each filter only reads rows matching its own group's criteria (documented in a code comment; pinned by a 13-group matrix test).
2. **The 6-way `waves`/`wave_curations` UNION-ALL id scan (`getAllWaveRelatedGroups`) now runs only when the wave-groups entity blob is cold.** Previously it ran on every compute and its result was discarded whenever the redis blob was warm. Cache key and stored shape are unchanged (rolling-deploy compatible).
3. **`GROUP_CONCAT` ownings query → plain row select, grouped in JS.** This is also a correctness fix: nothing raises `group_concat_max_len` (MySQL default 1024 chars), so a full-set whale's token list silently truncates and token-specific owns-groups can wrongly deny eligibility. Row select cannot truncate. Same method signature, timer keys and output shape (lowercased contract → lowercase string token ids, duplicates preserved).
4. **Lock-wait polish:** losers of the per-profile compute lock now check the cache *before* the first sleep (4 checks / 3 sleeps ≤225ms, was 4 sleeps ≤300ms first-check-after-75ms).

## Measurement notes

- Compute latency on miss goes from Σ(fetch times) to ~max(fetch time); with the companion PRs (read-attribution log #1730, surgical invalidation, indexes #1731) the p99 effect is directly observable via `[ELIGIBILITY_READ]` `computeMs`.
- The timer key `getGroupsUserIsEligibleFor->getAllWaveRelatedGroups` now only appears on blob miss — dashboards tracking it will show a drop (that is the point).
- Parallel fetches raise per-request read-pool demand slightly during misses (bounded: ≤6 concurrent queries per compute); with the stampede fix this nets far fewer concurrent computes overall.

## Tests

16 tests green (9 pre-existing + 6 new + 1 db): blob-warm skips the id scan; blob-cold populates and caches; 13-group semantics matrix asserting exact result order across tdh/owns/sent-rep/rep-by-user/grant/banned/by-identity/exclusion-only cases; conditional fetches skipped when no candidate needs them; lock-wait returns without sleeping when the entry is present; ownings row-grouping (asserts no GROUP_CONCAT in SQL). Lint (`--max-warnings=0`) and `tsc --noEmit` clean.

## Notes

- Only caller of the refactored method is `computeGroupsUserIsEligibleFor` (verified repo-wide).
- docs/architecture.md not updated: no change to system shape.
- Help-bot knowledge not updated: no user-visible behavior change (the GROUP_CONCAT fix only ever *adds* correctly-owned tokens that truncation could previously drop).

## Deployment

- `api` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved group eligibility results by handling more matching criteria consistently, including token ownership, ratings, grant eligibility, and wave-related groups.
  * Reduced unnecessary waits and repeated lookups during eligibility checks, making group loading more responsive.
  * Fixed token ownership grouping so owned tokens are matched reliably regardless of case.
* **Refactor**
  * Streamlined eligibility processing to preload required data before filtering groups, improving efficiency and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->