### PR TITLE
Allow hiding link previews on drop creation

### DIFF
--- a/src/api-serverless/openapi.yaml
+++ b/src/api-serverless/openapi.yaml
@@ -12126,7 +12126,9 @@ components:
           type: boolean
           description: >-
             When true, create the drop with generated external link previews
-            hidden.
+            hidden. Omit or set to false to leave previews visible.
+            Signature-required drops must include this field in the signed
+            payload when present.
     ApiCreateGroup:
       type: object
       required:

--- a/src/api-serverless/openapi.yaml
+++ b/src/api-serverless/openapi.yaml
@@ -12122,6 +12122,11 @@ components:
             $ref: "#/components/schemas/ApiDropGroupMention"
         poll:
           $ref: "#/components/schemas/ApiCreateDropPollRequest"
+        hide_link_preview:
+          type: boolean
+          description: >-
+            When true, create the drop with generated external link previews
+            hidden.
     ApiCreateGroup:
       type: object
       required:

--- a/src/api-serverless/restructure-openapi.ts
+++ b/src/api-serverless/restructure-openapi.ts
@@ -59,7 +59,7 @@ if (data.components?.schemas) {
 }
 
 // Convert to YAML
-const yamlString = yaml.dump(data, { indent: 2 });
+const yamlString = yaml.dump(data, { indent: 2, quotingType: '"' });
 
 // Write the sorted and formatted YAML back to the file
 fs.writeFileSync(filePath, yamlString, 'utf8');

--- a/src/api-serverless/restructure-openapi.ts
+++ b/src/api-serverless/restructure-openapi.ts
@@ -59,10 +59,7 @@ if (data.components?.schemas) {
 }
 
 // Convert to YAML
