### PR TITLE
Trim minting claim metadata whitespace

### DIFF
--- a/pr-reports/1738.md
+++ b/pr-reports/1738.md
@@ -13,6 +13,7 @@ This PR prevents leading and trailing whitespace from persisting or propagating 
 - Minting claim PATCH trims editable metadata before persistence, converts empty trimmed `external_url` to `null`, and resets `metadata_location` when metadata changes.
 - Arweave metadata generation trims dirty claim row metadata before emitting JSON.
 - NFT indexing trims `metadata.name` before assigning `nfts.name` without broad description normalization.
+- Review follow-up hardens empty-after-trim behavior: API claim edits reject empty trimmed `name`, `description`, and attribute `trait_type`; dirty existing drop metadata with empty keys or values is skipped during claim attribute construction.
 
 ## Backend Impact
 - New services: None
@@ -36,4 +37,4 @@ None.
 Structured metadata now has leading and trailing whitespace removed server-side across drop submission, minting-claim conversion/editing, Arweave upload, and NFT name indexing. Existing dirty drops or claim rows are sanitized when they flow through conversion or upload.
 
 ## Risks / Follow-Ups
-The standard Jest path currently encounters an unrelated `json2csv` type diagnostic in `src/rates/ratings.service.ts` before some focused suites can run with normal ts-jest diagnostics. Focused runtime coverage was run for the changed behavior surfaces.
+The standard local Jest path currently encounters an unrelated `json2csv` type diagnostic in `src/rates/ratings.service.ts` before some focused suites can run with normal ts-jest diagnostics. Focused runtime coverage was run for the changed behavior surfaces.

--- a/pr-reports/1738.md
+++ b/pr-reports/1738.md
@@ -18,7 +18,7 @@ This PR prevents leading and trailing whitespace from persisting or propagating 
 ## Backend Impact
 - New services: None
 - Changed services: `api`, `claimsBuilder`, `claimsMediaArweaveUploader`, `nftsLoop`
-- Planned/deployed services: Staging deploys dispatched for `api`, `claimsBuilder`, `claimsMediaArweaveUploader`, and `nftsLoop`
+- Planned/deployed services: Staging deploys dispatched for `api`, `claimsBuilder`, `claimsMediaArweaveUploader`, and `nftsLoop`; a follow-up `nftsLoop` deploy was dispatched after expanding NFT metadata normalization.
 - API: Drop validation/persistence and minting-claim PATCH sanitization changed server-side
 - DB/entities/migrations: No schema, entity, or migration changes
 - Queues/events/integrations: Arweave upload payload generation changed for existing dirty claim rows
@@ -30,12 +30,13 @@ None.
 - Deployed API: `api`
 - Deployed Lambdas/services: `claimsBuilder`, `claimsMediaArweaveUploader`, `nftsLoop`
 - Not deployed: None
-- Deployment order executed: `api` -> `claimsBuilder` -> `claimsMediaArweaveUploader` -> `nftsLoop`
+- Deployment order executed: `api` -> `claimsBuilder` -> `claimsMediaArweaveUploader` -> `nftsLoop`; follow-up `nftsLoop`
 - GitHub Actions run links or run IDs:
   - `api`: https://github.com/6529-Collections/6529seize-backend/actions/runs/28997253426
   - `claimsBuilder`: https://github.com/6529-Collections/6529seize-backend/actions/runs/28997257270
   - `claimsMediaArweaveUploader`: https://github.com/6529-Collections/6529seize-backend/actions/runs/28997260998
-  - `nftsLoop`: https://github.com/6529-Collections/6529seize-backend/actions/runs/28997264775
+  - `nftsLoop` initial: https://github.com/6529-Collections/6529seize-backend/actions/runs/28997264775
+  - `nftsLoop` follow-up: https://github.com/6529-Collections/6529seize-backend/actions/runs/28998043362
 
 ## Release Notes
 Structured metadata now has leading and trailing whitespace removed server-side across drop submission, minting-claim conversion/editing, Arweave upload, and NFT metadata indexing. Existing dirty drops or claim rows are sanitized when they flow through conversion or upload.

--- a/pr-reports/1738.md
+++ b/pr-reports/1738.md
@@ -18,7 +18,7 @@ This PR prevents leading and trailing whitespace from persisting or propagating 
 ## Backend Impact
 - New services: None
 - Changed services: `api`, `claimsBuilder`, `claimsMediaArweaveUploader`, `nftsLoop`
-- Planned/deployed services: Staging deploys dispatched for `api`, `claimsBuilder`, `claimsMediaArweaveUploader`, and `nftsLoop`; a follow-up `nftsLoop` deploy was dispatched after expanding NFT metadata normalization.
+- Planned/deployed services: Staging deploys dispatched for `api`, `claimsBuilder`, `claimsMediaArweaveUploader`, and `nftsLoop`; `nftsLoop` was redeployed after expanding NFT metadata normalization; all affected services were redeployed after refreshing the PR branch from `main`.
 - API: Drop validation/persistence and minting-claim PATCH sanitization changed server-side
 - DB/entities/migrations: No schema, entity, or migration changes
 - Queues/events/integrations: Arweave upload payload generation changed for existing dirty claim rows
@@ -30,13 +30,17 @@ None.
 - Deployed API: `api`
 - Deployed Lambdas/services: `claimsBuilder`, `claimsMediaArweaveUploader`, `nftsLoop`
 - Not deployed: None
-- Deployment order executed: `api` -> `claimsBuilder` -> `claimsMediaArweaveUploader` -> `nftsLoop`; follow-up `nftsLoop`
+- Deployment order executed: `api` -> `claimsBuilder` -> `claimsMediaArweaveUploader` -> `nftsLoop`; follow-up `nftsLoop`; main-refresh redeploy `api` -> `claimsBuilder` -> `claimsMediaArweaveUploader` -> `nftsLoop`
 - GitHub Actions run links or run IDs:
   - `api`: https://github.com/6529-Collections/6529seize-backend/actions/runs/28997253426
   - `claimsBuilder`: https://github.com/6529-Collections/6529seize-backend/actions/runs/28997257270
   - `claimsMediaArweaveUploader`: https://github.com/6529-Collections/6529seize-backend/actions/runs/28997260998
   - `nftsLoop` initial: https://github.com/6529-Collections/6529seize-backend/actions/runs/28997264775
   - `nftsLoop` follow-up: https://github.com/6529-Collections/6529seize-backend/actions/runs/28998043362
+  - `api` main-refresh redeploy: https://github.com/6529-Collections/6529seize-backend/actions/runs/28999689784
+  - `claimsBuilder` main-refresh redeploy: https://github.com/6529-Collections/6529seize-backend/actions/runs/28999694643
+  - `claimsMediaArweaveUploader` main-refresh redeploy: https://github.com/6529-Collections/6529seize-backend/actions/runs/28999699112
+  - `nftsLoop` main-refresh redeploy: https://github.com/6529-Collections/6529seize-backend/actions/runs/28999703780
 
 ## Release Notes
 Structured metadata now has leading and trailing whitespace removed server-side across drop submission, minting-claim conversion/editing, Arweave upload, and NFT metadata indexing. Existing dirty drops or claim rows are sanitized when they flow through conversion or upload.

--- a/pr-reports/1738.md
+++ b/pr-reports/1738.md
@@ -1,0 +1,39 @@
+# PR Report: Trim Minting Claim Metadata Whitespace
+
+PR: https://github.com/6529-Collections/6529seize-backend/pull/1738
+Branch: codex/trim-minting-claim-metadata -> main
+Related PRs: None
+
+## Summary
+This PR prevents leading and trailing whitespace from persisting or propagating through The Memes structured drop metadata, drop-to-minting-claim conversion, claim PATCH edits, Arweave metadata upload, and NFT name indexing paths.
+
+## What Changed
+- Drop creation/update validation and persistence now normalize drop `title`, metadata `data_key`, and metadata `data_value`; freeform drop part content is left unchanged.
+- Minting-claim conversion trims existing dirty drop metadata before assigning claim name, description, trait types, and string attribute values.
+- Minting claim PATCH trims editable metadata before persistence, converts empty trimmed `external_url` to `null`, and resets `metadata_location` when metadata changes.
+- Arweave metadata generation trims dirty claim row metadata before emitting JSON.
+- NFT indexing trims `metadata.name` before assigning `nfts.name` without broad description normalization.
+
+## Backend Impact
+- New services: None
+- Changed services: `api`, `claimsBuilder`, `claimsMediaArweaveUploader`, `nftsLoop`
+- Planned/deployed services: Planned only; not deployed by request
+- API: Drop validation/persistence and minting-claim PATCH sanitization changed server-side
+- DB/entities/migrations: No schema, entity, or migration changes
+- Queues/events/integrations: Arweave upload payload generation changed for existing dirty claim rows
+
+## Config / Env
+None.
+
+## Backend Deployment
+- Deployed API: None
+- Deployed Lambdas/services: None
+- Not deployed: `api`, `claimsBuilder`, `claimsMediaArweaveUploader`, `nftsLoop`; deployment intentionally skipped by request
+- Deployment order executed: None
+- GitHub Actions run links or run IDs: None
+
+## Release Notes
+Structured metadata now has leading and trailing whitespace removed server-side across drop submission, minting-claim conversion/editing, Arweave upload, and NFT name indexing. Existing dirty drops or claim rows are sanitized when they flow through conversion or upload.
+
+## Risks / Follow-Ups
+The standard Jest path currently encounters an unrelated `json2csv` type diagnostic in `src/rates/ratings.service.ts` before some focused suites can run with normal ts-jest diagnostics. Focused runtime coverage was run for the changed behavior surfaces.

