### PR TITLE
Add CI pipeline wave alerts

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -253,6 +253,21 @@ jobs:
           content: '@everyone'
           color: 0xff0000
 
+      - name: Notify CI wave about failure
+        if: failure()
+        continue-on-error: true
+        env:
+          CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING }}
+          CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING }}
+          CI_PIPELINES_WAVE_WEBHOOK_URL_PROD: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_PROD }}
+          CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD }}
+          CI_PIPELINES_TARGET_ENV: ${{ github.event.inputs.environment }}
+          CI_PIPELINES_STATUS: failure
+          CI_PIPELINES_TITLE: Seize-Lambda ${{ github.event.inputs.environment }} ${{ github.event.inputs.service }} DEPLOY CI pipeline is broken!!!
+          CI_PIPELINES_ENVIRONMENT: ${{ github.event.inputs.environment }}
+          CI_PIPELINES_SERVICE: ${{ github.event.inputs.service }}
+        run: node scripts/notify-ci-wave.mjs
+
       - name: Notify about success
         uses: sarisia/actions-status-discord@v1
         if: success()
@@ -261,3 +276,18 @@ jobs:
         with:
           title: Seize-Lambda ${{ github.event.inputs.environment }} ${{ github.event.inputs.service }} DEPLOY CI pipeline complete
           color: 0x00ff00
+
+      - name: Notify CI wave about success
+        if: success()
+        continue-on-error: true
+        env:
+          CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING }}
+          CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING }}
+          CI_PIPELINES_WAVE_WEBHOOK_URL_PROD: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_PROD }}
+          CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD }}
+          CI_PIPELINES_TARGET_ENV: ${{ github.event.inputs.environment }}
+          CI_PIPELINES_STATUS: success
+          CI_PIPELINES_TITLE: Seize-Lambda ${{ github.event.inputs.environment }} ${{ github.event.inputs.service }} DEPLOY CI pipeline complete
+          CI_PIPELINES_ENVIRONMENT: ${{ github.event.inputs.environment }}
+          CI_PIPELINES_SERVICE: ${{ github.event.inputs.service }}
+        run: node scripts/notify-ci-wave.mjs

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -259,6 +259,7 @@ jobs:
         env:
           CI_PIPELINES_ALERT_URL: ${{ vars.CI_PIPELINES_ALERT_URL }}
           CI_PIPELINES_ALERT_SECRET: ${{ secrets.CI_PIPELINES_ALERT_SECRET }}
+          CI_PIPELINES_ALERT_API_AUTH: ${{ secrets.CI_PIPELINES_ALERT_API_AUTH }}
           CI_PIPELINES_TARGET_ENV: ${{ github.event.inputs.environment }}
           CI_PIPELINES_STATUS: failure
           CI_PIPELINES_TITLE: Seize-Lambda ${{ github.event.inputs.environment }} ${{ github.event.inputs.service }} DEPLOY CI pipeline is broken!!!
@@ -281,6 +282,7 @@ jobs:
         env:
           CI_PIPELINES_ALERT_URL: ${{ vars.CI_PIPELINES_ALERT_URL }}
           CI_PIPELINES_ALERT_SECRET: ${{ secrets.CI_PIPELINES_ALERT_SECRET }}
+          CI_PIPELINES_ALERT_API_AUTH: ${{ secrets.CI_PIPELINES_ALERT_API_AUTH }}
           CI_PIPELINES_TARGET_ENV: ${{ github.event.inputs.environment }}
           CI_PIPELINES_STATUS: success
           CI_PIPELINES_TITLE: Seize-Lambda ${{ github.event.inputs.environment }} ${{ github.event.inputs.service }} DEPLOY CI pipeline complete

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -253,18 +253,29 @@ jobs:
           content: '@everyone'
           color: 0xff0000
 
-      - name: Notify CI wave about failure
-        if: failure()
+      - name: Notify staging CI wave about failure
+        if: failure() && github.event.inputs.environment == 'staging'
         continue-on-error: true
         env:
           CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING }}
           CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING }}
-          CI_PIPELINES_WAVE_WEBHOOK_URL_PROD: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_PROD }}
-          CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD }}
-          CI_PIPELINES_TARGET_ENV: ${{ github.event.inputs.environment }}
+          CI_PIPELINES_TARGET_ENV: staging
           CI_PIPELINES_STATUS: failure
           CI_PIPELINES_TITLE: Seize-Lambda ${{ github.event.inputs.environment }} ${{ github.event.inputs.service }} DEPLOY CI pipeline is broken!!!
-          CI_PIPELINES_ENVIRONMENT: ${{ github.event.inputs.environment }}
+          CI_PIPELINES_ENVIRONMENT: staging
+          CI_PIPELINES_SERVICE: ${{ github.event.inputs.service }}
+        run: node scripts/notify-ci-wave.mjs
+
+      - name: Notify production CI wave about failure
+        if: failure() && github.event.inputs.environment == 'prod'
+        continue-on-error: true
+        env:
+          CI_PIPELINES_WAVE_WEBHOOK_URL_PROD: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_PROD }}
+          CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD }}
+          CI_PIPELINES_TARGET_ENV: prod
+          CI_PIPELINES_STATUS: failure
+          CI_PIPELINES_TITLE: Seize-Lambda ${{ github.event.inputs.environment }} ${{ github.event.inputs.service }} DEPLOY CI pipeline is broken!!!
+          CI_PIPELINES_ENVIRONMENT: prod
           CI_PIPELINES_SERVICE: ${{ github.event.inputs.service }}
         run: node scripts/notify-ci-wave.mjs
 
@@ -277,17 +288,28 @@ jobs:
           title: Seize-Lambda ${{ github.event.inputs.environment }} ${{ github.event.inputs.service }} DEPLOY CI pipeline complete
           color: 0x00ff00
 
-      - name: Notify CI wave about success
-        if: success()
+      - name: Notify staging CI wave about success
+        if: success() && github.event.inputs.environment == 'staging'
         continue-on-error: true
         env:
           CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING }}
           CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING }}
-          CI_PIPELINES_WAVE_WEBHOOK_URL_PROD: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_PROD }}
-          CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD }}
-          CI_PIPELINES_TARGET_ENV: ${{ github.event.inputs.environment }}
+          CI_PIPELINES_TARGET_ENV: staging
           CI_PIPELINES_STATUS: success
           CI_PIPELINES_TITLE: Seize-Lambda ${{ github.event.inputs.environment }} ${{ github.event.inputs.service }} DEPLOY CI pipeline complete
-          CI_PIPELINES_ENVIRONMENT: ${{ github.event.inputs.environment }}
+          CI_PIPELINES_ENVIRONMENT: staging
+          CI_PIPELINES_SERVICE: ${{ github.event.inputs.service }}
+        run: node scripts/notify-ci-wave.mjs
+
+      - name: Notify production CI wave about success
+        if: success() && github.event.inputs.environment == 'prod'
+        continue-on-error: true
+        env:
+          CI_PIPELINES_WAVE_WEBHOOK_URL_PROD: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_PROD }}
+          CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD }}
+          CI_PIPELINES_TARGET_ENV: prod
+          CI_PIPELINES_STATUS: success
+          CI_PIPELINES_TITLE: Seize-Lambda ${{ github.event.inputs.environment }} ${{ github.event.inputs.service }} DEPLOY CI pipeline complete
+          CI_PIPELINES_ENVIRONMENT: prod
           CI_PIPELINES_SERVICE: ${{ github.event.inputs.service }}
         run: node scripts/notify-ci-wave.mjs

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -253,29 +253,16 @@ jobs:
           content: '@everyone'
           color: 0xff0000
 
-      - name: Notify staging CI wave about failure
-        if: failure() && github.event.inputs.environment == 'staging'
+      - name: Notify CI wave about failure
+        if: failure()
         continue-on-error: true
         env:
-          CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING }}
-          CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING }}
-          CI_PIPELINES_TARGET_ENV: staging
+          CI_PIPELINES_ALERT_URL: ${{ vars.CI_PIPELINES_ALERT_URL }}
+          CI_PIPELINES_ALERT_SECRET: ${{ secrets.CI_PIPELINES_ALERT_SECRET }}
+          CI_PIPELINES_TARGET_ENV: ${{ github.event.inputs.environment }}
           CI_PIPELINES_STATUS: failure
           CI_PIPELINES_TITLE: Seize-Lambda ${{ github.event.inputs.environment }} ${{ github.event.inputs.service }} DEPLOY CI pipeline is broken!!!
-          CI_PIPELINES_ENVIRONMENT: staging
-          CI_PIPELINES_SERVICE: ${{ github.event.inputs.service }}
-        run: node scripts/notify-ci-wave.mjs
-
-      - name: Notify production CI wave about failure
-        if: failure() && github.event.inputs.environment == 'prod'
-        continue-on-error: true
-        env:
-          CI_PIPELINES_WAVE_WEBHOOK_URL_PROD: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_PROD }}
-          CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD }}
-          CI_PIPELINES_TARGET_ENV: prod
-          CI_PIPELINES_STATUS: failure
-          CI_PIPELINES_TITLE: Seize-Lambda ${{ github.event.inputs.environment }} ${{ github.event.inputs.service }} DEPLOY CI pipeline is broken!!!
-          CI_PIPELINES_ENVIRONMENT: prod
+          CI_PIPELINES_ENVIRONMENT: ${{ github.event.inputs.environment }}
           CI_PIPELINES_SERVICE: ${{ github.event.inputs.service }}
         run: node scripts/notify-ci-wave.mjs
 
@@ -288,28 +275,15 @@ jobs:
           title: Seize-Lambda ${{ github.event.inputs.environment }} ${{ github.event.inputs.service }} DEPLOY CI pipeline complete
           color: 0x00ff00
 
-      - name: Notify staging CI wave about success
-        if: success() && github.event.inputs.environment == 'staging'
+      - name: Notify CI wave about success
+        if: success()
         continue-on-error: true
         env:
-          CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING }}
-          CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING }}
-          CI_PIPELINES_TARGET_ENV: staging
+          CI_PIPELINES_ALERT_URL: ${{ vars.CI_PIPELINES_ALERT_URL }}
+          CI_PIPELINES_ALERT_SECRET: ${{ secrets.CI_PIPELINES_ALERT_SECRET }}
+          CI_PIPELINES_TARGET_ENV: ${{ github.event.inputs.environment }}
           CI_PIPELINES_STATUS: success
           CI_PIPELINES_TITLE: Seize-Lambda ${{ github.event.inputs.environment }} ${{ github.event.inputs.service }} DEPLOY CI pipeline complete
-          CI_PIPELINES_ENVIRONMENT: staging
-          CI_PIPELINES_SERVICE: ${{ github.event.inputs.service }}
-        run: node scripts/notify-ci-wave.mjs
-
-      - name: Notify production CI wave about success
-        if: success() && github.event.inputs.environment == 'prod'
-        continue-on-error: true
-        env:
-          CI_PIPELINES_WAVE_WEBHOOK_URL_PROD: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_PROD }}
-          CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD: ${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD }}
-          CI_PIPELINES_TARGET_ENV: prod
-          CI_PIPELINES_STATUS: success
-          CI_PIPELINES_TITLE: Seize-Lambda ${{ github.event.inputs.environment }} ${{ github.event.inputs.service }} DEPLOY CI pipeline complete
-          CI_PIPELINES_ENVIRONMENT: prod
+          CI_PIPELINES_ENVIRONMENT: ${{ github.event.inputs.environment }}
           CI_PIPELINES_SERVICE: ${{ github.event.inputs.service }}
         run: node scripts/notify-ci-wave.mjs

--- a/scripts/generate-deploy-config.mjs
+++ b/scripts/generate-deploy-config.mjs
@@ -254,6 +254,7 @@ jobs:
         env:
           CI_PIPELINES_ALERT_URL: \${{ vars.CI_PIPELINES_ALERT_URL }}
           CI_PIPELINES_ALERT_SECRET: \${{ secrets.CI_PIPELINES_ALERT_SECRET }}
+          CI_PIPELINES_ALERT_API_AUTH: \${{ secrets.CI_PIPELINES_ALERT_API_AUTH }}
           CI_PIPELINES_TARGET_ENV: \${{ github.event.inputs.environment }}
           CI_PIPELINES_STATUS: failure
           CI_PIPELINES_TITLE: Seize-Lambda \${{ github.event.inputs.environment }} \${{ github.event.inputs.service }} DEPLOY CI pipeline is broken!!!
@@ -276,6 +277,7 @@ jobs:
         env:
           CI_PIPELINES_ALERT_URL: \${{ vars.CI_PIPELINES_ALERT_URL }}
           CI_PIPELINES_ALERT_SECRET: \${{ secrets.CI_PIPELINES_ALERT_SECRET }}
+          CI_PIPELINES_ALERT_API_AUTH: \${{ secrets.CI_PIPELINES_ALERT_API_AUTH }}
           CI_PIPELINES_TARGET_ENV: \${{ github.event.inputs.environment }}
           CI_PIPELINES_STATUS: success
           CI_PIPELINES_TITLE: Seize-Lambda \${{ github.event.inputs.environment }} \${{ github.event.inputs.service }} DEPLOY CI pipeline complete

--- a/scripts/generate-deploy-config.mjs
+++ b/scripts/generate-deploy-config.mjs
@@ -248,18 +248,29 @@ jobs:
           content: '@everyone'
           color: 0xff0000
 
-      - name: Notify CI wave about failure
-        if: failure()
+      - name: Notify staging CI wave about failure
+        if: failure() && github.event.inputs.environment == 'staging'
         continue-on-error: true
         env:
           CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING: \${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING }}
           CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING: \${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING }}
-          CI_PIPELINES_WAVE_WEBHOOK_URL_PROD: \${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_PROD }}
-          CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD: \${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD }}
-          CI_PIPELINES_TARGET_ENV: \${{ github.event.inputs.environment }}
+          CI_PIPELINES_TARGET_ENV: staging
           CI_PIPELINES_STATUS: failure
           CI_PIPELINES_TITLE: Seize-Lambda \${{ github.event.inputs.environment }} \${{ github.event.inputs.service }} DEPLOY CI pipeline is broken!!!
-          CI_PIPELINES_ENVIRONMENT: \${{ github.event.inputs.environment }}
+          CI_PIPELINES_ENVIRONMENT: staging
+          CI_PIPELINES_SERVICE: \${{ github.event.inputs.service }}
+        run: node scripts/notify-ci-wave.mjs
+
+      - name: Notify production CI wave about failure
+        if: failure() && github.event.inputs.environment == 'prod'
+        continue-on-error: true
+        env:
+          CI_PIPELINES_WAVE_WEBHOOK_URL_PROD: \${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_PROD }}
+          CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD: \${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD }}
+          CI_PIPELINES_TARGET_ENV: prod
+          CI_PIPELINES_STATUS: failure
+          CI_PIPELINES_TITLE: Seize-Lambda \${{ github.event.inputs.environment }} \${{ github.event.inputs.service }} DEPLOY CI pipeline is broken!!!
+          CI_PIPELINES_ENVIRONMENT: prod
           CI_PIPELINES_SERVICE: \${{ github.event.inputs.service }}
         run: node scripts/notify-ci-wave.mjs
 
@@ -272,18 +283,29 @@ jobs:
           title: Seize-Lambda \${{ github.event.inputs.environment }} \${{ github.event.inputs.service }} DEPLOY CI pipeline complete
           color: 0x00ff00
 
-      - name: Notify CI wave about success
-        if: success()
+      - name: Notify staging CI wave about success
+        if: success() && github.event.inputs.environment == 'staging'
         continue-on-error: true
         env:
           CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING: \${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING }}
           CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING: \${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING }}
-          CI_PIPELINES_WAVE_WEBHOOK_URL_PROD: \${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_PROD }}
-          CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD: \${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD }}
-          CI_PIPELINES_TARGET_ENV: \${{ github.event.inputs.environment }}
+          CI_PIPELINES_TARGET_ENV: staging
           CI_PIPELINES_STATUS: success
           CI_PIPELINES_TITLE: Seize-Lambda \${{ github.event.inputs.environment }} \${{ github.event.inputs.service }} DEPLOY CI pipeline complete
