### PR TITLE
Use structured auth for GitHub webhook drops

### DIFF
--- a/pr-reports/1736.md
+++ b/pr-reports/1736.md
@@ -1,0 +1,31 @@
+# PR Report: GitHub Webhook Structured Auth
+
+## Summary
+
+Updates the `/gh-hooks` drop-posting integration so `GitHubIssueDropService`
+uses the structured wallet authentication path instead of the legacy short nonce
+flow before posting into the configured wave.
+
+## Changes
+
+- Replaces the legacy `/api/auth/nonce?short_nonce=true` request with a
+  structured `/api/auth/session-nonce` request for the webhook wallet.
+- Signs the returned structured `signable_message` with
+  `GH_WEBHOOK_WALLET_PRIVATE_KEY` and continues using the bearer-token
+  `/api/auth/login` response for `/api/drops`.
+- Preserves `GH_WEBHOOK_WAVE_ID` semantics and existing GitHub issue / pull
+  request drop formatting.
+- Extends focused service tests to cover the structured auth sequence, bearer
+  token use, URL-only issue posts, and merged PR URL plus summary posts.
+
+## Deployment
+
+Deploy `api` when this change is intentionally released. No staging or
+production deployment was performed for this PR.
+
+## Risks / Follow-Ups
+
+- The PR is intentionally marked `DONT MERGE` in the title and label per
+  operator request.
+- Rollback is a normal revert of this PR, which restores the prior short-nonce
+  authentication sequence.

--- a/pr-reports/1736.md
+++ b/pr-reports/1736.md
@@ -13,10 +13,15 @@ flow before posting into the configured wave.
 - Signs the returned structured `signable_message` with
   `GH_WEBHOOK_WALLET_PRIVATE_KEY` and continues using the bearer-token
   `/api/auth/login` response for `/api/drops`.
+- Validates the structured nonce response, expected native login message, and
+  login token before signing or posting.
+- Preserves `API_BASE_URL` path prefixes when building the auth and drop
+  request URLs.
 - Preserves `GH_WEBHOOK_WAVE_ID` semantics and existing GitHub issue / pull
   request drop formatting.
 - Extends focused service tests to cover the structured auth sequence, bearer
-  token use, URL-only issue posts, and merged PR URL plus summary posts.
+  token use, malformed auth responses, URL prefix handling, URL-only issue
+  posts, and merged PR URL plus summary posts.
 
 ## Deployment
 

--- a/pr-reports/1736.md
+++ b/pr-reports/1736.md
@@ -1,12 +1,16 @@
 # PR Report: GitHub Webhook Structured Auth
 
+PR: https://github.com/6529-Collections/6529seize-backend/pull/1736
+Branch: codex/gh-hooks-v2-auth -> main
+Related PRs: None
+
 ## Summary
 
 Updates the `/gh-hooks` drop-posting integration so `GitHubIssueDropService`
 uses the structured wallet authentication path instead of the legacy short nonce
 flow before posting into the configured wave.
 
-## Changes
+## What Changed
 
 - Replaces the legacy `/api/auth/nonce?short_nonce=true` request with a
   structured `/api/auth/session-nonce` request for the webhook wallet.
@@ -20,17 +24,56 @@ flow before posting into the configured wave.
 - Preserves `GH_WEBHOOK_WAVE_ID` semantics and existing GitHub issue / pull
   request drop formatting.
 - Extends focused service tests to cover the structured auth sequence, bearer
-  token use, malformed auth responses, URL prefix handling, URL-only issue
-  posts, and merged PR URL plus summary posts.
+  token use, malformed auth responses, URL prefix handling, unexpected
+  structured auth context, URL-only issue posts, and merged PR URL plus summary
+  posts.
 
-## Deployment
+## Backend Impact
 
