### PR TITLE
Fix backend release note generation

### DIFF
--- a/src/release-notes/release-note-generation.service.test.ts
+++ b/src/release-notes/release-note-generation.service.test.ts
@@ -340,6 +340,52 @@ describe('ReleaseNoteGenerationService', () => {
     expect(content).not.toContain('*bold*');
   });
 
+  it('compacts oversized release context while retaining every pull request', async () => {
+    const pullRequests = Array.from({ length: 20 }, (_, index) => ({
+      ...context.pull_requests[0],
+      number: index + 1,
+      url: `https://github.com/6529-Collections/6529seize-backend/pull/${index + 1}`,
+      title: `Release change ${index + 1}`,
+      body: 'x'.repeat(12000),
+      contributors: [],
+      commit_messages: [`Release change ${index + 1}`]
+    }));
+    const promptAndGetReply = jest.fn().mockResolvedValue(
+      JSON.stringify({
+        pull_requests: pullRequests.map((pullRequest) => ({
+          number: pullRequest.number,
+          summary: `Summarized change ${pullRequest.number}.`
+        }))
+      })
+    );
+    const createDrop = jest.fn().mockResolvedValue({});
+    const service = new ReleaseNoteGenerationService(
+      {
+        getReleaseContext: jest.fn().mockResolvedValue({
+          ...context,
+          pull_requests: pullRequests
+        }),
+        getReleasePrompt: jest.fn().mockResolvedValue('Repository prompt.')
+      } as unknown as ReleaseNoteGitHubService,
+      { promptAndGetReply } as AiPrompter,
+      { createDrop } as unknown as DropCreationApiService,
+      {
+        getIdsByHandles: jest.fn().mockResolvedValue({})
+      } as unknown as IdentitiesDb,
+      {},
+      createDropsRepository()
+    );
+
+    const outcome = await service.generateAndPost(request, {});
+
+    const prompt = promptAndGetReply.mock.calls[0][0] as string;
+    expect(outcome).toBe('published');
+    expect(prompt.length).toBeLessThan(200000);
+    expect(prompt).toContain('Release change 20');
+    expect(prompt).not.toContain('x'.repeat(3000));
+    expect(createDrop).toHaveBeenCalledTimes(1);
+  });
+
   it('skips generation when the release drop already exists', async () => {
     const getReleaseContext = jest.fn();
     const promptAndGetReply = jest.fn();
@@ -353,9 +399,35 @@ describe('ReleaseNoteGenerationService', () => {
       createDropsRepository('existing-drop')
     );
 
-    await service.generateAndPost(request, {});
+    const outcome = await service.generateAndPost(request, {});
 
+    expect(outcome).toBe('already-published');
     expect(getReleaseContext).not.toHaveBeenCalled();
+    expect(promptAndGetReply).not.toHaveBeenCalled();
+    expect(createDrop).not.toHaveBeenCalled();
+  });
+
+  it('reports a missing baseline without generating content', async () => {
+    const getReleaseContext = jest.fn().mockResolvedValue(null);
+    const getReleasePrompt = jest.fn();
+    const promptAndGetReply = jest.fn();
+    const createDrop = jest.fn();
+    const service = new ReleaseNoteGenerationService(
+      {
+        getReleaseContext,
+        getReleasePrompt
+      } as unknown as ReleaseNoteGitHubService,
+      { promptAndGetReply } as AiPrompter,
+      { createDrop } as unknown as DropCreationApiService,
+      { getIdsByHandles: jest.fn() } as unknown as IdentitiesDb,
+      undefined,
+      createDropsRepository()
+    );
+
+    const outcome = await service.generateAndPost(request, {});
+
+    expect(outcome).toBe('no-baseline');
+    expect(getReleasePrompt).not.toHaveBeenCalled();
     expect(promptAndGetReply).not.toHaveBeenCalled();
     expect(createDrop).not.toHaveBeenCalled();
   });

--- a/src/release-notes/release-note-generation.service.ts
+++ b/src/release-notes/release-note-generation.service.ts
@@ -41,9 +41,18 @@ const MAX_BODY_LENGTH = 12000;
 const MAX_COMMIT_MESSAGES = 25;
 const MAX_COMMIT_MESSAGE_LENGTH = 500;
 const MAX_CHANGED_FILES = 300;
+const COMPACT_BODY_LENGTH = 2000;
+const COMPACT_COMMIT_MESSAGES = 5;
+const COMPACT_CHANGED_FILES = 50;
 const MAX_SUMMARY_LENGTH = 600;
 const MAX_RELEASE_CONTEXT_LENGTH = 200000;
 const RELEASE_NOTE_ID_METADATA_KEY = 'release_note_id';
+
+export type ReleaseNoteGenerationOutcome =
+  | 'published'
+  | 'already-published'
+  | 'no-baseline'
+  | 'no-pull-requests';
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -163,9 +172,57 @@ function sanitizeContext(context: GitHubReleaseContext) {
       commit_messages: pullRequest.commit_messages
         .slice(0, MAX_COMMIT_MESSAGES)
         .map((message) => message.slice(0, MAX_COMMIT_MESSAGE_LENGTH)),
-      changed_files: pullRequest.changed_files.slice(0, MAX_CHANGED_FILES)
+      changed_files: pullRequest.changed_files
+        .slice(0, MAX_CHANGED_FILES)
+        .map(({ filename, additions, deletions, changes }) => ({
+          filename,
+          additions,
+          deletions,
+          changes
+        }))
     }))
   };