-          CI_PIPELINES_ENVIRONMENT: \${{ github.event.inputs.environment }}
+          CI_PIPELINES_ENVIRONMENT: staging
+          CI_PIPELINES_SERVICE: \${{ github.event.inputs.service }}
+        run: node scripts/notify-ci-wave.mjs
+
+      - name: Notify production CI wave about success
+        if: success() && github.event.inputs.environment == 'prod'
+        continue-on-error: true
+        env:
+          CI_PIPELINES_WAVE_WEBHOOK_URL_PROD: \${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_PROD }}
+          CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD: \${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD }}
+          CI_PIPELINES_TARGET_ENV: prod
+          CI_PIPELINES_STATUS: success
+          CI_PIPELINES_TITLE: Seize-Lambda \${{ github.event.inputs.environment }} \${{ github.event.inputs.service }} DEPLOY CI pipeline complete
+          CI_PIPELINES_ENVIRONMENT: prod
           CI_PIPELINES_SERVICE: \${{ github.event.inputs.service }}
         run: node scripts/notify-ci-wave.mjs
 `;

--- a/scripts/generate-deploy-config.mjs
+++ b/scripts/generate-deploy-config.mjs
@@ -248,29 +248,16 @@ jobs:
           content: '@everyone'
           color: 0xff0000
 
-      - name: Notify staging CI wave about failure
-        if: failure() && github.event.inputs.environment == 'staging'
+      - name: Notify CI wave about failure
+        if: failure()
         continue-on-error: true
         env:
-          CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING: \${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING }}
-          CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING: \${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING }}
-          CI_PIPELINES_TARGET_ENV: staging
+          CI_PIPELINES_ALERT_URL: \${{ vars.CI_PIPELINES_ALERT_URL }}
+          CI_PIPELINES_ALERT_SECRET: \${{ secrets.CI_PIPELINES_ALERT_SECRET }}
+          CI_PIPELINES_TARGET_ENV: \${{ github.event.inputs.environment }}
           CI_PIPELINES_STATUS: failure
           CI_PIPELINES_TITLE: Seize-Lambda \${{ github.event.inputs.environment }} \${{ github.event.inputs.service }} DEPLOY CI pipeline is broken!!!
-          CI_PIPELINES_ENVIRONMENT: staging
-          CI_PIPELINES_SERVICE: \${{ github.event.inputs.service }}
-        run: node scripts/notify-ci-wave.mjs
-
-      - name: Notify production CI wave about failure
-        if: failure() && github.event.inputs.environment == 'prod'
-        continue-on-error: true
-        env:
-          CI_PIPELINES_WAVE_WEBHOOK_URL_PROD: \${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_PROD }}
-          CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD: \${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD }}
-          CI_PIPELINES_TARGET_ENV: prod
-          CI_PIPELINES_STATUS: failure
-          CI_PIPELINES_TITLE: Seize-Lambda \${{ github.event.inputs.environment }} \${{ github.event.inputs.service }} DEPLOY CI pipeline is broken!!!
-          CI_PIPELINES_ENVIRONMENT: prod
+          CI_PIPELINES_ENVIRONMENT: \${{ github.event.inputs.environment }}
           CI_PIPELINES_SERVICE: \${{ github.event.inputs.service }}
         run: node scripts/notify-ci-wave.mjs
 
@@ -283,29 +270,16 @@ jobs:
           title: Seize-Lambda \${{ github.event.inputs.environment }} \${{ github.event.inputs.service }} DEPLOY CI pipeline complete
           color: 0x00ff00
 
-      - name: Notify staging CI wave about success
-        if: success() && github.event.inputs.environment == 'staging'
+      - name: Notify CI wave about success
+        if: success()
         continue-on-error: true
         env:
-          CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING: \${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING }}
-          CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING: \${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING }}
-          CI_PIPELINES_TARGET_ENV: staging
+          CI_PIPELINES_ALERT_URL: \${{ vars.CI_PIPELINES_ALERT_URL }}
+          CI_PIPELINES_ALERT_SECRET: \${{ secrets.CI_PIPELINES_ALERT_SECRET }}
+          CI_PIPELINES_TARGET_ENV: \${{ github.event.inputs.environment }}
           CI_PIPELINES_STATUS: success
           CI_PIPELINES_TITLE: Seize-Lambda \${{ github.event.inputs.environment }} \${{ github.event.inputs.service }} DEPLOY CI pipeline complete
-          CI_PIPELINES_ENVIRONMENT: staging
-          CI_PIPELINES_SERVICE: \${{ github.event.inputs.service }}
-        run: node scripts/notify-ci-wave.mjs
-
-      - name: Notify production CI wave about success
-        if: success() && github.event.inputs.environment == 'prod'
-        continue-on-error: true
-        env:
-          CI_PIPELINES_WAVE_WEBHOOK_URL_PROD: \${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_PROD }}
-          CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD: \${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD }}
-          CI_PIPELINES_TARGET_ENV: prod
-          CI_PIPELINES_STATUS: success
-          CI_PIPELINES_TITLE: Seize-Lambda \${{ github.event.inputs.environment }} \${{ github.event.inputs.service }} DEPLOY CI pipeline complete
-          CI_PIPELINES_ENVIRONMENT: prod
+          CI_PIPELINES_ENVIRONMENT: \${{ github.event.inputs.environment }}
           CI_PIPELINES_SERVICE: \${{ github.event.inputs.service }}
         run: node scripts/notify-ci-wave.mjs
 `;

--- a/scripts/generate-deploy-config.mjs
+++ b/scripts/generate-deploy-config.mjs
@@ -248,6 +248,21 @@ jobs:
           content: '@everyone'
           color: 0xff0000
 
+      - name: Notify CI wave about failure
+        if: failure()
+        continue-on-error: true
+        env:
+          CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING: \${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING }}
+          CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING: \${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING }}
+          CI_PIPELINES_WAVE_WEBHOOK_URL_PROD: \${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_PROD }}
+          CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD: \${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD }}
+          CI_PIPELINES_TARGET_ENV: \${{ github.event.inputs.environment }}
+          CI_PIPELINES_STATUS: failure
+          CI_PIPELINES_TITLE: Seize-Lambda \${{ github.event.inputs.environment }} \${{ github.event.inputs.service }} DEPLOY CI pipeline is broken!!!
+          CI_PIPELINES_ENVIRONMENT: \${{ github.event.inputs.environment }}
+          CI_PIPELINES_SERVICE: \${{ github.event.inputs.service }}
+        run: node scripts/notify-ci-wave.mjs
+
       - name: Notify about success
         uses: sarisia/actions-status-discord@v1
         if: success()
@@ -256,6 +271,21 @@ jobs:
         with:
           title: Seize-Lambda \${{ github.event.inputs.environment }} \${{ github.event.inputs.service }} DEPLOY CI pipeline complete
           color: 0x00ff00
+
+      - name: Notify CI wave about success
+        if: success()
+        continue-on-error: true
+        env:
+          CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING: \${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING }}
+          CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING: \${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING }}
+          CI_PIPELINES_WAVE_WEBHOOK_URL_PROD: \${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_URL_PROD }}
+          CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD: \${{ secrets.CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD }}
+          CI_PIPELINES_TARGET_ENV: \${{ github.event.inputs.environment }}
+          CI_PIPELINES_STATUS: success
+          CI_PIPELINES_TITLE: Seize-Lambda \${{ github.event.inputs.environment }} \${{ github.event.inputs.service }} DEPLOY CI pipeline complete
+          CI_PIPELINES_ENVIRONMENT: \${{ github.event.inputs.environment }}
+          CI_PIPELINES_SERVICE: \${{ github.event.inputs.service }}
+        run: node scripts/notify-ci-wave.mjs
 `;
 }
 

--- a/scripts/notify-ci-wave.mjs
+++ b/scripts/notify-ci-wave.mjs
@@ -2,12 +2,8 @@
 import crypto from 'node:crypto';
 
 const {
-  CI_PIPELINES_WAVE_WEBHOOK_URL,
-  CI_PIPELINES_WAVE_WEBHOOK_SECRET,
-  CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING,
-  CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING,
-  CI_PIPELINES_WAVE_WEBHOOK_URL_PROD,
-  CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD,
+  CI_PIPELINES_ALERT_URL,
+  CI_PIPELINES_ALERT_SECRET,
   CI_PIPELINES_TARGET_ENV,
   CI_PIPELINES_STATUS,
   CI_PIPELINES_TITLE,
@@ -31,50 +27,36 @@ function requireValue(name, value) {
   return value;
 }
 
-function resolveWebhookConfig() {
-  const targetEnv = (CI_PIPELINES_TARGET_ENV || CI_PIPELINES_ENVIRONMENT || '')
+function normalizeTargetEnvironment(value) {
+  const targetEnv = (value || '')
     .trim()
     .toLowerCase();
-  if (targetEnv === 'prod' || targetEnv === 'production') {
-    return {
-      targetEnv,
-      url: CI_PIPELINES_WAVE_WEBHOOK_URL_PROD,
-      secret: CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD
-    };
+  if (!targetEnv) {
+    return null;
   }
-  if (targetEnv === 'staging') {
-    return {
-      targetEnv,
-      url: CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING,
-      secret: CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING
-    };
+  if (
+    targetEnv === 'staging' ||
+    targetEnv === 'prod' ||
+    targetEnv === 'production'
+  ) {
+    return targetEnv;
   }
-  if (targetEnv) {
-    return {
-      targetEnv,
-      unsupported: true
-    };
-  }
-  return {
-    targetEnv: 'default',
-    url: CI_PIPELINES_WAVE_WEBHOOK_URL,
-    secret: CI_PIPELINES_WAVE_WEBHOOK_SECRET
-  };
+  return `unsupported:${targetEnv}`;
 }
 
-const webhookConfig = resolveWebhookConfig();
+const targetEnvironment = normalizeTargetEnvironment(
+  CI_PIPELINES_TARGET_ENV || CI_PIPELINES_ENVIRONMENT
+);
 
-if (webhookConfig.unsupported) {
+if (targetEnvironment?.startsWith('unsupported:')) {
   console.error(
-    `Unsupported CI pipeline wave target environment: ${webhookConfig.targetEnv}`
+    `Unsupported CI pipeline alert target environment: ${targetEnvironment.slice(12)}`
   );
   process.exit(1);
 }
 
-if (!webhookConfig.url || !webhookConfig.secret) {
-  console.log(
-    `CI pipeline wave webhook is not configured for ${webhookConfig.targetEnv}; skipping.`
-  );
+if (!CI_PIPELINES_ALERT_URL || !CI_PIPELINES_ALERT_SECRET) {
+  console.log('CI pipeline alert receiver is not configured; skipping.');
   process.exit(0);
 }
 
@@ -82,8 +64,6 @@ const repository = requireValue('GITHUB_REPOSITORY', GITHUB_REPOSITORY);
 const runId = requireValue('GITHUB_RUN_ID', GITHUB_RUN_ID);
 const status = requireValue('CI_PIPELINES_STATUS', CI_PIPELINES_STATUS);
 const title = requireValue('CI_PIPELINES_TITLE', CI_PIPELINES_TITLE);
-const targetEnvironment =
-  CI_PIPELINES_TARGET_ENV || CI_PIPELINES_ENVIRONMENT || null;
 
 const payload = {
   repo: repository.split('/').pop() ?? repository,
@@ -95,19 +75,19 @@ const payload = {
   run_url: `${GITHUB_SERVER_URL}/${repository}/actions/runs/${runId}`,
   sha: GITHUB_SHA || null,
   branch: GITHUB_REF_NAME || null,
-  environment: targetEnvironment,
+  environment: targetEnvironment || null,
   service: CI_PIPELINES_SERVICE || null
 };
 
 const body = Buffer.from(JSON.stringify(payload));
 const timestamp = Math.floor(Date.now() / 1000).toString();
 const signature = crypto
-  .createHmac('sha256', webhookConfig.secret)
+  .createHmac('sha256', CI_PIPELINES_ALERT_SECRET)
   .update(`${timestamp}.`)
   .update(body)
   .digest('hex');
 
-const response = await fetch(webhookConfig.url, {
+const response = await fetch(CI_PIPELINES_ALERT_URL, {
   method: 'POST',
   headers: {
     'content-type': 'application/json',

--- a/scripts/notify-ci-wave.mjs
+++ b/scripts/notify-ci-wave.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+import crypto from 'node:crypto';
+
+const {
+  CI_PIPELINES_WAVE_WEBHOOK_URL,
+  CI_PIPELINES_WAVE_WEBHOOK_SECRET,
+  CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING,
+  CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING,
+  CI_PIPELINES_WAVE_WEBHOOK_URL_PROD,
+  CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD,
+  CI_PIPELINES_TARGET_ENV,
+  CI_PIPELINES_STATUS,
+  CI_PIPELINES_TITLE,
+  CI_PIPELINES_DESCRIPTION,
+  CI_PIPELINES_ENVIRONMENT,
+  CI_PIPELINES_SERVICE,
+  CI_PIPELINES_WORKFLOW,
+  GITHUB_REPOSITORY,
+  GITHUB_WORKFLOW,
+  GITHUB_RUN_ID,
+  GITHUB_SERVER_URL = 'https://github.com',
+  GITHUB_SHA,
+  GITHUB_REF_NAME
+} = process.env;
+
+function requireValue(name, value) {
+  if (!value) {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+}
+
+function resolveWebhookConfig() {
+  const targetEnv = (CI_PIPELINES_TARGET_ENV || CI_PIPELINES_ENVIRONMENT || '')
+    .trim()
+    .toLowerCase();
+  if (targetEnv === 'prod' || targetEnv === 'production') {
+    return {
+      url: CI_PIPELINES_WAVE_WEBHOOK_URL_PROD,
+      secret: CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD
+    };
+  }
+  if (targetEnv === 'staging') {
+    return {
+      url: CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING,
+      secret: CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING
+    };
+  }
+  return {
+    url: CI_PIPELINES_WAVE_WEBHOOK_URL,
+    secret: CI_PIPELINES_WAVE_WEBHOOK_SECRET
+  };
+}
+
+const webhookConfig = resolveWebhookConfig();
+
+if (!webhookConfig.url || !webhookConfig.secret) {
+  console.log('CI pipeline wave webhook is not configured; skipping.');
+  process.exit(0);
+}
+
+const repository = requireValue('GITHUB_REPOSITORY', GITHUB_REPOSITORY);
+const runId = requireValue('GITHUB_RUN_ID', GITHUB_RUN_ID);
+const status = requireValue('CI_PIPELINES_STATUS', CI_PIPELINES_STATUS);
+const title = requireValue('CI_PIPELINES_TITLE', CI_PIPELINES_TITLE);
+
+const payload = {
+  repo: repository.split('/').pop() ?? repository,
+  workflow: CI_PIPELINES_WORKFLOW || GITHUB_WORKFLOW || 'GitHub Actions',
+  status,
+  title,
+  description: CI_PIPELINES_DESCRIPTION || null,
+  run_id: runId,
+  run_url: `${GITHUB_SERVER_URL}/${repository}/actions/runs/${runId}`,
+  sha: GITHUB_SHA || null,
+  branch: GITHUB_REF_NAME || null,
+  environment: CI_PIPELINES_ENVIRONMENT || CI_PIPELINES_TARGET_ENV || null,
+  service: CI_PIPELINES_SERVICE || null
+};
+
+const body = Buffer.from(JSON.stringify(payload));
+const timestamp = Math.floor(Date.now() / 1000).toString();
+const signature = crypto
+  .createHmac('sha256', webhookConfig.secret)
+  .update(`${timestamp}.`)
+  .update(body)
+  .digest('hex');
+
+const response = await fetch(webhookConfig.url, {
+  method: 'POST',
+  headers: {
+    'content-type': 'application/json',
+    'x-6529-ci-timestamp': timestamp,
+    'x-6529-ci-signature': `sha256=${signature}`
+  },
+  body
+});
+
+if (!response.ok) {
+  const errorText = await response.text();
+  throw new Error(
+    `CI pipeline wave notification failed: ${response.status} ${response.statusText} ${errorText}`
+  );
+}
+
+console.log('CI pipeline wave notification sent.');

--- a/scripts/notify-ci-wave.mjs
+++ b/scripts/notify-ci-wave.mjs
@@ -36,17 +36,20 @@ function resolveWebhookConfig() {
     .toLowerCase();
   if (targetEnv === 'prod' || targetEnv === 'production') {
     return {
+      targetEnv,
       url: CI_PIPELINES_WAVE_WEBHOOK_URL_PROD,
       secret: CI_PIPELINES_WAVE_WEBHOOK_SECRET_PROD
     };
   }
   if (targetEnv === 'staging') {
     return {
+      targetEnv,
       url: CI_PIPELINES_WAVE_WEBHOOK_URL_STAGING,
       secret: CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING
     };
   }
   return {
+    targetEnv: targetEnv || 'default',
     url: CI_PIPELINES_WAVE_WEBHOOK_URL,
     secret: CI_PIPELINES_WAVE_WEBHOOK_SECRET
   };
@@ -55,7 +58,9 @@ function resolveWebhookConfig() {
 const webhookConfig = resolveWebhookConfig();
 
 if (!webhookConfig.url || !webhookConfig.secret) {
-  console.log('CI pipeline wave webhook is not configured; skipping.');
+  console.log(
+    `CI pipeline wave webhook is not configured for ${webhookConfig.targetEnv}; skipping.`
+  );
   process.exit(0);
 }
 
@@ -97,10 +102,10 @@ const response = await fetch(webhookConfig.url, {
 });
 
 if (!response.ok) {
-  const errorText = await response.text();
-  throw new Error(
-    `CI pipeline wave notification failed: ${response.status} ${response.statusText} ${errorText}`
+  console.error(
+    `CI pipeline wave notification failed: ${response.status} ${response.statusText}`
   );
+  process.exit(1);
 }
 
 console.log('CI pipeline wave notification sent.');

--- a/scripts/notify-ci-wave.mjs
+++ b/scripts/notify-ci-wave.mjs
@@ -25,7 +25,8 @@ const {
 
 function requireValue(name, value) {
   if (!value) {
-    throw new Error(`${name} is required`);
+    console.error(`${name} is required`);
+    process.exit(1);
   }
   return value;
 }
@@ -81,6 +82,8 @@ const repository = requireValue('GITHUB_REPOSITORY', GITHUB_REPOSITORY);
 const runId = requireValue('GITHUB_RUN_ID', GITHUB_RUN_ID);
 const status = requireValue('CI_PIPELINES_STATUS', CI_PIPELINES_STATUS);
 const title = requireValue('CI_PIPELINES_TITLE', CI_PIPELINES_TITLE);
+const targetEnvironment =
+  CI_PIPELINES_TARGET_ENV || CI_PIPELINES_ENVIRONMENT || null;
 
 const payload = {
   repo: repository.split('/').pop() ?? repository,
@@ -92,7 +95,7 @@ const payload = {
   run_url: `${GITHUB_SERVER_URL}/${repository}/actions/runs/${runId}`,
   sha: GITHUB_SHA || null,
   branch: GITHUB_REF_NAME || null,
-  environment: CI_PIPELINES_ENVIRONMENT || CI_PIPELINES_TARGET_ENV || null,
+  environment: targetEnvironment,
   service: CI_PIPELINES_SERVICE || null
 };
 

--- a/scripts/notify-ci-wave.mjs
+++ b/scripts/notify-ci-wave.mjs
@@ -46,6 +46,15 @@ function normalizeTargetEnvironment(value) {
   return `unsupported:${targetEnv}`;
 }
 
+function getFetchFailureMessage(error) {
+  if (error instanceof Error) {
+    return error.name === 'AbortError'
+      ? 'request timed out'
+      : error.message;
+  }
+  return 'unknown request error';
+}
+
 const targetEnvironment = normalizeTargetEnvironment(
   CI_PIPELINES_TARGET_ENV || CI_PIPELINES_ENVIRONMENT
 );
@@ -100,11 +109,25 @@ if (CI_PIPELINES_ALERT_API_AUTH) {
   headers['x-6529-auth'] = CI_PIPELINES_ALERT_API_AUTH;
 }
 
-const response = await fetch(CI_PIPELINES_ALERT_URL, {
-  method: 'POST',
-  headers,
-  body
-});
+const controller = new AbortController();
+const timeoutId = setTimeout(() => controller.abort(), 10_000);
+
+let response;
+try {
+  response = await fetch(CI_PIPELINES_ALERT_URL, {
+    method: 'POST',
+    headers,
+    body,
+    signal: controller.signal
+  });
+} catch (error) {
+  console.error(
+    `CI pipeline wave notification request failed: ${getFetchFailureMessage(error)}`
+  );
+  process.exit(1);
+} finally {
+  clearTimeout(timeoutId);
+}
 
 if (!response.ok) {
   console.error(

--- a/scripts/notify-ci-wave.mjs
+++ b/scripts/notify-ci-wave.mjs
@@ -15,6 +15,7 @@ const {
   GITHUB_REPOSITORY,
   GITHUB_WORKFLOW,
   GITHUB_RUN_ID,
+  GITHUB_RUN_NUMBER,
   GITHUB_SERVER_URL = 'https://github.com',
   GITHUB_SHA,
   GITHUB_REF_NAME
@@ -73,6 +74,7 @@ const payload = {
   title,
   description: CI_PIPELINES_DESCRIPTION || null,
   run_id: runId,
+  run_number: GITHUB_RUN_NUMBER || null,
   run_url: `${GITHUB_SERVER_URL}/${repository}/actions/runs/${runId}`,
   sha: GITHUB_SHA || null,
   branch: GITHUB_REF_NAME || null,

--- a/scripts/notify-ci-wave.mjs
+++ b/scripts/notify-ci-wave.mjs
@@ -48,14 +48,27 @@ function resolveWebhookConfig() {
       secret: CI_PIPELINES_WAVE_WEBHOOK_SECRET_STAGING
     };
   }
+  if (targetEnv) {
+    return {
+      targetEnv,
+      unsupported: true
+    };
+  }
   return {
-    targetEnv: targetEnv || 'default',
+    targetEnv: 'default',
     url: CI_PIPELINES_WAVE_WEBHOOK_URL,
     secret: CI_PIPELINES_WAVE_WEBHOOK_SECRET
   };
 }
 
 const webhookConfig = resolveWebhookConfig();
+
+if (webhookConfig.unsupported) {
+  console.error(
+    `Unsupported CI pipeline wave target environment: ${webhookConfig.targetEnv}`
+  );
+  process.exit(1);
+}
 
 if (!webhookConfig.url || !webhookConfig.secret) {
   console.log(

--- a/scripts/notify-ci-wave.mjs
+++ b/scripts/notify-ci-wave.mjs
@@ -4,6 +4,7 @@ import crypto from 'node:crypto';
 const {
   CI_PIPELINES_ALERT_URL,
   CI_PIPELINES_ALERT_SECRET,
+  CI_PIPELINES_ALERT_API_AUTH,
   CI_PIPELINES_TARGET_ENV,
   CI_PIPELINES_STATUS,
   CI_PIPELINES_TITLE,
@@ -87,13 +88,19 @@ const signature = crypto
   .update(body)
   .digest('hex');
 
+const headers = {
+  'content-type': 'application/json',
+  'x-6529-ci-timestamp': timestamp,
+  'x-6529-ci-signature': `sha256=${signature}`
+};
+
+if (CI_PIPELINES_ALERT_API_AUTH) {
+  headers['x-6529-auth'] = CI_PIPELINES_ALERT_API_AUTH;
+}
+
 const response = await fetch(CI_PIPELINES_ALERT_URL, {
   method: 'POST',
-  headers: {
-    'content-type': 'application/json',
-    'x-6529-ci-timestamp': timestamp,
-    'x-6529-ci-signature': `sha256=${signature}`
-  },
+  headers,
   body
 });
 

--- a/src/api-serverless/src/app.ts
+++ b/src/api-serverless/src/app.ts
@@ -56,6 +56,7 @@ import publicWavesRoutes from './waves/waves-public.routes';
 import wavesRoutes from './waves/waves.routes';
 import xtdhRoutes from './xtdh/xtdh.routes';
 import nftLinksRoutes from './nft-links/nft-links.routes';
+import ciPipelineAlertRoutes from './ci-pipeline-alerts/ci-pipeline-alert.routes';
 
 import * as Sentry from '@sentry/serverless';
 import { NextFunction, Request, Response } from 'express';
@@ -726,7 +727,11 @@ async function initializeApp() {
       verify: (req: any, _res: any, buf: Buffer) => {
         // Store raw body only for webhook endpoints that need signature verification
         const url = (req.url ?? '').split('?')[0];
-        if (url === '/gh-hooks' || url === '/dev-alerts') {
+        if (
+          url === '/gh-hooks' ||
+          url === '/dev-alerts' ||
+          url === '/ci-pipeline-alerts'
+        ) {
           req.rawBody = buf;
         }
       }
@@ -1570,6 +1575,7 @@ async function initializeApp() {
   });
 
   rootRouter.use('/deploy', deployRoutes);
+  rootRouter.use('/ci-pipeline-alerts', ciPipelineAlertRoutes);
 
   rootRouter.get('/health/ui', async (req, res) => {
     const healthData = await getHealthData();

--- a/src/api-serverless/src/app.ts
+++ b/src/api-serverless/src/app.ts
@@ -727,10 +727,13 @@ async function initializeApp() {
       verify: (req: any, _res: any, buf: Buffer) => {
         // Store raw body only for webhook endpoints that need signature verification
         const url = (req.url ?? '').split('?')[0];
+        const isCiPipelineAlertsPath =
+          url === '/ci-pipeline-alerts' ||
+          url.startsWith('/ci-pipeline-alerts/');
         if (
           url === '/gh-hooks' ||
           url === '/dev-alerts' ||
-          url === '/ci-pipeline-alerts'
+          isCiPipelineAlertsPath
         ) {
           req.rawBody = buf;
         }

--- a/src/api-serverless/src/app.ts
+++ b/src/api-serverless/src/app.ts
@@ -56,7 +56,7 @@ import publicWavesRoutes from './waves/waves-public.routes';
 import wavesRoutes from './waves/waves.routes';
 import xtdhRoutes from './xtdh/xtdh.routes';
 import nftLinksRoutes from './nft-links/nft-links.routes';
-import ciPipelineAlertRoutes from './ci-pipeline-alerts/ci-pipeline-alert.routes';
+import ciPipelineAlertRoutes from '@/api/ci-pipeline-alerts/ci-pipeline-alert.routes';
 
 import * as Sentry from '@sentry/serverless';
 import { NextFunction, Request, Response } from 'express';

--- a/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.routes.test.ts
+++ b/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.routes.test.ts
@@ -16,6 +16,7 @@ jest.mock('./ci-pipeline-alert.service', () => ({
   }
 }));
 
+import fc from 'fast-check';
 import { getRedisClient } from '@/redis';
 import {
   buildCiPipelineAlertDedupeKey,
@@ -83,6 +84,57 @@ function makeResponse() {
   return res as any;
 }
 
+const alertTextCharacters =
+  'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-'.split('');
+const alertTextArbitrary = fc
+  .array(fc.constantFrom(...alertTextCharacters), {
+    minLength: 1,
+    maxLength: 40
+  })
+  .map((chars) => chars.join(''));
+
+const optionalAlertTextArbitrary = fc.option(alertTextArbitrary, { nil: null });
+
+const ciPipelineAlertChangedFields = [
+  'repo',
+  'workflow',
+  'run_id',
+  'run_url',
+  'status',
+  'title',
+  'description',
+  'sha',
+  'branch',
+  'environment',
+  'service'
+] as const;
+
+const ciPipelineAlertRequestArbitrary = fc
+  .record({
+    repo: alertTextArbitrary,
+    workflow: alertTextArbitrary,
+    status: fc.constantFrom('success' as const, 'failure' as const),
+    title: alertTextArbitrary,
+    run_id: alertTextArbitrary,
+    run_number: optionalAlertTextArbitrary,
+    run_url: alertTextArbitrary.map(
+      (runId) =>
+        `https://github.com/6529-Collections/repo/actions/runs/${runId}`
+    ),
+    description: optionalAlertTextArbitrary,
+    sha: optionalAlertTextArbitrary,
+    branch: optionalAlertTextArbitrary,
+    environment: fc.constantFrom('staging', 'prod', 'production'),
+    service: optionalAlertTextArbitrary
+  })
+  .map((request) => ({
+    ...request,
+    repo: `6529-${request.repo}`,
+    workflow: `workflow-${request.workflow}`,
+    title: `title-${request.title}`,
+    run_id: `run-${request.run_id}`
+  }));
+
 describe('ci pipeline alert routes', () => {
   let originalAlertSecret: string | undefined;
 
@@ -120,6 +172,36 @@ describe('ci pipeline alert routes', () => {
         })
       )
     ).toEqual({ ok: true });