-Deploy `api` when this change is intentionally released. No staging or
-production deployment was performed for this PR.
+- New services: None
+- Changed services: `api`
+- Planned/deployed services: `api`
+- API: outbound `/gh-hooks` wave-posting auth now uses `/api/auth/session-nonce`
+  with `client_type=native`, followed by structured `/api/auth/login`.
+- DB/entities/migrations: None
+- Queues/events/integrations: GitHub webhook ingestion behavior and accepted
+  event types are unchanged; the outbound first-party auth sequence used before
+  creating a drop is updated.
+
+## Config / Env
+
+- `GH_WEBHOOK_SECRET`: pre-existing required API env secret used to verify
+  GitHub webhook signatures. Unchanged.
+- `GH_WEBHOOK_WALLET_PRIVATE_KEY`: pre-existing required API env secret for the
+  webhook poster wallet. Unchanged; now signs the structured session-v2 auth
+  message instead of a short nonce.
+- `GH_WEBHOOK_WAVE_ID`: pre-existing required API env value for the target wave.
+  Unchanged.
+- `API_BASE_URL`: pre-existing optional API env value used for first-party API
+  calls from this service. When unset, the service falls back to
+  `https://api.6529.io`.
+
+## Backend Deployment
+
+- Deployed API: `api`
+- Deployed Lambdas/services: None
+- Not deployed: None for staging; production deployment is separate operator
+  action.
+- Deployment order executed: `api`
+- GitHub Actions run links or run IDs for each backend deploy:
+  https://github.com/6529-Collections/6529seize-backend/actions/runs/28997357252
+
+## Release Notes
+
+The GitHub webhook drop poster now authenticates through the current structured
+session-v2 wallet flow before posting issue and merged-PR links to the
+configured wave. Issue/reopened drops remain URL-only, and merged PR drops
+remain URL plus summary.
 
 ## Risks / Follow-Ups
 
-- The PR is intentionally marked `DONT MERGE` in the title and label per
-  operator request.
-- Rollback is a normal revert of this PR, which restores the prior short-nonce
-  authentication sequence.
+- A staging `/api/auth/session-nonce?client_type=native` smoke confirmed the
+  expected native structured auth response. A live `/gh-hooks` webhook was not
+  manually fired to avoid creating an extra staging wave drop.
+- Rollback is a normal revert of this PR plus redeploying `api`, which restores
+  the prior short-nonce authentication sequence.

--- a/src/api-serverless/src/github/github-issue-drop-service.test.ts
+++ b/src/api-serverless/src/github/github-issue-drop-service.test.ts
@@ -1,4 +1,5 @@
 import { AiPrompter } from '@/abusiveness/ai-prompter';
+import { Wallet, verifyMessage } from 'ethers';
 import fetch from 'node-fetch';
 import { GitHubIssueDropService } from './github-issue-drop.service';
 
@@ -6,6 +7,21 @@ jest.mock('node-fetch', () => jest.fn());
 
 const PRIVATE_KEY =
   '0x59c6995e998f97a5a0044966f094538423616ff67a53e886e68660d054d60f1a';
+const CLIENT_ADDRESS = new Wallet(PRIVATE_KEY).address;
+const SIGNABLE_MESSAGE = [
+  '6529 Authentication',
+  'Version: 2',
+  'Audience: api.test',
+  'Domain: native',
+  'Session Type: native',
+  `Wallet: ${CLIENT_ADDRESS}`,
+  'Chain ID: 1',
+  'Issued At: 2026-01-01T00:00:00.000Z',
+  'Expiration Time: 2026-01-01T00:05:00.000Z',
+  'Nonce: github-auth-nonce',
+  'Action: login',
+  'Purpose: Sign this message to authenticate with 6529.'
+].join('\n');
 const PR_URL = 'https://github.com/6529-Collections/test/pull/456';
 const ISSUE_URL = 'https://github.com/6529-Collections/test/issues/123';
 