-let yamlString = yaml.dump(data, { indent: 2 });
-
-// Replace single quotes with double quotes
-yamlString = yamlString.replace(/'/g, '"');
+const yamlString = yaml.dump(data, { indent: 2 });
 
 // Write the sorted and formatted YAML back to the file
 fs.writeFileSync(filePath, yamlString, 'utf8');

--- a/src/api-serverless/src/drops/drop-creation-api-service.test.ts
+++ b/src/api-serverless/src/drops/drop-creation-api-service.test.ts
@@ -160,95 +160,105 @@ describe('DropCreationApiService.createDrop', () => {
     jest.clearAllMocks();
   });
 
-  it('invalidates unread cache after the drop transaction commits', async () => {
-    const connection = {} as any;
-    const order: string[] = [];
-    const dropsDb = {
-      executeNativeQueriesInTransaction: jest.fn(
-        async (callback: (connection: unknown) => Promise<unknown>) => {
-          order.push('transaction');
-          const result = await callback(connection);
-          order.push('committed');
-          return result;
+  it.each([true, false])(
+    'persists explicit hideLinkPreview=%s before invalidating unread cache',
+    async (hideLinkPreview) => {
+      const connection = {} as any;
+      const order: string[] = [];
+      const dropsDb = {
+        executeNativeQueriesInTransaction: jest.fn(
+          async (callback: (connection: unknown) => Promise<unknown>) => {
+            order.push('transaction');
+            const result = await callback(connection);
+            order.push('committed');
+            return result;
+          }
+        )
+      };
+      const dropsMappers = {
+        createDropApiToUseCaseModel: jest.fn().mockReturnValue({
+          wave_id: 'wave-1',
+          drop_type: DropType.CHAT
+        })
+      };
+      const createOrUpdateDrop = {
+        preResolveIdentityNomination: jest.fn().mockResolvedValue(null),
+        execute: jest.fn().mockImplementation(async () => {
+          order.push('drop-written');
+          return {
+            drop_id: 'drop-1',
+            pending_push_notification_ids: []
+          };
+        })
+      };
+      const dropPollsApiService = {
+        createPollForDrop: jest.fn().mockResolvedValue(undefined)
+      };
+      const dropsService = {
+        findDropByIdOrThrow: jest.fn().mockResolvedValue({
+          id: 'drop-1',
+          wave_id: 'wave-1'
+        })
+      };
+      const wsListenersNotifier = {
+        notifyAboutDropUpdate: jest.fn().mockResolvedValue(undefined)
+      };
+      const dropNftLinksDb = {
+        findByDropId: jest.fn().mockResolvedValue([])
+      };
+      const service = new DropCreationApiService(
+        dropsService as never,
+        dropsDb as never,
+        dropsMappers as never,
+        createOrUpdateDrop as never,
+        {} as never,
+        wsListenersNotifier as never,
+        dropNftLinksDb as never,
+        {} as never,
+        dropPollsApiService as never
+      );
+      jest
+        .spyOn(waveScoreService, 'requestWaveScoreRefreshBestEffort')
+        .mockResolvedValue(undefined);
+      (invalidateWaveUnreadCacheForWave as jest.Mock).mockImplementationOnce(
+        async () => {
+          order.push('unread-cache-invalidated');
         }
-      )
-    };
-    const dropsMappers = {
-      createDropApiToUseCaseModel: jest.fn().mockReturnValue({
-        wave_id: 'wave-1',
-        drop_type: DropType.CHAT
-      })
-    };
-    const createOrUpdateDrop = {
-      preResolveIdentityNomination: jest.fn().mockResolvedValue(null),
-      execute: jest.fn().mockImplementation(async () => {
-        order.push('drop-written');
-        return {
-          drop_id: 'drop-1',
-          pending_push_notification_ids: []
-        };
-      })
-    };
-    const dropPollsApiService = {
-      createPollForDrop: jest.fn().mockResolvedValue(undefined)
-    };
-    const dropsService = {
-      findDropByIdOrThrow: jest.fn().mockResolvedValue({
-        id: 'drop-1',
-        wave_id: 'wave-1'
-      })
-    };
-    const wsListenersNotifier = {
-      notifyAboutDropUpdate: jest.fn().mockResolvedValue(undefined)
-    };
-    const dropNftLinksDb = {
-      findByDropId: jest.fn().mockResolvedValue([])
-    };
-    const service = new DropCreationApiService(
-      dropsService as never,
-      dropsDb as never,
-      dropsMappers as never,
-      createOrUpdateDrop as never,
-      {} as never,
-      wsListenersNotifier as never,
-      dropNftLinksDb as never,
-      {} as never,
-      dropPollsApiService as never
-    );
-    jest
-      .spyOn(waveScoreService, 'requestWaveScoreRefreshBestEffort')
-      .mockResolvedValue(undefined);
-    (invalidateWaveUnreadCacheForWave as jest.Mock).mockImplementationOnce(
-      async () => {
-        order.push('unread-cache-invalidated');
-      }
-    );
+      );
 
-    await service.createDrop(
-      {
-        createDropRequest: {} as never,
-        authorId: 'author-profile',
-        representativeId: 'author-profile',
-        hideLinkPreview: true
-      },
-      { timer: undefined } as never
-    );
+      await service.createDrop(
+        {
+          createDropRequest: { hide_link_preview: hideLinkPreview } as never,
+          authorId: 'author-profile',
+          representativeId: 'author-profile',
+          hideLinkPreview
+        },
+        { timer: undefined } as never
+      );
 
-    expect(createOrUpdateDrop.execute).toHaveBeenCalledWith(
-      expect.objectContaining({
-        hide_link_preview: true
-      }),
-      false,
-      expect.anything()
-    );
-    expect(invalidateWaveUnreadCacheForWave).toHaveBeenCalledWith('wave-1');
-    expect(order).toEqual([
-      'transaction',
-      'drop-written',
-      'committed',
-      'unread-cache-invalidated'
-    ]);
-  });
+      expect(dropsMappers.createDropApiToUseCaseModel).toHaveBeenCalledWith(
+        expect.objectContaining({
+          request: expect.objectContaining({
+            hide_link_preview: hideLinkPreview
+          })
+        })
+      );
+      expect(createOrUpdateDrop.execute).toHaveBeenCalledWith(
+        expect.objectContaining({
+          hide_link_preview: hideLinkPreview
+        }),
+        false,
+        expect.anything()
+      );
+      expect(invalidateWaveUnreadCacheForWave).toHaveBeenCalledWith('wave-1');
+      expect(order).toEqual([
+        'transaction',
+        'drop-written',
+        'committed',
+        'unread-cache-invalidated'
+      ]);
+    }
+  );
 
   it('waits for pending push notifications to be enqueued before resolving', async () => {
     const connection = {} as any;

--- a/src/api-serverless/src/drops/drop-hasher.test.ts
+++ b/src/api-serverless/src/drops/drop-hasher.test.ts
@@ -1,5 +1,5 @@
-import { DropHasher } from '../api-serverless/src/drops/drop-hasher';
-import { ApiCreateDropRequest } from '../api-serverless/src/generated/models/ApiCreateDropRequest';
+import { ApiCreateDropRequest } from '@/api/generated/models/ApiCreateDropRequest';
+import { DropHasher } from '@/api/drops/drop-hasher';
 
 describe('DropHasher', () => {
   const dropHasher = new DropHasher();

--- a/src/api-serverless/src/drops/drop-signature-verifier.test.ts
+++ b/src/api-serverless/src/drops/drop-signature-verifier.test.ts
@@ -145,6 +145,24 @@ describe('DropSignatureVerifier', () => {
     ).resolves.toBe(true);
   });
 
+  it.each([true, false])(
+    'accepts structured drop signatures with hide_link_preview=%s',
+    async (hideLinkPreview) => {
+      const drop = await signDropAsStructuredMessage({
+        ...createDrop(),
+        hide_link_preview: hideLinkPreview
+      });
+
+      await expect(
+        verifier.isDropSignedByAnyOfGivenWallets({
+          wallets: [wallet.address],
+          drop,
+          termsOfService
+        })
+      ).resolves.toBe(true);
+    }
+  );
+
   it('accepts structured drop signatures from unregistered client domains', async () => {
     process.env.AUTH_SIGNATURE_ALLOWED_DOMAINS = '6529.io';
     const drop = await signDropAsStructuredMessage(

--- a/src/api-serverless/src/drops/drop-signature-verifier.test.ts
+++ b/src/api-serverless/src/drops/drop-signature-verifier.test.ts
@@ -109,6 +109,15 @@ describe('DropSignatureVerifier', () => {
     };
   }
 
+  const signatureStrategies: Array<{
+    name: string;
+    sign: (drop: ApiCreateDropRequest) => Promise<ApiCreateDropRequest>;
+  }> = [
+    { name: 'text hash', sign: signDropAsText },
+    { name: 'raw hash byte', sign: signDropAsRawHashBytes },
+    { name: 'structured', sign: signDropAsStructuredMessage }
+  ];
+
   it('accepts current text hash signatures', async () => {
     const drop = await signDropAsText(createDrop());
 
@@ -160,6 +169,25 @@ describe('DropSignatureVerifier', () => {
           termsOfService
         })
       ).resolves.toBe(true);
+    }
+  );
+
+  it.each(signatureStrategies)(
+    'rejects $name signatures when hide_link_preview is added after signing',
+    async ({ sign }) => {
+      const signedDrop = await sign(createDrop());
+      const tamperedDrop = {
+        ...signedDrop,
+        hide_link_preview: true
+      };
+
+      await expect(
+        verifier.isDropSignedByAnyOfGivenWallets({
+          wallets: [wallet.address],
+          drop: tamperedDrop,
+          termsOfService
+        })
+      ).resolves.toBe(false);
     }
   );
 

--- a/src/api-serverless/src/drops/drop-validator.test.ts
+++ b/src/api-serverless/src/drops/drop-validator.test.ts
@@ -1,5 +1,5 @@
 import { ApiDropType } from '@/api/generated/models/ApiDropType';
-import { NewDropSchema } from '@/api/drops/drop.validator';
+import { NewDropSchema, UpdateDropSchema } from '@/api/drops/drop.validator';
 
 describe('NewDropSchema', () => {
   const futureTimestamp = Date.now() + 60_000;
@@ -225,6 +225,20 @@ describe('NewDropSchema', () => {
     }
   );
 
+  it.each([true, false])(
+    'accepts hide_link_preview=%s on participatory create requests',
+    (hideLinkPreview) => {
+      const result = NewDropSchema.validate({
+        ...createDropWithMetadata('artist', 'Artist'),
+        hide_link_preview: hideLinkPreview
+      });
+
+      expect(result.error).toBeUndefined();
+      expect(result.value.drop_type).toBe(ApiDropType.Participatory);
+      expect(result.value.hide_link_preview).toBe(hideLinkPreview);
+    }
+  );
+
   it('keeps hidden link preview unset when omitted on create requests', () => {
     const result = NewDropSchema.validate({
       ...createDropWithMetadata('artist', 'Artist'),
@@ -361,6 +375,31 @@ describe('NewDropSchema', () => {
 
     expect(result.error?.message).toContain(
       'poll closing_time must be in the future'
+    );
+  });
+});
+
+describe('UpdateDropSchema', () => {
+  it('rejects hide_link_preview because preview visibility updates use the dedicated endpoint', () => {
+    const result = UpdateDropSchema.validate({
+      title: 'Updated',
+      parts: [
+        {
+          content: 'Updated content',
+          media: [],
+          attachments: []
+        }
+      ],
+      referenced_nfts: [],
+      mentioned_users: [],
+      mentioned_waves: [],
+      metadata: [],
+      signature: null,
+      hide_link_preview: true
+    });
+
+    expect(result.error?.message).toContain(
+      '"hide_link_preview" is not allowed'
     );
   });
 });

--- a/src/api-serverless/src/drops/drop-validator.test.ts
+++ b/src/api-serverless/src/drops/drop-validator.test.ts
@@ -211,15 +211,28 @@ describe('NewDropSchema', () => {
     });
   });
 
-  it('accepts hidden link previews on create requests', () => {
+  it.each([true, false])(
+    'accepts hide_link_preview=%s on create requests',
+    (hideLinkPreview) => {
+      const result = NewDropSchema.validate({
+        ...createDropWithMetadata('artist', 'Artist'),
+        drop_type: ApiDropType.Chat,
+        hide_link_preview: hideLinkPreview
+      });
+
+      expect(result.error).toBeUndefined();
+      expect(result.value.hide_link_preview).toBe(hideLinkPreview);
+    }
+  );
+
+  it('keeps hidden link preview unset when omitted on create requests', () => {
     const result = NewDropSchema.validate({
       ...createDropWithMetadata('artist', 'Artist'),
-      drop_type: ApiDropType.Chat,
-      hide_link_preview: true
+      drop_type: ApiDropType.Chat
     });
 
     expect(result.error).toBeUndefined();
-    expect(result.value.hide_link_preview).toBe(true);
+    expect(result.value.hide_link_preview).toBeUndefined();
   });
 
   it('accepts anonymous polls for chat drops', () => {

--- a/src/api-serverless/src/drops/drop-validator.test.ts
+++ b/src/api-serverless/src/drops/drop-validator.test.ts
@@ -211,6 +211,17 @@ describe('NewDropSchema', () => {
     });
   });
 
+  it('accepts hidden link previews on create requests', () => {
+    const result = NewDropSchema.validate({
+      ...createDropWithMetadata('artist', 'Artist'),
+      drop_type: ApiDropType.Chat,
+      hide_link_preview: true
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.value.hide_link_preview).toBe(true);
+  });
+
   it('accepts anonymous polls for chat drops', () => {
     const result = NewDropSchema.validate({
       ...createDropWithMetadata('artist', 'Artist'),

--- a/src/api-serverless/src/drops/drop.validator.ts
+++ b/src/api-serverless/src/drops/drop.validator.ts
@@ -234,7 +234,8 @@ export const NewDropSchema: Joi.ObjectSchema<ApiCreateDropRequest> = Joi.object(
       is: ApiDropType.Chat,
       then: NewDropPollSchema.optional(),
       otherwise: Joi.forbidden()
-    })
+    }),
+    hide_link_preview: Joi.boolean().optional()
   }
 );
 

--- a/src/api-serverless/src/drops/drops.routes.ts
+++ b/src/api-serverless/src/drops/drops.routes.ts
@@ -228,7 +228,8 @@ router.post(
         authorId: authorProfileId,
         representativeId: authenticationContext.isAuthenticatedAsProxy()
           ? authenticationContext.roleProfileId!
-          : authorProfileId
+          : authorProfileId,
+        hideLinkPreview: newDrop.hide_link_preview
       },
       { timer, authenticationContext }
     );

--- a/src/api-serverless/src/drops/drops.routes.ts
+++ b/src/api-serverless/src/drops/drops.routes.ts
@@ -220,6 +220,7 @@ router.post(
       reply_to: newDrop.reply_to,
       drop_type: newDrop.drop_type,
       signature: newDrop.signature,
+      hide_link_preview: newDrop.hide_link_preview,
       is_additional_action_promised: newDrop.is_additional_action_promised
     };
     const createdDrop = await dropCreationService.createDrop(

--- a/src/api-serverless/src/generated/models/ApiCreateDropRequest.ts
+++ b/src/api-serverless/src/generated/models/ApiCreateDropRequest.ts
@@ -28,6 +28,9 @@ export class ApiCreateDropRequest {
     'is_additional_action_promised'?: boolean;
     'mentioned_groups'?: Array<ApiDropGroupMention>;
     'poll'?: ApiCreateDropPollRequest;
+    /**
+    * When true, create the drop with generated external link previews hidden. Omit or set to false to leave previews visible. Signature-required drops must include this field in the signed payload when present.
+    */
     'hide_link_preview'?: boolean;
     'title'?: string | null;
     'parts': Array<ApiCreateDropPart>;
@@ -161,4 +164,5 @@ export class ApiCreateDropRequest {
     public constructor() {
     }
 }
+
 

--- a/src/api-serverless/src/generated/models/ApiCreateDropRequest.ts
+++ b/src/api-serverless/src/generated/models/ApiCreateDropRequest.ts
@@ -28,6 +28,7 @@ export class ApiCreateDropRequest {
     'is_additional_action_promised'?: boolean;
     'mentioned_groups'?: Array<ApiDropGroupMention>;
     'poll'?: ApiCreateDropPollRequest;
+    'hide_link_preview'?: boolean;
     'title'?: string | null;
     'parts': Array<ApiCreateDropPart>;
     'referenced_nfts': Array<ApiDropReferencedNFT>;
@@ -84,6 +85,12 @@ export class ApiCreateDropRequest {
             "name": "poll",
             "baseName": "poll",
             "type": "ApiCreateDropPollRequest",
+            "format": ""
+        },
+        {
+            "name": "hide_link_preview",
+            "baseName": "hide_link_preview",
+            "type": "boolean",
             "format": ""
         },
         {
@@ -154,5 +161,4 @@ export class ApiCreateDropRequest {
     public constructor() {
     }
 }
-
 

--- a/src/api-serverless/src/generated/models/ObjectSerializer.ts
+++ b/src/api-serverless/src/generated/models/ObjectSerializer.ts
@@ -585,7 +585,7 @@ import { ApiCreateConnectionShareResponse    , ApiCreateConnectionShareResponseT
 import { ApiCreateDropMedia } from '../models/ApiCreateDropMedia';
 import { ApiCreateDropPart } from '../models/ApiCreateDropPart';
 import { ApiCreateDropPollRequest } from '../models/ApiCreateDropPollRequest';
-import { ApiCreateDropRequest                 } from '../models/ApiCreateDropRequest';
+import { ApiCreateDropRequest                  } from '../models/ApiCreateDropRequest';
 import { ApiCreateGroup } from '../models/ApiCreateGroup';
 import { ApiCreateGroupDescription          } from '../models/ApiCreateGroupDescription';
 import { ApiCreateLegacyDesktopConnectionShareRequest , ApiCreateLegacyDesktopConnectionShareRequestClientTypeEnum     } from '../models/ApiCreateLegacyDesktopConnectionShareRequest';

--- a/src/tests/drop-hasher.test.ts
+++ b/src/tests/drop-hasher.test.ts
@@ -60,4 +60,24 @@ describe('DropHasher', () => {
       })
     );
   });
+
+  it('ignores undefined hide link preview but hashes explicit false', () => {
+    const baseHash = dropHasher.hash({
+      drop: aDrop,
+      termsOfService: null
+    });
+
+    expect(
+      dropHasher.hash({
+        drop: { ...aDrop, hide_link_preview: undefined },
+        termsOfService: null
+      })
+    ).toBe(baseHash);
+    expect(
+      dropHasher.hash({
+        drop: { ...aDrop, hide_link_preview: false },
+        termsOfService: null
+      })
+    ).not.toBe(baseHash);
+  });
 });

--- a/src/tests/drop-hasher.test.ts
+++ b/src/tests/drop-hasher.test.ts
@@ -46,4 +46,18 @@ describe('DropHasher', () => {
       })
     );
   });
+
+  it('hide link preview affects the hash when present', () => {
+    expect(
+      dropHasher.hash({
+        drop: aDrop,
+        termsOfService: null
+      })
+    ).not.toBe(
+      dropHasher.hash({
+        drop: { ...aDrop, hide_link_preview: true },
+        termsOfService: null
+      })
+    );
+  });
 });


### PR DESCRIPTION
## Issue
- Creating a drop with an external link currently requires a second request to hide the generated link preview, so clients can briefly show the preview before it is toggled off.

## Fix
- Add optional `hide_link_preview` support to `ApiCreateDropRequest` and pass the validated value through the existing drop-creation service hook.

## Changes
- Documents `hide_link_preview` on create-drop requests in OpenAPI.
- Allows `NewDropSchema` to validate the optional boolean.
- Passes the flag from `POST /drops` into `dropCreationService.createDrop`.
- Updates the generated create-drop request model for the new field.
- Adds validator and hashing coverage so signature-required drops include the flag in the signed payload when present.

## Validation
- `npm run lint` passed.
- `npm test -- --runInBand src/api-serverless/src/drops/drop-validator.test.ts src/api-serverless/src/drops/drop-creation-api-service.test.ts src/tests/drop-hasher.test.ts` was attempted but blocked before test execution by an existing TypeScript error in `src/rates/ratings.service.ts` around the `json2csv` overload.
- `cd src/api-serverless && npm run generate:openapi` was attempted; `restructure-openapi` completed, but the OpenAPI generator could not complete because the local environment lacks the Java runtime required by the generator. The generated request model change was kept minimal and matches the new OpenAPI field.
- CI was not awaited per request.

## Risk
- Level: Low
- Why: The new field is optional and existing create-drop requests continue to omit it. Clients that send it on signature-required waves must include it in the signed create payload.
- Rollback: Revert the API contract/model and route pass-through.

## Deployment
- Deploy `api`.

## Review Notes
- Please focus on the public create-drop request shape and signature/hash behavior for requests that include `hide_link_preview`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional `hide_link_preview` setting when creating drops.
  * External link previews can now be hidden for supported drops.
  * The setting is included in signed drop payloads when provided.

* **Bug Fixes**
  * Ensured the preference is preserved during drop creation and affects drop verification consistently.
  * Improved cache invalidation timing after drop creation completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->