### PR TITLE
Improve CI wave alert formatting

### DIFF
--- a/pr-reports/1747.md
+++ b/pr-reports/1747.md
@@ -15,6 +15,7 @@ CI pipeline wave alerts now render the sender-provided title and description ins
 - Show the optional alert description before workflow metadata while bounding it separately so run links remain visible.
 - Normalize sender text into a single escaped Markdown line so CI payloads cannot inject message structure or disguised links.
 - Format the exact `desktop` service from `6529-core` as `6529 Desktop`.
+- Mark staging alert headings with 🚧 so pre-production messages are immediately distinguishable.
 - Preserve status markers and valid Unicode when long headings are truncated.
 - Preserve failure mentions and linked branch, commit, and workflow-run metadata.
 

--- a/pr-reports/1747.md
+++ b/pr-reports/1747.md
@@ -1,0 +1,34 @@
+# PR Report: Improve CI wave alert formatting
+
+PR: https://github.com/6529-Collections/6529seize-backend/pull/1747
+Branch: `codex/ci-wave-message-formatting` -> `main`
+Related PRs: https://github.com/6529-Collections/6529-core/pull/217
+
+## Summary
+
+CI pipeline wave alerts now render the sender-provided title and description instead of describing every workflow outcome as a generic deploy. Outcome emojis make successes and failures scannable, while desktop alerts use the product label `6529 Desktop`.
+
+## What Changed
+
+- Use the alert title as the environment-prefixed heading.
+- Append ✅ or ❌ when the matching outcome emoji is not already present.
+- Show the optional alert description before workflow metadata.
+- Format services from `6529-core` whose service identifier begins with `desktop` as `6529 Desktop`.
+- Preserve failure mentions and linked branch, commit, and workflow-run metadata.
+
+## Backend Impact
+
+- New services: None
+- Changed services: `api`
+- Required service order or ownership: Deploy `api` only
+- API: Internal CI pipeline alert drop formatting changed; the request contract is unchanged.
+- DB/entities/migrations: Not affected
+- Queues/events/integrations: CI pipeline alert senders are unchanged and remain compatible.
+
+## Config / Env
+
+No configuration or environment changes.
+
+## Release Notes
+
+CI wave messages now identify the real workflow outcome, include useful sender details, and clearly distinguish successful and failed runs with emojis. Desktop notifications are labeled `6529 Desktop`.

--- a/pr-reports/1747.md
+++ b/pr-reports/1747.md
@@ -11,9 +11,11 @@ CI pipeline wave alerts now render the sender-provided title and description ins
 ## What Changed
 
 - Use the alert title as the environment-prefixed heading.
-- Append ✅ or ❌ when the matching outcome emoji is not already present.
-- Show the optional alert description before workflow metadata.
-- Format services from `6529-core` whose service identifier begins with `desktop` as `6529 Desktop`.
+- Normalize existing outcome markers and append exactly one authoritative ✅ or ❌.
+- Show the optional alert description before workflow metadata while bounding it separately so run links remain visible.
+- Normalize sender text into a single escaped Markdown line so CI payloads cannot inject message structure or disguised links.
+- Format the exact `desktop` service from `6529-core` as `6529 Desktop`.
+- Preserve status markers and valid Unicode when long headings are truncated.
 - Preserve failure mentions and linked branch, commit, and workflow-run metadata.
 
 ## Backend Impact

