### PR TITLE
Count unread drops across all subwaves

### DIFF
--- a/src/api-serverless/openapi.yaml
+++ b/src/api-serverless/openapi.yaml
@@ -19302,6 +19302,12 @@ components:
         first_unread_drop_serial_no:
           type: integer
           format: int64
+        subwave_unread_drops:
+          type: integer
+          format: int64
+          description: >-
+            Unread drops across all visible subwaves, independent of whether the
+            authenticated profile follows each subwave.
         followed_subwaves_count:
           type: integer
           format: int64

--- a/src/api-serverless/src/generated/models/ApiWaveOverviewContextProfileContext.ts
+++ b/src/api-serverless/src/generated/models/ApiWaveOverviewContextProfileContext.ts
@@ -19,6 +19,10 @@ export class ApiWaveOverviewContextProfileContext {
     'next_drop_allowed'?: number;
     'unread_drops': number;
     'first_unread_drop_serial_no'?: number;
+    /**
+    * Unread drops across all visible subwaves, independent of whether the authenticated profile follows each subwave.
+    */
+    'subwave_unread_drops'?: number;
     'followed_subwaves_count'?: number;
     'latest_followed_subwave_activity_timestamp'?: number;
     'hidden_followed_subwave_unread_drops'?: number;
@@ -63,6 +67,12 @@ export class ApiWaveOverviewContextProfileContext {
         {
             "name": "first_unread_drop_serial_no",
             "baseName": "first_unread_drop_serial_no",
+            "type": "number",
+            "format": "int64"
+        },
+        {
+            "name": "subwave_unread_drops",
+            "baseName": "subwave_unread_drops",
             "type": "number",
             "format": "int64"
         },

--- a/src/api-serverless/src/waves/api-wave-overview-mapper.test.ts
+++ b/src/api-serverless/src/waves/api-wave-overview-mapper.test.ts
@@ -449,6 +449,7 @@ describe('ApiWaveOverviewMapper', () => {
         can_chat: true,
         unread_drops: 7,
         first_unread_drop_serial_no: 19,
+        subwave_unread_drops: 0,
         followed_subwaves_count: 0,
         hidden_followed_subwave_unread_drops: 0,
         muted: true
@@ -514,6 +515,7 @@ describe('ApiWaveOverviewMapper', () => {
       can_chat: false,
       next_drop_allowed: nextDropTimestamp,
       unread_drops: 0,
+      subwave_unread_drops: 0,
       followed_subwaves_count: 0,
       hidden_followed_subwave_unread_drops: 0,
       muted: false
@@ -533,6 +535,7 @@ describe('ApiWaveOverviewMapper', () => {
         'wave-1': {
           followed_subwaves_count: 2,
           latest_followed_subwave_activity_timestamp: 999,
+          subwave_unread_drops: 9,
           hidden_followed_subwave_unread_drops: 5,
           first_hidden_followed_subwave_unread_drop_serial_no: 77
         }
@@ -560,6 +563,7 @@ describe('ApiWaveOverviewMapper', () => {
           subscribed: false,
           pinned: false,
           unread_drops: 0,
+          subwave_unread_drops: 9,
           followed_subwaves_count: 2,
           latest_followed_subwave_activity_timestamp: 999,
           hidden_followed_subwave_unread_drops: 5,

--- a/src/api-serverless/src/waves/api-wave-overview.mapper.ts
+++ b/src/api-serverless/src/waves/api-wave-overview.mapper.ts
@@ -572,6 +572,7 @@ export class ApiWaveOverviewMapper {
           groupIdsUserIsEligibleFor.includes(wave.chat_group_id)) &&
         nextDropAllowed === undefined,
       unread_drops: unreadDropsCount,
+      subwave_unread_drops: followedSubwaveContext?.subwave_unread_drops ?? 0,
       followed_subwaves_count:
         followedSubwaveContext?.followed_subwaves_count ?? 0,
       hidden_followed_subwave_unread_drops:

--- a/src/api-serverless/src/waves/waves-api-db.test.ts
+++ b/src/api-serverless/src/waves/waves-api-db.test.ts
@@ -101,6 +101,37 @@ const betaSubwave = aWave(
   { id: 'wave-sub-beta', serial_no: 12, name: 'Beta Subwave' }
 );
 
+const unfollowedUnreadSubwave = aWave(
+  {
+    created_by: author.profile_id!,
+    parent_wave_id: parentWave.id
+  },
+  { id: 'wave-sub-unfollowed', serial_no: 101, name: 'Unfollowed Subwave' }
+);
+
+const unfollowedOnlyParentWave = aWave(
+  {
+    created_by: author.profile_id!
+  },
+  {
+    id: 'wave-unfollowed-only-parent',
+    serial_no: 102,
+    name: 'Unfollowed Only Parent'
+  }
+);
+
+const unfollowedOnlySubwave = aWave(
+  {
+    created_by: author.profile_id!,
+    parent_wave_id: unfollowedOnlyParentWave.id
+  },
+  {
+    id: 'wave-unfollowed-only-child',
+    serial_no: 103,
+    name: 'Unfollowed Only Child'
+  }
+);
+
 const hiddenParentWave = aWave(
   {
     created_by: author.profile_id!,
@@ -548,11 +579,14 @@ describeWithSeed(
 describeWithSeed(
   'WavesApiDb followed subwave overview containers',
   [
-    withIdentities([author]),
+    withIdentities([author, unreadReader]),
     withWaves([
       parentWave,
       alphaSubwave,
       betaSubwave,
+      unfollowedUnreadSubwave,
+      unfollowedOnlyParentWave,
+      unfollowedOnlySubwave,
       hiddenParentWave,
       publicSubwaveOfHiddenParent,
       followedRootWave,
@@ -684,6 +718,18 @@ describeWithSeed(
           reader_id: author.profile_id!,
           latest_read_timestamp: 800,
           muted: true
+        },
+        {
+          wave_id: unfollowedUnreadSubwave.id,
+          reader_id: author.profile_id!,
+          latest_read_timestamp: 800,
+          muted: false
+        },
+        {
+          wave_id: unfollowedOnlySubwave.id,
+          reader_id: author.profile_id!,
+          latest_read_timestamp: 800,
+          muted: false
         }
       ]
     },
@@ -723,6 +769,34 @@ describeWithSeed(
           wave_id: betaSubwave.id,
           author_id: author.profile_id!,
           created_at: 1000,
+          updated_at: null,
+          title: null,
+          parts_count: 1,
+          reply_to_drop_id: null,
+          reply_to_part_id: null,
+          drop_type: DropType.CHAT,
+          signature: null,
+          hide_link_preview: false
+        },
+        {
+          id: 'unfollowed-subwave-unread-drop',
+          wave_id: unfollowedUnreadSubwave.id,
+          author_id: unreadReader.profile_id!,
+          created_at: 950,
+          updated_at: null,
+          title: null,
+          parts_count: 1,
+          reply_to_drop_id: null,
+          reply_to_part_id: null,
+          drop_type: DropType.CHAT,
+          signature: null,
+          hide_link_preview: false
+        },
+        {
+          id: 'unfollowed-only-subwave-unread-drop',
+          wave_id: unfollowedOnlySubwave.id,
+          author_id: unreadReader.profile_id!,
+          created_at: 975,
           updated_at: null,
           title: null,
           parts_count: 1,
@@ -790,7 +864,7 @@ describeWithSeed(
       ]);
     });
 
-    it('summarizes hidden followed subwave activity and unread counts', async () => {
+    it('summarizes followed activity and all visible subwave unread counts', async () => {
       const contexts =
         await repo.findFollowedSubwaveOverviewContextsByParentWaveId(
           {
@@ -804,8 +878,29 @@ describeWithSeed(
       expect(contexts[parentWave.id]).toEqual({
         followed_subwaves_count: 2,
         latest_followed_subwave_activity_timestamp: 900,
+        subwave_unread_drops: 1,
         hidden_followed_subwave_unread_drops: 2,
         first_hidden_followed_subwave_unread_drop_serial_no: expect.any(Number)
+      });
+    });
+
+    it('returns subwave unread counts when no child is followed', async () => {
+      const contexts =
+        await repo.findFollowedSubwaveOverviewContextsByParentWaveId(
+          {
+            identityId: author.profile_id!,
+            parentWaveIds: [unfollowedOnlyParentWave.id],
+            eligibleGroups: []
+          },
+          ctx
+        );
+
+      expect(contexts[unfollowedOnlyParentWave.id]).toEqual({
+        followed_subwaves_count: 0,
+        latest_followed_subwave_activity_timestamp: null,
+        subwave_unread_drops: 1,
+        hidden_followed_subwave_unread_drops: 0,
+        first_hidden_followed_subwave_unread_drop_serial_no: null
       });
     });
 
@@ -959,6 +1054,7 @@ describeWithSeed(
       expect(contexts[mutedContainerParentWave.id]).toEqual({
         followed_subwaves_count: 1,
         latest_followed_subwave_activity_timestamp: null,
+        subwave_unread_drops: 0,
         hidden_followed_subwave_unread_drops: 0,
         first_hidden_followed_subwave_unread_drop_serial_no: null
       });

--- a/src/api-serverless/src/waves/waves-api-db.test.ts
+++ b/src/api-serverless/src/waves/waves-api-db.test.ts
@@ -1,6 +1,7 @@
 import 'reflect-metadata';
 import {
   DROPS_TABLE,
+  IDENTITY_MUTES_TABLE,
   IDENTITY_SUBSCRIPTIONS_TABLE,
   PINNED_WAVES_TABLE,
   WAVE_CHAT_DROP_COOLDOWNS_TABLE,
@@ -44,6 +45,15 @@ const unreadReader = anIdentity(
     profile_id: 'profile-unread-reader',
     primary_address: 'wallet-unread-reader',
     handle: 'unread-reader'
+  }
+);
+const mutedUnreadReader = anIdentity(
+  {},
+  {
+    consolidation_key: 'identity-muted-unread-reader',
+    profile_id: 'profile-muted-unread-reader',
+    primary_address: 'wallet-muted-unread-reader',
+    handle: 'muted-unread-reader'
   }
 );
 
@@ -579,7 +589,7 @@ describeWithSeed(
 describeWithSeed(
   'WavesApiDb followed subwave overview containers',
   [
-    withIdentities([author, unreadReader]),
+    withIdentities([author, unreadReader, mutedUnreadReader]),
     withWaves([
       parentWave,
       alphaSubwave,
@@ -705,6 +715,16 @@ describeWithSeed(
       ]
     },
     {
+      table: IDENTITY_MUTES_TABLE,
+      rows: [
+        {
+          muter_id: author.profile_id!,
+          muted_identity_id: mutedUnreadReader.profile_id!,
+          created_at: 1
+        }
+      ]
+    },
+    {
       table: WAVE_READER_METRICS_TABLE,
       rows: [
         {
@@ -755,6 +775,34 @@ describeWithSeed(
           wave_id: alphaSubwave.id,
           author_id: author.profile_id!,
           created_at: 900,
+          updated_at: null,
+          title: null,
+          parts_count: 1,
+          reply_to_drop_id: null,
+          reply_to_part_id: null,
+          drop_type: DropType.CHAT,
+          signature: null,
+          hide_link_preview: false
+        },
+        {
+          id: 'alpha-other-author-unread-drop',
+          wave_id: alphaSubwave.id,
+          author_id: unreadReader.profile_id!,
+          created_at: 875,
+          updated_at: null,
+          title: null,
+          parts_count: 1,
+          reply_to_drop_id: null,
+          reply_to_part_id: null,
+          drop_type: DropType.CHAT,
+          signature: null,
+          hide_link_preview: false
+        },
+        {
+          id: 'alpha-muted-author-unread-drop',
+          wave_id: alphaSubwave.id,
+          author_id: mutedUnreadReader.profile_id!,
+          created_at: 880,
           updated_at: null,
           title: null,
           parts_count: 1,
@@ -878,8 +926,8 @@ describeWithSeed(
       expect(contexts[parentWave.id]).toEqual({
         followed_subwaves_count: 2,
         latest_followed_subwave_activity_timestamp: 900,
-        subwave_unread_drops: 1,
-        hidden_followed_subwave_unread_drops: 2,
+        subwave_unread_drops: 2,
+        hidden_followed_subwave_unread_drops: 1,
         first_hidden_followed_subwave_unread_drop_serial_no: expect.any(Number)
       });
     });

--- a/src/api-serverless/src/waves/waves.api.db.ts
+++ b/src/api-serverless/src/waves/waves.api.db.ts
@@ -1714,8 +1714,9 @@ export class WavesApiDb extends LazyDbAccessCompatibleService {
         parentWaveIds,
         eligibleGroups,
         getValue: async () => {
-          // Keep hidden unread live so wave-reader-metric invalidations are
-          // visible immediately; only coalesce identical concurrent reads.
+          // Unread is not persistently cached. Equivalent concurrent reads are
+          // coalesced only until this query settles, so read and mute changes
+          // are visible on the next request.
           return this.db.execute<HiddenFollowedSubwaveUnreadRow>(
             `
               select
@@ -1727,10 +1728,20 @@ export class WavesApiDb extends LazyDbAccessCompatibleService {
                   end
                 ) as subwave_unread_drops,
                 count(
-                  case when child_follow.id is not null then d.id end
+                  case
+                    when child_follow.id is not null
+                      and d.author_id != :identityId
+                      and muted_author.id is null
+                      then d.id
+                  end
                 ) as hidden_followed_subwave_unread_drops,
                 min(
-                  case when child_follow.id is not null then d.serial_no end
+                  case
+                    when child_follow.id is not null
+                      and d.author_id != :identityId
+                      and muted_author.id is null
+                      then d.serial_no
+                  end
                 ) as first_hidden_followed_subwave_unread_drop_serial_no
               from ${WAVES_TABLE} child
               join ${WAVES_TABLE} parent

--- a/src/api-serverless/src/waves/waves.api.db.ts
+++ b/src/api-serverless/src/waves/waves.api.db.ts
@@ -124,6 +124,7 @@ type FollowedSubwaveActivityRow = {
 
 type HiddenFollowedSubwaveUnreadRow = {
   parent_wave_id: string;
+  subwave_unread_drops: number | string;
   hidden_followed_subwave_unread_drops: number | string;
   first_hidden_followed_subwave_unread_drop_serial_no: number | string | null;
 };
@@ -152,6 +153,7 @@ type UnreadDmDropsCountRow = {
 export interface FollowedSubwaveOverviewContext {
   readonly followed_subwaves_count: number;
   readonly latest_followed_subwave_activity_timestamp: number | null;
+  readonly subwave_unread_drops: number;
   readonly hidden_followed_subwave_unread_drops: number;
   readonly first_hidden_followed_subwave_unread_drop_serial_no: number | null;
 }
@@ -1718,8 +1720,18 @@ export class WavesApiDb extends LazyDbAccessCompatibleService {
             `
               select
                 child.parent_wave_id,
-                count(d.id) as hidden_followed_subwave_unread_drops,
-                min(d.serial_no) as first_hidden_followed_subwave_unread_drop_serial_no
+                count(
+                  case
+                    when d.author_id != :identityId and muted_author.id is null
+                      then d.id
+                  end
+                ) as subwave_unread_drops,
+                count(
+                  case when child_follow.id is not null then d.id end
+                ) as hidden_followed_subwave_unread_drops,
+                min(
+                  case when child_follow.id is not null then d.serial_no end
+                ) as first_hidden_followed_subwave_unread_drop_serial_no
               from ${WAVES_TABLE} child
               join ${WAVES_TABLE} parent
                 on parent.id = child.parent_wave_id
@@ -1727,7 +1739,7 @@ export class WavesApiDb extends LazyDbAccessCompatibleService {
               left join ${WAVE_READER_METRICS_TABLE} parent_reader
                 on parent_reader.wave_id = parent.id
                and parent_reader.reader_id = :identityId
-              join ${IDENTITY_SUBSCRIPTIONS_TABLE} child_follow
+              left join ${IDENTITY_SUBSCRIPTIONS_TABLE} child_follow
                 on child_follow.subscriber_id = :identityId
                and child_follow.target_id = child.id
                and child_follow.target_type = :waveTargetType
@@ -1740,6 +1752,9 @@ export class WavesApiDb extends LazyDbAccessCompatibleService {
               join ${DROPS_TABLE} d
                 on d.wave_id = child.id
                and d.created_at > child_reader.latest_read_timestamp
+              left join ${IDENTITY_MUTES_TABLE} muted_author
+                on muted_author.muter_id = :identityId
+               and muted_author.muted_identity_id = d.author_id
               where child.parent_wave_id in (:parentWaveIds)
                 and coalesce(parent_reader.muted, false) = false
                 and ${this.getWaveVisibilityFilter(
@@ -1772,6 +1787,7 @@ export class WavesApiDb extends LazyDbAccessCompatibleService {
         (acc, [parentWaveId, activity]) => {
           acc[parentWaveId] = {
             ...activity,
+            subwave_unread_drops: 0,
             hidden_followed_subwave_unread_drops: 0,
             first_hidden_followed_subwave_unread_drop_serial_no: null
           };
@@ -1781,12 +1797,16 @@ export class WavesApiDb extends LazyDbAccessCompatibleService {
       );
 
       for (const row of unreadRows) {
-        const existing = result[row.parent_wave_id];
-        if (!existing) {
-          continue;
-        }
+        const existing = result[row.parent_wave_id] ?? {
+          followed_subwaves_count: 0,
+          latest_followed_subwave_activity_timestamp: null,
+          subwave_unread_drops: 0,
+          hidden_followed_subwave_unread_drops: 0,
+          first_hidden_followed_subwave_unread_drop_serial_no: null
+        };
         result[row.parent_wave_id] = {
           ...existing,
+          subwave_unread_drops: Number(row.subwave_unread_drops),
           hidden_followed_subwave_unread_drops: Number(
             row.hidden_followed_subwave_unread_drops
           ),


### PR DESCRIPTION
## Issue
- Parent wave unread badges only counted followed subwaves, so the total beside the subwave control could disagree with the visible child unread badges.

## Fix
- Add an additive aggregate that counts unread drops across every visible subwave with reader state, independent of follow status.
- Preserve the legacy followed-only fields for a zero-downtime backend-first rollout.

## Changes
- Extend the wave overview profile context with `subwave_unread_drops`.
- Count unread drops using the same self-author, muted-profile, muted-wave, visibility, and reader-baseline rules as individual wave unread state.
- Return aggregate context even when no child subwave is followed.
- Add database and mapper regression coverage for mixed followed/unfollowed children and fully unfollowed child sets.
- No database migration or architecture-document update is needed.

## Validation
- `npm run lint`
- `npm run build` (226 suites, 2,027 tests passed)
- Focused wave database regression tests (2 passed)
- `cd src/api-serverless && npm run restructure-openapi && npm run generate && npm run build`

## Risk
- Level: Medium
- Why: additive API field with a broader unread aggregate query; no schema or destructive contract change.
- Rollback: redeploy the prior `api` version; the legacy followed-only fields remain intact.

## Deployment
- Deploy `api` only.
- Deploy backend before the corresponding frontend change in staging and production.

## Review Notes
- Please focus on unread parity with individual child counts and query behavior for parents with no followed children.