@@ -19,9 +35,17 @@ type MockResponse = {
 
 type CreateDropRequestBody = {
   wave_id: string;
+  signer_address: string;
   parts: Array<{
     content: string;
   }>;
+};
+
+type LoginRequestBody = {
+  client_address: string;
+  client_signature: string;
+  server_signature: string;
+  is_safe_wallet: boolean;
 };
 
 function createJsonResponse(jsonPayload: unknown): MockResponse {
@@ -42,6 +66,25 @@ function getCreateDropBody(): CreateDropRequestBody {
 
   const request = createDropCall[1] as { body: string };
   return JSON.parse(request.body) as CreateDropRequestBody;
+}
+
+function getFetchUrl(callIndex: number): URL {
+  const call = jest.mocked(fetch).mock.calls[callIndex];
+  if (!call) {
+    throw new Error(`Expected fetch call ${callIndex}`);
+  }
+
+  return new URL(String(call[0]));
+}
+
+function getLoginBody(): LoginRequestBody {
+  const loginCall = jest.mocked(fetch).mock.calls[1];
+  if (!loginCall) {
+    throw new Error('Expected login request');
+  }
+
+  const request = loginCall[1] as { body: string };
+  return JSON.parse(request.body) as LoginRequestBody;
 }
 
 describe('GitHubIssueDropService', () => {
@@ -65,7 +108,7 @@ describe('GitHubIssueDropService', () => {
     fetchMock
       .mockResolvedValueOnce(
         createJsonResponse({
-          nonce: 'nonce',
+          signable_message: SIGNABLE_MESSAGE,
           server_signature: 'server-signature'
         }) as never
       )
@@ -116,9 +159,59 @@ describe('GitHubIssueDropService', () => {
     );
     expect(getCreateDropBody()).toMatchObject({
       wave_id: 'wave-1',
+      signer_address: CLIENT_ADDRESS,
       parts: [
         {
           content: `${PR_URL}\n\nMembers can now read clearer release notes about user-facing changes.`
+        }
+      ]
+    });
+  });
+
+  it('uses session-v2 structured auth before posting the drop', async () => {
+    await new GitHubIssueDropService(aiPrompter).postGhIssueDrop(
+      ISSUE_URL,
+      'issue',
+      {
+        action: 'reopened'
+      }
+    );
+
+    const sessionNonceUrl = getFetchUrl(0);
+    expect(sessionNonceUrl.pathname).toBe('/api/auth/session-nonce');
+    expect(sessionNonceUrl.searchParams.get('signer_address')).toBe(
+      CLIENT_ADDRESS
+    );
+    expect(sessionNonceUrl.searchParams.get('client_type')).toBe('native');
+    expect(sessionNonceUrl.searchParams.get('short_nonce')).toBeNull();
+
+    const loginUrl = getFetchUrl(1);
+    expect(loginUrl.pathname).toBe('/api/auth/login');
+    expect(loginUrl.searchParams.get('signer_address')).toBe(CLIENT_ADDRESS);
+
+    const loginBody = getLoginBody();
+    expect(loginBody).toMatchObject({
+      client_address: CLIENT_ADDRESS,
+      server_signature: 'server-signature',
+      is_safe_wallet: false
+    });
+    expect(
+      verifyMessage(SIGNABLE_MESSAGE, loginBody.client_signature).toLowerCase()
+    ).toBe(CLIENT_ADDRESS.toLowerCase());
+
+    const createDropUrl = getFetchUrl(2);
+    expect(createDropUrl.pathname).toBe('/api/drops');
+    expect(fetchMock.mock.calls[2][1]).toMatchObject({
+      headers: expect.objectContaining({
+        authorization: 'Bearer auth-token'
+      })
+    });
+    expect(getCreateDropBody()).toMatchObject({
+      wave_id: 'wave-1',
+      signer_address: CLIENT_ADDRESS,
+      parts: [
+        {
+          content: ISSUE_URL
         }
       ]
     });
@@ -136,6 +229,7 @@ describe('GitHubIssueDropService', () => {
     expect(aiPrompter.promptAndGetReply).not.toHaveBeenCalled();
     expect(getCreateDropBody()).toMatchObject({
       wave_id: 'wave-1',
+      signer_address: CLIENT_ADDRESS,
       parts: [
         {
           content: ISSUE_URL

--- a/src/api-serverless/src/github/github-issue-drop-service.test.ts
+++ b/src/api-serverless/src/github/github-issue-drop-service.test.ts
@@ -8,6 +8,8 @@ jest.mock('node-fetch', () => jest.fn());
 const PRIVATE_KEY =
   '0x59c6995e998f97a5a0044966f094538423616ff67a53e886e68660d054d60f1a';
 const CLIENT_ADDRESS = new Wallet(PRIVATE_KEY).address;
+const ISSUED_AT = new Date(Date.now() - 1_000).toISOString();
+const EXPIRATION_TIME = new Date(Date.now() + 5 * 60 * 1_000).toISOString();
 const SIGNABLE_MESSAGE = [
   '6529 Authentication',
   'Version: 2',
@@ -16,8 +18,8 @@ const SIGNABLE_MESSAGE = [
   'Session Type: native',
   `Wallet: ${CLIENT_ADDRESS}`,
   'Chain ID: 1',
-  'Issued At: 2026-01-01T00:00:00.000Z',
-  'Expiration Time: 2026-01-01T00:05:00.000Z',
+  `Issued At: ${ISSUED_AT}`,
+  `Expiration Time: ${EXPIRATION_TIME}`,
   'Nonce: github-auth-nonce',
   'Action: login',
   'Purpose: Sign this message to authenticate with 6529.'
@@ -87,6 +89,22 @@ function getLoginBody(): LoginRequestBody {
   return JSON.parse(request.body) as LoginRequestBody;
 }
 
+function mockSuccessfulAuth(fetchMock: jest.MockedFunction<typeof fetch>) {
+  fetchMock
+    .mockResolvedValueOnce(
+      createJsonResponse({
+        signable_message: SIGNABLE_MESSAGE,
+        server_signature: 'server-signature'
+      }) as never
+    )
+    .mockResolvedValueOnce(
+      createJsonResponse({
+        token: 'auth-token'
+      }) as never
+    )
+    .mockResolvedValueOnce(createJsonResponse({}) as never);
+}
+
 describe('GitHubIssueDropService', () => {
   const fetchMock = jest.mocked(fetch);
   let aiPrompter: jest.Mocked<AiPrompter>;
@@ -105,19 +123,7 @@ describe('GitHubIssueDropService', () => {
     aiPrompter = {
       promptAndGetReply: jest.fn()
     };
-    fetchMock
-      .mockResolvedValueOnce(
-        createJsonResponse({
-          signable_message: SIGNABLE_MESSAGE,
-          server_signature: 'server-signature'
-        }) as never
-      )
-      .mockResolvedValueOnce(
-        createJsonResponse({
-          token: 'auth-token'
-        }) as never
-      )
-      .mockResolvedValueOnce(createJsonResponse({}) as never);
+    mockSuccessfulAuth(fetchMock);
   });
 
   afterEach(() => {
@@ -215,6 +221,67 @@ describe('GitHubIssueDropService', () => {
         }
       ]
     });
+  });
+
+  it('preserves path prefixes from API_BASE_URL when building API requests', async () => {
+    process.env.API_BASE_URL = 'https://api.test/base/';
+
+    await new GitHubIssueDropService(aiPrompter).postGhIssueDrop(
+      ISSUE_URL,
+      'issue',
+      {
+        action: 'opened'
+      }
+    );
+
+    expect(getFetchUrl(0).pathname).toBe('/base/api/auth/session-nonce');
+    expect(getFetchUrl(1).pathname).toBe('/base/api/auth/login');
+    expect(getFetchUrl(2).pathname).toBe('/base/api/drops');
+  });
+
+  it('rejects malformed session nonce responses before signing', async () => {
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValueOnce(
+      createJsonResponse({
+        server_signature: 'server-signature'
+      }) as never
+    );
+
+    await expect(
+      new GitHubIssueDropService(aiPrompter).postGhIssueDrop(
+        ISSUE_URL,
+        'issue',
+        {
+          action: 'opened'
+        }
+      )
+    ).rejects.toThrow('Invalid session nonce response');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects malformed login responses before posting the drop', async () => {
+    fetchMock.mockReset();
+    fetchMock
+      .mockResolvedValueOnce(
+        createJsonResponse({
+          signable_message: SIGNABLE_MESSAGE,
+          server_signature: 'server-signature'
+        }) as never
+      )
+      .mockResolvedValueOnce(
+        createJsonResponse({ refresh_token: 'ignored' }) as never
+      );
+
+    await expect(
+      new GitHubIssueDropService(aiPrompter).postGhIssueDrop(
+        ISSUE_URL,
+        'issue',
+        {
+          action: 'opened'
+        }
+      )
+    ).rejects.toThrow('Invalid login response');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
   it('posts non-merged GitHub events without asking AI for a summary', async () => {

--- a/src/api-serverless/src/github/github-issue-drop-service.test.ts
+++ b/src/api-serverless/src/github/github-issue-drop-service.test.ts
@@ -10,20 +10,7 @@ const PRIVATE_KEY =
 const CLIENT_ADDRESS = new Wallet(PRIVATE_KEY).address;
 const ISSUED_AT = new Date(Date.now() - 1_000).toISOString();
 const EXPIRATION_TIME = new Date(Date.now() + 5 * 60 * 1_000).toISOString();
-const SIGNABLE_MESSAGE = [
-  '6529 Authentication',
-  'Version: 2',
-  'Audience: api.test',
-  'Domain: native',
-  'Session Type: native',
-  `Wallet: ${CLIENT_ADDRESS}`,
-  'Chain ID: 1',
-  `Issued At: ${ISSUED_AT}`,
-  `Expiration Time: ${EXPIRATION_TIME}`,
-  'Nonce: github-auth-nonce',
-  'Action: login',
-  'Purpose: Sign this message to authenticate with 6529.'
-].join('\n');
+const SIGNABLE_MESSAGE = buildSignableMessage();
 const PR_URL = 'https://github.com/6529-Collections/test/pull/456';
 const ISSUE_URL = 'https://github.com/6529-Collections/test/issues/123';
 
@@ -49,6 +36,29 @@ type LoginRequestBody = {
   server_signature: string;
   is_safe_wallet: boolean;
 };
+
+function buildSignableMessage({
+  action = 'login',
+  expirationTime = EXPIRATION_TIME
+}: {
+  action?: string;
+  expirationTime?: string;
+} = {}): string {
+  return [
+    '6529 Authentication',
+    'Version: 2',
+    'Audience: api.test',
+    'Domain: native',
+    'Session Type: native',
+    `Wallet: ${CLIENT_ADDRESS}`,
+    'Chain ID: 1',
+    `Issued At: ${ISSUED_AT}`,
+    `Expiration Time: ${expirationTime}`,
+    'Nonce: github-auth-nonce',
+    `Action: ${action}`,
+    'Purpose: Sign this message to authenticate with 6529.'
+  ].join('\n');
+}
 
 function createJsonResponse(jsonPayload: unknown): MockResponse {
   return {
@@ -243,6 +253,27 @@ describe('GitHubIssueDropService', () => {
     fetchMock.mockReset();
     fetchMock.mockResolvedValueOnce(
       createJsonResponse({
+        server_signature: 'server-signature'
+      }) as never
+    );
+
+    await expect(
+      new GitHubIssueDropService(aiPrompter).postGhIssueDrop(
+        ISSUE_URL,
+        'issue',
+        {
+          action: 'opened'
+        }
+      )
+    ).rejects.toThrow('Invalid session nonce response');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects session nonce messages for unexpected auth context', async () => {
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValueOnce(
+      createJsonResponse({
+        signable_message: buildSignableMessage({ action: 'link' }),
         server_signature: 'server-signature'
       }) as never
     );

--- a/src/api-serverless/src/github/github-issue-drop.service.ts
+++ b/src/api-serverless/src/github/github-issue-drop.service.ts
@@ -4,6 +4,7 @@ import { Wallet } from 'ethers';
 import fetch from 'node-fetch';
 import { env } from '../../../env';
 import { Logger } from '../../../logging';
+import { parseStructuredWalletSignatureMessage } from '../wallet-signatures/structured-wallet-signatures';
 import { GitHubWebhookAction } from './github-webhook-event';
 
 type GitHubDropTargetKind = 'issue' | 'pull request';
@@ -23,6 +24,20 @@ type LoginResponse = {
 const PULL_REQUEST_SUMMARY_MAX_LENGTH = 1000;
 const PULL_REQUEST_PROMPT_BODY_MAX_LENGTH = 12000;
 const GITHUB_WEBHOOK_AUTH_CLIENT_TYPE = 'native';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function getNonEmptyString(
+  value: Record<string, unknown>,
+  field: string
+): string | null {
+  const fieldValue = value[field];
+  return typeof fieldValue === 'string' && fieldValue.trim().length > 0
+    ? fieldValue
+    : null;
+}
 
 export class GitHubIssueDropService {
   private readonly logger = Logger.get(this.constructor.name);
@@ -82,10 +97,12 @@ export class GitHubIssueDropService {
       );
     }
 
-    const { signable_message, server_signature } =
-      (await nonceResp.json()) as SessionNonceResponse;
+    const sessionNonce = this.getValidatedSessionNonceResponse(
+      await nonceResp.json(),
+      clientAddress
+    );
 
-    const signedNonce = await wallet.signMessage(signable_message);
+    const signedNonce = await wallet.signMessage(sessionNonce.signable_message);
 
     const loginUrl = this.buildApiUrl(API_BASE_URL, '/api/auth/login', {
       signer_address: clientAddress
@@ -99,7 +116,7 @@ export class GitHubIssueDropService {
       body: JSON.stringify({
         client_address: clientAddress,
         client_signature: signedNonce,
-        server_signature,
+        server_signature: sessionNonce.server_signature,
         is_safe_wallet: false
       })
     });
@@ -110,8 +127,60 @@ export class GitHubIssueDropService {
       );
     }
 
-    const { token } = (await loginResp.json()) as LoginResponse;
-    return token;
+    return this.getValidatedLoginResponse(await loginResp.json()).token;
+  }
+
+  private getValidatedSessionNonceResponse(
+    payload: unknown,
+    clientAddress: string
+  ): SessionNonceResponse {
+    if (!isRecord(payload)) {
+      throw new Error('Invalid session nonce response');
+    }
+
+    const signableMessage = getNonEmptyString(payload, 'signable_message');
+    const serverSignature = getNonEmptyString(payload, 'server_signature');
+    if (!signableMessage || !serverSignature) {
+      throw new Error('Invalid session nonce response');
+    }
+
+    this.assertExpectedSessionNonceMessage(signableMessage, clientAddress);
+    return {
+      signable_message: signableMessage,
+      server_signature: serverSignature
+    };
+  }
+
+  private assertExpectedSessionNonceMessage(
+    signableMessage: string,
+    clientAddress: string
+  ): void {
+    const parsedMessage =
+      parseStructuredWalletSignatureMessage(signableMessage);
+    if (
+      !parsedMessage ||
+      parsedMessage.kind !== 'authentication' ||
+      parsedMessage.action !== 'login' ||
+      parsedMessage.domain !== GITHUB_WEBHOOK_AUTH_CLIENT_TYPE ||
+      parsedMessage.sessionType !== GITHUB_WEBHOOK_AUTH_CLIENT_TYPE ||
+      parsedMessage.wallet !== clientAddress.toLowerCase() ||
+      parsedMessage.expirationTime.getTime() <= Date.now()
+    ) {
+      throw new Error('Invalid session nonce response');
+    }
+  }
+
+  private getValidatedLoginResponse(payload: unknown): LoginResponse {
+    if (!isRecord(payload)) {
+      throw new Error('Invalid login response');
+    }
+
+    const token = getNonEmptyString(payload, 'token');
+    if (!token) {
+      throw new Error('Invalid login response');
+    }
+
+    return { token };
   }
 
   private buildApiUrl(
@@ -119,7 +188,10 @@ export class GitHubIssueDropService {
     path: string,
     query: Record<string, string>
   ): string {
-    const url = new URL(path, apiBaseUrl);
+    const url = new URL(apiBaseUrl);
+    const basePath = url.pathname.replace(/\/+$/, '');
+    const nextPath = path.replace(/^\/+/, '');
+    url.pathname = [basePath, nextPath].filter(Boolean).join('/');
     Object.entries(query).forEach(([key, value]) => {
       url.searchParams.set(key, value);
     });
@@ -249,8 +321,9 @@ export class GitHubIssueDropService {
     };
     const API_BASE_URL =
       env.getStringOrNull('API_BASE_URL') ?? 'https://api.6529.io';
+    const createDropUrl = this.buildApiUrl(API_BASE_URL, '/api/drops', {});
 
-    const resp = await fetch(`${API_BASE_URL}/api/drops`, {
+    const resp = await fetch(createDropUrl, {
       method: 'POST',
       headers: {
         accept: 'application/json',

--- a/src/api-serverless/src/github/github-issue-drop.service.ts
+++ b/src/api-serverless/src/github/github-issue-drop.service.ts
@@ -12,9 +12,17 @@ type PostGitHubDropOptions = {
   readonly title?: string;
   readonly body?: string;
 };
+type SessionNonceResponse = {
+  readonly signable_message: string;
+  readonly server_signature: string;
+};
+type LoginResponse = {
+  readonly token: string;
+};
 
 const PULL_REQUEST_SUMMARY_MAX_LENGTH = 1000;
 const PULL_REQUEST_PROMPT_BODY_MAX_LENGTH = 12000;
+const GITHUB_WEBHOOK_AUTH_CLIENT_TYPE = 'native';
 
 export class GitHubIssueDropService {
   private readonly logger = Logger.get(this.constructor.name);
@@ -55,39 +63,46 @@ export class GitHubIssueDropService {
   ): Promise<string> {
     const API_BASE_URL =
       env.getStringOrNull('API_BASE_URL') ?? 'https://api.6529.io';
-    const nonceResp = await fetch(
-      `${API_BASE_URL}/api/auth/nonce?signer_address=${clientAddress}&short_nonce=true`,
+    const sessionNonceUrl = this.buildApiUrl(
+      API_BASE_URL,
+      '/api/auth/session-nonce',
       {
-        headers: { accept: 'application/json' },
-        method: 'GET'
+        signer_address: clientAddress,
+        client_type: GITHUB_WEBHOOK_AUTH_CLIENT_TYPE
       }
     );
+    const nonceResp = await fetch(sessionNonceUrl, {
+      headers: { accept: 'application/json' },
+      method: 'GET'
+    });
 
     if (!nonceResp.ok) {
       throw new Error(
-        `Failed to get nonce: ${nonceResp.status} ${nonceResp.statusText}`
+        `Failed to get session nonce: ${nonceResp.status} ${nonceResp.statusText}`
       );
     }
 
-    const { nonce, server_signature } = await nonceResp.json();
+    const { signable_message, server_signature } =
+      (await nonceResp.json()) as SessionNonceResponse;
 
-    const signedNonce = await wallet.signMessage(nonce);
+    const signedNonce = await wallet.signMessage(signable_message);
 
-    const loginResp = await fetch(
-      `${API_BASE_URL}/api/auth/login?signer_address=${clientAddress}`,
-      {
-        headers: {
-          accept: 'application/json',
-          'content-type': 'application/json'
-        },
-        method: 'POST',
-        body: JSON.stringify({
-          client_address: clientAddress,
-          client_signature: signedNonce,
-          server_signature
-        })
-      }
-    );
+    const loginUrl = this.buildApiUrl(API_BASE_URL, '/api/auth/login', {
+      signer_address: clientAddress
+    });
+    const loginResp = await fetch(loginUrl, {
+      headers: {
+        accept: 'application/json',
+        'content-type': 'application/json'
+      },
+      method: 'POST',
+      body: JSON.stringify({
+        client_address: clientAddress,
+        client_signature: signedNonce,
+        server_signature,
+        is_safe_wallet: false
+      })
+    });
 
     if (!loginResp.ok) {
       throw new Error(
@@ -95,8 +110,20 @@ export class GitHubIssueDropService {
       );
     }
 
-    const { token } = await loginResp.json();
+    const { token } = (await loginResp.json()) as LoginResponse;
     return token;
+  }
+
+  private buildApiUrl(
+    apiBaseUrl: string,
+    path: string,
+    query: Record<string, string>
+  ): string {
+    const url = new URL(path, apiBaseUrl);
+    Object.entries(query).forEach(([key, value]) => {
+      url.searchParams.set(key, value);
+    });
+    return url.toString();
   }
 
   private async buildDropContent({

--- a/src/api-serverless/src/github/github-issue-drop.service.ts
+++ b/src/api-serverless/src/github/github-issue-drop.service.ts
@@ -23,6 +23,7 @@ type LoginResponse = {
 
 const PULL_REQUEST_SUMMARY_MAX_LENGTH = 1000;
 const PULL_REQUEST_PROMPT_BODY_MAX_LENGTH = 12000;
+// Must match the session-v2 client type expected by structured native auth.
 const GITHUB_WEBHOOK_AUTH_CLIENT_TYPE = 'native';
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/api-serverless/src/github/github-issue-drop.service.ts
+++ b/src/api-serverless/src/github/github-issue-drop.service.ts
@@ -39,6 +39,22 @@ function getNonEmptyString(
     : null;
 }
 
+function removeLeadingSlashes(value: string): string {
+  let startIndex = 0;
+  while (startIndex < value.length && value[startIndex] === '/') {
+    startIndex++;
+  }
+  return value.slice(startIndex);
+}
+
+function removeTrailingSlashes(value: string): string {
+  let endIndex = value.length;
+  while (endIndex > 0 && value[endIndex - 1] === '/') {
+    endIndex--;
+  }
+  return value.slice(0, endIndex);
+}
+
 export class GitHubIssueDropService {
   private readonly logger = Logger.get(this.constructor.name);
 
@@ -158,13 +174,12 @@ export class GitHubIssueDropService {
     const parsedMessage =
       parseStructuredWalletSignatureMessage(signableMessage);
     if (
-      !parsedMessage ||
-      parsedMessage.kind !== 'authentication' ||
-      parsedMessage.action !== 'login' ||
-      parsedMessage.domain !== GITHUB_WEBHOOK_AUTH_CLIENT_TYPE ||
-      parsedMessage.sessionType !== GITHUB_WEBHOOK_AUTH_CLIENT_TYPE ||
-      parsedMessage.wallet !== clientAddress.toLowerCase() ||
-      parsedMessage.expirationTime.getTime() <= Date.now()
+      parsedMessage?.kind !== 'authentication' ||
+      parsedMessage?.action !== 'login' ||
+      parsedMessage?.domain !== GITHUB_WEBHOOK_AUTH_CLIENT_TYPE ||
+      parsedMessage?.sessionType !== GITHUB_WEBHOOK_AUTH_CLIENT_TYPE ||
+      parsedMessage?.wallet !== clientAddress.toLowerCase() ||
+      parsedMessage?.expirationTime.getTime() <= Date.now()
     ) {
       throw new Error('Invalid session nonce response');
     }
@@ -189,8 +204,8 @@ export class GitHubIssueDropService {
     query: Record<string, string>
   ): string {
     const url = new URL(apiBaseUrl);
-    const basePath = url.pathname.replace(/\/+$/, '');
-    const nextPath = path.replace(/^\/+/, '');
+    const basePath = removeTrailingSlashes(url.pathname);
+    const nextPath = removeLeadingSlashes(path);
     url.pathname = [basePath, nextPath].filter(Boolean).join('/');
     Object.entries(query).forEach(([key, value]) => {
       url.searchParams.set(key, value);


### PR DESCRIPTION
## Issue
- The `/gh-hooks` wave-posting integration still authenticated through the legacy short-nonce wallet flow before posting GitHub issue and pull request drops.

## Fix
- Switch `GitHubIssueDropService` to request a structured session nonce, sign the returned `signable_message`, and authenticate through the existing bearer-token `/api/auth/login` path before calling `/api/drops`.

## Changes
- Replaces the legacy `/api/auth/nonce?short_nonce=true` request with `/api/auth/session-nonce?client_type=native`.
- Preserves the configured `GH_WEBHOOK_WAVE_ID` target and the existing `/api/drops` payload shape.
- Keeps issue/reopened posts URL-only and merged PR posts as URL plus summary.
- Adds focused coverage for the structured auth request sequence, bearer token use, and unchanged drop content formatting.

## Validation
- `npm test -- --runInBand src/api-serverless/src/github/github-issue-drop-service.test.ts`
- `npm run lint`

## Risk
- Level: Low
- Why: The change is scoped to the GitHub webhook drop-posting auth sequence and leaves webhook signature verification, event parsing, dedupe, wave config, and drop formatting intact.
- Rollback: Revert this PR to restore the previous legacy short-nonce authentication flow.

## Deployment
- Deploy `api` when this is intentionally merged and released.
- No staging or production deployment was performed.

## Review Notes
- This PR is intentionally marked `DONT MERGE` per operator request.