--- a/pr-reports/1738.md
+++ b/pr-reports/1738.md
@@ -46,4 +46,4 @@ None.
 Structured metadata now has leading and trailing whitespace removed server-side across drop submission, minting-claim conversion/editing, Arweave upload, and NFT metadata indexing. Existing dirty drops or claim rows are sanitized when they flow through conversion or upload.
 
 ## Risks / Follow-Ups
-The standard local Jest path currently encounters an unrelated `json2csv` type diagnostic in `src/rates/ratings.service.ts` before some focused suites can run with normal ts-jest diagnostics. Focused runtime coverage was run for the changed behavior surfaces.
+None. The backend PR workflow runs `npm run build`, and the root build script runs Jest before TypeScript compilation; the workflow passed on the prior reviewed head, so the added Jest suites are exercised in CI. The generated `MintingClaimUpdateRequest` model already types `external_url` as `string | null`, so the empty-string runtime allowance remains within the existing generated TypeScript contract and does not require a generated model diff.

--- a/pr-reports/1738.md
+++ b/pr-reports/1738.md
@@ -18,7 +18,7 @@ This PR prevents leading and trailing whitespace from persisting or propagating 
 ## Backend Impact
 - New services: None
 - Changed services: `api`, `claimsBuilder`, `claimsMediaArweaveUploader`, `nftsLoop`
-- Planned/deployed services: Staging deploys dispatched for `api`, `claimsBuilder`, `claimsMediaArweaveUploader`, and `nftsLoop`; `nftsLoop` was redeployed after expanding NFT metadata normalization; all affected services were redeployed after refreshing the PR branch from `main`.
+- Planned/deployed services: Staging deploys dispatched for `api`, `claimsBuilder`, `claimsMediaArweaveUploader`, and `nftsLoop`; `nftsLoop` was redeployed after expanding NFT metadata normalization; all affected services were redeployed after each PR branch refresh from `main`.
 - API: Drop validation/persistence and minting-claim PATCH sanitization changed server-side
 - DB/entities/migrations: No schema, entity, or migration changes
 - Queues/events/integrations: Arweave upload payload generation changed for existing dirty claim rows
@@ -30,7 +30,7 @@ None.
 - Deployed API: `api`
 - Deployed Lambdas/services: `claimsBuilder`, `claimsMediaArweaveUploader`, `nftsLoop`
 - Not deployed: None
-- Deployment order executed: `api` -> `claimsBuilder` -> `claimsMediaArweaveUploader` -> `nftsLoop`; follow-up `nftsLoop`; main-refresh redeploy `api` -> `claimsBuilder` -> `claimsMediaArweaveUploader` -> `nftsLoop`
+- Deployment order executed: `api` -> `claimsBuilder` -> `claimsMediaArweaveUploader` -> `nftsLoop`; follow-up `nftsLoop`; main-refresh redeploy `api` -> `claimsBuilder` -> `claimsMediaArweaveUploader` -> `nftsLoop`; latest-main redeploy `api` -> `claimsBuilder` -> `claimsMediaArweaveUploader` -> `nftsLoop`
 - GitHub Actions run links or run IDs:
   - `api`: https://github.com/6529-Collections/6529seize-backend/actions/runs/28997253426
   - `claimsBuilder`: https://github.com/6529-Collections/6529seize-backend/actions/runs/28997257270
@@ -41,6 +41,10 @@ None.
   - `claimsBuilder` main-refresh redeploy: https://github.com/6529-Collections/6529seize-backend/actions/runs/28999694643
   - `claimsMediaArweaveUploader` main-refresh redeploy: https://github.com/6529-Collections/6529seize-backend/actions/runs/28999699112
   - `nftsLoop` main-refresh redeploy: https://github.com/6529-Collections/6529seize-backend/actions/runs/28999703780
+  - `api` latest-main redeploy: https://github.com/6529-Collections/6529seize-backend/actions/runs/29012034121
+  - `claimsBuilder` latest-main redeploy: https://github.com/6529-Collections/6529seize-backend/actions/runs/29012041438
+  - `claimsMediaArweaveUploader` latest-main redeploy: https://github.com/6529-Collections/6529seize-backend/actions/runs/29012046802
+  - `nftsLoop` latest-main redeploy: https://github.com/6529-Collections/6529seize-backend/actions/runs/29012052482
 
 ## Release Notes
 Structured metadata now has leading and trailing whitespace removed server-side across drop submission, minting-claim conversion/editing, Arweave upload, and NFT metadata indexing. Existing dirty drops or claim rows are sanitized when they flow through conversion or upload.

--- a/pr-reports/1738.md
+++ b/pr-reports/1738.md
@@ -18,7 +18,7 @@ This PR prevents leading and trailing whitespace from persisting or propagating 
 ## Backend Impact
 - New services: None
 - Changed services: `api`, `claimsBuilder`, `claimsMediaArweaveUploader`, `nftsLoop`
-- Planned/deployed services: Planned only; not deployed by request
+- Planned/deployed services: Staging deploys dispatched for `api`, `claimsBuilder`, `claimsMediaArweaveUploader`, and `nftsLoop`
 - API: Drop validation/persistence and minting-claim PATCH sanitization changed server-side
 - DB/entities/migrations: No schema, entity, or migration changes
 - Queues/events/integrations: Arweave upload payload generation changed for existing dirty claim rows
@@ -27,11 +27,15 @@ This PR prevents leading and trailing whitespace from persisting or propagating 
 None.
 
 ## Backend Deployment
-- Deployed API: None
-- Deployed Lambdas/services: None
-- Not deployed: `api`, `claimsBuilder`, `claimsMediaArweaveUploader`, `nftsLoop`; deployment intentionally skipped by request
-- Deployment order executed: None
-- GitHub Actions run links or run IDs: None
+- Deployed API: `api`
+- Deployed Lambdas/services: `claimsBuilder`, `claimsMediaArweaveUploader`, `nftsLoop`
+- Not deployed: None
+- Deployment order executed: `api` -> `claimsBuilder` -> `claimsMediaArweaveUploader` -> `nftsLoop`
+- GitHub Actions run links or run IDs:
+  - `api`: https://github.com/6529-Collections/6529seize-backend/actions/runs/28997253426
+  - `claimsBuilder`: https://github.com/6529-Collections/6529seize-backend/actions/runs/28997257270
+  - `claimsMediaArweaveUploader`: https://github.com/6529-Collections/6529seize-backend/actions/runs/28997260998
+  - `nftsLoop`: https://github.com/6529-Collections/6529seize-backend/actions/runs/28997264775
 
 ## Release Notes
 Structured metadata now has leading and trailing whitespace removed server-side across drop submission, minting-claim conversion/editing, Arweave upload, and NFT name indexing. Existing dirty drops or claim rows are sanitized when they flow through conversion or upload.

--- a/pr-reports/1738.md
+++ b/pr-reports/1738.md
@@ -5,14 +5,14 @@ Branch: codex/trim-minting-claim-metadata -> main
 Related PRs: None
 
 ## Summary
-This PR prevents leading and trailing whitespace from persisting or propagating through The Memes structured drop metadata, drop-to-minting-claim conversion, claim PATCH edits, Arweave metadata upload, and NFT name indexing paths.
+This PR prevents leading and trailing whitespace from persisting or propagating through The Memes structured drop metadata, drop-to-minting-claim conversion, claim PATCH edits, Arweave metadata upload, and NFT metadata indexing paths.
 
 ## What Changed
 - Drop creation/update validation and persistence now normalize drop `title`, metadata `data_key`, and metadata `data_value`; freeform drop part content is left unchanged.
 - Minting-claim conversion trims existing dirty drop metadata before assigning claim name, description, trait types, and string attribute values.
 - Minting claim PATCH trims editable metadata before persistence, converts empty trimmed `external_url` to `null`, and resets `metadata_location` when metadata changes.
 - Arweave metadata generation trims dirty claim row metadata before emitting JSON.
-- NFT indexing trims `metadata.name` before assigning `nfts.name` without broad description normalization.
+- NFT indexing trims structured `metadata.name`, `metadata.description`, attribute `trait_type`, and string attribute values before persisting metadata-derived fields and metadata JSON; internal whitespace and newlines are preserved.
 - Review follow-up hardens empty-after-trim behavior: API claim edits reject empty trimmed `name`, `description`, and attribute `trait_type`; dirty existing drop metadata with empty keys or values is skipped during claim attribute construction.
 
 ## Backend Impact