+  });
+
+  it('verifies arbitrary signed alert payloads within timestamp skew', () => {
+    fc.assert(
+      fc.property(
+        ciPipelineAlertRequestArbitrary,
+        fc.integer({ min: -250, max: 250 }),
+        (payload, timestampOffsetSeconds) => {
+          const rawBody = Buffer.from(JSON.stringify(payload));
+          const timestamp = (
+            Math.floor(Date.now() / 1000) + timestampOffsetSeconds
+          ).toString();
+          const signature = computeCiPipelineAlertSignature({
+            secret: 'test-secret',
+            timestamp,
+            rawBody
+          });
+
+          expect(
+            verifyCiPipelineAlertSignature(
+              makeRequest({
+                rawBody,
+                timestamp,
+                signature: `sha256=${signature}`
+              })
+            )
+          ).toEqual({ ok: true });
+        }
+      )
+    );
   });
 
   it('rejects expired signatures', () => {
@@ -194,6 +276,37 @@ describe('ci pipeline alert routes', () => {
           'https://github.com/6529-Collections/6529-core/actions/runs/99/attempts/2',
         description: 'retry failure'
       })
+    );
+  });
+
+  it('builds distinct dedupe keys for arbitrary changed alert fields', () => {
+    const changedFieldArbitrary = fc.constantFrom(
+      ...ciPipelineAlertChangedFields
+    );
+
+    fc.assert(
+      fc.property(
+        ciPipelineAlertRequestArbitrary,
+        changedFieldArbitrary,
+        alertTextArbitrary,
+        (request, changedField, nextValue) => {
+          const currentValue = request[changedField] ?? '';
+          const changedValue =
+            changedField === 'status'
+              ? request.status === 'success'
+                ? 'failure'
+                : 'success'
+              : `${currentValue}${nextValue}`;
+          const changedRequest = {
+            ...request,
+            [changedField]: changedValue
+          };
+
+          expect(buildCiPipelineAlertDedupeKey(changedRequest)).not.toBe(
+            buildCiPipelineAlertDedupeKey(request)
+          );
+        }
+      )
     );
   });
 

