### PR TITLE
Fix release notes log group resource

### DIFF
--- a/src/releaseNotesGenerationLoop/serverless.yaml
+++ b/src/releaseNotesGenerationLoop/serverless.yaml
@@ -36,7 +36,7 @@ functions:
 
 resources:
   Resources:
-    ReleaseNotesGenerationLogGroup:
+    ReleaseNotesGenerationLoopLogGroup:
       Type: AWS::Logs::LogGroup
       Properties:
         LogGroupName: /aws/lambda/releaseNotesGenerationLoop


### PR DESCRIPTION
Fixes the production deployment failure caused by two CloudFormation log-group resources targeting `/aws/lambda/releaseNotesGenerationLoop`.

Renames the manual logical resource to `ReleaseNotesGenerationLoopLogGroup`, matching the established loop convention and Serverless generated logical ID. The compiled template now contains exactly one log-group resource.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the service’s log group naming configuration for improved consistency.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->