+}
+
+function serializeReleaseContext(context: GitHubReleaseContext): string {
+  const sanitized = sanitizeContext(context);
+  const serialized = JSON.stringify(sanitized);
+  if (serialized.length <= MAX_RELEASE_CONTEXT_LENGTH) {
+    return serialized;
+  }
+
+  const compact = {
+    ...sanitized,
+    pull_requests: sanitized.pull_requests.map((pullRequest) => ({
+      ...pullRequest,
+      body: pullRequest.body?.slice(0, COMPACT_BODY_LENGTH) ?? null,
+      commit_messages: pullRequest.commit_messages.slice(
+        0,
+        COMPACT_COMMIT_MESSAGES
+      ),
+      changed_files: pullRequest.changed_files.slice(0, COMPACT_CHANGED_FILES)
+    }))
+  };
+  const compactSerialized = JSON.stringify(compact);
+  if (compactSerialized.length <= MAX_RELEASE_CONTEXT_LENGTH) {
+    return compactSerialized;
+  }
+
+  const minimal = {
+    previous_sha: context.previous_sha,
+    current_sha: context.current_sha,
+    pull_requests: context.pull_requests.map(({ number, title }) => ({
+      number,
+      title
+    }))
+  };
+  const minimalSerialized = JSON.stringify(minimal);
+  if (minimalSerialized.length > MAX_RELEASE_CONTEXT_LENGTH) {
+    throw new Error(
+      `Release context exceeds maximum of ${MAX_RELEASE_CONTEXT_LENGTH} characters after compaction`
+    );
+  }
+  return minimalSerialized;
 }
 
 export class ReleaseNoteGenerationService {
@@ -185,7 +242,7 @@ export class ReleaseNoteGenerationService {
   public async generateAndPost(
     request: ReleaseNoteGenerationRequest,
     ctx: RequestContext
-  ): Promise<void> {
+  ): Promise<ReleaseNoteGenerationOutcome> {
     const botProfileId = env.getStringOrThrow('CI_PIPELINES_BOT_PROFILE_ID');
     const waveId = env.getStringOrThrow('CI_RELEASES_WAVE_ID');
     const publicationId = buildReleaseNotePublicationId(request);
@@ -201,20 +258,20 @@ export class ReleaseNoteGenerationService {
       this.logger.info(
         `Skipping release note ${publicationId}; drop ${existingDropId} already exists`
       );
-      return;
+      return 'already-published';
     }
     const context = await this.githubService.getReleaseContext(request);
     if (!context) {
       this.logger.info(
         `Skipping release notes for ${request.repo} run ${request.run_id}; no previous successful production run was found`
       );
-      return;
+      return 'no-baseline';
     }
     if (!context.pull_requests.length) {
       this.logger.info(
         `Skipping release notes for ${request.repo} run ${request.run_id}; no merged pull requests were found`
       );
-      return;
+      return 'no-pull-requests';
     }
     const repositoryPrompt = await this.githubService.getReleasePrompt(request);
 
@@ -244,18 +301,14 @@ export class ReleaseNoteGenerationService {
         authenticationContext: AuthenticationContext.fromProfileId(botProfileId)
       }
     );
+    return 'published';
   }
 
   private buildPrompt(
     repositoryPrompt: string,
     context: GitHubReleaseContext
   ): string {
-    const serializedContext = JSON.stringify(sanitizeContext(context));
-    if (serializedContext.length > MAX_RELEASE_CONTEXT_LENGTH) {
-      throw new Error(
-        `Release context exceeds maximum of ${MAX_RELEASE_CONTEXT_LENGTH} characters`
-      );
-    }
+    const serializedContext = serializeReleaseContext(context);
     return [
       repositoryPrompt.trim(),
       '',

--- a/src/release-notes/release-note-github.service.test.ts
+++ b/src/release-notes/release-note-github.service.test.ts
@@ -21,6 +21,23 @@ const request: ReleaseNoteGenerationRequest = {
   deployed_at: '2026-07-13T11:38:00.000Z'
 };
 
+const response = (payload: unknown) => ({
+  ok: true,
+  status: 200,
+  statusText: 'OK',
+  headers: { get: jest.fn().mockReturnValue(null) },
+  json: jest.fn().mockResolvedValue(payload)
+});
+
+const currentRun = {
+  id: 123,
+  name: 'Web Deploy - PROD',
+  display_title: 'Web Deploy - PROD',
+  head_sha: 'abc123',
+  run_number: 45,
+  workflow_id: 7
+};
+
 describe('ReleaseNoteGitHubService', () => {
   const originalToken = process.env.RELEASE_NOTES_GITHUB_TOKEN;
 
@@ -76,23 +93,22 @@ describe('ReleaseNoteGitHubService', () => {
   });
 
   it('does not use a frontend non-production run as the release baseline', async () => {
-    (fetch as unknown as jest.Mock).mockResolvedValue({
-      ok: true,
-      status: 200,
-      statusText: 'OK',
-      headers: { get: jest.fn().mockReturnValue(null) },
-      json: jest.fn().mockResolvedValue({
-        workflow_runs: [
-          {
-            id: 122,
-            name: 'Deploy Staging',
-            display_title: 'Deploy Staging',
-            head_sha: 'previous-sha',
-            run_number: 44
-          }
-        ]
-      })
-    });
+    (fetch as unknown as jest.Mock)
+      .mockResolvedValueOnce(response(currentRun))
+      .mockResolvedValueOnce(
+        response({
+          workflow_runs: [
+            {
+              id: 122,
+              name: 'Deploy Staging',
+              display_title: 'Deploy Staging',
+              head_sha: 'previous-sha',
+              run_number: 44,
+              workflow_id: 7
+            }
+          ]
+        })
+      );
 
     const context = await new ReleaseNoteGitHubService().getReleaseContext({
       ...request,
@@ -101,35 +117,27 @@ describe('ReleaseNoteGitHubService', () => {
     });
 
     expect(context).toBeNull();
-    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledTimes(2);
   });
 
   it('finds a previous production run when run_number is missing', async () => {
     (fetch as unknown as jest.Mock)
-      .mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        statusText: 'OK',
-        headers: { get: jest.fn().mockReturnValue(null) },
-        json: jest.fn().mockResolvedValue({
+      .mockResolvedValueOnce(response(currentRun))
+      .mockResolvedValueOnce(
+        response({
           workflow_runs: [
             {
               id: 122,
               name: 'Web Deploy - PROD',
               display_title: 'Web Deploy - PROD',
               head_sha: 'previous-sha',
-              run_number: 44
+              run_number: 44,
+              workflow_id: 7
             }
           ]
         })
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        statusText: 'OK',
-        headers: { get: jest.fn().mockReturnValue(null) },
-        json: jest.fn().mockResolvedValue({ commits: [], total_commits: 0 })
-      });
+      )
+      .mockResolvedValueOnce(response({ commits: [], total_commits: 0 }));
 
     const context = await new ReleaseNoteGitHubService().getReleaseContext(
       request
@@ -140,27 +148,36 @@ describe('ReleaseNoteGitHubService', () => {
       current_sha: 'abc123',
       pull_requests: []
     });
-    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(fetch).toHaveBeenCalledTimes(3);
+    expect(fetch).toHaveBeenNthCalledWith(
+      2,
+      'https://api.github.com/repos/6529-Collections/6529seize-frontend/actions/workflows/7/runs?status=success&branch=main&per_page=100&page=1',
+      expect.any(Object)
+    );
   });
 
-  it('attributes backend pull requests to their directly changed deployed services', async () => {
-    const response = (payload: unknown) => ({
-      ok: true,
-      status: 200,
-      statusText: 'OK',
-      headers: { get: jest.fn().mockReturnValue(null) },
-      json: jest.fn().mockResolvedValue(payload)
-    });
+  it('uses service-specific backend run names from the deploy workflow', async () => {
     (fetch as unknown as jest.Mock)
+      .mockResolvedValueOnce(
+        response({
+          id: 123,
+          name: 'Deploy claimsBuilder to prod',
+          display_title: 'Deploy claimsBuilder to prod',
+          head_sha: 'current-sha',
+          run_number: 45,
+          workflow_id: 82013288
+        })
+      )
       .mockResolvedValueOnce(
         response({
           workflow_runs: [
             {
               id: 122,
-              name: 'Deploy a service',
+              name: 'Deploy api to prod',
               display_title: 'Deploy api to prod',
               head_sha: 'previous-sha',
-              run_number: 44
+              run_number: 44,
+              workflow_id: 82013288
             }
           ]
         })
@@ -214,7 +231,9 @@ describe('ReleaseNoteGitHubService', () => {
             filename: 'src/api-serverless/src/profiles/routes.ts',
             additions: 4,
             deletions: 1,
-            changes: 5
+            changes: 5,
+            patch: 'x'.repeat(300000),
+            blob_url: 'https://github.com/example/blob/api-commit/routes.ts'
           }
         ])
       )
@@ -241,11 +260,84 @@ describe('ReleaseNoteGitHubService', () => {
     });
 
     expect(context?.pull_requests).toEqual([
-      expect.objectContaining({ number: 101, candidate_services: ['api'] }),
+      expect.objectContaining({
+        number: 101,
+        candidate_services: ['api'],
+        changed_files: [
+          {
+            filename: 'src/api-serverless/src/profiles/routes.ts',
+            additions: 4,
+            deletions: 1,
+            changes: 5
+          }
+        ]
+      }),
       expect.objectContaining({
         number: 102,
         candidate_services: ['claimsBuilder']
       })
     ]);
+    expect(fetch).toHaveBeenNthCalledWith(
+      2,
+      'https://api.github.com/repos/6529-Collections/6529seize-backend/actions/workflows/82013288/runs?status=success&branch=main&per_page=100&page=1',
+      expect.any(Object)
+    );
+  });
+
+  it('paginates past successful runs from the current backend SHA', async () => {
+    const sameShaRuns = Array.from({ length: 100 }, (_, index) => ({
+      id: 1000 + index,
+      name: `Deploy service${index} to prod`,
+      display_title: `Deploy service${index} to prod`,
+      head_sha: 'current-sha',
+      run_number: 199 - index,
+      workflow_id: 82013288
+    }));
+    (fetch as unknown as jest.Mock)
+      .mockResolvedValueOnce(
+        response({
+          id: 123,
+          name: 'Deploy s3Uploader to prod',
+          display_title: 'Deploy s3Uploader to prod',
+          head_sha: 'current-sha',
+          run_number: 200,
+          workflow_id: 82013288
+        })
+      )
+      .mockResolvedValueOnce(response({ workflow_runs: sameShaRuns }))
+      .mockResolvedValueOnce(
+        response({
+          workflow_runs: [
+            {
+              id: 122,
+              name: 'Deploy api to prod',
+              display_title: 'Deploy api to prod',
+              head_sha: 'previous-sha',
+              run_number: 99,
+              workflow_id: 82013288
+            }
+          ]
+        })
+      )
+      .mockResolvedValueOnce(response({ commits: [], total_commits: 0 }));
+
+    const context = await new ReleaseNoteGitHubService().getReleaseContext({
+      ...request,
+      repo: '6529seize-backend',
+      workflow: 'Deploy a service',
+      run_number: '200',
+      sha: 'current-sha',
+      branch: 'main',
+      service: 's3Uploader',
+      release_group_id: 'backend-release',
+      release_group_services: ['s3Uploader']
+    });
+
+    expect(context?.previous_sha).toBe('previous-sha');
+    expect(fetch).toHaveBeenNthCalledWith(
+      3,
+      'https://api.github.com/repos/6529-Collections/6529seize-backend/actions/workflows/82013288/runs?status=success&branch=main&per_page=100&page=2',
+      expect.any(Object)
+    );
   });
 });

--- a/src/release-notes/release-note-github.service.ts
+++ b/src/release-notes/release-note-github.service.ts
@@ -10,6 +10,7 @@ interface GitHubWorkflowRun {
   readonly display_title: string;
   readonly head_sha: string;
   readonly run_number: number;
+  readonly workflow_id: number;
 }
 
 interface GitHubWorkflowRunsResponse {
@@ -83,6 +84,7 @@ interface AggregatedPullRequest {
 
 const MAX_COMPARE_PAGES = 3;
 const MAX_FILE_PAGES = 3;
+const MAX_WORKFLOW_RUN_PAGES = 10;
 const PAGE_SIZE = 100;
 const BACKEND_REPO = '6529seize-backend';
 const FRONTEND_REPO = '6529seize-frontend';
@@ -329,25 +331,42 @@ export class ReleaseNoteGitHubService {
     repository: string,
     request: ReleaseNoteGenerationRequest
   ): Promise<GitHubWorkflowRun | null> {
-    const branch = encodeURIComponent(normalizeBranch(request.branch));
-    const payload = await this.api<GitHubWorkflowRunsResponse>(
-      `/repos/${repository}/actions/runs?status=success&branch=${branch}&per_page=${PAGE_SIZE}`
+    const currentRun = await this.api<GitHubWorkflowRun>(
+      `/repos/${repository}/actions/runs/${encodeURIComponent(request.run_id)}`
     );
-    const currentRunNumber = request.run_number
-      ? Number(request.run_number)
-      : null;
+    if (
+      String(currentRun.id) !== request.run_id ||
+      currentRun.head_sha !== request.sha ||
+      !Number.isSafeInteger(currentRun.workflow_id)
+    ) {
+      throw new Error(
+        `GitHub release run ${request.run_id} does not match the queued release metadata`
+      );
+    }
 
-    return (
-      payload.workflow_runs?.find(
+    const branch = encodeURIComponent(normalizeBranch(request.branch));
+    for (let page = 1; page <= MAX_WORKFLOW_RUN_PAGES; page++) {
+      const payload = await this.api<GitHubWorkflowRunsResponse>(
+        `/repos/${repository}/actions/workflows/${currentRun.workflow_id}/runs?status=success&branch=${branch}&per_page=${PAGE_SIZE}&page=${page}`
+      );
+      const runs = payload.workflow_runs ?? [];
+      const previousRun = runs.find(
         (run) =>
           String(run.id) !== request.run_id &&
           run.head_sha !== request.sha &&
-          run.name === request.workflow &&
-          (currentRunNumber === null ||
-            !Number.isFinite(currentRunNumber) ||
-            run.run_number < currentRunNumber) &&
+          run.workflow_id === currentRun.workflow_id &&
+          run.run_number < currentRun.run_number &&
           isMatchingProductionRun(run, request)
-      ) ?? null
+      );
+      if (previousRun) {
+        return previousRun;
+      }
+      if (runs.length < PAGE_SIZE) {
+        return null;
+      }
+    }
+    throw new Error(
+      `Previous successful production run was not found within ${MAX_WORKFLOW_RUN_PAGES * PAGE_SIZE} workflow runs`
     );
   }
 
@@ -517,7 +536,14 @@ export class ReleaseNoteGitHubService {
       const pageFiles = await this.api<GitHubPullRequestFile[]>(
         `/repos/${repository}/pulls/${pullRequestNumber}/files?per_page=${PAGE_SIZE}&page=${page}`
       );
-      files.push(...pageFiles);
+      files.push(
+        ...pageFiles.map(({ filename, additions, deletions, changes }) => ({
+          filename,
+          additions,
+          deletions,
+          changes
+        }))
+      );
       if (pageFiles.length < PAGE_SIZE) {
         break;
       }

--- a/src/releaseNotesGenerationLoop/index.test.ts
+++ b/src/releaseNotesGenerationLoop/index.test.ts
@@ -206,6 +206,27 @@ describe('processRequest', () => {
     );
   });
 
+  it('does not record deduplication when no release baseline exists', async () => {
+    const redis = buildRedis(['api', 'worker'], {
+      'release-note-group:6529seize-backend:backend-release:abc123:run:worker':
+        JSON.stringify(workerRun)
+    });
+
+    await processRequest(request, {
+      redis: redis as any,
+      generateAndPost: jest.fn().mockResolvedValue('no-baseline')
+    });
+
+    expect(redis.set).not.toHaveBeenCalledWith(
+      'release-note:6529seize-backend:backend-release:abc123',
+      '1',
+      { EX: 7776000 }
+    );
+    expect(redis.del).toHaveBeenCalledWith(
+      'release-note:6529seize-backend:backend-release:abc123:processing'
+    );
+  });
+
   it('sanitizes the deployed SHA in Redis keys', async () => {
     const redis = buildRedis(['api', 'worker'], {
       'release-note-group:6529seize-backend:backend-release:abc-123:run:worker':

--- a/src/releaseNotesGenerationLoop/index.ts
+++ b/src/releaseNotesGenerationLoop/index.ts
@@ -254,13 +254,15 @@ export async function processRequest(
       releaseNoteGenerationService.generateAndPost.bind(
         releaseNoteGenerationService
       );
-    await generateAndPost(
+    const outcome = await generateAndPost(
       { ...request, release_group_runs: releaseGroupRuns },
       {}
     );
-    await redis.set(dedupeKey, '1', {
-      EX: RELEASE_NOTE_DEDUPE_TTL_SECONDS
-    });
+    if (outcome !== 'no-baseline') {
+      await redis.set(dedupeKey, '1', {
+        EX: RELEASE_NOTE_DEDUPE_TTL_SECONDS
+      });
+    }
   } finally {
     await redis.del(processingKey);
   }


### PR DESCRIPTION
## Issue

- Backend production release notes could not find an earlier deploy because GitHub exposes service-specific run names such as `Deploy s3Uploader to prod`, while the queue payload carries the workflow name `Deploy a service`.
- GitHub changed-file responses also leaked full diff patches into the Bedrock context, allowing a small release to exceed the 200,000-character safety limit.

## Fix

- Resolve the current GitHub run by ID and use its stable workflow ID to find previous successful production runs.
- Paginate workflow runs, exclude the current SHA/group runs, and retain existing production/group filtering.
- Strip changed-file data to reviewed fields and progressively compact oversized model context while retaining every PR.
- Leave missing-baseline events replayable instead of recording them as completed.

## Changes

- Added workflow-scoped, paginated release baseline discovery.
- Added explicit generation outcomes for publication, existing drops, missing baselines, and empty PR ranges.
- Preserved group-level deduplication for terminal outcomes while allowing missing-baseline replay.
- Added regression coverage for real backend run names, pagination, grouped processing, oversized GitHub patches, and context compaction.

## Validation

- 24 focused release-note and grouping tests pass.
- Changed-file ESLint passes with zero warnings.
- TypeScript compilation passes.
- The broad backend suite reached an unrelated existing failure in `waves-api-db.test.ts`; no Waves or database files are changed here.

## Risk

- Level: Medium
- Why: This changes production release-note baseline selection and prompt preparation, but not deployment execution or the CI notification path.
- Rollback: Revert this PR and redeploy `releaseNotesGenerationLoop`.

## Deployment

- After merge, deploy `releaseNotesGenerationLoop` only.
- No API, database, frontend, or other service deployment is required.

## Review Notes

- Confirm workflow identity is derived from GitHub's stable workflow ID rather than the mutable display name.
- Confirm compaction retains every PR number/title and never forwards GitHub diff patches.
