### PR TITLE
Compact subscription notification links

### DIFF
--- a/pr-reports/1743.md
+++ b/pr-reports/1743.md
@@ -1,0 +1,48 @@
+# PR Report: Compact subscription notification links
+
+PR: https://github.com/6529-Collections/6529seize-backend/pull/1743
+Branch: agent/subscription-notification-link-format -> main
+Related PRs: None
+
+## Summary
+
+Subscription bot notifications now show compact inline links instead of raw URLs in wave and Discord-style subscription messages.
+
+## What Changed
+
+- Daily subscription list notifications render `6529.io` and `Arweave` as inline Markdown links.
+- Subscription top-up notifications render `6529.io` and `Etherscan` as inline Markdown links.
+- Subscription redemption warning transaction links render as labeled Etherscan links.
+
+## Backend Impact
+
+- New services: None
+- Changed services: `subscriptionsDaily`, `subscriptionsTopUpLoop`
+- Planned/deployed services: `subscriptionsDaily`, `subscriptionsTopUpLoop`
+- API: Not affected
+- DB/entities/migrations: Not affected
+- Queues/events/integrations: Not affected
+
+## Config / Env
+
+No config or environment changes.
+
+## Backend Deployment
+
+- Deployed API: None
+- Deployed Lambdas/services: `subscriptionsDaily`, `subscriptionsTopUpLoop`
+- Not deployed: `api`, `dbMigrationsLoop`, and other Lambda services; not affected
+- Deployment order executed:
+  1. `subscriptionsDaily`
+  2. `subscriptionsTopUpLoop`
+- GitHub Actions run links or run IDs:
+  - `subscriptionsDaily`: https://github.com/6529-Collections/6529seize-backend/actions/runs/29011903508
+  - `subscriptionsTopUpLoop`: https://github.com/6529-Collections/6529seize-backend/actions/runs/29011903567
+
+## Release Notes
+
+Subscription bot posts use cleaner inline destination links for subscription lists, top-ups, and transaction references.
+
+## Risks / Follow-Ups
+
+Staging deploy workflows were dispatched from `1a-staging` commit `7ddbde3818dcc6525b3b78edf9d5e61f1cf8eb98` but not awaited by explicit request.

--- a/src/subscription-wave-notifier.test.ts
+++ b/src/subscription-wave-notifier.test.ts
@@ -78,11 +78,7 @@ describe('subscription wave notifier message formatting', () => {
       [
         '📋 Published provisional list of Subscriptions for [The Memes #312](https://6529.io/the-memes/312)',
         '',
-        'View on 6529.io:',
-        'https://6529.io/open-data/meme-subscriptions',
-        '',
-        'View on Arweave:',
-        'https://arweave.net/subscriptions'
+        'View on [6529.io](https://6529.io/open-data/meme-subscriptions) | [Arweave](https://arweave.net/subscriptions)'
       ].join('\n')
     );
   });
@@ -124,11 +120,7 @@ describe('subscription wave notifier message formatting', () => {
         '',
         'Profile: @[6529er]',
         '',
-        'View on 6529.io:',
-        'https://6529.io/0x1234/subscriptions',
-        '',
-        'View on Etherscan:',
-        'https://etherscan.io/tx/0xabc'
+        'View on [6529.io](https://6529.io/0x1234/subscriptions) | [Etherscan](https://etherscan.io/tx/0xabc)'
       ].join('\n')
     );
   });