--- a/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.routes.test.ts
+++ b/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.routes.test.ts
@@ -1,7 +1,13 @@
+const mockRouterPost = jest.fn();
+
 jest.mock('@/api/async.router', () => ({
   asyncRouter: () => ({
-    post: jest.fn()
+    post: mockRouterPost
   })
+}));
+
+jest.mock('@/redis', () => ({
+  getRedisClient: jest.fn()
 }));
 
 jest.mock('./ci-pipeline-alert.service', () => ({
@@ -10,20 +16,26 @@ jest.mock('./ci-pipeline-alert.service', () => ({
   }
 }));
 
+import { getRedisClient } from '@/redis';
 import {
   buildCiPipelineAlertDedupeKey,
   computeCiPipelineAlertSignature,
   verifyCiPipelineAlertSignature
 } from './ci-pipeline-alert.routes';
+import { ciPipelineAlertService } from './ci-pipeline-alert.service';
+
+const ciPipelineAlertHandler = mockRouterPost.mock.calls[0][1];
 
 function makeRequest({
   rawBody,
   timestamp,
-  signature
+  signature,
+  body
 }: {
   readonly rawBody: Buffer;
   readonly timestamp?: string;
   readonly signature?: string;
+  readonly body?: Record<string, unknown>;
 }) {
   const headers: Record<string, string | undefined> = {
     'x-6529-ci-timestamp': timestamp,
@@ -31,14 +43,50 @@ function makeRequest({
   };
   return {
     rawBody,
+    body,
     get: jest.fn((name: string) => headers[name.toLowerCase()])
   } as any;
+}
+
+function makeAlertRequest(body: Record<string, unknown> = {}) {
+  const requestBody = {
+    repo: '6529seize-backend',
+    workflow: 'Deploy a service',
+    status: 'failure',
+    title: 'Backend deploy failed',
+    run_id: '123',
+    run_url:
+      'https://github.com/6529-Collections/6529seize-backend/actions/runs/123',
+    ...body
+  };
+  const rawBody = Buffer.from(JSON.stringify(requestBody));
+  const timestamp = Math.floor(Date.now() / 1000).toString();
+  const signature = computeCiPipelineAlertSignature({
+    secret: 'test-secret',
+    timestamp,
+    rawBody
+  });
+  return makeRequest({
+    rawBody,
+    timestamp,
+    signature: `sha256=${signature}`,
+    body: requestBody
+  });
+}
+
+function makeResponse() {
+  const res = {
+    status: jest.fn().mockReturnThis(),
+    send: jest.fn().mockReturnThis()
+  };
+  return res as any;
 }
 
 describe('ci pipeline alert routes', () => {
   let originalSecret: string | undefined;
 
   beforeEach(() => {
+    jest.clearAllMocks();
     originalSecret = process.env.CI_PIPELINES_WEBHOOK_SECRET;
     process.env.CI_PIPELINES_WEBHOOK_SECRET = 'test-secret';
   });
@@ -146,5 +194,53 @@ describe('ci pipeline alert routes', () => {
         description: 'retry failure'
       })
     );
+  });
+
+  it('posts alerts without Redis dedupe when Redis is unavailable', async () => {
+    (getRedisClient as jest.Mock).mockReturnValue(null);
+    (ciPipelineAlertService.postAlert as jest.Mock).mockResolvedValue(undefined);
+    const res = makeResponse();
+
+    await ciPipelineAlertHandler(makeAlertRequest(), res);
+
+    expect(ciPipelineAlertService.postAlert).toHaveBeenCalledTimes(1);
+    expect(res.status).not.toHaveBeenCalled();
+    expect(res.send).toHaveBeenCalledWith({});
+  });
+
+  it('acknowledges in-flight duplicate alerts without returning an error', async () => {
+    const redis = {
+      get: jest.fn().mockResolvedValue(null),
+      set: jest.fn().mockResolvedValue(null),
+      del: jest.fn()
+    };
+    (getRedisClient as jest.Mock).mockReturnValue(redis);
+    const res = makeResponse();
+
+    await ciPipelineAlertHandler(makeAlertRequest(), res);
+
+    expect(ciPipelineAlertService.postAlert).not.toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+    expect(res.send).toHaveBeenCalledWith({});
+  });
+
+  it('logs post failures and still acknowledges the webhook', async () => {
+    const redis = {
+      get: jest.fn().mockResolvedValue(null),
+      set: jest.fn().mockResolvedValueOnce('OK'),
+      del: jest.fn().mockResolvedValue(1)
+    };
+    (getRedisClient as jest.Mock).mockReturnValue(redis);
+    (ciPipelineAlertService.postAlert as jest.Mock).mockRejectedValue(
+      new Error('wave unavailable')
+    );
+    const res = makeResponse();
+
+    await ciPipelineAlertHandler(makeAlertRequest(), res);
+
+    expect(ciPipelineAlertService.postAlert).toHaveBeenCalledTimes(1);
+    expect(redis.del).toHaveBeenCalledTimes(1);
+    expect(res.status).not.toHaveBeenCalled();
+    expect(res.send).toHaveBeenCalledWith({});
   });
 });

--- a/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.routes.test.ts
+++ b/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.routes.test.ts
@@ -83,19 +83,19 @@ function makeResponse() {
 }
 
 describe('ci pipeline alert routes', () => {
-  let originalSecret: string | undefined;
+  let originalAlertSecret: string | undefined;
 
   beforeEach(() => {
     jest.clearAllMocks();
-    originalSecret = process.env.CI_PIPELINES_WEBHOOK_SECRET;
-    process.env.CI_PIPELINES_WEBHOOK_SECRET = 'test-secret';
+    originalAlertSecret = process.env.CI_PIPELINES_ALERT_SECRET;
+    process.env.CI_PIPELINES_ALERT_SECRET = 'test-secret';
   });
 
   afterEach(() => {
-    if (originalSecret === undefined) {
-      delete process.env.CI_PIPELINES_WEBHOOK_SECRET;
+    if (originalAlertSecret === undefined) {
+      delete process.env.CI_PIPELINES_ALERT_SECRET;
     } else {
-      process.env.CI_PIPELINES_WEBHOOK_SECRET = originalSecret;
+      process.env.CI_PIPELINES_ALERT_SECRET = originalAlertSecret;
     }
   });
 

--- a/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.routes.test.ts
+++ b/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.routes.test.ts
@@ -57,6 +57,7 @@ function makeAlertRequest(body: Record<string, unknown> = {}) {
     run_id: '123',
     run_url:
       'https://github.com/6529-Collections/6529seize-backend/actions/runs/123',
+    environment: 'production',
     ...body
   };
   const rawBody = Buffer.from(JSON.stringify(requestBody));
@@ -198,7 +199,9 @@ describe('ci pipeline alert routes', () => {
 
   it('posts alerts without Redis dedupe when Redis is unavailable', async () => {
     (getRedisClient as jest.Mock).mockReturnValue(null);
-    (ciPipelineAlertService.postAlert as jest.Mock).mockResolvedValue(undefined);
+    (ciPipelineAlertService.postAlert as jest.Mock).mockResolvedValue(
+      undefined
+    );
     const res = makeResponse();
 
     await ciPipelineAlertHandler(makeAlertRequest(), res);
@@ -206,6 +209,28 @@ describe('ci pipeline alert routes', () => {
     expect(ciPipelineAlertService.postAlert).toHaveBeenCalledTimes(1);
     expect(res.status).not.toHaveBeenCalled();
     expect(res.send).toHaveBeenCalledWith({});
+  });
+
+  it('rejects signed alert payloads with missing environments', async () => {
+    (getRedisClient as jest.Mock).mockReturnValue(null);
+    const res = makeResponse();
+
+    await expect(
+      ciPipelineAlertHandler(makeAlertRequest({ environment: undefined }), res)
+    ).rejects.toThrow('"environment" is required');
+
+    expect(ciPipelineAlertService.postAlert).not.toHaveBeenCalled();
+  });
+
+  it('rejects signed alert payloads with unsupported environments', async () => {
+    (getRedisClient as jest.Mock).mockReturnValue(null);
+    const res = makeResponse();
+
+    await expect(
+      ciPipelineAlertHandler(makeAlertRequest({ environment: 'sandbox' }), res)
+    ).rejects.toThrow('"environment" must be one of');
+
+    expect(ciPipelineAlertService.postAlert).not.toHaveBeenCalled();
   });
 
   it('acknowledges in-flight duplicate alerts without returning an error', async () => {

--- a/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.routes.test.ts
+++ b/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.routes.test.ts
@@ -1,0 +1,122 @@
+jest.mock('@/api/async.router', () => ({
+  asyncRouter: () => ({
+    post: jest.fn()
+  })
+}));
+
+jest.mock('./ci-pipeline-alert.service', () => ({
+  ciPipelineAlertService: {
+    postAlert: jest.fn()
+  }
+}));
+
+import {
+  buildCiPipelineAlertDedupeKey,
+  computeCiPipelineAlertSignature,
+  verifyCiPipelineAlertSignature
+} from './ci-pipeline-alert.routes';
+
+function makeRequest({
+  rawBody,
+  timestamp,
+  signature
+}: {
+  readonly rawBody: Buffer;
+  readonly timestamp?: string;
+  readonly signature?: string;
+}) {
+  const headers: Record<string, string | undefined> = {
+    'x-6529-ci-timestamp': timestamp,
+    'x-6529-ci-signature': signature
+  };
+  return {
+    rawBody,
+    get: jest.fn((name: string) => headers[name.toLowerCase()])
+  } as any;
+}
+
+describe('ci pipeline alert routes', () => {
+  let originalSecret: string | undefined;
+
+  beforeEach(() => {
+    originalSecret = process.env.CI_PIPELINES_WEBHOOK_SECRET;
+    process.env.CI_PIPELINES_WEBHOOK_SECRET = 'test-secret';
+  });
+
+  afterEach(() => {
+    if (originalSecret === undefined) {
+      delete process.env.CI_PIPELINES_WEBHOOK_SECRET;
+    } else {
+      process.env.CI_PIPELINES_WEBHOOK_SECRET = originalSecret;
+    }
+  });
+
+  it('verifies signed alert payloads', () => {
+    const rawBody = Buffer.from(
+      JSON.stringify({ repo: '6529seize-frontend', run_id: '1' })
+    );
+    const timestamp = Math.floor(Date.now() / 1000).toString();
+    const signature = computeCiPipelineAlertSignature({
+      secret: 'test-secret',
+      timestamp,
+      rawBody
+    });
+
+    expect(
+      verifyCiPipelineAlertSignature(
+        makeRequest({
+          rawBody,
+          timestamp,
+          signature: `sha256=${signature}`
+        })
+      )
+    ).toEqual({ ok: true });
+  });
+
+  it('rejects expired signatures', () => {
+    const rawBody = Buffer.from('{}');
+    const timestamp = (Math.floor(Date.now() / 1000) - 1000).toString();
+    const signature = computeCiPipelineAlertSignature({
+      secret: 'test-secret',
+      timestamp,
+      rawBody
+    });
+
+    expect(
+      verifyCiPipelineAlertSignature(
+        makeRequest({
+          rawBody,
+          timestamp,
+          signature
+        })
+      )
+    ).toMatchObject({
+      ok: false,
+      statusCode: 401
+    });
+  });
+
+  it('builds distinct dedupe keys for different notification titles', () => {
+    const common = {
+      repo: '6529-core',
+      workflow: 'Build 6529 Desktop',
+      status: 'success' as const,
+      run_id: '99',
+      run_url: 'https://github.com/6529-Collections/6529-core/actions/runs/99'
+    };
+
+    expect(
+      buildCiPipelineAlertDedupeKey({
+        ...common,
+        title: '6529 Desktop - S3 links published',
+        environment: 'Production'
+      })
+    ).not.toEqual(
+      buildCiPipelineAlertDedupeKey({
+        ...common,
+        title: '6529 Desktop - Build complete',
+        environment: 'Production'
+      })
+    );
+  });
+});

--- a/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.routes.test.ts
+++ b/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.routes.test.ts
@@ -119,4 +119,32 @@ describe('ci pipeline alert routes', () => {
       })
     );
   });
+
+  it('builds distinct dedupe keys for different alert payload details', () => {
+    const common = {
+      repo: '6529-core',
+      workflow: 'Build 6529 Desktop',
+      status: 'failure' as const,
+      run_id: '99',
+      title: '6529 Desktop - Build failed',
+      environment: 'Production',
+      service: 'desktop'
+    };
+
+    expect(
+      buildCiPipelineAlertDedupeKey({
+        ...common,
+        run_url:
+          'https://github.com/6529-Collections/6529-core/actions/runs/99',
+        description: 'first failure'
+      })
+    ).not.toEqual(
+      buildCiPipelineAlertDedupeKey({
+        ...common,
+        run_url:
+          'https://github.com/6529-Collections/6529-core/actions/runs/99/attempts/2',
+        description: 'retry failure'
+      })
+    );
+  });
 });

--- a/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.routes.ts
+++ b/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.routes.ts
@@ -151,8 +151,12 @@ export function buildCiPipelineAlertDedupeKey(
         request.repo,
         request.workflow,
         request.run_id,
+        request.run_url,
         request.status,
         request.title,
+        request.description ?? '',
+        request.sha ?? '',
+        request.branch ?? '',
         request.environment ?? '',
         request.service ?? ''
       ])
@@ -180,39 +184,44 @@ router.post(
       CiPipelineAlertRequestSchema
     );
     const redis = getRedisClient();
+    if (!redis) {
+      logger.error('Rejected CI pipeline alert: Redis dedupe is unavailable');
+      return res.status(503).send({
+        error: 'CI pipeline alert dedupe unavailable'
+      });
+    }
+
     const cacheKey = buildCiPipelineAlertDedupeKey(request);
     const processingKey = `${cacheKey}:processing`;
     let lockAcquired = false;
 
-    if (redis) {
-      const alreadyProcessed = await redis.get(cacheKey);
-      if (alreadyProcessed) {
-        logger.info(`Duplicate CI pipeline alert ${cacheKey}, skipping`);
-        return res.send({});
-      }
-      const lockWasSet = await redis.set(processingKey, '1', {
-        NX: true,
-        EX: CI_PIPELINE_ALERT_PROCESSING_LOCK_TTL_SECONDS
-      });
-      if (!lockWasSet) {
-        logger.info(`CI pipeline alert ${cacheKey} is already processing`);
-        return res.send({});
-      }
-      lockAcquired = true;
+    const alreadyProcessed = await redis.get(cacheKey);
+    if (alreadyProcessed) {
+      logger.info(`Duplicate CI pipeline alert ${cacheKey}, skipping`);
+      return res.send({});
     }
+    const lockWasSet = await redis.set(processingKey, '1', {
+      NX: true,
+      EX: CI_PIPELINE_ALERT_PROCESSING_LOCK_TTL_SECONDS
+    });
+    if (!lockWasSet) {
+      logger.info(`CI pipeline alert ${cacheKey} is already processing`);
+      return res.status(409).send({
+        error: 'CI pipeline alert is already processing'
+      });
+    }
+    lockAcquired = true;
 
     try {
       await ciPipelineAlertService.postAlert(request, {
         timer: Timer.getFromRequest(req)
       });
-      if (redis) {
-        await redis.set(cacheKey, '1', {
-          EX: CI_PIPELINE_ALERT_DEDUPE_TTL_SECONDS
-        });
-      }
+      await redis.set(cacheKey, '1', {
+        EX: CI_PIPELINE_ALERT_DEDUPE_TTL_SECONDS
+      });
       return res.send({});
     } finally {
-      if (redis && lockAcquired) {
+      if (lockAcquired) {
         try {
           await redis.del(processingKey);
         } catch (err) {

--- a/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.routes.ts
+++ b/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.routes.ts
@@ -35,7 +35,11 @@ const CiPipelineAlertRequestSchema: Joi.ObjectSchema<CiPipelineAlertRequest> =
       .required(),
     sha: Joi.string().trim().max(100).allow(null, '').optional(),
     branch: Joi.string().trim().max(200).allow(null, '').optional(),
-    environment: Joi.string().trim().max(100).allow(null, '').optional(),
+    environment: Joi.string()
+      .trim()
+      .lowercase()
+      .valid('staging', 'prod', 'production')
+      .required(),
     service: Joi.string().trim().max(200).allow(null, '').optional()
   }).unknown(false);
 

--- a/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.routes.ts
+++ b/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.routes.ts
@@ -28,6 +28,7 @@ const CiPipelineAlertRequestSchema: Joi.ObjectSchema<CiPipelineAlertRequest> =
     title: Joi.string().trim().min(1).max(250).required(),
     description: Joi.string().trim().max(5000).allow(null, '').optional(),
     run_id: Joi.string().trim().min(1).max(100).required(),
+    run_number: Joi.string().trim().max(100).allow(null, '').optional(),
     run_url: Joi.string()
       .trim()
       .uri({ scheme: ['http', 'https'] })

--- a/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.routes.ts
+++ b/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.routes.ts
@@ -51,6 +51,16 @@ type SignatureVerificationResult =
       readonly statusCode: number;
     };
 
+type CiPipelineAlertRedis = NonNullable<ReturnType<typeof getRedisClient>>;
+
+interface CiPipelineAlertProcessingState {
+  readonly cacheKey: string;
+  readonly processingKey: string;
+  readonly redis: CiPipelineAlertRedis | null;
+  readonly lockAcquired: boolean;
+  readonly shouldSkip: boolean;
+}
+
 function timingSafeEqualHex(a: string, b: string): boolean {
   const aBuffer = Buffer.from(a, 'hex');
   const bBuffer = Buffer.from(b, 'hex');
@@ -173,6 +183,126 @@ export function buildCiPipelineAlertDedupeKey(
   return `ci-pipeline-alert:${hash}`;
 }
 
+async function prepareCiPipelineAlertProcessing(
+  request: CiPipelineAlertRequest
+): Promise<CiPipelineAlertProcessingState> {
+  const cacheKey = buildCiPipelineAlertDedupeKey(request);
+  const processingKey = `${cacheKey}:processing`;
+  const redis = getRedisClient();
+
+  if (!redis) {
+    logger.warn(
+      `Redis dedupe is unavailable for CI pipeline alert ${cacheKey}; posting without dedupe`
+    );
+    return {
+      cacheKey,
+      processingKey,
+      redis: null,
+      lockAcquired: false,
+      shouldSkip: false
+    };
+  }
+
+  try {
+    const alreadyProcessed = await redis.get(cacheKey);
+    if (alreadyProcessed) {
+      logger.info(`Duplicate CI pipeline alert ${cacheKey}, skipping`);
+      return {
+        cacheKey,
+        processingKey,
+        redis,
+        lockAcquired: false,
+        shouldSkip: true
+      };
+    }
+
+    const lockWasSet = await redis.set(processingKey, '1', {
+      NX: true,
+      EX: CI_PIPELINE_ALERT_PROCESSING_LOCK_TTL_SECONDS
+    });
+    if (!lockWasSet) {
+      logger.info(`CI pipeline alert ${cacheKey} is already processing`);
+      return {
+        cacheKey,
+        processingKey,
+        redis,
+        lockAcquired: false,
+        shouldSkip: true
+      };
+    }
+
+    return {
+      cacheKey,
+      processingKey,
+      redis,
+      lockAcquired: true,
+      shouldSkip: false
+    };
+  } catch (err) {
+    logger.warn(
+      `Failed to use Redis dedupe for CI pipeline alert ${cacheKey}; posting without dedupe: ${err}`
+    );
+    return {
+      cacheKey,
+      processingKey,
+      redis,
+      lockAcquired: false,
+      shouldSkip: false
+    };
+  }
+}
+
+async function markCiPipelineAlertProcessed(
+  redis: CiPipelineAlertRedis,
+  cacheKey: string
+): Promise<void> {
+  try {
+    await redis.set(cacheKey, '1', {
+      EX: CI_PIPELINE_ALERT_DEDUPE_TTL_SECONDS
+    });
+  } catch (err) {
+    logger.warn(
+      `Failed to mark CI pipeline alert ${cacheKey} as processed: ${err}`
+    );
+  }
+}
+
+async function releaseCiPipelineAlertProcessingLock(
+  redis: CiPipelineAlertRedis,
+  processingKey: string
+): Promise<void> {
+  try {
+    await redis.del(processingKey);
+  } catch (err) {
+    logger.warn(
+      `Failed to release CI pipeline alert processing lock ${processingKey}: ${err}`
+    );
+  }
+}
+
+async function postCiPipelineAlert(
+  request: CiPipelineAlertRequest,
+  processingState: CiPipelineAlertProcessingState,
+  req: Request
+): Promise<void> {
+  const { cacheKey, lockAcquired, processingKey, redis } = processingState;
+
+  try {
+    await ciPipelineAlertService.postAlert(request, {
+      timer: Timer.getFromRequest(req)
+    });
+    if (redis && lockAcquired) {
+      await markCiPipelineAlertProcessed(redis, cacheKey);
+    }
+  } catch (err) {
+    logger.error(`Failed to post CI pipeline alert ${cacheKey}: ${err}`);
+  } finally {
+    if (redis && lockAcquired) {
+      await releaseCiPipelineAlertProcessingLock(redis, processingKey);
+    }
+  }
+}
+
 router.post(
   '/',
   async (
@@ -191,66 +321,12 @@ router.post(
       req.body,
       CiPipelineAlertRequestSchema
     );
-    const cacheKey = buildCiPipelineAlertDedupeKey(request);
-    const processingKey = `${cacheKey}:processing`;
-    const redis = getRedisClient();
-    let lockAcquired = false;
-
-    if (!redis) {
-      logger.warn(
-        `Redis dedupe is unavailable for CI pipeline alert ${cacheKey}; posting without dedupe`
-      );
-    } else {
-      try {
-        const alreadyProcessed = await redis.get(cacheKey);
-        if (alreadyProcessed) {
-          logger.info(`Duplicate CI pipeline alert ${cacheKey}, skipping`);
-          return res.send({});
-        }
-        const lockWasSet = await redis.set(processingKey, '1', {
-          NX: true,
-          EX: CI_PIPELINE_ALERT_PROCESSING_LOCK_TTL_SECONDS
-        });
-        if (!lockWasSet) {
-          logger.info(`CI pipeline alert ${cacheKey} is already processing`);
-          return res.send({});
-        }
-        lockAcquired = true;
-      } catch (err) {
-        logger.warn(
-          `Failed to use Redis dedupe for CI pipeline alert ${cacheKey}; posting without dedupe: ${err}`
-        );
-      }
+    const processingState = await prepareCiPipelineAlertProcessing(request);
+    if (processingState.shouldSkip) {
+      return res.send({});
     }
 
-    try {
-      await ciPipelineAlertService.postAlert(request, {
-        timer: Timer.getFromRequest(req)
-      });
-      if (redis && lockAcquired) {
-        try {
-          await redis.set(cacheKey, '1', {
-            EX: CI_PIPELINE_ALERT_DEDUPE_TTL_SECONDS
-          });
-        } catch (err) {
-          logger.warn(
-            `Failed to mark CI pipeline alert ${cacheKey} as processed: ${err}`
-          );
-        }
-      }
-    } catch (err) {
-      logger.error(`Failed to post CI pipeline alert ${cacheKey}: ${err}`);
-    } finally {
-      if (redis && lockAcquired) {
-        try {
-          await redis.del(processingKey);
-        } catch (err) {
-          logger.warn(
-            `Failed to release CI pipeline alert processing lock ${processingKey}: ${err}`
-          );
-        }
-      }
-    }
+    await postCiPipelineAlert(request, processingState, req);
     return res.send({});
   }
 );

--- a/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.routes.ts
+++ b/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.routes.ts
@@ -1,0 +1,228 @@
+import * as crypto from 'node:crypto';
+import { Request, Response } from 'express';
+import * as Joi from 'joi';
+import { env } from '@/env';
+import { Logger } from '@/logging';
+import { getRedisClient } from '@/redis';
+import { Timer } from '@/time';
+import { asyncRouter } from '@/api/async.router';
+import { ApiResponse } from '@/api/api-response';
+import { getValidatedByJoiOrThrow } from '@/api/validation';
+import {
+  CiPipelineAlertRequest,
+  ciPipelineAlertService
+} from './ci-pipeline-alert.service';
+
+const router = asyncRouter();
+const logger = Logger.get('CiPipelineAlertRoutes');
+
+const CI_PIPELINE_ALERT_SIGNATURE_SKEW_SECONDS = 300;
+const CI_PIPELINE_ALERT_DEDUPE_TTL_SECONDS = 86400;
+const CI_PIPELINE_ALERT_PROCESSING_LOCK_TTL_SECONDS = 300;
+
+const CiPipelineAlertRequestSchema: Joi.ObjectSchema<CiPipelineAlertRequest> =
+  Joi.object<CiPipelineAlertRequest>({
+    repo: Joi.string().trim().min(1).max(200).required(),
+    workflow: Joi.string().trim().min(1).max(200).required(),
+    status: Joi.string().valid('success', 'failure').required(),
+    title: Joi.string().trim().min(1).max(250).required(),
+    description: Joi.string().trim().max(5000).allow(null, '').optional(),
+    run_id: Joi.string().trim().min(1).max(100).required(),
+    run_url: Joi.string()
+      .trim()
+      .uri({ scheme: ['http', 'https'] })
+      .max(1000)
+      .required(),
+    sha: Joi.string().trim().max(100).allow(null, '').optional(),
+    branch: Joi.string().trim().max(200).allow(null, '').optional(),
+    environment: Joi.string().trim().max(100).allow(null, '').optional(),
+    service: Joi.string().trim().max(200).allow(null, '').optional()
+  }).unknown(false);
+
+type SignatureVerificationResult =
+  | { readonly ok: true }
+  | {
+      readonly ok: false;
+      readonly reason: string;
+      readonly statusCode: number;
+    };
+
+function timingSafeEqualHex(a: string, b: string): boolean {
+  const aBuffer = Buffer.from(a, 'hex');
+  const bBuffer = Buffer.from(b, 'hex');
+  if (aBuffer.length !== bBuffer.length) {
+    return false;
+  }
+  return crypto.timingSafeEqual(aBuffer, bBuffer);
+}
+
+function normalizeSignatureHeader(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+  const signature = value.startsWith('sha256=') ? value.slice(7) : value;
+  return /^[a-f0-9]{64}$/i.test(signature) ? signature.toLowerCase() : null;
+}
+
+export function computeCiPipelineAlertSignature({
+  secret,
+  timestamp,
+  rawBody
+}: {
+  readonly secret: string;
+  readonly timestamp: string;
+  readonly rawBody: Buffer;
+}): string {
+  return crypto
+    .createHmac('sha256', secret)
+    .update(`${timestamp}.`)
+    .update(rawBody)
+    .digest('hex');
+}
+
+export function verifyCiPipelineAlertSignature(
+  req: Request
+): SignatureVerificationResult {
+  const rawBody = (req as Request & { rawBody?: Buffer }).rawBody;
+  if (!rawBody) {
+    return {
+      ok: false,
+      reason: 'Raw body not available',
+      statusCode: 500
+    };
+  }
+
+  const timestamp = req.get('x-6529-ci-timestamp');
+  if (!timestamp) {
+    return {
+      ok: false,
+      reason: 'Missing x-6529-ci-timestamp',
+      statusCode: 400
+    };
+  }
+  const timestampNumber = Number(timestamp);
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  if (
+    !Number.isInteger(timestampNumber) ||
+    Math.abs(nowSeconds - timestampNumber) >
+      CI_PIPELINE_ALERT_SIGNATURE_SKEW_SECONDS
+  ) {
+    return {
+      ok: false,
+      reason: 'Invalid or expired x-6529-ci-timestamp',
+      statusCode: 401
+    };
+  }
+
+  const providedSignature = normalizeSignatureHeader(
+    req.get('x-6529-ci-signature')
+  );
+  if (!providedSignature) {
+    return {
+      ok: false,
+      reason: 'Missing or invalid x-6529-ci-signature',
+      statusCode: 400
+    };
+  }
+
+  const expectedSignature = computeCiPipelineAlertSignature({
+    secret: env.getStringOrThrow('CI_PIPELINES_WEBHOOK_SECRET'),
+    timestamp,
+    rawBody
+  });
+  if (!timingSafeEqualHex(expectedSignature, providedSignature)) {
+    return {
+      ok: false,
+      reason: 'Invalid signature',
+      statusCode: 401
+    };
+  }
+
+  return { ok: true };
+}
+
+export function buildCiPipelineAlertDedupeKey(
+  request: CiPipelineAlertRequest
+): string {
+  const hash = crypto
+    .createHash('sha256')
+    .update(
+      JSON.stringify([
+        request.repo,
+        request.workflow,
+        request.run_id,
+        request.status,
+        request.title,
+        request.environment ?? '',
+        request.service ?? ''
+      ])
+    )
+    .digest('hex');
+  return `ci-pipeline-alert:${hash}`;
+}
+
+router.post(
+  '/',
+  async (
+    req: Request<any, any, CiPipelineAlertRequest, any, any>,
+    res: Response<ApiResponse<Record<string, never>>>
+  ) => {
+    const verification = verifyCiPipelineAlertSignature(req);
+    if (!verification.ok) {
+      logger.warn(`Rejected CI pipeline alert: ${verification.reason}`);
+      return res.status(verification.statusCode).send({
+        error: verification.reason
+      });
+    }
+
+    const request = getValidatedByJoiOrThrow(
+      req.body,
+      CiPipelineAlertRequestSchema
+    );
+    const redis = getRedisClient();
+    const cacheKey = buildCiPipelineAlertDedupeKey(request);
+    const processingKey = `${cacheKey}:processing`;
+    let lockAcquired = false;
+
+    if (redis) {
+      const alreadyProcessed = await redis.get(cacheKey);
+      if (alreadyProcessed) {
+        logger.info(`Duplicate CI pipeline alert ${cacheKey}, skipping`);
+        return res.send({});
+      }
+      const lockWasSet = await redis.set(processingKey, '1', {
+        NX: true,
+        EX: CI_PIPELINE_ALERT_PROCESSING_LOCK_TTL_SECONDS
+      });
+      if (!lockWasSet) {
+        logger.info(`CI pipeline alert ${cacheKey} is already processing`);
+        return res.send({});
+      }
+      lockAcquired = true;
+    }
+
+    try {
+      await ciPipelineAlertService.postAlert(request, {
+        timer: Timer.getFromRequest(req)
+      });
+      if (redis) {
+        await redis.set(cacheKey, '1', {
+          EX: CI_PIPELINE_ALERT_DEDUPE_TTL_SECONDS
+        });
+      }
+      return res.send({});
+    } finally {
+      if (redis && lockAcquired) {
+        try {
+          await redis.del(processingKey);
+        } catch (err) {
+          logger.warn(
+            `Failed to release CI pipeline alert processing lock ${processingKey}: ${err}`
+          );
+        }
+      }
+    }
+  }
+);
+
+export default router;

--- a/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.routes.ts
+++ b/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.routes.ts
@@ -80,6 +80,10 @@ export function computeCiPipelineAlertSignature({
     .digest('hex');
 }
 
+function getCiPipelineAlertSecret(): string {
+  return env.getStringOrThrow('CI_PIPELINES_ALERT_SECRET');
+}
+
 export function verifyCiPipelineAlertSignature(
   req: Request
 ): SignatureVerificationResult {
@@ -126,7 +130,7 @@ export function verifyCiPipelineAlertSignature(
   }
 
   const expectedSignature = computeCiPipelineAlertSignature({
-    secret: env.getStringOrThrow('CI_PIPELINES_WEBHOOK_SECRET'),
+    secret: getCiPipelineAlertSecret(),
     timestamp,
     rawBody
   });

--- a/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.routes.ts
+++ b/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.routes.ts
@@ -183,45 +183,57 @@ router.post(
       req.body,
       CiPipelineAlertRequestSchema
     );
-    const redis = getRedisClient();
-    if (!redis) {
-      logger.error('Rejected CI pipeline alert: Redis dedupe is unavailable');
-      return res.status(503).send({
-        error: 'CI pipeline alert dedupe unavailable'
-      });
-    }
-
     const cacheKey = buildCiPipelineAlertDedupeKey(request);
     const processingKey = `${cacheKey}:processing`;
+    const redis = getRedisClient();
     let lockAcquired = false;
 
-    const alreadyProcessed = await redis.get(cacheKey);
-    if (alreadyProcessed) {
-      logger.info(`Duplicate CI pipeline alert ${cacheKey}, skipping`);
-      return res.send({});
+    if (!redis) {
+      logger.warn(
+        `Redis dedupe is unavailable for CI pipeline alert ${cacheKey}; posting without dedupe`
+      );
+    } else {
+      try {
+        const alreadyProcessed = await redis.get(cacheKey);
+        if (alreadyProcessed) {
+          logger.info(`Duplicate CI pipeline alert ${cacheKey}, skipping`);
+          return res.send({});
+        }
+        const lockWasSet = await redis.set(processingKey, '1', {
+          NX: true,
+          EX: CI_PIPELINE_ALERT_PROCESSING_LOCK_TTL_SECONDS
+        });
+        if (!lockWasSet) {
+          logger.info(`CI pipeline alert ${cacheKey} is already processing`);
+          return res.send({});
+        }
+        lockAcquired = true;
+      } catch (err) {
+        logger.warn(
+          `Failed to use Redis dedupe for CI pipeline alert ${cacheKey}; posting without dedupe: ${err}`
+        );
+      }
     }
-    const lockWasSet = await redis.set(processingKey, '1', {
-      NX: true,
-      EX: CI_PIPELINE_ALERT_PROCESSING_LOCK_TTL_SECONDS
-    });
-    if (!lockWasSet) {
-      logger.info(`CI pipeline alert ${cacheKey} is already processing`);
-      return res.status(409).send({
-        error: 'CI pipeline alert is already processing'
-      });
-    }
-    lockAcquired = true;
 
     try {
       await ciPipelineAlertService.postAlert(request, {
         timer: Timer.getFromRequest(req)
       });
-      await redis.set(cacheKey, '1', {
-        EX: CI_PIPELINE_ALERT_DEDUPE_TTL_SECONDS
-      });
-      return res.send({});
+      if (redis && lockAcquired) {
+        try {
+          await redis.set(cacheKey, '1', {
+            EX: CI_PIPELINE_ALERT_DEDUPE_TTL_SECONDS
+          });
+        } catch (err) {
+          logger.warn(
+            `Failed to mark CI pipeline alert ${cacheKey} as processed: ${err}`
+          );
+        }
+      }
+    } catch (err) {
+      logger.error(`Failed to post CI pipeline alert ${cacheKey}: ${err}`);
     } finally {
-      if (lockAcquired) {
+      if (redis && lockAcquired) {
         try {
           await redis.del(processingKey);
         } catch (err) {
@@ -231,6 +243,7 @@ router.post(
         }
       }
     }
+    return res.send({});
   }
 );
 

--- a/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.test.ts
+++ b/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.test.ts
@@ -90,7 +90,7 @@ describe('CiPipelineAlertService', () => {
         representativeId: 'bot-profile',
         createDropRequest: expect.objectContaining({
           wave_id: 'prod-wave',
-          title: '[PROD] Deploy Failed',
+          title: null,
           mentioned_users: [
             {
               mentioned_profile_id: 'profile-1',
@@ -105,6 +105,8 @@ describe('CiPipelineAlertService', () => {
             expect.objectContaining({
               content: expect.stringContaining(
                 [
+                  '[PROD] Deploy Failed',
+                  '',
                   'cc @[ALICE] @[Bob]',
                   '',
                   'Service: Frontend - web',
@@ -158,12 +160,14 @@ describe('CiPipelineAlertService', () => {
       expect.objectContaining({
         createDropRequest: expect.objectContaining({
           wave_id: 'staging-wave',
-          title: '[STAGING] Deploy Succeeded',
+          title: null,
           mentioned_users: [],
           parts: [
             expect.objectContaining({
               content: expect.stringContaining(
                 [
+                  '[STAGING] Deploy Succeeded',
+                  '',
                   'Service: Frontend - web',
                   'Workflow: Web Deploy - PROD',
                   'Branch: main',
@@ -177,6 +181,25 @@ describe('CiPipelineAlertService', () => {
       }),
       expect.anything()
     );
+    expect(
+      dropCreationApiService.createDrop.mock.calls[0][0].createDropRequest
+        .parts[0].content
+    ).toBe(
+      [
+        '[STAGING] Deploy Succeeded',
+        '',
+        'Service: Frontend - web',
+        'Workflow: Web Deploy - PROD',
+        'Branch: main',
+        'Commit: [abc12345](https://github.com/6529-Collections/6529seize-frontend/commit/abc1234567890)',
+        'Run: [#6082](https://github.com/6529-Collections/6529seize-frontend/actions/runs/12345)'
+      ].join('\n')
+    );
+    expect(
+      dropCreationApiService.createDrop.mock.calls[0][0].createDropRequest
+        .parts[0].content
+        .startsWith('\n')
+    ).toBe(false);
     expect(
       dropCreationApiService.createDrop.mock.calls[0][0].createDropRequest
         .parts[0].content

--- a/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.test.ts
+++ b/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.test.ts
@@ -76,14 +76,15 @@ describe('CiPipelineAlertService', () => {
       dropCreationApiService as any,
       identitiesRepository as any
     );
-    const ctx = { connection: {} };
+    const ctx = {};
 
     await service.postAlert(baseRequest, ctx as any);
 
-    expect(identitiesRepository.getIdsByHandles).toHaveBeenCalledWith(
-      ['alice', 'Bob', 'missing'],
-      ctx.connection
-    );
+    expect(identitiesRepository.getIdsByHandles).toHaveBeenCalledWith([
+      'alice',
+      'Bob',
+      'missing'
+    ]);
     expect(dropCreationApiService.createDrop).toHaveBeenCalledWith(
       expect.objectContaining({
         authorId: 'bot-profile',
@@ -204,6 +205,40 @@ describe('CiPipelineAlertService', () => {
       dropCreationApiService.createDrop.mock.calls[0][0].createDropRequest
         .parts[0].content
     ).not.toContain('cc @[');
+    expect(dropCreationApiService.toggleHideLinkPreview).toHaveBeenCalledWith(
+      {
+        dropId: 'drop-1',
+        hideLinkPreview: true
+      },
+      expect.objectContaining({
+        authenticationContext: expect.objectContaining({
+          authenticatedProfileId: 'bot-profile'
+        })
+      })
+    );
+  });
+
+  it('still succeeds when hiding link previews fails after drop creation', async () => {
+    dropCreationApiService.toggleHideLinkPreview.mockRejectedValue(
+      new Error('preview unavailable')
+    );
+    const service = new CiPipelineAlertService(
+      dropCreationApiService as any,
+      identitiesRepository as any
+    );
+
+    await expect(
+      service.postAlert(
+        {
+          ...baseRequest,
+          status: 'success',
+          environment: 'staging'
+        },
+        {}
+      )
+    ).resolves.toBeUndefined();
+
+    expect(dropCreationApiService.createDrop).toHaveBeenCalledTimes(1);
     expect(dropCreationApiService.toggleHideLinkPreview).toHaveBeenCalledWith(
       {
         dropId: 'drop-1',

--- a/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.test.ts
+++ b/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.test.ts
@@ -89,9 +89,11 @@ describe('CiPipelineAlertService', () => {
       expect.objectContaining({
         authorId: 'bot-profile',
         representativeId: 'bot-profile',
+        hideLinkPreview: true,
         createDropRequest: expect.objectContaining({
           wave_id: 'prod-wave',
           title: null,
+          metadata: [],
           mentioned_users: [
             {
               mentioned_profile_id: 'profile-1',
@@ -127,17 +129,7 @@ describe('CiPipelineAlertService', () => {
         })
       })
     );
-    expect(dropCreationApiService.toggleHideLinkPreview).toHaveBeenCalledWith(
-      {
-        dropId: 'drop-1',
-        hideLinkPreview: true
-      },
-      expect.objectContaining({
-        authenticationContext: expect.objectContaining({
-          authenticatedProfileId: 'bot-profile'
-        })
-      })
-    );
+    expect(dropCreationApiService.toggleHideLinkPreview).not.toHaveBeenCalled();
   });
 
   it('routes staging successes without resolving or adding mentions', async () => {
@@ -159,9 +151,11 @@ describe('CiPipelineAlertService', () => {
     expect(identitiesRepository.getIdsByHandles).not.toHaveBeenCalled();
     expect(dropCreationApiService.createDrop).toHaveBeenCalledWith(
       expect.objectContaining({
+        hideLinkPreview: true,
         createDropRequest: expect.objectContaining({
           wave_id: 'staging-wave',
           title: null,
+          metadata: [],
           mentioned_users: [],
           parts: [
             expect.objectContaining({
@@ -205,50 +199,6 @@ describe('CiPipelineAlertService', () => {
       dropCreationApiService.createDrop.mock.calls[0][0].createDropRequest
         .parts[0].content
     ).not.toContain('cc @[');
-    expect(dropCreationApiService.toggleHideLinkPreview).toHaveBeenCalledWith(
-      {
-        dropId: 'drop-1',
-        hideLinkPreview: true
-      },
-      expect.objectContaining({
-        authenticationContext: expect.objectContaining({
-          authenticatedProfileId: 'bot-profile'
-        })
-      })
-    );
-  });
-
-  it('still succeeds when hiding link previews fails after drop creation', async () => {
-    dropCreationApiService.toggleHideLinkPreview.mockRejectedValue(
-      new Error('preview unavailable')
-    );
-    const service = new CiPipelineAlertService(
-      dropCreationApiService as any,
-      identitiesRepository as any
-    );
-
-    await expect(
-      service.postAlert(
-        {
-          ...baseRequest,
-          status: 'success',
-          environment: 'staging'
-        },
-        {}
-      )
-    ).resolves.toBeUndefined();
-
-    expect(dropCreationApiService.createDrop).toHaveBeenCalledTimes(1);
-    expect(dropCreationApiService.toggleHideLinkPreview).toHaveBeenCalledWith(
-      {
-        dropId: 'drop-1',
-        hideLinkPreview: true
-      },
-      expect.objectContaining({
-        authenticationContext: expect.objectContaining({
-          authenticatedProfileId: 'bot-profile'
-        })
-      })
-    );
+    expect(dropCreationApiService.toggleHideLinkPreview).not.toHaveBeenCalled();
   });
 });

--- a/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.test.ts
+++ b/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.test.ts
@@ -50,7 +50,7 @@ describe('CiPipelineAlertService', () => {
     };
     identitiesRepository = {
       getIdsByHandles: jest.fn().mockResolvedValue({
-        alice: 'profile-1',
+        ALICE: 'profile-1',
         Bob: 'profile-2'
       })
     };
@@ -89,7 +89,7 @@ describe('CiPipelineAlertService', () => {
           mentioned_users: [
             {
               mentioned_profile_id: 'profile-1',
-              handle_in_content: 'alice'
+              handle_in_content: 'ALICE'
             },
             {
               mentioned_profile_id: 'profile-2',
@@ -98,7 +98,7 @@ describe('CiPipelineAlertService', () => {
           ],
           parts: [
             expect.objectContaining({
-              content: expect.stringContaining('cc @[alice] @[Bob]')
+              content: expect.stringContaining('cc @[ALICE] @[Bob]')
             })
           ]
         })

--- a/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.test.ts
+++ b/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.test.ts
@@ -19,9 +19,10 @@ const baseRequest = {
   title: 'Seize PROD WEB DEPLOY: CI pipeline is broken!!!',
   description: 'abc123 - Fix deploy',
   run_id: '12345',
+  run_number: '6082',
   run_url:
     'https://github.com/6529-Collections/6529seize-frontend/actions/runs/12345',
-  sha: 'abc123',
+  sha: 'abc1234567890',
   branch: 'main',
   environment: 'production',
   service: 'web'
@@ -85,7 +86,7 @@ describe('CiPipelineAlertService', () => {
         representativeId: 'bot-profile',
         createDropRequest: expect.objectContaining({
           wave_id: 'prod-wave',
-          title: 'CI failure: Seize PROD WEB DEPLOY: CI pipeline is broken!!!',
+          title: '[PROD] Deploy Failed',
           mentioned_users: [
             {
               mentioned_profile_id: 'profile-1',
@@ -98,7 +99,17 @@ describe('CiPipelineAlertService', () => {
           ],
           parts: [
             expect.objectContaining({
-              content: expect.stringContaining('cc @[ALICE] @[Bob]')
+              content: expect.stringContaining(
+                [
+                  'cc @[ALICE] @[Bob]',
+                  '',
+                  'Service: Frontend - web',
+                  'Workflow: Web Deploy - PROD',
+                  'Branch: main',
+                  'Commit: [abc12345](https://github.com/6529-Collections/6529seize-frontend/commit/abc1234567890)',
+                  'Run: [#6082](https://github.com/6529-Collections/6529seize-frontend/actions/runs/12345)'
+                ].join('\n')
+              )
             })
           ]
         })
@@ -132,15 +143,28 @@ describe('CiPipelineAlertService', () => {
       expect.objectContaining({
         createDropRequest: expect.objectContaining({
           wave_id: 'staging-wave',
+          title: '[STAGING] Deploy Succeeded',
           mentioned_users: [],
           parts: [
             expect.objectContaining({
-              content: expect.not.stringContaining('cc @[')
+              content: expect.stringContaining(
+                [
+                  'Service: Frontend - web',
+                  'Workflow: Web Deploy - PROD',
+                  'Branch: main',
+                  'Commit: [abc12345](https://github.com/6529-Collections/6529seize-frontend/commit/abc1234567890)',
+                  'Run: [#6082](https://github.com/6529-Collections/6529seize-frontend/actions/runs/12345)'
+                ].join('\n')
+              )
             })
           ]
         })
       }),
       expect.anything()
     );
+    expect(
+      dropCreationApiService.createDrop.mock.calls[0][0].createDropRequest
+        .parts[0].content
+    ).not.toContain('cc @[');
   });
 });

--- a/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.test.ts
+++ b/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.test.ts
@@ -1,0 +1,141 @@
+jest.mock('@/api/drops/drop-creation.api.service', () => ({
+  dropCreationService: {
+    createDrop: jest.fn()
+  }
+}));
+
+jest.mock('@/identities/identities.db', () => ({
+  identitiesDb: {
+    getProfileHandlesByIds: jest.fn()
+  }
+}));
+
+import { CiPipelineAlertService } from './ci-pipeline-alert.service';
+
+const baseRequest = {
+  repo: '6529seize-frontend',
+  workflow: 'Web Deploy - PROD',
+  status: 'failure' as const,
+  title: 'Seize PROD WEB DEPLOY: CI pipeline is broken!!!',
+  description: 'abc123 - Fix deploy',
+  run_id: '12345',
+  run_url:
+    'https://github.com/6529-Collections/6529seize-frontend/actions/runs/12345',
+  sha: 'abc123',
+  branch: 'main',
+  environment: 'production',
+  service: 'web'
+};
+
+describe('CiPipelineAlertService', () => {
+  let originalEnv: Record<string, string | undefined>;
+  let dropCreationApiService: { createDrop: jest.Mock };
+  let identitiesRepository: { getProfileHandlesByIds: jest.Mock };
+
+  beforeEach(() => {
+    originalEnv = {
+      CI_PIPELINES_WAVE_ID: process.env.CI_PIPELINES_WAVE_ID,
+      CI_PIPELINES_BOT_PROFILE_ID: process.env.CI_PIPELINES_BOT_PROFILE_ID,
+      CI_PIPELINES_FAILURE_MENTION_PROFILE_IDS:
+        process.env.CI_PIPELINES_FAILURE_MENTION_PROFILE_IDS
+    };
+    process.env.CI_PIPELINES_WAVE_ID = 'wave-1';
+    process.env.CI_PIPELINES_BOT_PROFILE_ID = 'bot-profile';
+    process.env.CI_PIPELINES_FAILURE_MENTION_PROFILE_IDS =
+      'profile-1, profile-2, profile-1, missing-profile';
+    dropCreationApiService = {
+      createDrop: jest.fn().mockResolvedValue({})
+    };
+    identitiesRepository = {
+      getProfileHandlesByIds: jest.fn().mockResolvedValue({
+        'profile-1': 'alice',
+        'profile-2': 'bob'
+      })
+    };
+  });
+
+  afterEach(() => {
+    for (const [name, value] of Object.entries(originalEnv)) {
+      if (value === undefined) {
+        delete process.env[name];
+      } else {
+        process.env[name] = value;
+      }
+    }
+  });
+
+  it('posts failures with configured profile mentions', async () => {
+    const service = new CiPipelineAlertService(
+      dropCreationApiService as any,
+      identitiesRepository as any
+    );
+
+    await service.postAlert(baseRequest, {});
+
+    expect(identitiesRepository.getProfileHandlesByIds).toHaveBeenCalledWith(
+      ['profile-1', 'profile-2', 'missing-profile'],
+      {}
+    );
+    expect(dropCreationApiService.createDrop).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authorId: 'bot-profile',
+        representativeId: 'bot-profile',
+        createDropRequest: expect.objectContaining({
+          wave_id: 'wave-1',
+          title: 'CI failure: Seize PROD WEB DEPLOY: CI pipeline is broken!!!',
+          mentioned_users: [
+            {
+              mentioned_profile_id: 'profile-1',
+              handle_in_content: 'alice'
+            },
+            {
+              mentioned_profile_id: 'profile-2',
+              handle_in_content: 'bob'
+            }
+          ],
+          parts: [
+            expect.objectContaining({
+              content: expect.stringContaining('cc @[alice] @[bob]')
+            })
+          ]
+        })
+      }),
+      expect.objectContaining({
+        authenticationContext: expect.objectContaining({
+          authenticatedProfileId: 'bot-profile'
+        })
+      })
+    );
+  });
+
+  it('posts successes without resolving or adding mentions', async () => {
+    const service = new CiPipelineAlertService(
+      dropCreationApiService as any,
+      identitiesRepository as any
+    );
+
+    await service.postAlert(
+      {
+        ...baseRequest,
+        status: 'success',
+        title: 'Seize PROD WEB DEPLOY: CI pipeline complete'
+      },
+      {}
+    );
+
+    expect(identitiesRepository.getProfileHandlesByIds).not.toHaveBeenCalled();
+    expect(dropCreationApiService.createDrop).toHaveBeenCalledWith(
+      expect.objectContaining({
+        createDropRequest: expect.objectContaining({
+          mentioned_users: [],
+          parts: [
+            expect.objectContaining({
+              content: expect.not.stringContaining('cc @[')
+            })
+          ]
+        })
+      }),
+      expect.anything()
+    );
+  });
+});

--- a/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.test.ts
+++ b/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.test.ts
@@ -196,9 +196,9 @@ describe('CiPipelineAlertService', () => {
       ].join('\n')
     );
     expect(
-      dropCreationApiService.createDrop.mock.calls[0][0].createDropRequest
-        .parts[0].content
-        .startsWith('\n')
+      dropCreationApiService.createDrop.mock.calls[0][0].createDropRequest.parts[0].content.startsWith(
+        '\n'
+      )
     ).toBe(false);
     expect(
       dropCreationApiService.createDrop.mock.calls[0][0].createDropRequest

--- a/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.test.ts
+++ b/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.test.ts
@@ -6,7 +6,7 @@ jest.mock('@/api/drops/drop-creation.api.service', () => ({
 
 jest.mock('@/identities/identities.db', () => ({
   identitiesDb: {
-    getProfileHandlesByIds: jest.fn()
+    getIdsByHandles: jest.fn()
   }
 }));
 
@@ -30,26 +30,28 @@ const baseRequest = {
 describe('CiPipelineAlertService', () => {
   let originalEnv: Record<string, string | undefined>;
   let dropCreationApiService: { createDrop: jest.Mock };
-  let identitiesRepository: { getProfileHandlesByIds: jest.Mock };
+  let identitiesRepository: { getIdsByHandles: jest.Mock };
 
   beforeEach(() => {
     originalEnv = {
-      CI_PIPELINES_WAVE_ID: process.env.CI_PIPELINES_WAVE_ID,
+      CI_PIPELINES_STAGING_WAVE_ID: process.env.CI_PIPELINES_STAGING_WAVE_ID,
+      CI_PIPELINES_PROD_WAVE_ID: process.env.CI_PIPELINES_PROD_WAVE_ID,
       CI_PIPELINES_BOT_PROFILE_ID: process.env.CI_PIPELINES_BOT_PROFILE_ID,
-      CI_PIPELINES_FAILURE_MENTION_PROFILE_IDS:
-        process.env.CI_PIPELINES_FAILURE_MENTION_PROFILE_IDS
+      CI_PIPELINES_FAILURE_MENTION_PROFILE_HANDLES:
+        process.env.CI_PIPELINES_FAILURE_MENTION_PROFILE_HANDLES
     };
-    process.env.CI_PIPELINES_WAVE_ID = 'wave-1';
+    process.env.CI_PIPELINES_STAGING_WAVE_ID = 'staging-wave';
+    process.env.CI_PIPELINES_PROD_WAVE_ID = 'prod-wave';
     process.env.CI_PIPELINES_BOT_PROFILE_ID = 'bot-profile';
-    process.env.CI_PIPELINES_FAILURE_MENTION_PROFILE_IDS =
-      'profile-1, profile-2, profile-1, missing-profile';
+    process.env.CI_PIPELINES_FAILURE_MENTION_PROFILE_HANDLES =
+      '@alice, @[Bob], alice, missing';
     dropCreationApiService = {
       createDrop: jest.fn().mockResolvedValue({})
     };
     identitiesRepository = {
-      getProfileHandlesByIds: jest.fn().mockResolvedValue({
-        'profile-1': 'alice',
-        'profile-2': 'bob'
+      getIdsByHandles: jest.fn().mockResolvedValue({
+        alice: 'profile-1',
+        Bob: 'profile-2'
       })
     };
   });
@@ -69,19 +71,20 @@ describe('CiPipelineAlertService', () => {
       dropCreationApiService as any,
       identitiesRepository as any
     );
+    const ctx = { connection: {} };
 
-    await service.postAlert(baseRequest, {});
+    await service.postAlert(baseRequest, ctx as any);
 
-    expect(identitiesRepository.getProfileHandlesByIds).toHaveBeenCalledWith(
-      ['profile-1', 'profile-2', 'missing-profile'],
-      {}
+    expect(identitiesRepository.getIdsByHandles).toHaveBeenCalledWith(
+      ['alice', 'Bob', 'missing'],
+      ctx.connection
     );
     expect(dropCreationApiService.createDrop).toHaveBeenCalledWith(
       expect.objectContaining({
         authorId: 'bot-profile',
         representativeId: 'bot-profile',
         createDropRequest: expect.objectContaining({
-          wave_id: 'wave-1',
+          wave_id: 'prod-wave',
           title: 'CI failure: Seize PROD WEB DEPLOY: CI pipeline is broken!!!',
           mentioned_users: [
             {
@@ -90,12 +93,12 @@ describe('CiPipelineAlertService', () => {
             },
             {
               mentioned_profile_id: 'profile-2',
-              handle_in_content: 'bob'
+              handle_in_content: 'Bob'
             }
           ],
           parts: [
             expect.objectContaining({
-              content: expect.stringContaining('cc @[alice] @[bob]')
+              content: expect.stringContaining('cc @[alice] @[Bob]')
             })
           ]
         })
@@ -108,7 +111,7 @@ describe('CiPipelineAlertService', () => {
     );
   });
 
-  it('posts successes without resolving or adding mentions', async () => {
+  it('routes staging successes without resolving or adding mentions', async () => {
     const service = new CiPipelineAlertService(
       dropCreationApiService as any,
       identitiesRepository as any
@@ -118,15 +121,17 @@ describe('CiPipelineAlertService', () => {
       {
         ...baseRequest,
         status: 'success',
-        title: 'Seize PROD WEB DEPLOY: CI pipeline complete'
+        title: 'Seize Lambda staging api DEPLOY CI pipeline complete',
+        environment: 'staging'
       },
       {}
     );
 
-    expect(identitiesRepository.getProfileHandlesByIds).not.toHaveBeenCalled();
+    expect(identitiesRepository.getIdsByHandles).not.toHaveBeenCalled();
     expect(dropCreationApiService.createDrop).toHaveBeenCalledWith(
       expect.objectContaining({
         createDropRequest: expect.objectContaining({
+          wave_id: 'staging-wave',
           mentioned_users: [],
           parts: [
             expect.objectContaining({

--- a/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.test.ts
+++ b/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.test.ts
@@ -30,7 +30,10 @@ const baseRequest = {
 
 describe('CiPipelineAlertService', () => {
   let originalEnv: Record<string, string | undefined>;
-  let dropCreationApiService: { createDrop: jest.Mock };
+  let dropCreationApiService: {
+    createDrop: jest.Mock;
+    toggleHideLinkPreview: jest.Mock;
+  };
   let identitiesRepository: { getIdsByHandles: jest.Mock };
 
   beforeEach(() => {
@@ -47,7 +50,8 @@ describe('CiPipelineAlertService', () => {
     process.env.CI_PIPELINES_FAILURE_MENTION_PROFILE_HANDLES =
       '@alice, @[Bob], alice, missing';
     dropCreationApiService = {
-      createDrop: jest.fn().mockResolvedValue({})
+      createDrop: jest.fn().mockResolvedValue({ id: 'drop-1' }),
+      toggleHideLinkPreview: jest.fn().mockResolvedValue({})
     };
     identitiesRepository = {
       getIdsByHandles: jest.fn().mockResolvedValue({
@@ -120,6 +124,17 @@ describe('CiPipelineAlertService', () => {
         })
       })
     );
+    expect(dropCreationApiService.toggleHideLinkPreview).toHaveBeenCalledWith(
+      {
+        dropId: 'drop-1',
+        hideLinkPreview: true
+      },
+      expect.objectContaining({
+        authenticationContext: expect.objectContaining({
+          authenticatedProfileId: 'bot-profile'
+        })
+      })
+    );
   });
 
   it('routes staging successes without resolving or adding mentions', async () => {
@@ -166,5 +181,16 @@ describe('CiPipelineAlertService', () => {
       dropCreationApiService.createDrop.mock.calls[0][0].createDropRequest
         .parts[0].content
     ).not.toContain('cc @[');
+    expect(dropCreationApiService.toggleHideLinkPreview).toHaveBeenCalledWith(
+      {
+        dropId: 'drop-1',
+        hideLinkPreview: true
+      },
+      expect.objectContaining({
+        authenticationContext: expect.objectContaining({
+          authenticatedProfileId: 'bot-profile'
+        })
+      })
+    );
   });
 });

--- a/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.test.ts
+++ b/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.test.ts
@@ -10,7 +10,15 @@ jest.mock('@/identities/identities.db', () => ({
   }
 }));
 
-import { CiPipelineAlertService } from './ci-pipeline-alert.service';
+import fc from 'fast-check';
+import {
+  CiPipelineAlertService,
+  formatMarkdownLink,
+  normalizeConfiguredHandle,
+  normalizeTargetEnvironment,
+  parseProfileHandles,
+  truncate
+} from './ci-pipeline-alert.service';
 
 const baseRequest = {
   repo: '6529seize-frontend',
@@ -69,6 +77,107 @@ describe('CiPipelineAlertService', () => {
         process.env[name] = value;
       }
     }
+  });
+
+  it('keeps truncated arbitrary content within the target length', () => {
+    fc.assert(
+      fc.property(
+        fc.string(),
+        fc.integer({ min: 3, max: 120 }),
+        (value, maxLength) => {
+          const truncated = truncate(value, maxLength);
+
+          expect(truncated.length).toBeLessThanOrEqual(maxLength);
+          if (value.length <= maxLength) {
+            expect(truncated).toBe(value);
+          } else {
+            expect(truncated).toBe(`${value.slice(0, maxLength - 3)}...`);
+          }
+        }
+      )
+    );
+  });
+
+  it('escapes arbitrary markdown link labels', () => {
+    fc.assert(
+      fc.property(fc.string(), fc.string(), (label, url) => {
+        const escapedLabel = label
+          .split('[')
+          .join(String.raw`\[`)
+          .split(']')
+          .join(String.raw`\]`);
+
+        expect(formatMarkdownLink(label, url)).toBe(
+          `[${escapedLabel}](${url})`
+        );
+      })
+    );
+  });
+
+  it('normalizes arbitrary configured profile handles', () => {
+    const handleCharacters =
+      'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-'.split(
+        ''
+      );
+    const handleArbitrary = fc
+      .array(fc.constantFrom(...handleCharacters), {
+        minLength: 1,
+        maxLength: 30
+      })
+      .map((chars) => chars.join(''));
+
+    fc.assert(
+      fc.property(handleArbitrary, (handle) => {
+        expect(normalizeConfiguredHandle(` @${handle} `)).toBe(handle);
+        expect(normalizeConfiguredHandle(` @[${handle}] `)).toBe(handle);
+      })
+    );
+  });
+
+  it('dedupes arbitrary configured profile handles case-insensitively', () => {
+    const handleCharacters =
+      'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-'.split(
+        ''
+      );
+    const handleArbitrary = fc
+      .array(fc.constantFrom(...handleCharacters), {
+        minLength: 1,
+        maxLength: 20
+      })
+      .map((chars) => chars.join(''));
+
+    fc.assert(
+      fc.property(fc.array(handleArbitrary, { maxLength: 20 }), (handles) => {
+        const input = handles
+          .flatMap((handle) => [` @${handle} `, ` @[${handle.toUpperCase()}] `])
+          .join(',');
+        const parsedHandles = parseProfileHandles(input);
+        const normalizedHandles = parsedHandles.map((handle) =>
+          handle.toLowerCase()
+        );
+
+        expect(new Set(normalizedHandles).size).toBe(parsedHandles.length);
+        for (const parsedHandle of parsedHandles) {
+          expect(parsedHandle).not.toMatch(/^@/);
+        }
+      })
+    );
+  });
+
+  it('normalizes arbitrary target environment casing and spacing', () => {
+    fc.assert(
+      fc.property(
+        fc.constantFrom('staging', 'prod', 'production'),
+        fc.constantFrom('', ' ', '  ', '\t', '\n'),
+        fc.constantFrom('', ' ', '  ', '\t', '\n'),
+        (environment, prefixWhitespace, suffixWhitespace) => {
+          const paddedEnvironment = `${prefixWhitespace}${environment.toUpperCase()}${suffixWhitespace}`;
+          const expected = environment === 'production' ? 'prod' : environment;
+
+          expect(normalizeTargetEnvironment(paddedEnvironment)).toBe(expected);
+        }
+      )
+    );
   });
 
   it('posts failures with configured profile mentions', async () => {

--- a/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.ts
+++ b/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.ts
@@ -141,7 +141,12 @@ function getGithubRepoUrl(request: CiPipelineAlertRequest): string | null {
 }
 
 function formatMarkdownLink(label: string, url: string): string {
-  return `[${label.replace(/\[/g, '\\[').replace(/\]/g, '\\]')}](${url})`;
+  const escapedLabel = label
+    .split('[')
+    .join(String.raw`\[`)
+    .split(']')
+    .join(String.raw`\]`);
+  return `[${escapedLabel}](${url})`;
 }
 
 function formatCommit(request: CiPipelineAlertRequest): string | null {

--- a/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.ts
+++ b/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.ts
@@ -35,7 +35,7 @@ interface MentionedProfile {
 const MAX_DROP_CONTENT_LENGTH = 30000;
 const MAX_DROP_TITLE_LENGTH = 250;
 
-function truncate(value: string, maxLength: number): string {
+export function truncate(value: string, maxLength: number): string {
   if (value.length <= maxLength) {
     return value;
   }
@@ -49,7 +49,7 @@ function normalizeOptionalValue(
   return trimmed || null;
 }
 
-function parseProfileHandles(value: string | null): string[] {
+export function parseProfileHandles(value: string | null): string[] {
   if (!value) {
     return [];
   }
@@ -67,7 +67,7 @@ function parseProfileHandles(value: string | null): string[] {
     });
 }
 
-function normalizeConfiguredHandle(value: string): string {
+export function normalizeConfiguredHandle(value: string): string {
   const trimmed = value.trim();
   const bracketMention = /^@\[([^\]]+)\]$/.exec(trimmed);
   if (bracketMention) {
@@ -76,7 +76,7 @@ function normalizeConfiguredHandle(value: string): string {
   return trimmed.startsWith('@') ? trimmed.slice(1).trim() : trimmed;
 }
 
-function normalizeTargetEnvironment(value: string | null | undefined) {
+export function normalizeTargetEnvironment(value: string | null | undefined) {
   const normalizedValue = normalizeOptionalValue(value)?.toLowerCase();
   if (normalizedValue === 'staging') {
     return 'staging';
@@ -140,12 +140,24 @@ function getGithubRepoUrl(request: CiPipelineAlertRequest): string | null {
   }
 }
 
-function formatMarkdownLink(label: string, url: string): string {
-  const escapedLabel = label
-    .split('[')
-    .join(String.raw`\[`)
-    .split(']')
-    .join(String.raw`\]`);
+function replaceAllLiteral(
+  value: string,
+  searchValue: string,
+  replaceValue: string
+): string {
+  return (
+    value as string & {
+      replaceAll(searchValue: string, replaceValue: string): string;
+    }
+  ).replaceAll(searchValue, replaceValue);
+}
+
+export function formatMarkdownLink(label: string, url: string): string {
+  const escapedLabel = replaceAllLiteral(
+    replaceAllLiteral(label, '[', String.raw`\[`),
+    ']',
+    String.raw`\]`
+  );
   return `[${escapedLabel}](${url})`;
 }
 

--- a/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.ts
+++ b/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.ts
@@ -1,0 +1,223 @@
+import { AuthenticationContext } from '@/auth-context';
+import { ApiCreateDropRequest } from '@/api/generated/models/ApiCreateDropRequest';
+import { ApiDropType } from '@/api/generated/models/ApiDropType';
+import {
+  DropCreationApiService,
+  dropCreationService
+} from '@/api/drops/drop-creation.api.service';
+import { env } from '@/env';
+import { identitiesDb, IdentitiesDb } from '@/identities/identities.db';
+import { Logger } from '@/logging';
+import { RequestContext } from '@/request.context';
+
+export type CiPipelineAlertStatus = 'success' | 'failure';
+
+export interface CiPipelineAlertRequest {
+  readonly repo: string;
+  readonly workflow: string;
+  readonly status: CiPipelineAlertStatus;
+  readonly title: string;
+  readonly description?: string | null;
+  readonly run_id: string;
+  readonly run_url: string;
+  readonly sha?: string | null;
+  readonly branch?: string | null;
+  readonly environment?: string | null;
+  readonly service?: string | null;
+}
+
+interface MentionedProfile {
+  readonly profileId: string;
+  readonly handle: string;
+}
+
+const MAX_DROP_CONTENT_LENGTH = 30000;
+const MAX_DROP_TITLE_LENGTH = 250;
+
+function truncate(value: string, maxLength: number): string {
+  if (value.length <= maxLength) {
+    return value;
+  }
+  return `${value.slice(0, maxLength - 3)}...`;
+}
+
+function normalizeOptionalValue(
+  value: string | null | undefined
+): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+function parseProfileIds(value: string | null): string[] {
+  if (!value) {
+    return [];
+  }
+  const seen = new Set<string>();
+  return value
+    .split(',')
+    .map((profileId) => profileId.trim())
+    .filter((profileId) => {
+      if (!profileId || seen.has(profileId)) {
+        return false;
+      }
+      seen.add(profileId);
+      return true;
+    });
+}
+
+export class CiPipelineAlertService {
+  private readonly logger = Logger.get(this.constructor.name);
+
+  constructor(
+    private readonly dropCreationApiService: DropCreationApiService,
+    private readonly identitiesRepository: IdentitiesDb
+  ) {}
+
+  public async postAlert(
+    request: CiPipelineAlertRequest,
+    ctx: RequestContext
+  ): Promise<void> {
+    const waveId = env.getStringOrThrow('CI_PIPELINES_WAVE_ID');
+    const botProfileId = env.getStringOrThrow('CI_PIPELINES_BOT_PROFILE_ID');
+    const mentions =
+      request.status === 'failure'
+        ? await this.resolveFailureMentions(ctx)
+        : [];
+
+    const createDropRequest = this.buildCreateDropRequest({
+      request,
+      waveId,
+      mentions
+    });
+
+    await this.dropCreationApiService.createDrop(
+      {
+        createDropRequest,
+        authorId: botProfileId,
+        representativeId: botProfileId
+      },
+      {
+        ...ctx,
+        authenticationContext: AuthenticationContext.fromProfileId(botProfileId)
+      }
+    );
+  }
+
+  private async resolveFailureMentions(
+    ctx: RequestContext
+  ): Promise<MentionedProfile[]> {
+    const profileIds = parseProfileIds(
+      env.getStringOrNull('CI_PIPELINES_FAILURE_MENTION_PROFILE_IDS')
+    );
+    if (!profileIds.length) {
+      return [];
+    }
+
+    const handlesByProfileId =
+      await this.identitiesRepository.getProfileHandlesByIds(profileIds, ctx);
+    const missingProfileIds = profileIds.filter(
+      (profileId) => !handlesByProfileId[profileId]
+    );
+    if (missingProfileIds.length) {
+      this.logger.warn(
+        `Skipping CI pipeline alert mentions with missing handles: ${missingProfileIds.join(', ')}`
+      );
+    }
+
+    return profileIds
+      .map((profileId) => ({
+        profileId,
+        handle: handlesByProfileId[profileId]
+      }))
+      .filter((mention): mention is MentionedProfile => !!mention.handle);
+  }
+
+  private buildCreateDropRequest({
+    request,
+    waveId,
+    mentions
+  }: {
+    readonly request: CiPipelineAlertRequest;
+    readonly waveId: string;
+    readonly mentions: MentionedProfile[];
+  }): ApiCreateDropRequest {
+    const content = this.formatContent(request, mentions);
+    return {
+      title: truncate(
+        `CI ${request.status}: ${request.title}`,
+        MAX_DROP_TITLE_LENGTH
+      ),
+      drop_type: ApiDropType.Chat,
+      parts: [
+        {
+          content,
+          quoted_drop: null,
+          media: []
+        }
+      ],
+      mentioned_users: mentions.map((mention) => ({
+        mentioned_profile_id: mention.profileId,
+        handle_in_content: mention.handle
+      })),
+      mentioned_groups: [],
+      referenced_nfts: [],
+      metadata: [
+        { data_key: 'source', data_value: 'github-actions' },
+        { data_key: 'repo', data_value: request.repo },
+        { data_key: 'workflow', data_value: request.workflow },
+        { data_key: 'run_id', data_value: request.run_id },
+        { data_key: 'status', data_value: request.status }
+      ],
+      signature: null,
+      is_safe_signature: false,
+      wave_id: waveId
+    };
+  }
+
+  private formatContent(
+    request: CiPipelineAlertRequest,
+    mentions: MentionedProfile[]
+  ): string {
+    const lines = [`[${request.status.toUpperCase()}] ${request.title}`, ''];
+
+    if (mentions.length) {
+      lines.push(
+        `cc ${mentions.map((mention) => `@[${mention.handle}]`).join(' ')}`
+      );
+      lines.push('');
+    }
+
+    const description = normalizeOptionalValue(request.description);
+    if (description) {
+      lines.push(description);
+      lines.push('');
+    }
+
+    lines.push(`Repo: ${request.repo}`);
+    lines.push(`Workflow: ${request.workflow}`);
+    const environment = normalizeOptionalValue(request.environment);
+    if (environment) {
+      lines.push(`Environment: ${environment}`);
+    }
+    const service = normalizeOptionalValue(request.service);
+    if (service) {
+      lines.push(`Service: ${service}`);
+    }
+    const branch = normalizeOptionalValue(request.branch);
+    if (branch) {
+      lines.push(`Branch: ${branch}`);
+    }
+    const sha = normalizeOptionalValue(request.sha);
+    if (sha) {
+      lines.push(`Commit: ${sha}`);
+    }
+    lines.push(`Run: ${request.run_url}`);
+
+    return truncate(lines.join('\n'), MAX_DROP_CONTENT_LENGTH);
+  }
+}
+
+export const ciPipelineAlertService = new CiPipelineAlertService(
+  dropCreationService,
+  identitiesDb
+);

--- a/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.ts
+++ b/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.ts
@@ -193,33 +193,18 @@ export class CiPipelineAlertService {
     const authenticationContext =
       AuthenticationContext.fromProfileId(botProfileId);
 
-    const createdDrop = await this.dropCreationApiService.createDrop(
+    await this.dropCreationApiService.createDrop(
       {
         createDropRequest,
         authorId: botProfileId,
-        representativeId: botProfileId
+        representativeId: botProfileId,
+        hideLinkPreview: true
       },
       {
         ...ctx,
         authenticationContext
       }
     );
-    try {
-      await this.dropCreationApiService.toggleHideLinkPreview(
-        {
-          dropId: createdDrop.id,
-          hideLinkPreview: true
-        },
-        {
-          ...ctx,
-          authenticationContext
-        }
-      );
-    } catch (err) {
-      this.logger.warn(
-        `Failed to hide CI pipeline alert link previews for drop ${createdDrop.id}: ${err}`
-      );
-    }
   }
 
   private async resolveFailureMentions(): Promise<MentionedProfile[]> {
@@ -294,13 +279,7 @@ export class CiPipelineAlertService {
       })),
       mentioned_groups: [],
       referenced_nfts: [],
-      metadata: [
-        { data_key: 'source', data_value: 'github-actions' },
-        { data_key: 'repo', data_value: request.repo },
-        { data_key: 'workflow', data_value: request.workflow },
-        { data_key: 'run_id', data_value: request.run_id },
-        { data_key: 'status', data_value: request.status }
-      ],
+      metadata: [],
       signature: null,
       is_safe_signature: false,
       wave_id: waveId

--- a/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.ts
+++ b/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.ts
@@ -183,9 +183,7 @@ export class CiPipelineAlertService {
     const waveId = this.resolveWaveId(request);
     const botProfileId = env.getStringOrThrow('CI_PIPELINES_BOT_PROFILE_ID');
     const mentions =
-      request.status === 'failure'
-        ? await this.resolveFailureMentions(ctx)
-        : [];
+      request.status === 'failure' ? await this.resolveFailureMentions() : [];
 
     const createDropRequest = this.buildCreateDropRequest({
       request,
@@ -206,21 +204,25 @@ export class CiPipelineAlertService {
         authenticationContext
       }
     );
-    await this.dropCreationApiService.toggleHideLinkPreview(
-      {
-        dropId: createdDrop.id,
-        hideLinkPreview: true
-      },
-      {
-        ...ctx,
-        authenticationContext
-      }
-    );
+    try {
+      await this.dropCreationApiService.toggleHideLinkPreview(
+        {
+          dropId: createdDrop.id,
+          hideLinkPreview: true
+        },
+        {
+          ...ctx,
+          authenticationContext
+        }
+      );
+    } catch (err) {
+      this.logger.warn(
+        `Failed to hide CI pipeline alert link previews for drop ${createdDrop.id}: ${err}`
+      );
+    }
   }
 
-  private async resolveFailureMentions(
-    ctx: RequestContext
-  ): Promise<MentionedProfile[]> {
+  private async resolveFailureMentions(): Promise<MentionedProfile[]> {
     const configuredHandles = parseProfileHandles(
       env.getStringOrNull('CI_PIPELINES_FAILURE_MENTION_PROFILE_HANDLES')
     );
@@ -228,10 +230,8 @@ export class CiPipelineAlertService {
       return [];
     }
 
-    const profileIdsByHandle = await this.identitiesRepository.getIdsByHandles(
-      configuredHandles,
-      ctx.connection
-    );
+    const profileIdsByHandle =
+      await this.identitiesRepository.getIdsByHandles(configuredHandles);
     const mentionsByNormalizedHandle = new Map(
       Object.entries(profileIdsByHandle).map(([handle, profileId]) => [
         handle.toLowerCase(),

--- a/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.ts
+++ b/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.ts
@@ -180,8 +180,10 @@ export class CiPipelineAlertService {
       waveId,
       mentions
     });
+    const authenticationContext =
+      AuthenticationContext.fromProfileId(botProfileId);
 
-    await this.dropCreationApiService.createDrop(
+    const createdDrop = await this.dropCreationApiService.createDrop(
       {
         createDropRequest,
         authorId: botProfileId,
@@ -189,7 +191,17 @@ export class CiPipelineAlertService {
       },
       {
         ...ctx,
-        authenticationContext: AuthenticationContext.fromProfileId(botProfileId)
+        authenticationContext
+      }
+    );
+    await this.dropCreationApiService.toggleHideLinkPreview(
+      {
+        dropId: createdDrop.id,
+        hideLinkPreview: true
+      },
+      {
+        ...ctx,
+        authenticationContext
       }
     );
   }

--- a/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.ts
+++ b/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.ts
@@ -45,7 +45,7 @@ function normalizeOptionalValue(
   value: string | null | undefined
 ): string | null {
   const trimmed = value?.trim();
-  return trimmed ? trimmed : null;
+  return trimmed || null;
 }
 
 function parseProfileIds(value: string | null): string[] {
@@ -178,40 +178,29 @@ export class CiPipelineAlertService {
     request: CiPipelineAlertRequest,
     mentions: MentionedProfile[]
   ): string {
-    const lines = [`[${request.status.toUpperCase()}] ${request.title}`, ''];
-
-    if (mentions.length) {
-      lines.push(
-        `cc ${mentions.map((mention) => `@[${mention.handle}]`).join(' ')}`
-      );
-      lines.push('');
-    }
+    const mentionHandles = mentions
+      .map((mention) => '@[' + mention.handle + ']')
+      .join(' ');
+    const mentionLines = mentions.length ? [`cc ${mentionHandles}`, ''] : [];
 
     const description = normalizeOptionalValue(request.description);
-    if (description) {
-      lines.push(description);
-      lines.push('');
-    }
-
-    lines.push(`Repo: ${request.repo}`);
-    lines.push(`Workflow: ${request.workflow}`);
     const environment = normalizeOptionalValue(request.environment);
-    if (environment) {
-      lines.push(`Environment: ${environment}`);
-    }
     const service = normalizeOptionalValue(request.service);
-    if (service) {
-      lines.push(`Service: ${service}`);
-    }
     const branch = normalizeOptionalValue(request.branch);
-    if (branch) {
-      lines.push(`Branch: ${branch}`);
-    }
     const sha = normalizeOptionalValue(request.sha);
-    if (sha) {
-      lines.push(`Commit: ${sha}`);
-    }
-    lines.push(`Run: ${request.run_url}`);
+    const lines = [
+      `[${request.status.toUpperCase()}] ${request.title}`,
+      '',
+      ...mentionLines,
+      ...(description ? [description, ''] : []),
+      `Repo: ${request.repo}`,
+      `Workflow: ${request.workflow}`,
+      ...(environment ? [`Environment: ${environment}`] : []),
+      ...(service ? [`Service: ${service}`] : []),
+      ...(branch ? [`Branch: ${branch}`] : []),
+      ...(sha ? [`Commit: ${sha}`] : []),
+      `Run: ${request.run_url}`
+    ];
 
     return truncate(lines.join('\n'), MAX_DROP_CONTENT_LENGTH);
   }

--- a/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.ts
+++ b/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.ts
@@ -91,6 +91,13 @@ function formatStatusVerb(status: CiPipelineAlertStatus): string {
   return status === 'success' ? 'Succeeded' : 'Failed';
 }
 
+function formatAlertHeading(request: CiPipelineAlertRequest): string {
+  return truncate(
+    `[${formatEnvironmentLabel(request.environment)}] Deploy ${formatStatusVerb(request.status)}`,
+    MAX_DROP_TITLE_LENGTH
+  );
+}
+
 function formatEnvironmentLabel(value: string | null | undefined): string {
   const targetEnvironment = normalizeTargetEnvironment(value);
   return (
@@ -267,10 +274,7 @@ export class CiPipelineAlertService {
   }): ApiCreateDropRequest {
     const content = this.formatContent(request, mentions);
     return {
-      title: truncate(
-        `[${formatEnvironmentLabel(request.environment)}] Deploy ${formatStatusVerb(request.status)}`,
-        MAX_DROP_TITLE_LENGTH
-      ),
+      title: null,
       drop_type: ApiDropType.Chat,
       parts: [
         {
@@ -305,12 +309,15 @@ export class CiPipelineAlertService {
     const mentionHandles = mentions
       .map((mention) => '@[' + mention.handle + ']')
       .join(' ');
-    const mentionLines = mentions.length ? [`cc ${mentionHandles}`, ''] : [];
+    const mentionLines = mentions.length ? [`cc ${mentionHandles}`] : [];
 
     const branch = normalizeOptionalValue(request.branch);
     const commit = formatCommit(request);
     const lines = [
+      formatAlertHeading(request),
+      '',
       ...mentionLines,
+      ...(mentionLines.length ? [''] : []),
       `Service: ${formatServiceLabel(request)}`,
       `Workflow: ${request.workflow}`,
       ...(branch ? [`Branch: ${branch}`] : []),

--- a/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.ts
+++ b/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.ts
@@ -19,6 +19,7 @@ export interface CiPipelineAlertRequest {
   readonly title: string;
   readonly description?: string | null;
   readonly run_id: string;
+  readonly run_number?: string | null;
   readonly run_url: string;
   readonly sha?: string | null;
   readonly branch?: string | null;
@@ -84,6 +85,75 @@ function normalizeTargetEnvironment(value: string | null | undefined) {
     return 'prod';
   }
   return null;
+}
+
+function formatStatusVerb(status: CiPipelineAlertStatus): string {
+  return status === 'success' ? 'Succeeded' : 'Failed';
+}
+
+function formatEnvironmentLabel(value: string | null | undefined): string {
+  const targetEnvironment = normalizeTargetEnvironment(value);
+  return (
+    targetEnvironment ??
+    normalizeOptionalValue(value) ??
+    'ci'
+  ).toUpperCase();
+}
+
+function formatRepoLabel(repo: string): string {
+  const repoName = repo.split('/').pop() ?? repo;
+  if (repoName === '6529seize-backend') {
+    return 'Backend';
+  }
+  if (repoName === '6529seize-frontend') {
+    return 'Frontend';
+  }
+  if (repoName === '6529-core') {
+    return 'Core';
+  }
+  return repoName;
+}
+
+function formatServiceLabel(request: CiPipelineAlertRequest): string {
+  const repoLabel = formatRepoLabel(request.repo);
+  const service = normalizeOptionalValue(request.service);
+  return service ? `${repoLabel} - ${service}` : repoLabel;
+}
+
+function getGithubRepoUrl(request: CiPipelineAlertRequest): string | null {
+  try {
+    const runUrl = new URL(request.run_url);
+    const [owner, repo] = runUrl.pathname.split('/').filter(Boolean);
+    if (!owner || !repo) {
+      return null;
+    }
+    return `${runUrl.origin}/${owner}/${repo}`;
+  } catch {
+    return null;
+  }
+}
+
+function formatMarkdownLink(label: string, url: string): string {
+  return `[${label.replace(/\[/g, '\\[').replace(/\]/g, '\\]')}](${url})`;
+}
+
+function formatCommit(request: CiPipelineAlertRequest): string | null {
+  const sha = normalizeOptionalValue(request.sha);
+  if (!sha) {
+    return null;
+  }
+  const shortSha = sha.slice(0, 8);
+  const repoUrl = getGithubRepoUrl(request);
+  return repoUrl
+    ? formatMarkdownLink(shortSha, `${repoUrl}/commit/${sha}`)
+    : shortSha;
+}
+
+function formatRun(request: CiPipelineAlertRequest): string {
+  const runLabel = normalizeOptionalValue(request.run_number)
+    ? `#${normalizeOptionalValue(request.run_number)}`
+    : `#${request.run_id}`;
+  return formatMarkdownLink(runLabel, request.run_url);
 }
 
 export class CiPipelineAlertService {
@@ -186,7 +256,7 @@ export class CiPipelineAlertService {
     const content = this.formatContent(request, mentions);
     return {
       title: truncate(
-        `CI ${request.status}: ${request.title}`,
+        `[${formatEnvironmentLabel(request.environment)}] Deploy ${formatStatusVerb(request.status)}`,
         MAX_DROP_TITLE_LENGTH
       ),
       drop_type: ApiDropType.Chat,
@@ -225,23 +295,15 @@ export class CiPipelineAlertService {
       .join(' ');
     const mentionLines = mentions.length ? [`cc ${mentionHandles}`, ''] : [];
 
-    const description = normalizeOptionalValue(request.description);
-    const environment = normalizeOptionalValue(request.environment);
-    const service = normalizeOptionalValue(request.service);
     const branch = normalizeOptionalValue(request.branch);
-    const sha = normalizeOptionalValue(request.sha);
+    const commit = formatCommit(request);
     const lines = [
-      `[${request.status.toUpperCase()}] ${request.title}`,
-      '',
       ...mentionLines,
-      ...(description ? [description, ''] : []),
-      `Repo: ${request.repo}`,
+      `Service: ${formatServiceLabel(request)}`,
       `Workflow: ${request.workflow}`,
-      ...(environment ? [`Environment: ${environment}`] : []),
-      ...(service ? [`Service: ${service}`] : []),
       ...(branch ? [`Branch: ${branch}`] : []),
-      ...(sha ? [`Commit: ${sha}`] : []),
-      `Run: ${request.run_url}`
+      ...(commit ? [`Commit: ${commit}`] : []),
+      `Run: ${formatRun(request)}`
     ];
 
     return truncate(lines.join('\n'), MAX_DROP_CONTENT_LENGTH);

--- a/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.ts
+++ b/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.ts
@@ -68,7 +68,7 @@ function parseProfileHandles(value: string | null): string[] {
 
 function normalizeConfiguredHandle(value: string): string {
   const trimmed = value.trim();
-  const bracketMention = trimmed.match(/^@\[([^\]]+)\]$/u);
+  const bracketMention = /^@\[([^\]]+)\]$/.exec(trimmed);
   if (bracketMention) {
     return bracketMention[1].trim();
   }

--- a/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.ts
+++ b/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.ts
@@ -48,21 +48,42 @@ function normalizeOptionalValue(
   return trimmed || null;
 }
 
-function parseProfileIds(value: string | null): string[] {
+function parseProfileHandles(value: string | null): string[] {
   if (!value) {
     return [];
   }
-  const seen = new Set<string>();
+  const seenNormalizedHandles = new Set<string>();
   return value
     .split(',')
-    .map((profileId) => profileId.trim())
-    .filter((profileId) => {
-      if (!profileId || seen.has(profileId)) {
+    .map((handle) => normalizeConfiguredHandle(handle))
+    .filter((handle) => {
+      const normalizedHandle = handle.toLowerCase();
+      if (!handle || seenNormalizedHandles.has(normalizedHandle)) {
         return false;
       }
-      seen.add(profileId);
+      seenNormalizedHandles.add(normalizedHandle);
       return true;
     });
+}
+
+function normalizeConfiguredHandle(value: string): string {
+  const trimmed = value.trim();
+  const bracketMention = trimmed.match(/^@\[([^\]]+)\]$/u);
+  if (bracketMention) {
+    return bracketMention[1].trim();
+  }
+  return trimmed.startsWith('@') ? trimmed.slice(1).trim() : trimmed;
+}
+
+function normalizeTargetEnvironment(value: string | null | undefined) {
+  const normalizedValue = normalizeOptionalValue(value)?.toLowerCase();
+  if (normalizedValue === 'staging') {
+    return 'staging';
+  }
+  if (normalizedValue === 'prod' || normalizedValue === 'production') {
+    return 'prod';
+  }
+  return null;
 }
 
 export class CiPipelineAlertService {
@@ -77,7 +98,7 @@ export class CiPipelineAlertService {
     request: CiPipelineAlertRequest,
     ctx: RequestContext
   ): Promise<void> {
-    const waveId = env.getStringOrThrow('CI_PIPELINES_WAVE_ID');
+    const waveId = this.resolveWaveId(request);
     const botProfileId = env.getStringOrThrow('CI_PIPELINES_BOT_PROFILE_ID');
     const mentions =
       request.status === 'failure'
@@ -106,30 +127,51 @@ export class CiPipelineAlertService {
   private async resolveFailureMentions(
     ctx: RequestContext
   ): Promise<MentionedProfile[]> {
-    const profileIds = parseProfileIds(
-      env.getStringOrNull('CI_PIPELINES_FAILURE_MENTION_PROFILE_IDS')
+    const configuredHandles = parseProfileHandles(
+      env.getStringOrNull('CI_PIPELINES_FAILURE_MENTION_PROFILE_HANDLES')
     );
-    if (!profileIds.length) {
+    if (!configuredHandles.length) {
       return [];
     }
 
-    const handlesByProfileId =
-      await this.identitiesRepository.getProfileHandlesByIds(profileIds, ctx);
-    const missingProfileIds = profileIds.filter(
-      (profileId) => !handlesByProfileId[profileId]
+    const profileIdsByHandle = await this.identitiesRepository.getIdsByHandles(
+      configuredHandles,
+      ctx.connection
     );
-    if (missingProfileIds.length) {
+    const mentionsByNormalizedHandle = new Map(
+      Object.entries(profileIdsByHandle).map(([handle, profileId]) => [
+        handle.toLowerCase(),
+        {
+          profileId,
+          handle
+        }
+      ])
+    );
+    const missingHandles = configuredHandles.filter(
+      (handle) => !mentionsByNormalizedHandle.has(handle.toLowerCase())
+    );
+    if (missingHandles.length) {
       this.logger.warn(
-        `Skipping CI pipeline alert mentions with missing handles: ${missingProfileIds.join(', ')}`
+        `Skipping CI pipeline alert mentions with missing profiles: ${missingHandles.join(', ')}`
       );
     }
 
-    return profileIds
-      .map((profileId) => ({
-        profileId,
-        handle: handlesByProfileId[profileId]
-      }))
-      .filter((mention): mention is MentionedProfile => !!mention.handle);
+    return configuredHandles
+      .map((handle) => mentionsByNormalizedHandle.get(handle.toLowerCase()))
+      .filter((mention): mention is MentionedProfile => !!mention);
+  }
+
+  private resolveWaveId(request: CiPipelineAlertRequest): string {
+    const targetEnvironment = normalizeTargetEnvironment(request.environment);
+    if (targetEnvironment === 'staging') {
+      return env.getStringOrThrow('CI_PIPELINES_STAGING_WAVE_ID');
+    }
+    if (targetEnvironment === 'prod') {
+      return env.getStringOrThrow('CI_PIPELINES_PROD_WAVE_ID');
+    }
+    throw new Error(
+      `Unsupported CI pipeline alert environment: ${request.environment ?? 'missing'}`
+    );
   }
 
   private buildCreateDropRequest({

--- a/src/api-serverless/src/drops/drop-creation-api-service.test.ts
+++ b/src/api-serverless/src/drops/drop-creation-api-service.test.ts
@@ -228,11 +228,19 @@ describe('DropCreationApiService.createDrop', () => {
       {
         createDropRequest: {} as never,
         authorId: 'author-profile',
-        representativeId: 'author-profile'
+        representativeId: 'author-profile',
+        hideLinkPreview: true
       },
       { timer: undefined } as never
     );
 
+    expect(createOrUpdateDrop.execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        hide_link_preview: true
+      }),
+      false,
+      expect.anything()
+    );
     expect(invalidateWaveUnreadCacheForWave).toHaveBeenCalledWith('wave-1');
     expect(order).toEqual([
       'transaction',

--- a/src/api-serverless/src/drops/drop-creation.api.service.ts
+++ b/src/api-serverless/src/drops/drop-creation.api.service.ts
@@ -81,11 +81,13 @@ export class DropCreationApiService {
     {
       createDropRequest,
       authorId,
-      representativeId
+      representativeId,
+      hideLinkPreview
     }: {
       createDropRequest: ApiCreateDropRequest;
       authorId: string;
       representativeId: string;
+      hideLinkPreview?: boolean;
     },
     ctx: RequestContext
   ): Promise<ApiDrop> {
@@ -96,26 +98,33 @@ export class DropCreationApiService {
       authorId,
       proxyId
     });
+    const createModel: typeof model =
+      hideLinkPreview === undefined
+        ? model
+        : {
+            ...model,
+            hide_link_preview: hideLinkPreview
+          };
     const preResolvedIdentityNomination =
-      await this.createOrUpdateDrop.preResolveIdentityNomination(model, {
+      await this.createOrUpdateDrop.preResolveIdentityNomination(createModel, {
         timer: ctx.timer
       });
     const { drop, pendingPushNotificationIds } =
       await this.dropsDb.executeNativeQueriesInTransaction(
         async (connection) => {
           return await this.createDropWithGivenConnection(
-            { model, authorId, preResolvedIdentityNomination },
+            { model: createModel, authorId, preResolvedIdentityNomination },
             normalizeCreateDropPollRequest(createDropRequest.poll),
             { timer: ctx.timer!, connection }
           );
         }
       );
     await waveScoreService.requestWaveScoreRefreshBestEffort(
-      [model.wave_id],
+      [createModel.wave_id],
       WaveScoreDirtyRefreshReason.DROP_CHANGED,
       ctx
     );
-    await invalidateWaveUnreadCacheForWave(model.wave_id);
+    await invalidateWaveUnreadCacheForWave(createModel.wave_id);
     await this.sendPendingPushNotifications({
       dropId: drop.id,
       pendingPushNotificationIds

--- a/src/drops/create-or-update-drop.model.ts
+++ b/src/drops/create-or-update-drop.model.ts
@@ -11,6 +11,7 @@ export interface CreateOrUpdateDropModel {
   readonly mentioned_users: DropMentionedUserModel[];
   readonly mentioned_waves: DropMentionedWaveModel[];
   readonly metadata: DropMetadataModel[];
+  readonly hide_link_preview?: boolean;
   readonly author_identity: string;
   readonly author_id?: string;
   readonly proxy_identity?: string;

--- a/src/drops/create-or-update-drop.use-case.ts
+++ b/src/drops/create-or-update-drop.use-case.ts
@@ -1536,6 +1536,7 @@ export class CreateOrUpdateDropUseCase {
           serial_no: serialNo,
           drop_type: model.drop_type,
           signature: model.signature,
+          hide_link_preview: model.hide_link_preview,
           is_additional_action_promised: model.is_additional_action_promised
         },
         connection

--- a/src/drops/drops.db.ts
+++ b/src/drops/drops.db.ts
@@ -311,6 +311,7 @@ export class DropsDb extends LazyDbAccessCompatibleService {
     const waveId = newDropEntity.wave_id;
     const replyToDropId = newDropEntity.reply_to_drop_id;
     const newDropSerialNo = newDropEntity.serial_no;
+    const hideLinkPreview = newDropEntity.hide_link_preview ?? false;
     const now = Time.currentMillis();
     await Promise.all([
       this.db.execute(
@@ -370,6 +371,7 @@ export class DropsDb extends LazyDbAccessCompatibleService {
                                      parts_count,
                                      signature,
                                      is_additional_action_promised,
+                                     hide_link_preview,
                                      reply_to_drop_id,
                                      reply_to_part_id${
                                        newDropSerialNo !== null
@@ -386,11 +388,12 @@ export class DropsDb extends LazyDbAccessCompatibleService {
                  :parts_count,
                  :signature,
                  :is_additional_action_promised,
+                 :hide_link_preview,
                  :reply_to_drop_id,
                  :reply_to_part_id
               ${newDropSerialNo !== null ? `, :serial_no` : ``})`,
 
-        { ...newDropEntity },
+        { ...newDropEntity, hide_link_preview: hideLinkPreview },
         { wrappedConnection: connection }
       )
     ]);


### PR DESCRIPTION
## Summary
- Adds a signed `/ci-pipeline-alerts` endpoint that posts CI notifications into prod-hosted staging/prod CI waves based on the payload environment.
- Uses handle-based failure mentions via `CI_PIPELINES_FAILURE_MENTION_PROFILE_HANDLES`; no `@all`.
- Wires backend deploy success/failure notifications through one CI alert receiver (`vars.CI_PIPELINES_ALERT_URL` + `secrets.CI_PIPELINES_ALERT_SECRET`).

## Notes
- Draft / DONT MERGE by request.
- CI was not awaited.
- No deploy performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CI pipeline alert notifications for deployment success and failure.
  * Alert messages now include deployment details and links, and can tag configured recipients on failures.
  * CI alerts are now available through the app’s webhook handling.

* **Bug Fixes**
  * Added request validation, signature checks, and duplicate-alert protection for CI notifications.
  * Improved reliability so alerts still acknowledge even if downstream delivery fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->