@@ -38,7 +38,7 @@ None.
   - `nftsLoop`: https://github.com/6529-Collections/6529seize-backend/actions/runs/28997264775
 
 ## Release Notes
-Structured metadata now has leading and trailing whitespace removed server-side across drop submission, minting-claim conversion/editing, Arweave upload, and NFT name indexing. Existing dirty drops or claim rows are sanitized when they flow through conversion or upload.
+Structured metadata now has leading and trailing whitespace removed server-side across drop submission, minting-claim conversion/editing, Arweave upload, and NFT metadata indexing. Existing dirty drops or claim rows are sanitized when they flow through conversion or upload.
 
 ## Risks / Follow-Ups
 The standard local Jest path currently encounters an unrelated `json2csv` type diagnostic in `src/rates/ratings.service.ts` before some focused suites can run with normal ts-jest diagnostics. Focused runtime coverage was run for the changed behavior surfaces.

--- a/src/api-serverless/src/drops/drop-validator.test.ts
+++ b/src/api-serverless/src/drops/drop-validator.test.ts
@@ -38,6 +38,38 @@ describe('NewDropSchema', () => {
     expect(result.error).toBeUndefined();
   });
 
+  it('normalizes structured fields without trimming freeform part content', () => {
+    const result = NewDropSchema.validate({
+      ...createDropWithMetadata(' artist ', '  6529er  '),
+      title: '  The Loom  ',
+      parts: [
+        {
+          content: '  keep chat text as typed  ',
+          media: [],
+          attachments: []
+        }
+      ]
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.value.title).toBe('The Loom');
+    expect(result.value.parts[0].content).toBe('  keep chat text as typed  ');
+    expect(result.value.metadata[0]).toMatchObject({
+      data_key: 'artist',
+      data_value: '6529er'
+    });
+  });
+
+  it('rejects metadata fields that are empty after trimming', () => {
+    const result = NewDropSchema.validate(
+      createDropWithMetadata(' artist ', '   ')
+    );
+
+    expect(result.error?.message).toContain(
+      '"metadata[0].data_value" is not allowed to be empty'
+    );
+  });
+
   it('rejects metadata keys over 500 characters', () => {
     const result = NewDropSchema.validate(
       createDropWithMetadata('a'.repeat(501), 'value')

--- a/src/api-serverless/src/drops/drop-validator.test.ts
+++ b/src/api-serverless/src/drops/drop-validator.test.ts
@@ -58,6 +58,14 @@ describe('NewDropSchema', () => {
       data_key: 'artist',
       data_value: '6529er'
     });
+
+    const emptyTitleResult = NewDropSchema.validate({
+      ...createDropWithMetadata('artist', '6529er'),
+      title: '   '
+    });
+
+    expect(emptyTitleResult.error).toBeUndefined();
+    expect(emptyTitleResult.value.title).toBeNull();
   });
 
   it('rejects metadata fields that are empty after trimming', () => {

--- a/src/api-serverless/src/drops/drop.validator.ts
+++ b/src/api-serverless/src/drops/drop.validator.ts
@@ -120,8 +120,8 @@ function validateFuturePollClosingTime(
 }
 
 const MetadataSchema: Joi.ObjectSchema<DropMetadataEntity> = Joi.object({
-  data_key: Joi.string().min(1).max(500).required(),
-  data_value: Joi.string().min(1).required()
+  data_key: Joi.string().trim().min(1).max(500).required(),
+  data_value: Joi.string().trim().min(1).required()
 })
   .custom(validateDropMetadataValue)
   .messages({
@@ -178,7 +178,13 @@ const NewDropPollSchema: Joi.ObjectSchema<ApiCreateDropPollRequest> =
   });
 
 const baseDropFieldsValidators = {
-  title: Joi.string().optional().max(250).default(null).allow(null),
+  title: Joi.string()
+    .trim()
+    .optional()
+    .max(250)
+    .empty('')
+    .default(null)
+    .allow(null),
   parts: Joi.array().required().items(NewDropPartSchema).min(1),
   referenced_nfts: Joi.array()
     .optional()

--- a/src/api-serverless/src/minting-claims/api-minting-claims-service.test.ts
+++ b/src/api-serverless/src/minting-claims/api-minting-claims-service.test.ts
@@ -200,6 +200,37 @@ describe('buildUpdatesForClaimPatch', () => {
     expect(updates.name).toBe('updated-name');
     expect(updates.metadata_location).toBeNull();
   });
+
+  it('trims metadata fields and attributes before persistence', async () => {
+    const body: MintingClaimUpdateRequest = {
+      description: '  Loom  description  ',
+      name: ' The Loom ',
+      external_url: '   ',
+      attributes: [
+        {
+          trait_type: ' Artist ',
+          value: '  Digital  Artist  ',
+          display_type: 'text'
+        }
+      ]
+    };
+
+    const updates = await buildUpdatesForClaimPatch(body, baseClaim(), false);
+
+    expect(updates).toMatchObject({
+      description: 'Loom  description',
+      name: 'The Loom',
+      external_url: null,
+      attributes: [
+        {
+          trait_type: 'Artist',
+          value: 'Digital  Artist',
+          display_type: 'text'
+        }
+      ],
+      metadata_location: null
+    });
+  });
 });
 
 describe('patchMintingClaim', () => {

--- a/src/api-serverless/src/minting-claims/api-minting-claims-service.test.ts
+++ b/src/api-serverless/src/minting-claims/api-minting-claims-service.test.ts
@@ -11,6 +11,7 @@ import {
   computeImageDetails
 } from '@/minting-claims/media-inspector';
 import {
+  fetchMaxSeasonId,
   fetchMintingClaimByClaimId,
   updateMintingClaim
 } from '@/api/minting-claims/api.minting-claims.db';
@@ -85,9 +86,13 @@ describe('buildUpdatesForClaimPatch', () => {
     computeAnimationDetailsVideo as jest.MockedFunction<
       typeof computeAnimationDetailsVideo
     >;
+  const fetchMaxSeasonIdMock = fetchMaxSeasonId as jest.MockedFunction<
+    typeof fetchMaxSeasonId
+  >;
 
   beforeEach(() => {
     jest.clearAllMocks();
+    fetchMaxSeasonIdMock.mockResolvedValue(14);
   });
 
   it('clears image_location when image_url changes', async () => {
@@ -230,6 +235,54 @@ describe('buildUpdatesForClaimPatch', () => {
       ],
       metadata_location: null
     });
+  });
+
+  it('rejects name and description that are empty after trimming', async () => {
+    await expect(
+      buildUpdatesForClaimPatch({ name: '   ' }, baseClaim(), false)
+    ).rejects.toThrow('name is required');
+
+    await expect(
+      buildUpdatesForClaimPatch({ description: '   ' }, baseClaim(), false)
+    ).rejects.toThrow('description is required');
+  });
+
+  it('rejects attribute trait_type that is empty after trimming', async () => {
+    await expect(
+      buildUpdatesForClaimPatch(
+        {
+          attributes: [
+            {
+              trait_type: '   ',
+              value: 'value'
+            }
+          ]
+        },
+        baseClaim(),
+        false
+      )
+    ).rejects.toThrow('attribute trait_type is required');
+  });
+
+  it('normalizes camelCase traitType when extracting MEMES season attributes', async () => {
+    const body = {
+      attributes: [
+        {
+          traitType: ' Type - Season ',
+          value: ' 15 '
+        }
+      ]
+    } as unknown as MintingClaimUpdateRequest;
+
+    const updates = await buildUpdatesForClaimPatch(body, baseClaim(), true);
+
+    expect(updates.attributes).toEqual([
+      {
+        trait_type: 'Type - Season',
+        value: 15,
+        display_type: 'number'
+      }
+    ]);
   });
 });
 

--- a/src/api-serverless/src/minting-claims/api.minting-claims.routes.ts
+++ b/src/api-serverless/src/minting-claims/api.minting-claims.routes.ts
@@ -164,7 +164,7 @@ const ClaimsListQuerySchema = Joi.object({
 });
 
 const MintingClaimAttributeSchema = Joi.object({
-  trait_type: Joi.string().required(),
+  trait_type: Joi.string().trim().min(1).required(),
   value: Joi.alternatives()
     .try(Joi.string().allow(''), Joi.number())
     .required(),

--- a/src/api-serverless/src/minting-claims/api.minting-claims.routes.ts
+++ b/src/api-serverless/src/minting-claims/api.minting-claims.routes.ts
@@ -195,7 +195,7 @@ const StrictMintingClaimUpdateRequestSchema = Joi.object({
   description: Joi.string().optional(),
   name: Joi.string().optional(),
   image_url: Joi.string().allow(null).optional(),
-  external_url: Joi.string().allow(null).optional(),
+  external_url: Joi.string().allow(null, '').optional(),
   attributes: Joi.array().items(MintingClaimAttributeSchema).optional(),
   animation_url: Joi.string().allow(null).optional()
 });

--- a/src/api-serverless/src/minting-claims/api.minting-claims.service.ts
+++ b/src/api-serverless/src/minting-claims/api.minting-claims.service.ts
@@ -60,8 +60,26 @@ function normalizeOptionalUrl(value: string | null | undefined): string | null {
   return trimmed === '' ? null : trimmed;
 }
 
-function trimStringField(value: string): string {
-  return value.trim();
+function trimRequiredStringField(value: string, fieldName: string): string {
+  const trimmed = value.trim();
+  if (trimmed === '') {
+    throw new BadRequestException(`${fieldName} is required`);
+  }
+  return trimmed;
+}
+
+function trimAttributeTraitType(
+  sanitized: Record<string, unknown>,
+  fieldName: 'trait_type' | 'traitType'
+): void {
+  if (typeof sanitized[fieldName] !== 'string') {
+    return;
+  }
+  const trimmed = sanitized[fieldName].trim();
+  if (trimmed === '') {
+    throw new BadRequestException('attribute trait_type is required');
+  }
+  sanitized[fieldName] = trimmed;
 }
 
 function sanitizeMintingClaimAttribute(attribute: unknown): unknown {
@@ -73,12 +91,8 @@ function sanitizeMintingClaimAttribute(attribute: unknown): unknown {
   }
 
   const sanitized = { ...(attribute as Record<string, unknown>) };
-  if (typeof sanitized.trait_type === 'string') {
-    sanitized.trait_type = sanitized.trait_type.trim();
-  }
-  if (typeof sanitized.traitType === 'string') {
-    sanitized.traitType = sanitized.traitType.trim();
-  }
+  trimAttributeTraitType(sanitized, 'trait_type');
+  trimAttributeTraitType(sanitized, 'traitType');
   if (typeof sanitized.value === 'string') {
     sanitized.value = sanitized.value.trim();
   }
@@ -90,6 +104,14 @@ function sanitizeMintingClaimAttributes(attributes: unknown): unknown {
     return attributes;
   }
   return attributes.map(sanitizeMintingClaimAttribute);
+}
+
+function getMintingClaimAttributeTraitType(attribute: unknown): unknown {
+  if (typeof attribute !== 'object' || attribute == null) {
+    return null;
+  }
+  const record = attribute as { trait_type?: unknown; traitType?: unknown };
+  return record.trait_type ?? record.traitType ?? null;
 }
 
 function validateRequestedSeason(
@@ -117,10 +139,7 @@ function extractSeasonFromAttributes(attributes: unknown): number | null {
   }
 
   const seasonAttribute = attributes.find((attribute) => {
-    if (typeof attribute !== 'object' || attribute == null) {
-      return false;
-    }
-    const traitType = (attribute as { trait_type?: unknown }).trait_type;
+    const traitType = getMintingClaimAttributeTraitType(attribute);
     return traitType === TYPE_SEASON_TRAIT;
   }) as { value?: unknown } | undefined;
 
@@ -152,10 +171,7 @@ function normalizeAttributesWithSeason(
   }
 
   const filtered = attributes.filter((attribute) => {
-    if (typeof attribute !== 'object' || attribute == null) {
-      return true;
-    }
-    const traitType = (attribute as { trait_type?: unknown }).trait_type;
+    const traitType = getMintingClaimAttributeTraitType(attribute);
     return traitType !== TYPE_SEASON_TRAIT;
   });
 
@@ -292,12 +308,15 @@ export async function buildUpdatesForClaimPatch(
   let animationUrlChanged = false;
 
   if (body.description !== undefined) {
-    updates.description = trimStringField(body.description);
+    updates.description = trimRequiredStringField(
+      body.description,
+      'description'
+    );
     shouldResetMetadataLocation = true;
   }
 
   if (body.name !== undefined) {
-    updates.name = trimStringField(body.name);
+    updates.name = trimRequiredStringField(body.name, 'name');
     shouldResetMetadataLocation = true;
   }
 

--- a/src/api-serverless/src/minting-claims/api.minting-claims.service.ts
+++ b/src/api-serverless/src/minting-claims/api.minting-claims.service.ts
@@ -60,6 +60,38 @@ function normalizeOptionalUrl(value: string | null | undefined): string | null {
   return trimmed === '' ? null : trimmed;
 }
 
+function trimStringField(value: string): string {
+  return value.trim();
+}
+
+function sanitizeMintingClaimAttribute(attribute: unknown): unknown {
+  if (attribute == null || typeof attribute !== 'object') {
+    return attribute;
+  }
+  if (Array.isArray(attribute)) {
+    return attribute;
+  }
+
+  const sanitized = { ...(attribute as Record<string, unknown>) };
+  if (typeof sanitized.trait_type === 'string') {
+    sanitized.trait_type = sanitized.trait_type.trim();
+  }
+  if (typeof sanitized.traitType === 'string') {
+    sanitized.traitType = sanitized.traitType.trim();
+  }
+  if (typeof sanitized.value === 'string') {
+    sanitized.value = sanitized.value.trim();
+  }
+  return sanitized;
+}
+
+function sanitizeMintingClaimAttributes(attributes: unknown): unknown {
+  if (!Array.isArray(attributes)) {
+    return attributes;
+  }
+  return attributes.map(sanitizeMintingClaimAttribute);
+}
+
 function validateRequestedSeason(
   requestedSeason: number,
   maxSeason: number
@@ -220,11 +252,12 @@ async function applyAttributesFromBody(
   }
 
   if (!isMemesContract) {
-    updates.attributes = body.attributes;
+    updates.attributes = sanitizeMintingClaimAttributes(body.attributes);
     return true;
   }
 
-  const requestedSeason = extractSeasonFromAttributes(body.attributes);
+  const sanitizedAttributes = sanitizeMintingClaimAttributes(body.attributes);
+  const requestedSeason = extractSeasonFromAttributes(sanitizedAttributes);
   if (requestedSeason == null) {
     throw new BadRequestException(
       `attributes must include a numeric "${TYPE_SEASON_TRAIT}" trait for MEMES contract`
@@ -237,7 +270,7 @@ async function applyAttributesFromBody(
   );
 
   updates.attributes = normalizeAttributesWithSeason(
-    body.attributes,
+    sanitizedAttributes,
     validatedSeason
   );
 
@@ -259,12 +292,12 @@ export async function buildUpdatesForClaimPatch(
   let animationUrlChanged = false;
 
   if (body.description !== undefined) {
-    updates.description = body.description;
+    updates.description = trimStringField(body.description);
     shouldResetMetadataLocation = true;
   }
 
   if (body.name !== undefined) {
-    updates.name = body.name;
+    updates.name = trimStringField(body.name);
     shouldResetMetadataLocation = true;
   }
 
@@ -279,7 +312,7 @@ export async function buildUpdatesForClaimPatch(
   }
 
   if (body.external_url !== undefined) {
-    updates.external_url = body.external_url;
+    updates.external_url = normalizeOptionalUrl(body.external_url);
     shouldResetMetadataLocation = true;
   }
 

--- a/src/drops/create-or-update-drop-use-case.test.ts
+++ b/src/drops/create-or-update-drop-use-case.test.ts
@@ -19,6 +19,7 @@ import { CLOUDFRONT_LINK } from '@/constants';
 import {
   CreateOrUpdateDropUseCase,
   normalizeDropGroupMentions,
+  sanitizeDropStructuredFields,
   validateDropMediaAttachment
 } from './create-or-update-drop.use-case';
 
@@ -162,6 +163,41 @@ describe('CreateOrUpdateDropUseCase', () => {
       ...overrides
     };
   }
+
+  it('sanitizes structured drop fields without touching part content', () => {
+    const model = {
+      ...createChatDropModel(),
+      title: '  The Loom  ',
+      parts: [
+        {
+          content: '  keep chat text as typed  ',
+          quoted_drop: null,
+          media: []
+        }
+      ],
+      metadata: [
+        {
+          data_key: ' artist ',
+          data_value: '  6529er  '
+        }
+      ]
+    };
+
+    expect(sanitizeDropStructuredFields(model)).toMatchObject({
+      title: 'The Loom',
+      parts: [
+        {
+          content: '  keep chat text as typed  '
+        }
+      ],
+      metadata: [
+        {
+          data_key: 'artist',
+          data_value: '6529er'
+        }
+      ]
+    });
+  });
 
   async function verifyIdentitySubmissionDuplicates(
     useCase: CreateOrUpdateDropUseCase

--- a/src/drops/create-or-update-drop-use-case.test.ts
+++ b/src/drops/create-or-update-drop-use-case.test.ts
@@ -179,11 +179,17 @@ describe('CreateOrUpdateDropUseCase', () => {
         {
           data_key: ' artist ',
           data_value: '  6529er  '
+        },
+        {
+          data_key: ' empty ',
+          data_value: '   '
         }
       ]
     };
 
-    expect(sanitizeDropStructuredFields(model)).toMatchObject({
+    const sanitized = sanitizeDropStructuredFields(model);
+
+    expect(sanitized).toMatchObject({
       title: 'The Loom',
       parts: [
         {
@@ -197,6 +203,30 @@ describe('CreateOrUpdateDropUseCase', () => {
         }
       ]
     });
+    expect(sanitized.metadata).toHaveLength(1);
+    expect(model.metadata[0]).toMatchObject({
+      data_key: ' artist ',
+      data_value: '  6529er  '
+    });
+  });
+
+  it('keeps identity nomination pre-resolution best-effort for empty metadata after trimming', async () => {
+    const useCase = createUseCase({ existingNominations: [] });
+
+    await expect(
+      useCase.preResolveIdentityNomination(
+        {
+          ...createIdentitySubmissionModel('   '),
+          metadata: [
+            {
+              data_key: ' identity ',
+              data_value: '   '
+            }
+          ]
+        },
+        {}
+      )
+    ).resolves.toBeNull();
   });
 
   async function verifyIdentitySubmissionDuplicates(

--- a/src/drops/create-or-update-drop.use-case.ts
+++ b/src/drops/create-or-update-drop.use-case.ts
@@ -189,6 +189,29 @@ type ResolvedMentionedUsers = Readonly<{
   mentionedUserIds: string[];
 }>;
 
+function sanitizeDropMetadataField(value: string, fieldName: string): string {
+  const trimmed = value.trim();
+  if (trimmed === '') {
+    throw new BadRequestException(`Drop metadata ${fieldName} is required`);
+  }
+  return trimmed;
+}
+
+export function sanitizeDropStructuredFields(
+  model: CreateOrUpdateDropModel
+): CreateOrUpdateDropModel {
+  const title = model.title?.trim() ?? null;
+  return {
+    ...model,
+    title: title === '' ? null : title,
+    metadata: model.metadata.map((metadata) => ({
+      ...metadata,
+      data_key: sanitizeDropMetadataField(metadata.data_key, 'data_key'),
+      data_value: sanitizeDropMetadataField(metadata.data_value, 'data_value')
+    }))
+  };
+}
+
 export class CreateOrUpdateDropUseCase {
   public constructor(
     private readonly dropsDb: DropsDb,
@@ -256,11 +279,13 @@ export class CreateOrUpdateDropUseCase {
       bypassChatSlowModeRestrictions?: boolean;
     }
   ): Promise<{ drop_id: string; pending_push_notification_ids: number[] }> {
+    const sanitizedModel = sanitizeDropStructuredFields(model);
     timer?.start(`${CreateOrUpdateDropUseCase.name}->execute`);
-    const authorId = model.author_id;
-    const proxyIdNecessary = !!model.proxy_identity && !model.proxy_id;
+    const authorId = sanitizedModel.author_id;
+    const proxyIdNecessary =
+      !!sanitizedModel.proxy_identity && !sanitizedModel.proxy_id;
     if (!authorId) {
-      const authorIdentity = model.author_identity;
+      const authorIdentity = sanitizedModel.author_identity;
       const resolvedAuthorId =
         await identityFetcher.getProfileIdByIdentityKeyOrThrow(
           {
@@ -269,7 +294,7 @@ export class CreateOrUpdateDropUseCase {
           {}
         );
       return this.execute(
-        { ...model, author_id: resolvedAuthorId },
+        { ...sanitizedModel, author_id: resolvedAuthorId },
         isDescriptionDrop,
         {
           timer,
@@ -280,7 +305,7 @@ export class CreateOrUpdateDropUseCase {
         }
       );
     } else if (proxyIdNecessary) {
-      const proxyIdentity = model.proxy_identity;
+      const proxyIdentity = sanitizedModel.proxy_identity;
       const resolvedProxyId =
         await identityFetcher.getProfileIdByIdentityKeyOrThrow(
           {
@@ -296,11 +321,11 @@ export class CreateOrUpdateDropUseCase {
         });
       if (!hasRequiredProxyAction) {
         throw new BadRequestException(
-          `Identity ${model.author_identity} hasn't allowed identity ${model.proxy_identity} to create drops on it's behalf`
+          `Identity ${sanitizedModel.author_identity} hasn't allowed identity ${sanitizedModel.proxy_identity} to create drops on it's behalf`
         );
       }
       return this.execute(
-        { ...model, proxy_id: resolvedProxyId },
+        { ...sanitizedModel, proxy_id: resolvedProxyId },
         isDescriptionDrop,
         {
           timer,
@@ -311,7 +336,7 @@ export class CreateOrUpdateDropUseCase {
         }
       );
     }
-    return await this.createOrUpdateDrop(model, isDescriptionDrop, {
+    return await this.createOrUpdateDrop(sanitizedModel, isDescriptionDrop, {
       timer,
       connection,
       preResolvedIdentityNomination,
@@ -324,15 +349,16 @@ export class CreateOrUpdateDropUseCase {
     model: CreateOrUpdateDropModel,
     { timer }: { timer?: Timer }
   ): Promise<PreResolvedEnsIdentityNomination | null> {
+    const sanitizedModel = sanitizeDropStructuredFields(model);
     timer?.start(
       `${CreateOrUpdateDropUseCase.name}->preResolveIdentityNomination`
     );
     try {
-      if (model.drop_type !== DropType.PARTICIPATORY) {
+      if (sanitizedModel.drop_type !== DropType.PARTICIPATORY) {
         return null;
       }
 
-      const identityMetadatas = model.metadata.filter(
+      const identityMetadatas = sanitizedModel.metadata.filter(
         (it) => it.data_key === 'identity'
       );
       if (identityMetadatas.length !== 1) {

--- a/src/drops/create-or-update-drop.use-case.ts
+++ b/src/drops/create-or-update-drop.use-case.ts
@@ -189,14 +189,6 @@ type ResolvedMentionedUsers = Readonly<{
   mentionedUserIds: string[];
 }>;
 
-function sanitizeDropMetadataField(value: string, fieldName: string): string {
-  const trimmed = value.trim();
-  if (trimmed === '') {
-    throw new BadRequestException(`Drop metadata ${fieldName} is required`);
-  }
-  return trimmed;
-}
-
 export function sanitizeDropStructuredFields(
   model: CreateOrUpdateDropModel
 ): CreateOrUpdateDropModel {
@@ -204,11 +196,15 @@ export function sanitizeDropStructuredFields(
   return {
     ...model,
     title: title === '' ? null : title,
-    metadata: model.metadata.map((metadata) => ({
-      ...metadata,
-      data_key: sanitizeDropMetadataField(metadata.data_key, 'data_key'),
-      data_value: sanitizeDropMetadataField(metadata.data_value, 'data_value')
-    }))
+    metadata: model.metadata
+      .map((metadata) => ({
+        ...metadata,
+        data_key: metadata.data_key.trim(),
+        data_value: metadata.data_value.trim()
+      }))
+      .filter(
+        (metadata) => metadata.data_key !== '' && metadata.data_value !== ''
+      )
   };
 }
 
@@ -279,13 +275,11 @@ export class CreateOrUpdateDropUseCase {
       bypassChatSlowModeRestrictions?: boolean;
     }
   ): Promise<{ drop_id: string; pending_push_notification_ids: number[] }> {
-    const sanitizedModel = sanitizeDropStructuredFields(model);
+    let resolvedModel = sanitizeDropStructuredFields(model);
     timer?.start(`${CreateOrUpdateDropUseCase.name}->execute`);
-    const authorId = sanitizedModel.author_id;
-    const proxyIdNecessary =
-      !!sanitizedModel.proxy_identity && !sanitizedModel.proxy_id;
+    let authorId = resolvedModel.author_id;
     if (!authorId) {
-      const authorIdentity = sanitizedModel.author_identity;
+      const authorIdentity = resolvedModel.author_identity;
       const resolvedAuthorId =
         await identityFetcher.getProfileIdByIdentityKeyOrThrow(
           {
@@ -293,19 +287,11 @@ export class CreateOrUpdateDropUseCase {
           },
           {}
         );
-      return this.execute(
-        { ...sanitizedModel, author_id: resolvedAuthorId },
-        isDescriptionDrop,
-        {
-          timer,
-          connection,
-          preResolvedIdentityNomination,
-          bypassChatLinkRestrictions,
-          bypassChatSlowModeRestrictions
-        }
-      );
-    } else if (proxyIdNecessary) {
-      const proxyIdentity = sanitizedModel.proxy_identity;
+      resolvedModel = { ...resolvedModel, author_id: resolvedAuthorId };
+      authorId = resolvedAuthorId;
+    }
+    if (!!resolvedModel.proxy_identity && !resolvedModel.proxy_id) {
+      const proxyIdentity = resolvedModel.proxy_identity;
       const resolvedProxyId =
         await identityFetcher.getProfileIdByIdentityKeyOrThrow(
           {
@@ -321,22 +307,12 @@ export class CreateOrUpdateDropUseCase {
         });
       if (!hasRequiredProxyAction) {
         throw new BadRequestException(
-          `Identity ${sanitizedModel.author_identity} hasn't allowed identity ${sanitizedModel.proxy_identity} to create drops on it's behalf`
+          `Identity ${resolvedModel.author_identity} hasn't allowed identity ${resolvedModel.proxy_identity} to create drops on it's behalf`
         );
       }
-      return this.execute(
-        { ...sanitizedModel, proxy_id: resolvedProxyId },
-        isDescriptionDrop,
-        {
-          timer,
-          connection,
-          preResolvedIdentityNomination,
-          bypassChatLinkRestrictions,
-          bypassChatSlowModeRestrictions
-        }
-      );
+      resolvedModel = { ...resolvedModel, proxy_id: resolvedProxyId };
     }
-    return await this.createOrUpdateDrop(sanitizedModel, isDescriptionDrop, {
+    return await this.createOrUpdateDrop(resolvedModel, isDescriptionDrop, {
       timer,
       connection,
       preResolvedIdentityNomination,

--- a/src/minting-claims/claims-media-arweave-upload.test.ts
+++ b/src/minting-claims/claims-media-arweave-upload.test.ts
@@ -398,6 +398,48 @@ describe('uploadMintingClaimToArweave', () => {
     );
   });
 
+  it('trims dirty claim metadata before uploading JSON', async () => {
+    const dirtyAttributes = buildMemesRawAttributes().map((attribute) => ({
+      ...attribute,
+      trait_type: ` ${attribute.trait_type} `,
+      value:
+        typeof attribute.value === 'string'
+          ? ` ${attribute.value} `
+          : attribute.value
+    }));
+
+    await uploadMintingClaimToArweave(
+      MEMES_CONTRACT,
+      baseClaim({
+        name: ' The Loom ',
+        description: '  Loom  description  ',
+        external_url: ' https://6529.io/the-memes/519 ',
+        claim_id: 519,
+        attributes: JSON.stringify(dirtyAttributes)
+      })
+    );
+
+    expect(uploadFileMock).toHaveBeenCalledTimes(2);
+    const metadataUploadBuffer = uploadFileMock.mock.calls[1]?.[0] as Buffer;
+    const uploadedMetadata = JSON.parse(metadataUploadBuffer.toString('utf8'));
+
+    expect(uploadedMetadata.name).toBe('The Loom');
+    expect(uploadedMetadata.description).toBe('Loom  description');
+    expect(uploadedMetadata.external_url).toBe('https://6529.io/the-memes/519');
+    expect(uploadedMetadata.attributes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          trait_type: 'Artist',
+          value: 'awhurst'
+        }),
+        expect.objectContaining({
+          trait_type: 'Gear',
+          value: 'gold chain'
+        })
+      ])
+    );
+  });
+
   it('does not re-emit stored media resolver URLs on image reuse', async () => {
     uploadFileMock.mockReset();
     uploadFileMock.mockResolvedValueOnce({

--- a/src/minting-claims/claims-media-arweave-upload.ts
+++ b/src/minting-claims/claims-media-arweave-upload.ts
@@ -399,8 +399,10 @@ function resolveAnimationContentTypeForUpload({
 function normalizeAttributesForArweave(attributes: unknown): unknown[] {
   if (!Array.isArray(attributes)) return [];
   return attributes.map((a: any) => {
-    const traitType = a.trait_type ?? a.traitType;
-    const value = a.value;
+    const rawTraitType = a.trait_type ?? a.traitType;
+    const traitType =
+      typeof rawTraitType === 'string' ? rawTraitType.trim() : rawTraitType;
+    const value = typeof a.value === 'string' ? a.value.trim() : a.value;
     const existingDisplayType = a.display_type ?? a.displayType ?? undefined;
     const existingMaxValue = a.max_value ?? a.maxValue ?? undefined;
 
@@ -412,7 +414,10 @@ function normalizeAttributesForArweave(attributes: unknown): unknown[] {
     ) {
       displayType = existingDisplayType ?? 'boost_percentage';
       maxValue = existingMaxValue ?? 100;
-    } else if (ARWEAVE_TYPE_NUMBER_TRAITS.has(traitType)) {
+    } else if (
+      typeof traitType === 'string' &&
+      ARWEAVE_TYPE_NUMBER_TRAITS.has(traitType)
+    ) {
       displayType = existingDisplayType ?? 'number';
     } else if (traitType === 'Artist') {
       displayType = existingDisplayType ?? 'text';
@@ -426,7 +431,8 @@ function normalizeAttributesForArweave(attributes: unknown): unknown[] {
     }
     if (
       displayType === 'boost_percentage' ||
-      ARWEAVE_TYPE_NUMBER_TRAITS.has(traitType)
+      (typeof traitType === 'string' &&
+        ARWEAVE_TYPE_NUMBER_TRAITS.has(traitType))
     ) {
       const out: Record<string, unknown> = {
         display_type: displayType,
@@ -484,7 +490,7 @@ function getMemeNameFromAttributes(attributes: unknown): string {
   if (!Array.isArray(attributes))
     throw new BadRequestException('Claim has no attributes');
   const memeNameAttr = attributes.find(
-    (a: any) => (a.trait_type ?? a.traitType) === MEME_NAME_TRAIT
+    (a: any) => getTrimmedTraitType(a) === MEME_NAME_TRAIT
   );
   const value = memeNameAttr?.value;
   if (value == null || typeof value !== 'string' || value.trim() === '') {
@@ -501,8 +507,7 @@ function extractSeasonFromAttributes(attributes: unknown): number | null {
   }
 
   const seasonAttribute = attributes.find(
-    (attribute: any) =>
-      (attribute?.trait_type ?? attribute?.traitType) === TYPE_SEASON_TRAIT
+    (attribute: any) => getTrimmedTraitType(attribute) === TYPE_SEASON_TRAIT
   ) as { value?: unknown } | undefined;
 
   if (!seasonAttribute) {
@@ -530,7 +535,7 @@ function attributesWithTypeTraits(
   claimId: number
 ): unknown[] {
   const filtered = rawAttributes.filter((a: any) => {
-    const tt = a.trait_type ?? a.traitType;
+    const tt = getTrimmedTraitType(a);
     return (
       tt !== TYPE_MEME_TRAIT &&
       tt !== TYPE_SEASON_TRAIT &&
@@ -562,11 +567,12 @@ function attributesWithTypeTraits(
 }
 
 function filterMemesAttributesToKnownTraits(attributes: unknown[]): unknown[] {
-  return attributes.filter((attribute: any) =>
-    MEMES_REQUIRED_FINAL_ATTRIBUTE_TRAITS.has(
-      attribute?.trait_type ?? attribute?.traitType
-    )
-  );
+  return attributes.filter((attribute: any) => {
+    const traitType = getTrimmedTraitType(attribute);
+    return (
+      traitType !== null && MEMES_REQUIRED_FINAL_ATTRIBUTE_TRAITS.has(traitType)
+    );
+  });
 }
 
 async function uploadClaimMetadataToArweave(
@@ -628,8 +634,8 @@ function buildArweaveMetadataPayload(
 
   const metadata: Record<string, unknown> = {
     created_by: ARWEAVE_METADATA_CREATED_BY,
-    description: claim.description ?? '',
-    name: claim.name,
+    description: claim.description?.trim() ?? '',
+    name: claim.name.trim(),
     attributes
   };
   const externalUrl = claim.external_url?.trim();
@@ -676,7 +682,7 @@ function validateAttributes(raw: unknown, requireMemeName: boolean): string[] {
   if (hasInvalidItems) issues.push('Attributes (invalid items)');
   if (requireMemeName) {
     const hasMemeName = raw.some(
-      (a: any) => (a.trait_type ?? a.traitType) === MEME_NAME_TRAIT
+      (a: any) => getTrimmedTraitType(a) === MEME_NAME_TRAIT
     );
     if (!hasMemeName) issues.push('Meme Name Attribute');
   }
@@ -684,11 +690,16 @@ function validateAttributes(raw: unknown, requireMemeName: boolean): string[] {
 }
 
 function getTraitType(attribute: any): string | null {
-  const traitType = attribute?.trait_type ?? attribute?.traitType;
-  if (typeof traitType !== 'string' || traitType.trim() === '') {
+  const traitType = getTrimmedTraitType(attribute);
+  if (traitType === null || traitType === '') {
     return null;
   }
   return traitType;
+}
+
+function getTrimmedTraitType(attribute: any): string | null {
+  const traitType = attribute?.trait_type ?? attribute?.traitType;
+  return typeof traitType === 'string' ? traitType.trim() : null;
 }
 
 function appendMemesFinalAttributeSchemaIssues(

--- a/src/minting-claims/minting-claim-from-drop-builder.test.ts
+++ b/src/minting-claims/minting-claim-from-drop-builder.test.ts
@@ -61,4 +61,49 @@ describe('buildMintingClaimRowFromDrop', () => {
       ])
     );
   });
+
+  it('trims dirty drop metadata while preserving internal whitespace', () => {
+    const metadatas: DropMetadataEntity[] = [
+      {
+        data_key: ' title ',
+        data_value: ' The Loom '
+      },
+      {
+        data_key: ' description ',
+        data_value: '  Loom  description  '
+      },
+      {
+        data_key: ' artist ',
+        data_value: '  Digital  Artist  '
+      },
+      {
+        data_key: ' custom trait ',
+        data_value: '  inner  spacing  '
+      }
+    ] as DropMetadataEntity[];
+
+    const row = buildMintingClaimRowFromDrop(
+      'drop-1',
+      MEMES_CONTRACT,
+      519,
+      [],
+      metadatas,
+      15
+    );
+
+    expect(row.name).toBe('The Loom');
+    expect(row.description).toBe('Loom  description');
+    expect(row.attributes).toEqual(
+      expect.arrayContaining([
+        {
+          trait_type: 'Artist',
+          value: 'Digital  Artist'
+        },
+        {
+          trait_type: 'Custom trait',
+          value: 'inner  spacing'
+        }
+      ])
+    );
+  });
 });

--- a/src/minting-claims/minting-claim-from-drop-builder.test.ts
+++ b/src/minting-claims/minting-claim-from-drop-builder.test.ts
@@ -79,6 +79,10 @@ describe('buildMintingClaimRowFromDrop', () => {
       {
         data_key: ' custom trait ',
         data_value: '  inner  spacing  '
+      },
+      {
+        data_key: ' empty ',
+        data_value: '   '
       }
     ] as DropMetadataEntity[];
 
@@ -103,6 +107,13 @@ describe('buildMintingClaimRowFromDrop', () => {
           trait_type: 'Custom trait',
           value: 'inner  spacing'
         }
+      ])
+    );
+    expect(row.attributes).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          trait_type: 'Empty'
+        })
       ])
     );
   });

--- a/src/minting-claims/minting-claim-from-drop.builder.ts
+++ b/src/minting-claims/minting-claim-from-drop.builder.ts
@@ -110,6 +110,16 @@ function attrValue(dataKey: string, dataValue: string): string | number {
   return dataValue;
 }
 
+function trimDropMetadata(
+  metadatas: DropMetadataEntity[]
+): DropMetadataEntity[] {
+  return metadatas.map((metadata) => ({
+    ...metadata,
+    data_key: metadata.data_key.trim(),
+    data_value: metadata.data_value.trim()
+  }));
+}
+
 function buildAttributes(
   metadatas: DropMetadataEntity[]
 ): MintingClaimAttribute[] {
@@ -209,11 +219,17 @@ export function buildMintingClaimRowFromDrop(
       `Invalid seasonId: ${seasonId}. Expected a positive integer`
     );
   }
-  const attributes = upsertSeasonTrait(buildAttributes(metadatas), seasonId);
-  const title = metadatas.find((m) => m.data_key === 'title')?.data_value ?? '';
+  const sanitizedMetadatas = trimDropMetadata(metadatas);
+  const attributes = upsertSeasonTrait(
+    buildAttributes(sanitizedMetadatas),
+    seasonId
+  );
+  const title =
+    sanitizedMetadatas.find((m) => m.data_key === 'title')?.data_value ?? '';
   const description =
-    metadatas.find((m) => m.data_key === 'description')?.data_value ?? '';
-  const additionalMedia = parseAdditionalMedia(metadatas);
+    sanitizedMetadatas.find((m) => m.data_key === 'description')?.data_value ??
+    '';
+  const additionalMedia = parseAdditionalMedia(sanitizedMetadatas);
   const previewImageUrl = additionalMedia?.preview_image ?? null;
 
   const htmlMedia = medias.find(

--- a/src/minting-claims/minting-claim-from-drop.builder.ts
+++ b/src/minting-claims/minting-claim-from-drop.builder.ts
@@ -126,6 +126,7 @@ function buildAttributes(
   const attrs: MintingClaimAttribute[] = [];
 
   for (const m of metadatas) {
+    if (m.data_key === '' || m.data_value === '') continue;
     if (METADATA_KEYS_SKIP.has(m.data_key)) continue;
     const traitType =
       DATA_KEY_TO_TRAIT_TYPE[m.data_key] ??

--- a/src/nftsLoop/nfts.test.ts
+++ b/src/nftsLoop/nfts.test.ts
@@ -2,6 +2,7 @@ import { getAnimationPaths } from '@/nftsLoop/nft-animation-paths';
 import {
   calculateNftHodlRate,
   getMemeTokenIdsForEditionSizeFloorRefresh,
+  normalizeMetadataNameForNft,
   resolveNftEditionSizeFloor
 } from '@/nftsLoop/nfts';
 
@@ -54,6 +55,12 @@ describe('getAnimationPaths', () => {
     ).toEqual({
       animation: 'https://example.com/interactive/index.html'
     });
+  });
+});
+
+describe('normalizeMetadataNameForNft', () => {
+  it('trims NFT metadata names without changing internal whitespace', () => {
+    expect(normalizeMetadataNameForNft(' The  Loom ')).toBe('The  Loom');
   });
 });
 

--- a/src/nftsLoop/nfts.test.ts
+++ b/src/nftsLoop/nfts.test.ts
@@ -3,6 +3,7 @@ import {
   calculateNftHodlRate,
   getMemeTokenIdsForEditionSizeFloorRefresh,
   normalizeMetadataNameForNft,
+  normalizeMetadataStructuredFieldsForNft,
   resolveNftEditionSizeFloor
 } from '@/nftsLoop/nfts';
 
@@ -61,6 +62,32 @@ describe('getAnimationPaths', () => {
 describe('normalizeMetadataNameForNft', () => {
   it('trims NFT metadata names without changing internal whitespace', () => {
     expect(normalizeMetadataNameForNft(' The  Loom ')).toBe('The  Loom');
+  });
+});
+
+describe('normalizeMetadataStructuredFieldsForNft', () => {
+  it('trims structured NFT metadata fields without changing internal whitespace', () => {
+    const normalized = normalizeMetadataStructuredFieldsForNft({
+      name: ' The  Loom ',
+      description: '\nLine one\nLine  two\n ',
+      attributes: [
+        { trait_type: ' Artist ', value: ' 6529er ' },
+        { trait_type: '\nMeme Name\t', value: '\tThe  Loom\n' },
+        { trait_type: 'Type - Meme', value: 519 },
+        { trait_type: 'Dynamic', value: false }
+      ]
+    });
+
+    expect(normalized).toEqual({
+      name: 'The  Loom',
+      description: 'Line one\nLine  two',
+      attributes: [
+        { trait_type: 'Artist', value: '6529er' },
+        { trait_type: 'Meme Name', value: 'The  Loom' },
+        { trait_type: 'Type - Meme', value: 519 },
+        { trait_type: 'Dynamic', value: false }
+      ]
+    });
   });
 });
 

--- a/src/nftsLoop/nfts.ts
+++ b/src/nftsLoop/nfts.ts
@@ -649,6 +649,10 @@ function validateMetadata(metadata: any) {
   }
 }
 
+export function normalizeMetadataNameForNft(name: unknown): string | null {
+  return typeof name === 'string' ? name.trim() : null;
+}
+
 function shouldStopDiscovery(msg: string): boolean {
   const lower = msg.toLowerCase();
   return (
@@ -698,7 +702,7 @@ async function buildBaseNft(
     mint_date: mintDate,
     mint_price: mintPrice,
     supply: tokenType === TokenType.ERC721 ? 1 : 0,
-    name: metadata.name,
+    name: normalizeMetadataNameForNft(metadata.name) ?? '',
     collection: config.collection,
     token_type: tokenType,
     description: text.replaceEmojisWithHex(metadata.description),
@@ -800,7 +804,7 @@ function rehydrateFromMetadata(entry: NftProcessingEntry) {
     findAttr(metadata, 'SEIZE ARTIST PROFILE') ?? nft.artist_seize_handle ?? '';
 
   // core fields
-  nft.name = metadata.name ?? nft.name ?? '';
+  nft.name = normalizeMetadataNameForNft(metadata.name) ?? nft.name ?? '';
   nft.description = text.replaceEmojisWithHex(metadata.description ?? '');
   nft.artist = artist;
   nft.artist_seize_handle = artistSeizeHandle;

--- a/src/nftsLoop/nfts.ts
+++ b/src/nftsLoop/nfts.ts
@@ -649,8 +649,53 @@ function validateMetadata(metadata: any) {
   }
 }
 
+function trimMetadataStringForNft(value: unknown): string | null {
+  return typeof value === 'string' ? value.trim() : null;
+}
+
 export function normalizeMetadataNameForNft(name: unknown): string | null {
-  return typeof name === 'string' ? name.trim() : null;
+  return trimMetadataStringForNft(name);
+}
+
+function normalizeMetadataDescriptionForNft(description: unknown): string {
+  return trimMetadataStringForNft(description) ?? '';
+}
+
+function normalizeMetadataAttributeForNft(attribute: MetaAttr): MetaAttr {
+  if (!isPlainObject(attribute)) {
+    return attribute;
+  }
+
+  return {
+    ...attribute,
+    trait_type:
+      typeof attribute.trait_type === 'string'
+        ? attribute.trait_type.trim()
+        : attribute.trait_type,
+    value:
+      typeof attribute.value === 'string'
+        ? attribute.value.trim()
+        : attribute.value
+  };
+}
+
+export function normalizeMetadataStructuredFieldsForNft(metadata: Meta): Meta {
+  if (!metadata || !isPlainObject(metadata)) {
+    return metadata;
+  }
+
+  return {
+    ...metadata,
+    name:
+      typeof metadata.name === 'string' ? metadata.name.trim() : metadata.name,
+    description:
+      typeof metadata.description === 'string'
+        ? metadata.description.trim()
+        : metadata.description,
+    attributes: Array.isArray(metadata.attributes)
+      ? metadata.attributes.map(normalizeMetadataAttributeForNft)
+      : metadata.attributes
+  };
 }
 
 function shouldStopDiscovery(msg: string): boolean {
@@ -670,23 +715,27 @@ async function buildBaseNft(
   metadata: any,
   EntityClass: typeof NFT | typeof LabNFT
 ): Promise<NFT | LabNFT> {
-  const format = metadata.image_details?.format ?? 'WEBP';
+  const normalizedMetadata = normalizeMetadataStructuredFieldsForNft(
+    metadata
+  ) as MetaObject;
+  const format = normalizedMetadata.image_details?.format ?? 'WEBP';
   const tokenPathOriginal = `${contract}/${id}.${format}`;
   const tokenPath = getTokenPath(contract, id, format);
   const { animation, compressedAnimation } = getAnimationPaths(
     contract,
     id,
-    metadata.animation ?? metadata.animation_url,
-    metadata.animation_details
+    normalizedMetadata.animation ?? normalizedMetadata.animation_url,
+    normalizedMetadata.animation_details
   );
 
   const artist =
-    metadata.attributes?.find((a: any) => a.trait_type === 'Artist')?.value ??
+    normalizedMetadata.attributes?.find((a: any) => a.trait_type === 'Artist')
+      ?.value ??
     config.artist ??
     '';
 
   const artistSeizeHandle =
-    metadata.attributes?.find(
+    normalizedMetadata.attributes?.find(
       (a: any) => a.trait_type?.toUpperCase() === 'SEIZE ARTIST PROFILE'
     )?.value ??
     config.artistSeizeHandle ??
@@ -702,20 +751,22 @@ async function buildBaseNft(
     mint_date: mintDate,
     mint_price: mintPrice,
     supply: tokenType === TokenType.ERC721 ? 1 : 0,
-    name: normalizeMetadataNameForNft(metadata.name) ?? '',
+    name: normalizeMetadataNameForNft(normalizedMetadata.name) ?? '',
     collection: config.collection,
     token_type: tokenType,
-    description: text.replaceEmojisWithHex(metadata.description),
+    description: text.replaceEmojisWithHex(
+      normalizeMetadataDescriptionForNft(normalizedMetadata.description)
+    ),
     artist,
     artist_seize_handle: artistSeizeHandle,
-    uri: metadata.uri ?? '',
+    uri: normalizedMetadata.uri ?? '',
     icon: `${NFT_SCALED60_IMAGE_LINK}${tokenPath}`,
     thumbnail: `${NFT_SCALED450_IMAGE_LINK}${tokenPath}`,
     scaled: `${NFT_SCALED1000_IMAGE_LINK}${tokenPath}`,
     image: `${NFT_ORIGINAL_IMAGE_LINK}${tokenPathOriginal}`,
     compressed_animation: compressedAnimation,
     animation: animation,
-    metadata,
+    metadata: normalizedMetadata,
     floor_price: 0,
     floor_price_from: null,
     market_cap: 0,
@@ -751,6 +802,7 @@ type MetaObject = {
   attributes?: MetaAttr[];
   name?: string;
   description?: string;
+  uri?: string;
 };
 
 type Meta = MetaObject | null | undefined;
@@ -782,8 +834,9 @@ function findAttr(md: NonNullable<Meta>, name: string): string | undefined {
 
 function rehydrateFromMetadata(entry: NftProcessingEntry) {
   const { nft } = entry;
-  const metadata: Meta = nft.metadata;
+  const metadata = normalizeMetadataStructuredFieldsForNft(nft.metadata);
   if (!metadata) return;
+  nft.metadata = metadata;
 
   // media paths
   const format: MediaFormat = metadata.image_details?.format ?? 'WEBP';
@@ -805,7 +858,9 @@ function rehydrateFromMetadata(entry: NftProcessingEntry) {
 
   // core fields
   nft.name = normalizeMetadataNameForNft(metadata.name) ?? nft.name ?? '';
-  nft.description = text.replaceEmojisWithHex(metadata.description ?? '');
+  nft.description = text.replaceEmojisWithHex(
+    normalizeMetadataDescriptionForNft(metadata.description)
+  );
   nft.artist = artist;
   nft.artist_seize_handle = artistSeizeHandle;
   nft.icon = `${NFT_SCALED60_IMAGE_LINK}${tokenPath}`;


### PR DESCRIPTION
## Issue
- The Memes drop-to-minting-claim metadata path could preserve leading/trailing whitespace from structured drop metadata, claim edits, Arweave metadata output, and NFT metadata-derived fields.
- Existing dirty drops and claim rows need defensive cleanup before conversion or Arweave upload.

## Fix
- Trim structured drop fields server-side while preserving freeform drop part content.
- Trim drop metadata during minting-claim conversion, claim PATCH metadata before persistence, and Arweave metadata output.
- Trim indexed NFT structured metadata before assigning/storing metadata-derived NFT fields.

## Changes
- Drop validator and create/update use case normalize `title`, metadata `data_key`, and metadata `data_value`.
- Drop-to-claim builder trims title, description, trait types, and string attribute values.
- Minting claim PATCH trims `name`, `description`, `external_url`, and attribute strings; empty external URLs persist as `null` and metadata location resets on metadata updates.
- Arweave upload trims dirty claim rows when building metadata JSON.
- NFT indexer trims `metadata.name`, `metadata.description`, attribute `trait_type`, and string attribute values while preserving internal whitespace/newlines.

## Validation
- `npm run lint`
- Focused Jest runtime pass for drop validator, drop persistence sanitizer, claim builder, claim PATCH, Arweave upload, and NFT name helper: 6 suites / 122 tests passed after latest `main` refresh.
- SonarCloud current inspected state before the latest push: zero new issues.
- No unresolved review threads were reported by the GitHub review-thread API before the latest push.
- Generated `MintingClaimUpdateRequest` already types `external_url` as `string | null`; the empty-string runtime allowance stays within that generated TypeScript contract.
- Latest PR CI after this report/update push was not awaited by request.

## Risk
- Level: Low
- Why: The change is limited to leading/trailing whitespace normalization for structured metadata paths, with tests covering new and existing dirty data flows.
- Rollback: Revert this PR; no DB schema or data migration changes are included.

## Deployment
- Latest PR refresh from `main`: merged `origin/main` into branch and pushed.
- Latest backend `1a-staging` merge: `dd83c40f2313e6f29dec7b5f75b65c2b3f43cd7c`.
- Staging deploys dispatched for `api`, `claimsBuilder`, `claimsMediaArweaveUploader`, and `nftsLoop`; deploy completion was not awaited by request.
- Latest deploy runs:
  - `api`: https://github.com/6529-Collections/6529seize-backend/actions/runs/29012034121
  - `claimsBuilder`: https://github.com/6529-Collections/6529seize-backend/actions/runs/29012041438
  - `claimsMediaArweaveUploader`: https://github.com/6529-Collections/6529seize-backend/actions/runs/29012046802
  - `nftsLoop`: https://github.com/6529-Collections/6529seize-backend/actions/runs/29012052482

## Review Notes
- Current behavior normalizes non-empty structured fields and rejects empty trimmed drop metadata/claim required metadata where applicable.
- Freeform drop part/chat content is not trimmed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Additional automatic whitespace cleanup is applied across drop creation/update, minting-claim patch updates, and NFT metadata processing, so saved/displayed titles, names, descriptions, and attribute fields are consistently normalized.
  * NFT metadata is now normalized both during creation and when metadata is reloaded.

* **Bug Fixes**
  * Whitespace-only values for required fields and attribute `trait_type` are now rejected, and effectively empty metadata entries are ignored instead of being persisted.
  * `external_url` is now treated more safely when empty (trimmed empties become null).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->