@@ -149,8 +141,7 @@ describe('subscription wave notifier message formatting', () => {
         '',
         '0xairdrop',
         '',
-        'Transaction:',
-        transactionLink,
+        `Transaction: [Etherscan](${transactionLink})`,
         '',
         '@[admin1] @[admin2]'
       ].join('\n')
@@ -167,8 +158,7 @@ describe('subscription wave notifier message formatting', () => {
         '',
         '0xkey',
         '',
-        'Transaction:',
-        transactionLink,
+        `Transaction: [Etherscan](${transactionLink})`,
         '',
         '@[admin1] @[admin2]'
       ].join('\n')
@@ -185,8 +175,7 @@ describe('subscription wave notifier message formatting', () => {
         '',
         '0xkey',
         '',
-        'Transaction:',
-        transactionLink,
+        `Transaction: [Etherscan](${transactionLink})`,
         '',
         '@[admin1] @[admin2]'
       ].join('\n')

--- a/src/subscription-wave-notifier.ts
+++ b/src/subscription-wave-notifier.ts
@@ -67,6 +67,22 @@ function buildSubscriptionsUrl(seizeDomain: string, wallet: string): string {
   return `https://${seizeDomain}.io/${wallet}/subscriptions`;
 }
 
+function buildMarkdownLink(label: string, url: string): string {
+  return `[${label}](${url})`;
+}
+
+function buildViewLinksLine(
+  primaryUrl: string,
+  secondaryLabel: string,
+  secondaryUrl: string
+): string {
+  return `View on ${buildMarkdownLink('6529.io', primaryUrl)} | ${buildMarkdownLink(secondaryLabel, secondaryUrl)}`;
+}
+
+function buildTransactionLine(transactionLink: string): string {
+  return `Transaction: ${buildMarkdownLink('Etherscan', transactionLink)}`;
+}
+
 export function buildDailySubscriptionsWaveMessage({
   memeId,
   seizeDomain,
@@ -79,11 +95,11 @@ export function buildDailySubscriptionsWaveMessage({
   return [
     `📋 Published provisional list of Subscriptions for [The Memes #${memeId}](https://${seizeDomain}.io/the-memes/${memeId})`,
     '',
-    'View on 6529.io:',
-    `https://${seizeDomain}.io/open-data/meme-subscriptions`,
-    '',
-    'View on Arweave:',
-    uploadLink
+    buildViewLinksLine(
+      `https://${seizeDomain}.io/open-data/meme-subscriptions`,
+      'Arweave',
+      uploadLink
+    )
   ].join('\n');
 }
 
@@ -116,11 +132,11 @@ export function buildSubscriptionTopUpWaveMessage({
   }
   lines.push(
     '',
-    'View on 6529.io:',
-    buildSubscriptionsUrl(seizeDomain, topUp.from_wallet),
-    '',
-    'View on Etherscan:',
-    etherscanLink
+    buildViewLinksLine(
+      buildSubscriptionsUrl(seizeDomain, topUp.from_wallet),
+      'Etherscan',
+      etherscanLink
+    )
   );
   return lines.join('\n');
 }
@@ -140,8 +156,7 @@ export function buildNoSubscriptionFoundWaveMessage({
       '',
       airdropAddress,
       '',
-      'Transaction:',
-      transactionLink
+      buildTransactionLine(transactionLink)
     ].join('\n'),
     adminHandles
   );
@@ -162,8 +177,7 @@ export function buildNoBalanceFoundWaveMessage({
       '',
       consolidationKey,
       '',
-      'Transaction:',
-      transactionLink
+      buildTransactionLine(transactionLink)
     ].join('\n'),
     adminHandles
   );
@@ -184,8 +198,7 @@ export function buildInsufficientBalanceWaveMessage({
       '',
       consolidationKey,
       '',
-      'Transaction:',
-      transactionLink
+      buildTransactionLine(transactionLink)
     ].join('\n'),
     adminHandles
   );

--- a/src/subscriptionsDaily/subscriptions.ts
+++ b/src/subscriptionsDaily/subscriptions.ts
@@ -64,8 +64,7 @@ export async function updateSubscriptions() {
   const seizeDomain =
     process.env.NODE_ENV === 'development' ? 'staging.6529' : '6529';
   let discordMessage = `📋 Published provisional list of Subscriptions for The Memes #${nextMemeId}`;
-  discordMessage += ` \n\n[View on 6529.io] \nhttps://${seizeDomain}.io/open-data/meme-subscriptions`;
-  discordMessage += ` \n\n[View on Arweave] \n${uploadLink}`;
+  discordMessage += ` \n\nView on [6529.io](https://${seizeDomain}.io/open-data/meme-subscriptions) | [Arweave](${uploadLink})`;
   await sendDiscordUpdate(
     process.env.SUBSCRIPTIONS_DISCORD_WEBHOOK as string,
     discordMessage,

--- a/src/subscriptionsTopUpLoop/db.subscriptions_topup.ts
+++ b/src/subscriptionsTopUpLoop/db.subscriptions_topup.ts
@@ -103,8 +103,7 @@ export async function persistTopUps(topUps: SubscriptionTopUp[]) {
       parseInt(process.env.SUBSCRIPTIONS_CHAIN_ID ?? '1'),
       topUp.hash
     );
-    discordMessage += ` \n\n[View on 6529.io] \nhttps://${seizeDomain}.io/${topUp.from_wallet}/subscriptions`;
-    discordMessage += ` \n\n[View on Etherscan] \n${link}`;
+    discordMessage += ` \n\nView on [6529.io](https://${seizeDomain}.io/${topUp.from_wallet}/subscriptions) | [Etherscan](${link})`;
     await sendDiscordUpdate(
       process.env.SUBSCRIPTIONS_DISCORD_WEBHOOK as string,
       discordMessage,


### PR DESCRIPTION
## Summary
- Replace raw subscription announcement destination URLs with compact inline Markdown links.
- Apply the same compact link style to subscription top-up notifications.
- Mask subscription warning transaction links as Etherscan Markdown links.

## Validation
- `npm run lint`
- Focused `src/subscription-wave-notifier.test.ts` Jest run with a minimal config that skips the repo global setup.