--- a/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.test.ts
+++ b/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.test.ts
@@ -217,7 +217,9 @@ describe('CiPipelineAlertService', () => {
             expect.objectContaining({
               content: expect.stringContaining(
                 [
-                  '[PROD] Deploy Failed',
+                  '[PROD] Seize PROD WEB DEPLOY: CI pipeline is broken!!! ❌',
+                  '',
+                  'abc123 - Fix deploy',
                   '',
                   'cc @[ALICE] @[Bob]',
                   '',
@@ -270,7 +272,9 @@ describe('CiPipelineAlertService', () => {
             expect.objectContaining({
               content: expect.stringContaining(
                 [
-                  '[STAGING] Deploy Succeeded',
+                  '[STAGING] Seize Lambda staging api DEPLOY CI pipeline complete ✅',
+                  '',
+                  'abc123 - Fix deploy',
                   '',
                   'Service: Frontend - web',
                   'Workflow: Web Deploy - PROD',
@@ -290,7 +294,9 @@ describe('CiPipelineAlertService', () => {
         .parts[0].content
     ).toBe(
       [
-        '[STAGING] Deploy Succeeded',
+        '[STAGING] Seize Lambda staging api DEPLOY CI pipeline complete ✅',
+        '',
+        'abc123 - Fix deploy',
         '',
         'Service: Frontend - web',
         'Workflow: Web Deploy - PROD',
@@ -309,5 +315,42 @@ describe('CiPipelineAlertService', () => {
         .parts[0].content
     ).not.toContain('cc @[');
     expect(dropCreationApiService.toggleHideLinkPreview).not.toHaveBeenCalled();
+  });
+
+  it('formats desktop alerts with the product label and existing emoji', async () => {
+    const service = new CiPipelineAlertService(
+      dropCreationApiService as any,
+      identitiesRepository as any
+    );
+
+    await service.postAlert(
+      {
+        ...baseRequest,
+        repo: '6529-core',
+        workflow: 'Publish',
+        status: 'success',
+        title: 'Desktop Publish completed 🚀',
+        description:
+          'Production v0.3.11 publish completed with S3 and Arweave links published and CloudFront invalidated.',
+        branch: 'v0.3.11',
+        service: 'desktop'
+      },
+      {}
+    );
+
+    expect(
+      dropCreationApiService.createDrop.mock.calls[0][0].createDropRequest
+        .parts[0].content
+    ).toContain(
+      [
+        '[PROD] Desktop Publish completed 🚀 ✅',
+        '',
+        'Production v0.3.11 publish completed with S3 and Arweave links published and CloudFront invalidated.',
+        '',
+        'Service: 6529 Desktop',
+        'Workflow: Publish',
+        'Branch: v0.3.11'
+      ].join('\n')
+    );
   });
 });

--- a/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.test.ts
+++ b/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.test.ts
@@ -91,7 +91,9 @@ describe('CiPipelineAlertService', () => {
           if (value.length <= maxLength) {
             expect(truncated).toBe(value);
           } else {
-            expect(truncated).toBe(`${value.slice(0, maxLength - 3)}...`);
+            expect(truncated.endsWith('...')).toBe(true);
+            expect(value.startsWith(truncated.slice(0, -3))).toBe(true);
+            expect(truncated.slice(0, -3)).not.toMatch(/[\uD800-\uDBFF]$/);
           }
         }
       )
@@ -333,7 +335,9 @@ describe('CiPipelineAlertService', () => {
         description:
           'Production v0.3.11 publish completed with S3 and Arweave links published and CloudFront invalidated.',
         branch: 'v0.3.11',
-        service: 'desktop'
+        service: 'desktop',
+        run_url:
+          'https://github.com/6529-Collections/6529-core/actions/runs/12345'
       },
       {}
     );
@@ -341,7 +345,7 @@ describe('CiPipelineAlertService', () => {
     expect(
       dropCreationApiService.createDrop.mock.calls[0][0].createDropRequest
         .parts[0].content
-    ).toContain(
+    ).toBe(
       [
         '[PROD] Desktop Publish completed 🚀 ✅',
         '',
@@ -349,8 +353,95 @@ describe('CiPipelineAlertService', () => {
         '',
         'Service: 6529 Desktop',
         'Workflow: Publish',
-        'Branch: v0.3.11'
+        'Branch: v0.3.11',
+        'Commit: [abc12345](https://github.com/6529-Collections/6529-core/commit/abc1234567890)',
+        'Run: [#6082](https://github.com/6529-Collections/6529-core/actions/runs/12345)'
       ].join('\n')
     );
+  });
+
+  it.each([null, ''])(
+    'falls back to the workflow for title %p',
+    async (title) => {
+      const service = new CiPipelineAlertService(
+        dropCreationApiService as any,
+        identitiesRepository as any
+      );
+
+      await service.postAlert({ ...baseRequest, title } as any, {});
+
+      expect(
+        dropCreationApiService.createDrop.mock.calls[0][0].createDropRequest.parts[0].content.startsWith(
+          '[PROD] Web Deploy - PROD ❌'
+        )
+      ).toBe(true);
+    }
+  );
+
+  it('normalizes conflicting status emojis', async () => {
+    const service = new CiPipelineAlertService(
+      dropCreationApiService as any,
+      identitiesRepository as any
+    );
+
+    await service.postAlert(
+      { ...baseRequest, title: 'Build succeeded ✅ ❌', status: 'success' },
+      {}
+    );
+
+    const content =
+      dropCreationApiService.createDrop.mock.calls[0][0].createDropRequest
+        .parts[0].content;
+    expect(content.startsWith('[PROD] Build succeeded ✅')).toBe(true);
+    expect(content.startsWith('[PROD] Build succeeded ✅ ❌')).toBe(false);
+  });
+
+  it('preserves the outcome and run metadata when text is long', async () => {
+    const service = new CiPipelineAlertService(
+      dropCreationApiService as any,
+      identitiesRepository as any
+    );
+
+    await service.postAlert(
+      {
+        ...baseRequest,
+        title: `${'a'.repeat(234)}🚀${'a'.repeat(20)}`,
+        description: `[details](${'https://example.com/'}${'b'.repeat(30000)})`
+      },
+      {}
+    );
+
+    const content =
+      dropCreationApiService.createDrop.mock.calls[0][0].createDropRequest
+        .parts[0].content;
+    const heading = content.split('\n')[0];
+    expect(heading.endsWith('❌')).toBe(true);
+    expect(heading.length).toBeLessThanOrEqual(250);
+    expect(Buffer.from(heading, 'utf8').toString('utf8')).toBe(heading);
+    expect(content).toContain(
+      'Run: [#6082](https://github.com/6529-Collections/6529seize-frontend/actions/runs/12345)'
+    );
+    expect(content).toContain('\\[details\\](');
+  });
+
+  it('only applies the desktop product label to the exact service', async () => {
+    const service = new CiPipelineAlertService(
+      dropCreationApiService as any,
+      identitiesRepository as any
+    );
+
+    await service.postAlert(
+      {
+        ...baseRequest,
+        repo: '6529-core',
+        service: 'desktop-canary'
+      },
+      {}
+    );
+
+    expect(
+      dropCreationApiService.createDrop.mock.calls[0][0].createDropRequest
+        .parts[0].content
+    ).toContain('Service: Core - desktop-canary');
   });
 });

--- a/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.test.ts
+++ b/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.test.ts
@@ -274,7 +274,7 @@ describe('CiPipelineAlertService', () => {
             expect.objectContaining({
               content: expect.stringContaining(
                 [
-                  '[STAGING] Seize Lambda staging api DEPLOY CI pipeline complete ✅',
+                  '[STAGING 🚧] Seize Lambda staging api DEPLOY CI pipeline complete ✅',
                   '',
                   'abc123 - Fix deploy',
                   '',
@@ -296,7 +296,7 @@ describe('CiPipelineAlertService', () => {
         .parts[0].content
     ).toBe(
       [
-        '[STAGING] Seize Lambda staging api DEPLOY CI pipeline complete ✅',
+        '[STAGING 🚧] Seize Lambda staging api DEPLOY CI pipeline complete ✅',
         '',
         'abc123 - Fix deploy',
         '',

--- a/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.ts
+++ b/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.ts
@@ -34,12 +34,17 @@ interface MentionedProfile {
 
 const MAX_DROP_CONTENT_LENGTH = 30000;
 const MAX_DROP_TITLE_LENGTH = 250;
+const MAX_ALERT_DESCRIPTION_LENGTH = 5000;
 
 export function truncate(value: string, maxLength: number): string {
   if (value.length <= maxLength) {
     return value;
   }
-  return `${value.slice(0, maxLength - 3)}...`;
+  const requestedEnd = maxLength - 3;
+  const sliceEnd = /[\uD800-\uDBFF]/.test(value.charAt(requestedEnd - 1))
+    ? requestedEnd - 1
+    : requestedEnd;
+  return `${value.slice(0, sliceEnd)}...`;
 }
 
 function normalizeOptionalValue(
@@ -91,16 +96,28 @@ function formatStatusEmoji(status: CiPipelineAlertStatus): string {
   return status === 'success' ? '✅' : '❌';
 }
 
+function sanitizeAlertText(value: string): string {
+  return value
+    .replace(/\s+/g, ' ')
+    .replace(/[[\]<>]/g, (character) => `\\${character}`)
+    .trim();
+}
+
 function formatAlertHeading(request: CiPipelineAlertRequest): string {
-  const title = normalizeOptionalValue(request.title) ?? request.workflow;
+  const environmentPrefix = `[${formatEnvironmentLabel(request.environment)}] `;
   const statusEmoji = formatStatusEmoji(request.status);
-  const titleWithStatus = title.includes(statusEmoji)
-    ? title
-    : `${title} ${statusEmoji}`;
-  return truncate(
-    `[${formatEnvironmentLabel(request.environment)}] ${titleWithStatus}`,
-    MAX_DROP_TITLE_LENGTH
+  const statusSuffix = ` ${statusEmoji}`;
+  const title = sanitizeAlertText(
+    normalizeOptionalValue(request.title) ?? request.workflow
+  )
+    .replace(/[✅❌]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+  const truncatedTitle = truncate(
+    title,
+    MAX_DROP_TITLE_LENGTH - environmentPrefix.length - statusSuffix.length
   );
+  return `${environmentPrefix}${truncatedTitle}${statusSuffix}`;
 }
 
 function formatEnvironmentLabel(value: string | null | undefined): string {
@@ -129,7 +146,7 @@ function formatRepoLabel(repo: string): string {
 function formatServiceLabel(request: CiPipelineAlertRequest): string {
   const repoLabel = formatRepoLabel(request.repo);
   const service = normalizeOptionalValue(request.service);
-  if (repoLabel === 'Core' && service?.toLowerCase().startsWith('desktop')) {
+  if (repoLabel === 'Core' && service?.toLowerCase() === 'desktop') {
     return '6529 Desktop';
   }
   return service ? `${repoLabel} - ${service}` : repoLabel;
@@ -318,10 +335,13 @@ export class CiPipelineAlertService {
     const branch = normalizeOptionalValue(request.branch);
     const commit = formatCommit(request);
     const description = normalizeOptionalValue(request.description);
+    const formattedDescription = description
+      ? truncate(sanitizeAlertText(description), MAX_ALERT_DESCRIPTION_LENGTH)
+      : null;
     const lines = [
       formatAlertHeading(request),
       '',
-      ...(description ? [description, ''] : []),
+      ...(formattedDescription ? [formattedDescription, ''] : []),
       ...mentionLines,
       ...(mentionLines.length ? [''] : []),
       `Service: ${formatServiceLabel(request)}`,

--- a/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.ts
+++ b/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.ts
@@ -87,13 +87,18 @@ export function normalizeTargetEnvironment(value: string | null | undefined) {
   return null;
 }
 
-function formatStatusVerb(status: CiPipelineAlertStatus): string {
-  return status === 'success' ? 'Succeeded' : 'Failed';
+function formatStatusEmoji(status: CiPipelineAlertStatus): string {
+  return status === 'success' ? '✅' : '❌';
 }
 
 function formatAlertHeading(request: CiPipelineAlertRequest): string {
+  const title = normalizeOptionalValue(request.title) ?? request.workflow;
+  const statusEmoji = formatStatusEmoji(request.status);
+  const titleWithStatus = title.includes(statusEmoji)
+    ? title
+    : `${title} ${statusEmoji}`;
   return truncate(
-    `[${formatEnvironmentLabel(request.environment)}] Deploy ${formatStatusVerb(request.status)}`,
+    `[${formatEnvironmentLabel(request.environment)}] ${titleWithStatus}`,
     MAX_DROP_TITLE_LENGTH
   );
 }
@@ -124,6 +129,9 @@ function formatRepoLabel(repo: string): string {
 function formatServiceLabel(request: CiPipelineAlertRequest): string {
   const repoLabel = formatRepoLabel(request.repo);
   const service = normalizeOptionalValue(request.service);
+  if (repoLabel === 'Core' && service?.toLowerCase().startsWith('desktop')) {
+    return '6529 Desktop';
+  }
   return service ? `${repoLabel} - ${service}` : repoLabel;
 }
 
@@ -309,9 +317,11 @@ export class CiPipelineAlertService {
 
     const branch = normalizeOptionalValue(request.branch);
     const commit = formatCommit(request);
+    const description = normalizeOptionalValue(request.description);
     const lines = [
       formatAlertHeading(request),
       '',
+      ...(description ? [description, ''] : []),
       ...mentionLines,
       ...(mentionLines.length ? [''] : []),
       `Service: ${formatServiceLabel(request)}`,

--- a/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.ts
+++ b/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.ts
@@ -104,7 +104,7 @@ function sanitizeAlertText(value: string): string {
 }
 
 function formatAlertHeading(request: CiPipelineAlertRequest): string {
-  const environmentPrefix = `[${formatEnvironmentLabel(request.environment)}] `;
+  const environmentPrefix = formatEnvironmentPrefix(request.environment);
   const statusEmoji = formatStatusEmoji(request.status);
   const statusSuffix = ` ${statusEmoji}`;
   const title = sanitizeAlertText(
@@ -118,6 +118,13 @@ function formatAlertHeading(request: CiPipelineAlertRequest): string {
     MAX_DROP_TITLE_LENGTH - environmentPrefix.length - statusSuffix.length
   );
   return `${environmentPrefix}${truncatedTitle}${statusSuffix}`;
+}
+
+function formatEnvironmentPrefix(value: string | null | undefined): string {
+  const environmentLabel = formatEnvironmentLabel(value);
+  const stagingEmoji =
+    normalizeTargetEnvironment(value) === 'staging' ? ' 🚧' : '';
+  return `[${environmentLabel}${stagingEmoji}] `;
 }
 
 function formatEnvironmentLabel(value: string | null | undefined): string {


### PR DESCRIPTION
## Issue
- CI wave alerts discard the sender-provided title and description, hardcode every outcome as a deploy, and label desktop alerts as `Core - desktop`.

## Fix
- Render the supplied alert title and description, with an explicit status emoji fallback.
- Present all desktop-owned core services as `6529 Desktop`.

## Changes
- Successful alerts include ✅ and failures include ❌ unless the title already carries the matching outcome emoji.
- Sender-specific context such as Publish, Linux, signing, and CloudFront now appears in the heading and details.
- Existing failure mentions, workflow, branch, commit, and run links remain unchanged.
- Added exact formatter coverage for existing frontend alerts and the desktop Publish payload.

## Validation
- `npm run lint`
- API package build
- Focused Jest execution was attempted, but repository global setup requires an unavailable local container runtime; the deployable API build and lint pass.

## Risk
- Level: Low
- Why: presentation-only change to CI alert drop content; routing, authentication, deduplication, and wave selection are unchanged.
- Rollback: revert the formatter commit and redeploy `api`.

## Deployment
- `api` only.

## Review Notes
- Review the exact line ordering and emoji fallback behavior in `ci-pipeline-alert.service.ts`.