### PR TITLE
Improve transactions API tail latency

### DIFF
--- a/src/db-api.test.ts
+++ b/src/db-api.test.ts
@@ -1,16 +1,16 @@
 import { addRememe, fetchTransactions } from '@/db-api';
 import { MEMES_CONTRACT } from '@/constants';
 import { ApiTransaction } from '@/api/generated/models/ApiTransaction';
-import { redisGet, redisSetJson } from '@/redis';
+import { redisCompareAndSetJson, redisGet } from '@/redis';
 import { sqlExecutor } from '@/sql-executor';
 
 jest.mock('@/redis', () => ({
-  redisGet: jest.fn(),
-  redisSetJson: jest.fn()
+  redisCompareAndSetJson: jest.fn(),
+  redisGet: jest.fn()
 }));
 
 const redisGetMock = jest.mocked(redisGet);
-const redisSetJsonMock = jest.mocked(redisSetJson);
+const redisCompareAndSetJsonMock = jest.mocked(redisCompareAndSetJson);
 
 describe('addRememe', () => {
   afterEach(() => {
@@ -56,7 +56,7 @@ describe('addRememe', () => {
 describe('fetchTransactions', () => {
   beforeEach(() => {
     redisGetMock.mockReset().mockResolvedValue(null);
-    redisSetJsonMock.mockReset().mockResolvedValue(undefined);
+    redisCompareAndSetJsonMock.mockReset().mockResolvedValue(true);
   });
 
   afterEach(() => {
@@ -64,27 +64,36 @@ describe('fetchTransactions', () => {
   });
 
   it('uses index-compatible ordering and seeds the API count cache', async () => {
-    const transaction = { transaction: '0xtx' } as ApiTransaction;
+    const firstTransaction = { transaction: '0xtx1' } as ApiTransaction;
+    const secondTransaction = { transaction: '0xtx2' } as ApiTransaction;
     const executeSpy = jest
       .spyOn(sqlExecutor, 'execute')
-      .mockImplementation(async (sql: string) => {
-        const normalizedSql = normalizeSql(sql);
-        if (normalizedSql.includes('count(1) as count')) {
-          return [{ count: 250, latest_block: 123 }];
+      .mockImplementation(
+        async (sql: string, params?: Record<string, unknown>) => {
+          const normalizedSql = normalizeSql(sql);
+          if (normalizedSql.includes('sum(count(1)) over () as count')) {
+            return [{ count: 250, latest_block: 123, latest_block_count: 3 }];
+          }
+          if (normalizedSql.startsWith('select transactions.*')) {
+            expect(params).toEqual(
+              expect.objectContaining({
+                transactionLimit: 2,
+                transactionOffset: 0
+              })
+            );
+            return [firstTransaction, secondTransaction];
+          }
+          throw new Error(`Unexpected SQL: ${normalizedSql}`);
         }
-        if (normalizedSql.startsWith('select transactions.*')) {
-          return [transaction];
-        }
-        throw new Error(`Unexpected SQL: ${normalizedSql}`);
-      });
+      );
 
     await expect(
-      fetchTransactions(100, 1, undefined, MEMES_CONTRACT, undefined, null)
+      fetchTransactions(1, 1, undefined, MEMES_CONTRACT, undefined, null)
     ).resolves.toEqual({
       count: 250,
       page: 1,
       next: 'true',
-      data: [transaction]
+      data: [firstTransaction]
     });
 
     const executedSql = executeSpy.mock.calls.map(([sql]) => normalizeSql(sql));
@@ -94,38 +103,48 @@ describe('fetchTransactions', () => {
     expect(dataSql).toContain(
       'order by block desc, transaction desc, from_address desc, to_address desc, contract desc, token_id desc'
     );
-    expect(redisSetJsonMock).toHaveBeenCalledWith(
+    expect(dataSql).toContain(
+      'limit :transactionlimit offset :transactionoffset'
+    );
+    expect(redisCompareAndSetJsonMock).toHaveBeenCalledWith(
       expect.stringContaining('__SEIZE_TRANSACTION_COUNT_'),
+      null,
       expect.objectContaining({
-        version: 1,
+        version: 2,
         count: 250,
-        latestBlock: 123
+        latestBlock: 123,
+        latestBlockCount: 3
       }),
       expect.anything()
     );
   });
 
-  it('increments a cached count using only newer matching blocks', async () => {
+  it('recounts the boundary block and uses compare-and-set for increments', async () => {
     const fullyRefreshedAt = Date.now();
-    redisGetMock.mockResolvedValue({
-      version: 1,
+    const cached = {
+      version: 2,
       count: 250,
       latestBlock: 123,
+      latestBlockCount: 3,
       fullyRefreshedAt
-    });
+    };
+    redisGetMock.mockResolvedValue(cached);
     const executeSpy = jest
       .spyOn(sqlExecutor, 'execute')
       .mockImplementation(
         async (sql: string, params?: Record<string, unknown>) => {
           const normalizedSql = normalizeSql(sql);
-          if (normalizedSql.includes('count(1) as count')) {
+          if (normalizedSql.includes('count(1) as block_count')) {
             expect(normalizedSql).toContain(
-              'transactions.block > :countafterblock'
+              'transactions.block >= :countfromblock'
             );
             expect(params).toEqual(
-              expect.objectContaining({ countAfterBlock: 123 })
+              expect.objectContaining({ countFromBlock: 123 })
             );
-            return [{ count: 4, latest_block: 130 }];
+            return [
+              { block: 123, block_count: 4 },
+              { block: 130, block_count: 2 }
+            ];
           }
           if (normalizedSql.startsWith('select transactions.*')) {
             return [];
@@ -137,19 +156,21 @@ describe('fetchTransactions', () => {
     await expect(
       fetchTransactions(100, 2, undefined, MEMES_CONTRACT, undefined, 'sales')
     ).resolves.toEqual({
-      count: 254,
+      count: 253,
       page: 2,
-      next: 'true',
+      next: null,
       data: []
     });
 
     expect(executeSpy).toHaveBeenCalledTimes(2);
-    expect(redisSetJsonMock).toHaveBeenCalledWith(
+    expect(redisCompareAndSetJsonMock).toHaveBeenCalledWith(
       expect.any(String),
+      cached,
       {
-        version: 1,
-        count: 254,
+        version: 2,
+        count: 253,
         latestBlock: 130,
+        latestBlockCount: 2,
         fullyRefreshedAt
       },
       expect.anything()
@@ -157,19 +178,21 @@ describe('fetchTransactions', () => {
   });
 
   it('periodically rebases a cached count to include historical backfills', async () => {
-    redisGetMock.mockResolvedValue({
-      version: 1,
+    const cached = {
+      version: 2,
       count: 250,
       latestBlock: 123,
+      latestBlockCount: 3,
       fullyRefreshedAt: Date.now() - 7 * 60 * 60 * 1000
-    });
+    };
+    redisGetMock.mockResolvedValue(cached);
     const executeSpy = jest
       .spyOn(sqlExecutor, 'execute')
       .mockImplementation(async (sql: string) => {
         const normalizedSql = normalizeSql(sql);
-        if (normalizedSql.includes('count(1) as count')) {
-          expect(normalizedSql).not.toContain('block > :countafterblock');
-          return [{ count: 275, latest_block: 140 }];
+        if (normalizedSql.includes('sum(count(1)) over () as count')) {
+          expect(normalizedSql).not.toContain('block >= :countfromblock');
+          return [{ count: 275, latest_block: 140, latest_block_count: 2 }];
         }
         if (normalizedSql.startsWith('select transactions.*')) {
           return [];
@@ -182,17 +205,19 @@ describe('fetchTransactions', () => {
     ).resolves.toEqual({
       count: 275,
       page: 1,
-      next: 'true',
+      next: null,
       data: []
     });
 
     expect(executeSpy).toHaveBeenCalledTimes(2);
-    expect(redisSetJsonMock).toHaveBeenCalledWith(
+    expect(redisCompareAndSetJsonMock).toHaveBeenCalledWith(
       expect.any(String),
+      cached,
       expect.objectContaining({
-        version: 1,
+        version: 2,
         count: 275,
         latestBlock: 140,
+        latestBlockCount: 2,
         fullyRefreshedAt: expect.any(Number)
       }),
       expect.anything()
@@ -226,8 +251,123 @@ describe('fetchTransactions', () => {
     });
 
     expect(redisGetMock).not.toHaveBeenCalled();
-    expect(redisSetJsonMock).not.toHaveBeenCalled();
+    expect(redisCompareAndSetJsonMock).not.toHaveBeenCalled();
     expect(executeSpy).toHaveBeenCalledTimes(3);
+  });
+
+  it('normalizes mixed-case filters before SQL and cache identity generation', async () => {
+    const executeSpy = jest
+      .spyOn(sqlExecutor, 'execute')
+      .mockImplementation(async (sql: string) => {
+        const normalizedSql = normalizeSql(sql);
+        if (normalizedSql.includes('sum(count(1)) over () as count')) {
+          expect(normalizedSql).toContain('where value > 0');
+          return [{ count: 1, latest_block: 123, latest_block_count: 1 }];
+        }
+        if (normalizedSql.startsWith('select transactions.*')) {
+          return [];
+        }
+        throw new Error(`Unexpected SQL: ${normalizedSql}`);
+      });
+
+    await fetchTransactions(
+      100,
+      1,
+      undefined,
+      MEMES_CONTRACT,
+      undefined,
+      'Sales'
+    );
+
+    expect(executeSpy).toHaveBeenCalledTimes(2);
+    expect(redisGetMock).toHaveBeenCalledWith(
+      expect.stringContaining('__SEIZE_TRANSACTION_COUNT_')
+    );
+  });
+
+  it('caps oversized pagination before binding limit and offset', async () => {
+    const executeSpy = jest
+      .spyOn(sqlExecutor, 'execute')
+      .mockImplementation(
+        async (sql: string, params?: Record<string, unknown>) => {
+          const normalizedSql = normalizeSql(sql);
+          if (normalizedSql.includes('sum(count(1)) over () as count')) {
+            return [];
+          }
+          if (normalizedSql.startsWith('select transactions.*')) {
+            expect(params).toEqual(
+              expect.objectContaining({
+                transactionLimit: 101,
+                transactionOffset: 999_900
+              })
+            );
+            return [];
+          }
+          throw new Error(`Unexpected SQL: ${normalizedSql}`);
+        }
+      );
+
+    await expect(
+      fetchTransactions(
+        Number.MAX_SAFE_INTEGER,
+        Number.MAX_SAFE_INTEGER,
+        undefined,
+        MEMES_CONTRACT,
+        undefined,
+        null
+      )
+    ).resolves.toEqual({ count: 0, page: 10_000, next: null, data: [] });
+
+    expect(executeSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps serving live rows when Redis read and write operations fail', async () => {
+    redisGetMock.mockRejectedValue(new Error('Redis read failed'));
+    redisCompareAndSetJsonMock.mockRejectedValue(
+      new Error('Redis write failed')
+    );
+    jest
+      .spyOn(sqlExecutor, 'execute')
+      .mockImplementation(async (sql: string) => {
+        const normalizedSql = normalizeSql(sql);
+        if (normalizedSql.includes('sum(count(1)) over () as count')) {
+          return [{ count: 1, latest_block: 123, latest_block_count: 1 }];
+        }
+        if (normalizedSql.startsWith('select transactions.*')) {
+          return [];
+        }
+        throw new Error(`Unexpected SQL: ${normalizedSql}`);
+      });
+
+    await expect(
+      fetchTransactions(100, 1, undefined, MEMES_CONTRACT, undefined, null)
+    ).resolves.toEqual({ count: 1, page: 1, next: null, data: [] });
+  });
+
+  it('uses a stale cached count if incremental reconciliation fails', async () => {
+    redisGetMock.mockResolvedValue({
+      version: 2,
+      count: 250,
+      latestBlock: 123,
+      latestBlockCount: 3,
+      fullyRefreshedAt: Date.now()
+    });
+    jest
+      .spyOn(sqlExecutor, 'execute')
+      .mockImplementation(async (sql: string) => {
+        const normalizedSql = normalizeSql(sql);
+        if (normalizedSql.includes('count(1) as block_count')) {
+          throw new Error('Database count failed');
+        }
+        if (normalizedSql.startsWith('select transactions.*')) {
+          return [];
+        }
+        throw new Error(`Unexpected SQL: ${normalizedSql}`);
+      });
+
+    await expect(
+      fetchTransactions(100, 1, undefined, MEMES_CONTRACT, undefined, null)
+    ).resolves.toEqual({ count: 250, page: 1, next: null, data: [] });
   });
 });
 

--- a/src/db-api.test.ts
+++ b/src/db-api.test.ts
@@ -111,9 +111,45 @@ describe('fetchTransactions', () => {
       null,
       expect.objectContaining({
         version: 2,
+        revision: expect.any(String),
         count: 250,
         latestBlock: 123,
         latestBlockCount: 3
+      }),
+      expect.anything()
+    );
+  });
+
+  it('replaces an invalid cached entry using its revision', async () => {
+    redisGetMock.mockResolvedValue({
+      version: 1,
+      revision: 'invalid-entry-revision',
+      count: -1
+    });
+    jest
+      .spyOn(sqlExecutor, 'execute')
+      .mockImplementation(async (sql: string) => {
+        const normalizedSql = normalizeSql(sql);
+        if (normalizedSql.includes('sum(count(1)) over () as count')) {
+          return [{ count: 1, latest_block: 123, latest_block_count: 1 }];
+        }
+        if (normalizedSql.startsWith('select transactions.*')) {
+          return [];
+        }
+        throw new Error(`Unexpected SQL: ${normalizedSql}`);
+      });
+
+    await expect(
+      fetchTransactions(100, 1, undefined, MEMES_CONTRACT, undefined, null)
+    ).resolves.toEqual({ count: 1, page: 1, next: null, data: [] });
+
+    expect(redisCompareAndSetJsonMock).toHaveBeenCalledWith(
+      expect.any(String),
+      'invalid-entry-revision',
+      expect.objectContaining({
+        version: 2,
+        revision: expect.any(String),
+        count: 1
       }),
       expect.anything()
     );
@@ -123,6 +159,7 @@ describe('fetchTransactions', () => {
     const fullyRefreshedAt = Date.now();
     const cached = {
       version: 2,
+      revision: 'revision-before-increment',
       count: 250,
       latestBlock: 123,
       latestBlockCount: 3,
@@ -165,14 +202,56 @@ describe('fetchTransactions', () => {
     expect(executeSpy).toHaveBeenCalledTimes(2);
     expect(redisCompareAndSetJsonMock).toHaveBeenCalledWith(
       expect.any(String),
-      cached,
-      {
+      cached.revision,
+      expect.objectContaining({
         version: 2,
+        revision: expect.any(String),
         count: 253,
         latestBlock: 130,
         latestBlockCount: 2,
         fullyRefreshedAt
-      },
+      }),
+      expect.anything()
+    );
+  });
+
+  it('returns the reconciled count when a concurrent cache writer wins', async () => {
+    const cached = {
+      version: 2,
+      revision: 'revision-before-conflict',
+      count: 250,
+      latestBlock: 123,
+      latestBlockCount: 3,
+      fullyRefreshedAt: Date.now()
+    };
+    redisGetMock.mockResolvedValue(cached);
+    redisCompareAndSetJsonMock.mockResolvedValue(false);
+    jest
+      .spyOn(sqlExecutor, 'execute')
+      .mockImplementation(async (sql: string) => {
+        const normalizedSql = normalizeSql(sql);
+        if (normalizedSql.includes('count(1) as block_count')) {
+          return [{ block: 123, block_count: 4 }];
+        }
+        if (normalizedSql.startsWith('select transactions.*')) {
+          return [];
+        }
+        throw new Error(`Unexpected SQL: ${normalizedSql}`);
+      });
+
+    await expect(
+      fetchTransactions(100, 1, undefined, MEMES_CONTRACT, undefined, null)
+    ).resolves.toEqual({ count: 251, page: 1, next: null, data: [] });
+
+    expect(redisCompareAndSetJsonMock).toHaveBeenCalledWith(
+      expect.any(String),
+      cached.revision,
+      expect.objectContaining({
+        revision: expect.any(String),
+        count: 251,
+        latestBlock: 123,
+        latestBlockCount: 4
+      }),
       expect.anything()
     );
   });
@@ -180,6 +259,7 @@ describe('fetchTransactions', () => {
   it('periodically rebases a cached count to include historical backfills', async () => {
     const cached = {
       version: 2,
+      revision: 'revision-before-rebase',
       count: 250,
       latestBlock: 123,
       latestBlockCount: 3,
@@ -212,9 +292,10 @@ describe('fetchTransactions', () => {
     expect(executeSpy).toHaveBeenCalledTimes(2);
     expect(redisCompareAndSetJsonMock).toHaveBeenCalledWith(
       expect.any(String),
-      cached,
+      cached.revision,
       expect.objectContaining({
         version: 2,
+        revision: expect.any(String),
         count: 275,
         latestBlock: 140,
         latestBlockCount: 2,
@@ -347,6 +428,7 @@ describe('fetchTransactions', () => {
   it('uses a stale cached count if incremental reconciliation fails', async () => {
     redisGetMock.mockResolvedValue({
       version: 2,
+      revision: 'revision-before-failure',
       count: 250,
       latestBlock: 123,
       latestBlockCount: 3,

--- a/src/db-api.test.ts
+++ b/src/db-api.test.ts
@@ -256,6 +256,35 @@ describe('fetchTransactions', () => {
     );
   });
 
+  it('does not rotate the revision when the read replica misses the boundary', async () => {
+    redisGetMock.mockResolvedValue({
+      version: 2,
+      revision: 'stable-revision',
+      count: 250,
+      latestBlock: 123,
+      latestBlockCount: 3,
+      fullyRefreshedAt: Date.now()
+    });
+    jest
+      .spyOn(sqlExecutor, 'execute')
+      .mockImplementation(async (sql: string) => {
+        const normalizedSql = normalizeSql(sql);
+        if (normalizedSql.includes('count(1) as block_count')) {
+          return [];
+        }
+        if (normalizedSql.startsWith('select transactions.*')) {
+          return [];
+        }
+        throw new Error(`Unexpected SQL: ${normalizedSql}`);
+      });
+
+    await expect(
+      fetchTransactions(100, 1, undefined, MEMES_CONTRACT, undefined, null)
+    ).resolves.toEqual({ count: 250, page: 1, next: null, data: [] });
+
+    expect(redisCompareAndSetJsonMock).not.toHaveBeenCalled();
+  });
+
   it('periodically rebases a cached count to include historical backfills', async () => {
     const cached = {
       version: 2,

--- a/src/db-api.test.ts
+++ b/src/db-api.test.ts
@@ -1,5 +1,16 @@
-import { addRememe } from '@/db-api';
+import { addRememe, fetchTransactions } from '@/db-api';
+import { MEMES_CONTRACT } from '@/constants';
+import { ApiTransaction } from '@/api/generated/models/ApiTransaction';
+import { redisGet, redisSetJson } from '@/redis';
 import { sqlExecutor } from '@/sql-executor';
+
+jest.mock('@/redis', () => ({
+  redisGet: jest.fn(),
+  redisSetJson: jest.fn()
+}));
+
+const redisGetMock = jest.mocked(redisGet);
+const redisSetJsonMock = jest.mocked(redisSetJson);
 
 describe('addRememe', () => {
   afterEach(() => {
@@ -41,3 +52,185 @@ describe('addRememe', () => {
     );
   });
 });
+
+describe('fetchTransactions', () => {
+  beforeEach(() => {
+    redisGetMock.mockReset().mockResolvedValue(null);
+    redisSetJsonMock.mockReset().mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('uses index-compatible ordering and seeds the API count cache', async () => {
+    const transaction = { transaction: '0xtx' } as ApiTransaction;
+    const executeSpy = jest
+      .spyOn(sqlExecutor, 'execute')
+      .mockImplementation(async (sql: string) => {
+        const normalizedSql = normalizeSql(sql);
+        if (normalizedSql.includes('count(1) as count')) {
+          return [{ count: 250, latest_block: 123 }];
+        }
+        if (normalizedSql.startsWith('select transactions.*')) {
+          return [transaction];
+        }
+        throw new Error(`Unexpected SQL: ${normalizedSql}`);
+      });
+
+    await expect(
+      fetchTransactions(100, 1, undefined, MEMES_CONTRACT, undefined, null)
+    ).resolves.toEqual({
+      count: 250,
+      page: 1,
+      next: 'true',
+      data: [transaction]
+    });
+
+    const executedSql = executeSpy.mock.calls.map(([sql]) => normalizeSql(sql));
+    const dataSql = executedSql.find((sql) =>
+      sql.startsWith('select transactions.*')
+    );
+    expect(dataSql).toContain(
+      'order by block desc, transaction desc, from_address desc, to_address desc, contract desc, token_id desc'
+    );
+    expect(redisSetJsonMock).toHaveBeenCalledWith(
+      expect.stringContaining('__SEIZE_TRANSACTION_COUNT_'),
+      expect.objectContaining({
+        version: 1,
+        count: 250,
+        latestBlock: 123
+      }),
+      expect.anything()
+    );
+  });
+
+  it('increments a cached count using only newer matching blocks', async () => {
+    const fullyRefreshedAt = Date.now();
+    redisGetMock.mockResolvedValue({
+      version: 1,
+      count: 250,
+      latestBlock: 123,
+      fullyRefreshedAt
+    });
+    const executeSpy = jest
+      .spyOn(sqlExecutor, 'execute')
+      .mockImplementation(
+        async (sql: string, params?: Record<string, unknown>) => {
+          const normalizedSql = normalizeSql(sql);
+          if (normalizedSql.includes('count(1) as count')) {
+            expect(normalizedSql).toContain(
+              'transactions.block > :countafterblock'
+            );
+            expect(params).toEqual(
+              expect.objectContaining({ countAfterBlock: 123 })
+            );
+            return [{ count: 4, latest_block: 130 }];
+          }
+          if (normalizedSql.startsWith('select transactions.*')) {
+            return [];
+          }
+          throw new Error(`Unexpected SQL: ${normalizedSql}`);
+        }
+      );
+
+    await expect(
+      fetchTransactions(100, 2, undefined, MEMES_CONTRACT, undefined, 'sales')
+    ).resolves.toEqual({
+      count: 254,
+      page: 2,
+      next: 'true',
+      data: []
+    });
+
+    expect(executeSpy).toHaveBeenCalledTimes(2);
+    expect(redisSetJsonMock).toHaveBeenCalledWith(
+      expect.any(String),
+      {
+        version: 1,
+        count: 254,
+        latestBlock: 130,
+        fullyRefreshedAt
+      },
+      expect.anything()
+    );
+  });
+
+  it('periodically rebases a cached count to include historical backfills', async () => {
+    redisGetMock.mockResolvedValue({
+      version: 1,
+      count: 250,
+      latestBlock: 123,
+      fullyRefreshedAt: Date.now() - 7 * 60 * 60 * 1000
+    });
+    const executeSpy = jest
+      .spyOn(sqlExecutor, 'execute')
+      .mockImplementation(async (sql: string) => {
+        const normalizedSql = normalizeSql(sql);
+        if (normalizedSql.includes('count(1) as count')) {
+          expect(normalizedSql).not.toContain('block > :countafterblock');
+          return [{ count: 275, latest_block: 140 }];
+        }
+        if (normalizedSql.startsWith('select transactions.*')) {
+          return [];
+        }
+        throw new Error(`Unexpected SQL: ${normalizedSql}`);
+      });
+
+    await expect(
+      fetchTransactions(100, 1, undefined, MEMES_CONTRACT, undefined, null)
+    ).resolves.toEqual({
+      count: 275,
+      page: 1,
+      next: 'true',
+      data: []
+    });
+
+    expect(executeSpy).toHaveBeenCalledTimes(2);
+    expect(redisSetJsonMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        version: 1,
+        count: 275,
+        latestBlock: 140,
+        fullyRefreshedAt: expect.any(Number)
+      }),
+      expect.anything()
+    );
+  });
+
+  it('falls back to an uncached exact count for wallet-specific requests', async () => {
+    const executeSpy = jest
+      .spyOn(sqlExecutor, 'execute')
+      .mockImplementation(async (sql: string) => {
+        const normalizedSql = normalizeSql(sql);
+        if (normalizedSql.startsWith('select wallet,display from ens')) {
+          return [];
+        }
+        if (normalizedSql.includes('count(1) as count')) {
+          return [{ count: 2, latest_block: 50 }];
+        }
+        if (normalizedSql.startsWith('select transactions.*')) {
+          return [];
+        }
+        throw new Error(`Unexpected SQL: ${normalizedSql}`);
+      });
+
+    await expect(
+      fetchTransactions(50, 1, '0xwallet', MEMES_CONTRACT, undefined, null)
+    ).resolves.toEqual({
+      count: 2,
+      page: 1,
+      next: null,
+      data: []
+    });
+
+    expect(redisGetMock).not.toHaveBeenCalled();
+    expect(redisSetJsonMock).not.toHaveBeenCalled();
+    expect(executeSpy).toHaveBeenCalledTimes(3);
+  });
+});
+
+function normalizeSql(sql: string): string {
+  return sql.replace(/\s+/g, ' ').trim().toLowerCase();
+}

--- a/src/db-api.ts
+++ b/src/db-api.ts
@@ -1035,6 +1035,9 @@ async function fetchTransactionCount(
       filters,
       cached
     );
+    if (!checkpoint) {
+      return cachedTransactionCountFallback(cached, startedAt);
+    }
     const updatedEntry: TransactionCountCacheEntry = {
       ...cached,
       ...checkpoint,
@@ -1100,7 +1103,7 @@ async function executeFullTransactionCountQuery(filters: {
 async function executeIncrementalTransactionCountQuery(
   filters: { filters: string; params: Record<string, unknown> },
   cached: TransactionCountCacheEntry
-): Promise<TransactionCountCheckpoint> {
+): Promise<TransactionCountCheckpoint | null> {
   const countFilters = constructFilters(
     filters.filters,
     `${TRANSACTIONS_TABLE}.block >= :countFromBlock`
@@ -1128,17 +1131,17 @@ async function executeIncrementalTransactionCountQuery(
     // The transactions table is append-only. A missing or smaller boundary
     // can only be a temporarily lagging replica, so never regress the cached
     // checkpoint. The next request will reconcile it again.
-    return cached;
+    return null;
   }
   const countedFromBoundary = rows.reduce(
     (total, row) => total + Number(row.block_count),
     0
   );
-  const latestRow = rows.at(-1);
+  const latestRow = rows[rows.length - 1];
   return {
     count: cached.count - cached.latestBlockCount + countedFromBoundary,
-    latestBlock: latestRow ? Number(latestRow.block) : cached.latestBlock,
-    latestBlockCount: latestRow ? Number(latestRow.block_count) : 0
+    latestBlock: Number(latestRow.block),
+    latestBlockCount: Number(latestRow.block_count)
   };
 }
 

--- a/src/db-api.ts
+++ b/src/db-api.ts
@@ -907,9 +907,10 @@ async function fetchPaginatedTransactions(
   const joins = `LEFT JOIN ${ENS_TABLE} ens1 ON ${TRANSACTIONS_TABLE}.from_address=ens1.wallet LEFT JOIN ${ENS_TABLE} ens2 ON ${TRANSACTIONS_TABLE}.to_address=ens2.wallet`;
   const orderBy =
     'block DESC, transaction DESC, from_address DESC, to_address DESC, contract DESC, token_id DESC';
+  const limitPart = pageSize > 0 ? `LIMIT ${pageSize}` : '';
   let dataSql = `SELECT ${fields} FROM ${TRANSACTIONS_TABLE} ${joins} ${
     filters.filters
-  } order by ${orderBy} ${pageSize > 0 ? `LIMIT ${pageSize}` : ''}`;
+  } order by ${orderBy} ${limitPart}`;
   if (page > 1) {
     dataSql += ` OFFSET ${pageSize * (page - 1)}`;
   }

--- a/src/db-api.ts
+++ b/src/db-api.ts
@@ -42,7 +42,7 @@ import {
 import { getConsolidationsSql } from './sql_helpers';
 
 import { Nft } from '@/alchemy-sdk';
-import { createHash } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import * as mysql from 'mysql';
 import {
   DEFAULT_PAGE_SIZE,
@@ -93,10 +93,16 @@ const MAX_TRANSACTION_PAGE = 10_000;
 
 interface TransactionCountCacheEntry {
   readonly version: number;
+  readonly revision: string;
   readonly count: number;
   readonly latestBlock: number;
   readonly latestBlockCount: number;
   readonly fullyRefreshedAt: number;
+}
+
+interface TransactionCountCacheReadResult {
+  readonly entry: TransactionCountCacheEntry | null;
+  readonly revisionToReplace: string | null;
 }
 
 interface FullTransactionCountQueryRow {
@@ -985,9 +991,8 @@ async function fetchTransactionCount(
     };
   }
 
-  const cached = countCacheKey
-    ? await readTransactionCountCache(countCacheKey)
-    : null;
+  const cacheRead = await readTransactionCountCache(countCacheKey);
+  const cached = cacheRead.entry;
   const needsFullRefresh =
     !cached ||
     Date.now() - cached.fullyRefreshedAt >=
@@ -998,10 +1003,15 @@ async function fetchTransactionCount(
       const checkpoint = await executeFullTransactionCountQuery(filters);
       const updatedEntry: TransactionCountCacheEntry = {
         version: TRANSACTION_COUNT_CACHE_VERSION,
+        revision: randomUUID(),
         ...checkpoint,
         fullyRefreshedAt: Date.now()
       };
-      await writeTransactionCountCache(countCacheKey, cached, updatedEntry);
+      await writeTransactionCountCache(
+        countCacheKey,
+        cacheRead.revisionToReplace,
+        updatedEntry
+      );
       return {
         count: checkpoint.count,
         source: cached ? 'cache_rebase' : 'cache_seed',
@@ -1027,9 +1037,14 @@ async function fetchTransactionCount(
     );
     const updatedEntry: TransactionCountCacheEntry = {
       ...cached,
-      ...checkpoint
+      ...checkpoint,
+      revision: randomUUID()
     };
-    await writeTransactionCountCache(countCacheKey, cached, updatedEntry);
+    await writeTransactionCountCache(
+      countCacheKey,
+      cached.revision,
+      updatedEntry
+    );
     return {
       count: updatedEntry.count,
       source: 'cache_increment',
@@ -1168,31 +1183,42 @@ function getTransactionCountCacheKey({
 
 async function readTransactionCountCache(
   key: string
-): Promise<TransactionCountCacheEntry | null> {
+): Promise<TransactionCountCacheReadResult> {
   try {
     const entry = await redisGet<unknown>(key);
-    return isTransactionCountCacheEntry(entry) ? entry : null;
+    return {
+      entry: isTransactionCountCacheEntry(entry) ? entry : null,
+      revisionToReplace: getRedisRevision(entry)
+    };
   } catch (error) {
     logger.warn('[TRANSACTION_COUNT_CACHE_READ_FAILED]', error);
-    return null;
+    return { entry: null, revisionToReplace: null };
   }
 }
 
 async function writeTransactionCountCache(
   key: string,
-  expected: TransactionCountCacheEntry | null,
+  expectedRevision: string | null,
   entry: TransactionCountCacheEntry
 ): Promise<void> {
   try {
     await redisCompareAndSetJson(
       key,
-      expected,
+      expectedRevision,
       entry,
       TRANSACTION_COUNT_CACHE_TTL
     );
   } catch (error) {
     logger.warn('[TRANSACTION_COUNT_CACHE_WRITE_FAILED]', error);
   }
+}
+
+function getRedisRevision(value: unknown): string | null {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+  const revision = (value as Record<string, unknown>).revision;
+  return typeof revision === 'string' && revision.length > 0 ? revision : null;
 }
 
 function isTransactionCountCacheEntry(
@@ -1204,6 +1230,8 @@ function isTransactionCountCacheEntry(
   const entry = value as Record<string, unknown>;
   return (
     entry.version === TRANSACTION_COUNT_CACHE_VERSION &&
+    typeof entry.revision === 'string' &&
+    entry.revision.length > 0 &&
     typeof entry.count === 'number' &&
     entry.count >= 0 &&
     typeof entry.latestBlock === 'number' &&

--- a/src/db-api.ts
+++ b/src/db-api.ts
@@ -42,6 +42,7 @@ import {
 import { getConsolidationsSql } from './sql_helpers';
 
 import { Nft } from '@/alchemy-sdk';
+import { createHash } from 'node:crypto';
 import * as mysql from 'mysql';
 import {
   NFTSearchResult,
@@ -61,6 +62,7 @@ import {
 import { consolidationTools } from './consolidation-tools';
 import { DbPoolName, DbQueryOptions } from './db-query.options';
 import { numbers } from './numbers';
+import { redisGet, redisSetJson } from './redis';
 import {
   CustomTypeCaster,
   execNativeTransactionally,
@@ -81,6 +83,32 @@ let write_pool: mysql.Pool;
 const WRITE_OPERATIONS = ['INSERT', 'UPDATE', 'DELETE', 'REPLACE'];
 
 const logger = Logger.get('DB_API');
+
+const TRANSACTION_COUNT_CACHE_VERSION = 1;
+const TRANSACTION_COUNT_CACHE_TTL = Time.days(7);
+const TRANSACTION_COUNT_FULL_REFRESH_INTERVAL = Time.hours(6);
+
+interface TransactionCountCacheEntry {
+  readonly version: number;
+  readonly count: number;
+  readonly latestBlock: number;
+  readonly fullyRefreshedAt: number;
+}
+
+interface TransactionCountQueryRow {
+  readonly count: number | string;
+  readonly latest_block: number | string;
+}
+
+interface TransactionCountResult {
+  readonly count: number;
+  readonly source:
+    | 'cache_increment'
+    | 'cache_rebase'
+    | 'cache_seed'
+    | 'exact_uncached';
+  readonly elapsedMs: number;
+}
 
 export async function connect() {
   if (read_pool && write_pool) {
@@ -743,15 +771,15 @@ export async function resolveEns(walletsStr: string) {
 }
 
 async function getTransactionFilters(
-  wallets: string,
-  nfts: string,
-  type_filter: string
+  wallets: string | undefined,
+  nfts: string | undefined,
+  type_filter: string | null | undefined
 ): Promise<{
   filters: string;
-  params: any;
+  params: Record<string, unknown>;
 } | null> {
   let filters = '';
-  const params: any = {};
+  const params: Record<string, unknown> = {};
   if (wallets) {
     const resolvedWallets = await resolveEns(wallets);
     if (resolvedWallets.length == 0) {
@@ -841,10 +869,10 @@ export async function fetchLabTransactions(
 export async function fetchTransactions(
   pageSize: number,
   page: number,
-  wallets: string,
-  contracts: string,
-  nfts: string,
-  type_filter: string
+  wallets: string | undefined,
+  contracts: string | undefined,
+  nfts: string | undefined,
+  type_filter: string | null | undefined
 ): Promise<ApiTransactionPage> {
   const filters = await getTransactionFilters(wallets, nfts, type_filter);
   if (!filters) {
@@ -859,31 +887,208 @@ export async function fetchTransactions(
     filters.params.contracts = contracts.split(',');
   }
 
-  return fetchPaginatedTransactions(pageSize, page, filters);
+  const countCacheKey = getTransactionCountCacheKey({
+    wallets,
+    contracts,
+    nfts,
+    typeFilter: type_filter
+  });
+
+  return fetchPaginatedTransactions(pageSize, page, filters, countCacheKey);
 }
 
 async function fetchPaginatedTransactions(
   pageSize: number,
   page: number,
-  filters: { filters: string; params: any }
-) {
+  filters: { filters: string; params: Record<string, unknown> },
+  countCacheKey: string | null
+): Promise<ApiTransactionPage> {
   const fields = `${TRANSACTIONS_TABLE}.*,ens1.display as from_display, ens2.display as to_display`;
   const joins = `LEFT JOIN ${ENS_TABLE} ens1 ON ${TRANSACTIONS_TABLE}.from_address=ens1.wallet LEFT JOIN ${ENS_TABLE} ens2 ON ${TRANSACTIONS_TABLE}.to_address=ens2.wallet`;
-
   const orderBy =
-    'block DESC, transaction DESC, contract DESC, token_id DESC, from_address DESC, to_address DESC';
+    'block DESC, transaction DESC, from_address DESC, to_address DESC, contract DESC, token_id DESC';
+  let dataSql = `SELECT ${fields} FROM ${TRANSACTIONS_TABLE} ${joins} ${
+    filters.filters
+  } order by ${orderBy} ${pageSize > 0 ? `LIMIT ${pageSize}` : ''}`;
+  if (page > 1) {
+    dataSql += ` OFFSET ${pageSize * (page - 1)}`;
+  }
 
-  return fetchPaginated<ApiTransaction>(
-    TRANSACTIONS_TABLE,
-    filters.params,
-    orderBy,
-    pageSize,
+  const requestStartedAt = Date.now();
+  const countPromise = fetchTransactionCount(filters, countCacheKey);
+  const dataStartedAt = Date.now();
+  const dataPromise = sqlExecutor
+    .execute<ApiTransaction>(dataSql, filters.params)
+    .then((data) => ({ data, elapsedMs: Date.now() - dataStartedAt }));
+  const [countResult, dataResult] = await Promise.all([
+    countPromise,
+    dataPromise
+  ]);
+  const totalElapsedMs = Date.now() - requestStartedAt;
+  logger.info(
+    `[TRANSACTION_PAGINATION_TIMING] [COUNT_SOURCE ${
+      countResult.source
+    }] [COUNT_MS ${countResult.elapsedMs}] [DATA_MS ${
+      dataResult.elapsedMs
+    }] [TOTAL_MS ${totalElapsedMs}]`
+  );
+
+  return {
+    count: countResult.count,
     page,
-    filters.filters,
-    fields,
-    joins,
-    undefined,
-    { skipJoinsOnCountQuery: true }
+    next: pageSize > 0 && countResult.count > pageSize * page ? 'true' : null,
+    data: dataResult.data
+  };
+}
+
+async function fetchTransactionCount(
+  filters: { filters: string; params: Record<string, unknown> },
+  countCacheKey: string | null
+): Promise<TransactionCountResult> {
+  const startedAt = Date.now();
+  const cached = countCacheKey
+    ? await readTransactionCountCache(countCacheKey)
+    : null;
+  const needsFullRefresh =
+    !cached ||
+    Date.now() - cached.fullyRefreshedAt >=
+      TRANSACTION_COUNT_FULL_REFRESH_INTERVAL.toMillis();
+
+  if (needsFullRefresh) {
+    const countRow = await executeTransactionCountQuery(filters, null);
+    if (countCacheKey) {
+      await writeTransactionCountCache(countCacheKey, {
+        version: TRANSACTION_COUNT_CACHE_VERSION,
+        count: Number(countRow.count),
+        latestBlock: Number(countRow.latest_block),
+        fullyRefreshedAt: Date.now()
+      });
+    }
+    let source: TransactionCountResult['source'] = 'exact_uncached';
+    if (countCacheKey) {
+      source = cached ? 'cache_rebase' : 'cache_seed';
+    }
+    return {
+      count: Number(countRow.count),
+      source,
+      elapsedMs: Date.now() - startedAt
+    };
+  }
+
+  // Transaction discovery persists complete blocks. Counting only rows after
+  // this checkpoint therefore keeps active contract/filter totals exact while
+  // avoiding a full historical scan on every API request. The periodic rebase
+  // above self-heals rare manual backfills into older blocks.
+  const countRow = await executeTransactionCountQuery(
+    filters,
+    cached.latestBlock
+  );
+  const updatedEntry: TransactionCountCacheEntry = {
+    ...cached,
+    count: cached.count + Number(countRow.count),
+    latestBlock: Number(countRow.latest_block)
+  };
+  await writeTransactionCountCache(countCacheKey!, updatedEntry);
+  return {
+    count: updatedEntry.count,
+    source: 'cache_increment',
+    elapsedMs: Date.now() - startedAt
+  };
+}
+
+async function executeTransactionCountQuery(
+  filters: { filters: string; params: Record<string, unknown> },
+  countAfterBlock: number | null
+): Promise<TransactionCountQueryRow> {
+  const isIncremental = countAfterBlock !== null;
+  const countFilters = isIncremental
+    ? constructFilters(
+        filters.filters,
+        `${TRANSACTIONS_TABLE}.block > :countAfterBlock`
+      )
+    : filters.filters;
+  const latestBlockFallback = isIncremental ? ':countAfterBlock' : '0';
+  const countSql = `
+    SELECT
+      COUNT(1) as count,
+      COALESCE(MAX(${TRANSACTIONS_TABLE}.block), ${latestBlockFallback}) as latest_block
+    FROM ${TRANSACTIONS_TABLE}
+    ${countFilters}
+  `;
+  const params = isIncremental
+    ? { ...filters.params, countAfterBlock }
+    : filters.params;
+  return sqlExecutor
+    .execute<TransactionCountQueryRow>(countSql, params)
+    .then((rows) => rows[0]);
+}
+
+function getTransactionCountCacheKey({
+  wallets,
+  contracts,
+  nfts,
+  typeFilter
+}: {
+  readonly wallets: string | undefined;
+  readonly contracts: string | undefined;
+  readonly nfts: string | undefined;
+  readonly typeFilter: string | null | undefined;
+}): string | null {
+  if (wallets || nfts) {
+    return null;
+  }
+  const cacheContracts = (contracts ?? '')
+    .split(',')
+    .filter(Boolean)
+    .sort((a, b) => a.localeCompare(b));
+  const cacheIdentity = JSON.stringify({
+    contracts: cacheContracts,
+    filter: typeFilter?.toLowerCase() ?? 'all'
+  });
+  const digest = createHash('sha256').update(cacheIdentity).digest('hex');
+  return `__SEIZE_TRANSACTION_COUNT_${
+    process.env.NODE_ENV ?? 'unknown'
+  }__${TRANSACTION_COUNT_CACHE_VERSION}__${digest}`;
+}
+
+async function readTransactionCountCache(
+  key: string
+): Promise<TransactionCountCacheEntry | null> {
+  try {
+    const entry = await redisGet<unknown>(key);
+    return isTransactionCountCacheEntry(entry) ? entry : null;
+  } catch (error) {
+    logger.warn('[TRANSACTION_COUNT_CACHE_READ_FAILED]', error);
+    return null;
+  }
+}
+
+async function writeTransactionCountCache(
+  key: string,
+  entry: TransactionCountCacheEntry
+): Promise<void> {
+  try {
+    await redisSetJson(key, entry, TRANSACTION_COUNT_CACHE_TTL);
+  } catch (error) {
+    logger.warn('[TRANSACTION_COUNT_CACHE_WRITE_FAILED]', error);
+  }
+}
+
+function isTransactionCountCacheEntry(
+  value: unknown
+): value is TransactionCountCacheEntry {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const entry = value as Record<string, unknown>;
+  return (
+    entry.version === TRANSACTION_COUNT_CACHE_VERSION &&
+    typeof entry.count === 'number' &&
+    entry.count >= 0 &&
+    typeof entry.latestBlock === 'number' &&
+    entry.latestBlock >= 0 &&
+    typeof entry.fullyRefreshedAt === 'number' &&
+    entry.fullyRefreshedAt > 0
   );
 }
 

--- a/src/db-api.ts
+++ b/src/db-api.ts
@@ -45,6 +45,7 @@ import { Nft } from '@/alchemy-sdk';
 import { createHash } from 'node:crypto';
 import * as mysql from 'mysql';
 import {
+  DEFAULT_PAGE_SIZE,
   NFTSearchResult,
   PaginatedResponse
 } from './api-serverless/src/api-constants';
@@ -62,7 +63,7 @@ import {
 import { consolidationTools } from './consolidation-tools';
 import { DbPoolName, DbQueryOptions } from './db-query.options';
 import { numbers } from './numbers';
-import { redisGet, redisSetJson } from './redis';
+import { redisCompareAndSetJson, redisGet } from './redis';
 import {
   CustomTypeCaster,
   execNativeTransactionally,
@@ -84,20 +85,35 @@ const WRITE_OPERATIONS = ['INSERT', 'UPDATE', 'DELETE', 'REPLACE'];
 
 const logger = Logger.get('DB_API');
 
-const TRANSACTION_COUNT_CACHE_VERSION = 1;
+const TRANSACTION_COUNT_CACHE_VERSION = 2;
 const TRANSACTION_COUNT_CACHE_TTL = Time.days(7);
 const TRANSACTION_COUNT_FULL_REFRESH_INTERVAL = Time.hours(6);
+const MAX_TRANSACTION_PAGE_SIZE = 100;
+const MAX_TRANSACTION_PAGE = 10_000;
 
 interface TransactionCountCacheEntry {
   readonly version: number;
   readonly count: number;
   readonly latestBlock: number;
+  readonly latestBlockCount: number;
   readonly fullyRefreshedAt: number;
 }
 
-interface TransactionCountQueryRow {
+interface FullTransactionCountQueryRow {
   readonly count: number | string;
   readonly latest_block: number | string;
+  readonly latest_block_count: number | string;
+}
+
+interface IncrementalTransactionCountQueryRow {
+  readonly block: number | string;
+  readonly block_count: number | string;
+}
+
+interface TransactionCountCheckpoint {
+  readonly count: number;
+  readonly latestBlock: number;
+  readonly latestBlockCount: number;
 }
 
 interface TransactionCountResult {
@@ -106,6 +122,7 @@ interface TransactionCountResult {
     | 'cache_increment'
     | 'cache_rebase'
     | 'cache_seed'
+    | 'cache_stale_fallback'
     | 'exact_uncached';
   readonly elapsedMs: number;
 }
@@ -874,7 +891,12 @@ export async function fetchTransactions(
   nfts: string | undefined,
   type_filter: string | null | undefined
 ): Promise<ApiTransactionPage> {
-  const filters = await getTransactionFilters(wallets, nfts, type_filter);
+  const normalizedTypeFilter = type_filter?.toLowerCase();
+  const filters = await getTransactionFilters(
+    wallets,
+    nfts,
+    normalizedTypeFilter
+  );
   if (!filters) {
     return returnEmpty();
   }
@@ -891,10 +913,16 @@ export async function fetchTransactions(
     wallets,
     contracts,
     nfts,
-    typeFilter: type_filter
+    typeFilter: normalizedTypeFilter
   });
+  const pagination = normalizeTransactionPagination(pageSize, page);
 
-  return fetchPaginatedTransactions(pageSize, page, filters, countCacheKey);
+  return fetchPaginatedTransactions(
+    pagination.pageSize,
+    pagination.page,
+    filters,
+    countCacheKey
+  );
 }
 
 async function fetchPaginatedTransactions(
@@ -907,19 +935,20 @@ async function fetchPaginatedTransactions(
   const joins = `LEFT JOIN ${ENS_TABLE} ens1 ON ${TRANSACTIONS_TABLE}.from_address=ens1.wallet LEFT JOIN ${ENS_TABLE} ens2 ON ${TRANSACTIONS_TABLE}.to_address=ens2.wallet`;
   const orderBy =
     'block DESC, transaction DESC, from_address DESC, to_address DESC, contract DESC, token_id DESC';
-  const limitPart = pageSize > 0 ? `LIMIT ${pageSize}` : '';
-  let dataSql = `SELECT ${fields} FROM ${TRANSACTIONS_TABLE} ${joins} ${
+  const dataSql = `SELECT ${fields} FROM ${TRANSACTIONS_TABLE} ${joins} ${
     filters.filters
-  } order by ${orderBy} ${limitPart}`;
-  if (page > 1) {
-    dataSql += ` OFFSET ${pageSize * (page - 1)}`;
-  }
+  } order by ${orderBy} LIMIT :transactionLimit OFFSET :transactionOffset`;
+  const dataParams = {
+    ...filters.params,
+    transactionLimit: pageSize + 1,
+    transactionOffset: pageSize * (page - 1)
+  };
 
   const requestStartedAt = Date.now();
   const countPromise = fetchTransactionCount(filters, countCacheKey);
   const dataStartedAt = Date.now();
   const dataPromise = sqlExecutor
-    .execute<ApiTransaction>(dataSql, filters.params)
+    .execute<ApiTransaction>(dataSql, dataParams)
     .then((data) => ({ data, elapsedMs: Date.now() - dataStartedAt }));
   const [countResult, dataResult] = await Promise.all([
     countPromise,
@@ -937,8 +966,8 @@ async function fetchPaginatedTransactions(
   return {
     count: countResult.count,
     page,
-    next: pageSize > 0 && countResult.count > pageSize * page ? 'true' : null,
-    data: dataResult.data
+    next: dataResult.data.length > pageSize ? 'true' : null,
+    data: dataResult.data.slice(0, pageSize)
   };
 }
 
@@ -947,6 +976,15 @@ async function fetchTransactionCount(
   countCacheKey: string | null
 ): Promise<TransactionCountResult> {
   const startedAt = Date.now();
+  if (!countCacheKey) {
+    const count = await executeExactTransactionCountQuery(filters);
+    return {
+      count,
+      source: 'exact_uncached',
+      elapsedMs: Date.now() - startedAt
+    };
+  }
+
   const cached = countCacheKey
     ? await readTransactionCountCache(countCacheKey)
     : null;
@@ -956,72 +994,148 @@ async function fetchTransactionCount(
       TRANSACTION_COUNT_FULL_REFRESH_INTERVAL.toMillis();
 
   if (needsFullRefresh) {
-    const countRow = await executeTransactionCountQuery(filters, null);
-    if (countCacheKey) {
-      await writeTransactionCountCache(countCacheKey, {
+    try {
+      const checkpoint = await executeFullTransactionCountQuery(filters);
+      const updatedEntry: TransactionCountCacheEntry = {
         version: TRANSACTION_COUNT_CACHE_VERSION,
-        count: Number(countRow.count),
-        latestBlock: Number(countRow.latest_block),
+        ...checkpoint,
         fullyRefreshedAt: Date.now()
-      });
+      };
+      await writeTransactionCountCache(countCacheKey, cached, updatedEntry);
+      return {
+        count: checkpoint.count,
+        source: cached ? 'cache_rebase' : 'cache_seed',
+        elapsedMs: Date.now() - startedAt
+      };
+    } catch (error) {
+      if (cached) {
+        logger.warn('[TRANSACTION_COUNT_REBASE_FAILED_USING_STALE]', error);
+        return cachedTransactionCountFallback(cached, startedAt);
+      }
+      throw error;
     }
-    let source: TransactionCountResult['source'] = 'exact_uncached';
-    if (countCacheKey) {
-      source = cached ? 'cache_rebase' : 'cache_seed';
-    }
-    return {
-      count: Number(countRow.count),
-      source,
-      elapsedMs: Date.now() - startedAt
-    };
   }
 
-  // Transaction discovery persists complete blocks. Counting only rows after
-  // this checkpoint therefore keeps active contract/filter totals exact while
-  // avoiding a full historical scan on every API request. The periodic rebase
-  // above self-heals rare manual backfills into older blocks.
-  const countRow = await executeTransactionCountQuery(
-    filters,
-    cached.latestBlock
+  try {
+    // Recount the checkpoint block as well as newer blocks. Replacing the
+    // cached boundary count makes delayed rows in the same block visible and
+    // keeps concurrent calculations idempotent. The Redis compare-and-set
+    // below prevents a slower request from overwriting a newer checkpoint.
+    const checkpoint = await executeIncrementalTransactionCountQuery(
+      filters,
+      cached
+    );
+    const updatedEntry: TransactionCountCacheEntry = {
+      ...cached,
+      ...checkpoint
+    };
+    await writeTransactionCountCache(countCacheKey, cached, updatedEntry);
+    return {
+      count: updatedEntry.count,
+      source: 'cache_increment',
+      elapsedMs: Date.now() - startedAt
+    };
+  } catch (error) {
+    logger.warn('[TRANSACTION_COUNT_INCREMENT_FAILED_USING_STALE]', error);
+    return cachedTransactionCountFallback(cached, startedAt);
+  }
+}
+
+async function executeExactTransactionCountQuery(filters: {
+  filters: string;
+  params: Record<string, unknown>;
+}): Promise<number> {
+  const countSql = `
+    SELECT COUNT(1) as count
+    FROM ${TRANSACTIONS_TABLE}
+    ${filters.filters}
+  `;
+  return sqlExecutor
+    .execute<{ count: number | string }>(countSql, filters.params)
+    .then((rows) => Number(rows[0].count));
+}
+
+async function executeFullTransactionCountQuery(filters: {
+  filters: string;
+  params: Record<string, unknown>;
+}): Promise<TransactionCountCheckpoint> {
+  const countSql = `
+    SELECT
+      ${TRANSACTIONS_TABLE}.block as latest_block,
+      COUNT(1) as latest_block_count,
+      SUM(COUNT(1)) OVER () as count
+    FROM ${TRANSACTIONS_TABLE}
+    ${filters.filters}
+    GROUP BY ${TRANSACTIONS_TABLE}.block
+    ORDER BY ${TRANSACTIONS_TABLE}.block DESC
+    LIMIT 1
+  `;
+  const row = await sqlExecutor
+    .execute<FullTransactionCountQueryRow>(countSql, filters.params)
+    .then((rows) => rows[0]);
+  return row
+    ? {
+        count: Number(row.count),
+        latestBlock: Number(row.latest_block),
+        latestBlockCount: Number(row.latest_block_count)
+      }
+    : { count: 0, latestBlock: 0, latestBlockCount: 0 };
+}
+
+async function executeIncrementalTransactionCountQuery(
+  filters: { filters: string; params: Record<string, unknown> },
+  cached: TransactionCountCacheEntry
+): Promise<TransactionCountCheckpoint> {
+  const countFilters = constructFilters(
+    filters.filters,
+    `${TRANSACTIONS_TABLE}.block >= :countFromBlock`
   );
-  const updatedEntry: TransactionCountCacheEntry = {
-    ...cached,
-    count: cached.count + Number(countRow.count),
-    latestBlock: Number(countRow.latest_block)
-  };
-  await writeTransactionCountCache(countCacheKey!, updatedEntry);
+  const countSql = `
+    SELECT
+      ${TRANSACTIONS_TABLE}.block as block,
+      COUNT(1) as block_count
+    FROM ${TRANSACTIONS_TABLE}
+    ${countFilters}
+    GROUP BY ${TRANSACTIONS_TABLE}.block
+    ORDER BY ${TRANSACTIONS_TABLE}.block ASC
+  `;
+  const rows = await sqlExecutor.execute<IncrementalTransactionCountQueryRow>(
+    countSql,
+    { ...filters.params, countFromBlock: cached.latestBlock }
+  );
+  const boundaryRow = rows.find(
+    (row) => Number(row.block) === cached.latestBlock
+  );
+  if (
+    !boundaryRow ||
+    Number(boundaryRow.block_count) < cached.latestBlockCount
+  ) {
+    // The transactions table is append-only. A missing or smaller boundary
+    // can only be a temporarily lagging replica, so never regress the cached
+    // checkpoint. The next request will reconcile it again.
+    return cached;
+  }
+  const countedFromBoundary = rows.reduce(
+    (total, row) => total + Number(row.block_count),
+    0
+  );
+  const latestRow = rows.at(-1);
   return {
-    count: updatedEntry.count,
-    source: 'cache_increment',
-    elapsedMs: Date.now() - startedAt
+    count: cached.count - cached.latestBlockCount + countedFromBoundary,
+    latestBlock: latestRow ? Number(latestRow.block) : cached.latestBlock,
+    latestBlockCount: latestRow ? Number(latestRow.block_count) : 0
   };
 }
 
-async function executeTransactionCountQuery(
-  filters: { filters: string; params: Record<string, unknown> },
-  countAfterBlock: number | null
-): Promise<TransactionCountQueryRow> {
-  const isIncremental = countAfterBlock !== null;
-  const countFilters = isIncremental
-    ? constructFilters(
-        filters.filters,
-        `${TRANSACTIONS_TABLE}.block > :countAfterBlock`
-      )
-    : filters.filters;
-  const latestBlockFallback = isIncremental ? ':countAfterBlock' : '0';
-  const countSql = `
-    SELECT
-      COUNT(1) as count,
-      COALESCE(MAX(${TRANSACTIONS_TABLE}.block), ${latestBlockFallback}) as latest_block
-    FROM ${TRANSACTIONS_TABLE}
-    ${countFilters}
-  `;
-  const params = isIncremental
-    ? { ...filters.params, countAfterBlock }
-    : filters.params;
-  return sqlExecutor
-    .execute<TransactionCountQueryRow>(countSql, params)
-    .then((rows) => rows[0]);
+function cachedTransactionCountFallback(
+  cached: TransactionCountCacheEntry,
+  startedAt: number
+): TransactionCountResult {
+  return {
+    count: cached.count,
+    source: 'cache_stale_fallback',
+    elapsedMs: Date.now() - startedAt
+  };
 }
 
 function getTransactionCountCacheKey({
@@ -1044,7 +1158,7 @@ function getTransactionCountCacheKey({
     .sort((a, b) => a.localeCompare(b));
   const cacheIdentity = JSON.stringify({
     contracts: cacheContracts,
-    filter: typeFilter?.toLowerCase() ?? 'all'
+    filter: typeFilter ?? 'all'
   });
   const digest = createHash('sha256').update(cacheIdentity).digest('hex');
   return `__SEIZE_TRANSACTION_COUNT_${
@@ -1066,10 +1180,16 @@ async function readTransactionCountCache(
 
 async function writeTransactionCountCache(
   key: string,
+  expected: TransactionCountCacheEntry | null,
   entry: TransactionCountCacheEntry
 ): Promise<void> {
   try {
-    await redisSetJson(key, entry, TRANSACTION_COUNT_CACHE_TTL);
+    await redisCompareAndSetJson(
+      key,
+      expected,
+      entry,
+      TRANSACTION_COUNT_CACHE_TTL
+    );
   } catch (error) {
     logger.warn('[TRANSACTION_COUNT_CACHE_WRITE_FAILED]', error);
   }
@@ -1088,9 +1208,26 @@ function isTransactionCountCacheEntry(
     entry.count >= 0 &&
     typeof entry.latestBlock === 'number' &&
     entry.latestBlock >= 0 &&
+    typeof entry.latestBlockCount === 'number' &&
+    entry.latestBlockCount >= 0 &&
     typeof entry.fullyRefreshedAt === 'number' &&
     entry.fullyRefreshedAt > 0
   );
+}
+
+function normalizeTransactionPagination(
+  pageSize: number,
+  page: number
+): { readonly pageSize: number; readonly page: number } {
+  const normalizedPageSize =
+    Number.isSafeInteger(pageSize) && pageSize > 0
+      ? Math.min(pageSize, MAX_TRANSACTION_PAGE_SIZE)
+      : DEFAULT_PAGE_SIZE;
+  const normalizedPage =
+    Number.isSafeInteger(page) && page > 0
+      ? Math.min(page, MAX_TRANSACTION_PAGE)
+      : 1;
+  return { pageSize: normalizedPageSize, page: normalizedPage };
 }
 
 export async function fetchGradientTdh(pageSize: number, page: number) {

--- a/src/redis.test.ts
+++ b/src/redis.test.ts
@@ -26,23 +26,26 @@ describe('redis cache eviction helpers', () => {
     scan,
     del = jest.fn().mockResolvedValue(undefined),
     connect = jest.fn().mockResolvedValue(undefined),
-    on = jest.fn()
+    on = jest.fn(),
+    eval: evalScript = jest.fn()
   }: {
     scan: jest.Mock;
     del?: jest.Mock;
     connect?: jest.Mock;
     on?: jest.Mock;
+    eval?: jest.Mock;
   }) {
     jest.doMock('redis', () => ({
       createClient: jest.fn(() => ({
         scan,
         del,
         connect,
-        on
+        on,
+        eval: evalScript
       }))
     }));
 
-    return { scan, del, connect, on };
+    return { scan, del, connect, on, eval: evalScript };
   }
 
   it('stops scanning when redis returns the terminal cursor as a string', async () => {
@@ -152,5 +155,53 @@ describe('redis cache eviction helpers', () => {
     if (!result.success) {
       expect(String(result.error)).toContain('Timed out after 1ms');
     }
+  });
+
+  it('atomically replaces the expected JSON value with a TTL', async () => {
+    const evalScript = jest.fn().mockResolvedValue(1);
+    const { connect } = mockRedisClient({
+      scan: jest.fn(),
+      eval: evalScript
+    });
+    const redisModule = await import('./redis');
+    const { Time } = await import('./time');
+
+    await redisModule.initRedis();
+    const updated = await redisModule.redisCompareAndSetJson(
+      'transaction-count',
+      { count: 1 },
+      { count: 2 },
+      Time.minutes(5)
+    );
+
+    expect(connect).toHaveBeenCalledTimes(1);
+    expect(updated).toBe(true);
+    expect(evalScript).toHaveBeenCalledWith(expect.any(String), {
+      keys: ['transaction-count'],
+      arguments: [
+        JSON.stringify({ count: 1 }),
+        JSON.stringify({ count: 2 }),
+        '300',
+        '__SEIZE_REDIS_VALUE_MISSING__'
+      ]
+    });
+  });
+
+  it('reports a compare-and-set conflict without overwriting the cache', async () => {
+    const evalScript = jest.fn().mockResolvedValue(0);
+    mockRedisClient({ scan: jest.fn(), eval: evalScript });
+    const redisModule = await import('./redis');
+    const { Time } = await import('./time');
+
+    await redisModule.initRedis();
+
+    await expect(
+      redisModule.redisCompareAndSetJson(
+        'transaction-count',
+        null,
+        { count: 1 },
+        Time.minutes(5)
+      )
+    ).resolves.toBe(false);
   });
 });

--- a/src/redis.test.ts
+++ b/src/redis.test.ts
@@ -169,8 +169,8 @@ describe('redis cache eviction helpers', () => {
     await redisModule.initRedis();
     const updated = await redisModule.redisCompareAndSetJson(
       'transaction-count',
-      { count: 1 },
-      { count: 2 },
+      'revision-1',
+      { revision: 'revision-2', count: 2 },
       Time.minutes(5)
     );
 
@@ -179,10 +179,9 @@ describe('redis cache eviction helpers', () => {
     expect(evalScript).toHaveBeenCalledWith(expect.any(String), {
       keys: ['transaction-count'],
       arguments: [
-        JSON.stringify({ count: 1 }),
-        JSON.stringify({ count: 2 }),
-        '300',
-        '__SEIZE_REDIS_VALUE_MISSING__'
+        'revision-1',
+        JSON.stringify({ revision: 'revision-2', count: 2 }),
+        '300'
       ]
     });
   });
@@ -199,9 +198,28 @@ describe('redis cache eviction helpers', () => {
       redisModule.redisCompareAndSetJson(
         'transaction-count',
         null,
-        { count: 1 },
+        { revision: 'revision-1', count: 1 },
         Time.minutes(5)
       )
     ).resolves.toBe(false);
+  });
+
+  it('rejects fractional TTL seconds before evaluating the script', async () => {
+    const evalScript = jest.fn();
+    mockRedisClient({ scan: jest.fn(), eval: evalScript });
+    const redisModule = await import('./redis');
+    const { Time } = await import('./time');
+
+    await redisModule.initRedis();
+
+    await expect(
+      redisModule.redisCompareAndSetJson(
+        'transaction-count',
+        null,
+        { revision: 'revision-1' },
+        Time.millis(1_500)
+      )
+    ).rejects.toThrow('positive whole seconds');
+    expect(evalScript).not.toHaveBeenCalled();
   });
 });

--- a/src/redis.ts
+++ b/src/redis.ts
@@ -91,6 +91,40 @@ export async function redisSetJson<T>(
   }
 }
 
+export async function redisCompareAndSetJson<T>(
+  key: string,
+  expected: T | null,
+  value: T,
+  ttl: Time
+): Promise<boolean> {
+  if (!redis) {
+    return false;
+  }
+  const missingValueMarker = '__SEIZE_REDIS_VALUE_MISSING__';
+  const result = await redis.eval(
+    `
+      local current = redis.call('GET', KEYS[1])
+      if ARGV[1] == ARGV[4] then
+        if current then return 0 end
+      elseif current ~= ARGV[1] then
+        return 0
+      end
+      redis.call('SET', KEYS[1], ARGV[2], 'EX', ARGV[3])
+      return 1
+    `,
+    {
+      keys: [key],
+      arguments: [
+        expected === null ? missingValueMarker : JSON.stringify(expected),
+        JSON.stringify(value),
+        String(ttl.toSeconds()),
+        missingValueMarker
+      ]
+    }
+  );
+  return Number(result) === 1;
+}
+
 export async function evictKeyFromRedisCache(key: string): Promise<any> {
   if (!redis) {
     return;

--- a/src/redis.ts
+++ b/src/redis.ts
@@ -91,23 +91,42 @@ export async function redisSetJson<T>(
   }
 }
 
-export async function redisCompareAndSetJson<T>(
+/**
+ * Replaces revisioned JSON only when the stored revision still matches.
+ * A null expected revision seeds absent or unrevisioned/corrupt values, while
+ * preserving any valid concurrent revisioned write.
+ */
+export async function redisCompareAndSetJson<
+  T extends { readonly revision: string }
+>(
   key: string,
-  expected: T | null,
+  expectedRevision: string | null,
   value: T,
   ttl: Time
 ): Promise<boolean> {
+  const ttlSeconds = ttl.toSeconds();
+  if (!Number.isSafeInteger(ttlSeconds) || ttlSeconds <= 0) {
+    throw new Error('Redis compare-and-set TTL must be positive whole seconds');
+  }
   if (!redis) {
     return false;
   }
-  const missingValueMarker = '__SEIZE_REDIS_VALUE_MISSING__';
   const result = await redis.eval(
     `
       local current = redis.call('GET', KEYS[1])
-      if ARGV[1] == ARGV[4] then
-        if current then return 0 end
-      elseif current ~= ARGV[1] then
-        return 0
+      if ARGV[1] == '' then
+        if current then
+          local decodedSuccessfully, decoded = pcall(cjson.decode, current)
+          if decodedSuccessfully and type(decoded) == 'table' and type(decoded.revision) == 'string' and decoded.revision ~= '' then
+            return 0
+          end
+        end
+      else
+        if not current then return 0 end
+        local decodedSuccessfully, decoded = pcall(cjson.decode, current)
+        if not decodedSuccessfully or type(decoded) ~= 'table' or decoded.revision ~= ARGV[1] then
+          return 0
+        end
       end
       redis.call('SET', KEYS[1], ARGV[2], 'EX', ARGV[3])
       return 1
@@ -115,10 +134,9 @@ export async function redisCompareAndSetJson<T>(
     {
       keys: [key],
       arguments: [
-        expected === null ? missingValueMarker : JSON.stringify(expected),
+        expectedRevision ?? '',
         JSON.stringify(value),
-        String(ttl.toSeconds()),
-        missingValueMarker
+        String(ttlSeconds)
       ]
     }
   );


### PR DESCRIPTION
## Issue

Production `/api/transactions` successful responses had a roughly 3 second p95/p99 tail, dominated by MEMES requests. The page query filesorted the full contract history and every request also performed a full exact count.

## Fix

- reorder only the `/transactions` page query tie-breakers to match existing transaction indexes
- maintain an API-owned Redis count checkpoint by contract/filter and increment it from newer complete blocks
- fully rebase cached counts every six hours to self-heal historical backfills
- run page data and count work concurrently
- retain exact-count fallback when Redis is unavailable and for wallet/NFT-specific requests
- add structured count/data timing logs

No transaction ingestion, indexing, processing, entity, migration, or frontend flow is changed.

## Evidence

Production read-replica benchmark for the MEMES page-one query:

- current page query: 1424.7 ms
- optimized page query: 2.3 ms
- incremental count query: 1.3 ms
- top-100 result set and ordering: identical

## Validation

- `npm test -- --runInBand src/db-api.test.ts` (5 passing)
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit`
- `npm run build` (226 suites, 2010 passing, 1 skipped)
- `cd src/api-serverless && npm run build`

## Risk and rollout

The cache is advisory and API-local: read/write failures fall back to the existing exact count. Personalized wallet/NFT counts remain uncached. Deployment changes only the API Lambda, first in staging and then production. No architecture or help-bot documentation update is required because the API contract and product behavior are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved transaction pagination with more accurate total counts and consistent ordering.
  * Transaction counts now update efficiently as new or historical activity is added.
  * Wallet-specific transaction searches return precise results without relying on shared count data.
  * Transaction filters now handle optional wallet, contract, NFT, and type criteria more reliably.

* **Tests**
  * Added comprehensive coverage for pagination, filtering, count updates, caching behavior, and query ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->