### PR TITLE
Refine backend release note layout

### DIFF
--- a/src/release-notes/release-note-generation.service.test.ts
+++ b/src/release-notes/release-note-generation.service.test.ts
@@ -150,7 +150,7 @@ describe('ReleaseNoteGenerationService', () => {
           parts: [
             expect.objectContaining({
               content: expect.stringContaining(
-                '- [PR #42](https://github.com/6529-Collections/6529seize-backend/pull/42): Made notification delivery more reliable. - @[alice6529] — Service: api'
+                '[PR #42](https://github.com/6529-Collections/6529seize-backend/pull/42): Made notification delivery more reliable. - @[alice6529]\n- Service: [api #45](https://github.com/6529-Collections/6529seize-backend/actions/runs/123)'
               )
             })
           ]
@@ -163,9 +163,8 @@ describe('ReleaseNoteGenerationService', () => {
     expect(content).toContain(
       '### Backend deploy · commit [current-](https://github.com/6529-Collections/6529seize-backend/commit/current-sha) — Jul 13, 11:38 AM UTC'
     );
-    expect(content).toContain(
-      'Runs: [api #45](https://github.com/6529-Collections/6529seize-backend/actions/runs/123), [pushNotificationsHandler #46](https://github.com/6529-Collections/6529seize-backend/actions/runs/456)'
-    );
+    expect(content).not.toContain('\n\n- Service:');
+    expect(content).not.toContain('Runs:');
     expect(content).not.toContain('Services affected:');
   });
 
@@ -227,7 +226,10 @@ describe('ReleaseNoteGenerationService', () => {
     const backendContent =
       createDrop.mock.calls[1][0].createDropRequest.parts[0].content;
     expect(backendContent).toContain(
-      '### Backend deploy [api #45](https://github.com/6529-Collections/6529seize-backend/actions/runs/123) · commit [current-](https://github.com/6529-Collections/6529seize-backend/commit/current-sha) — Jul 13, 11:38 AM UTC'
+      '### Backend deploy · commit [current-](https://github.com/6529-Collections/6529seize-backend/commit/current-sha) — Jul 13, 11:38 AM UTC'
+    );
+    expect(backendContent).toContain(
+      '- Service: [api #45](https://github.com/6529-Collections/6529seize-backend/actions/runs/123)'
     );
   });
 
@@ -299,8 +301,10 @@ describe('ReleaseNoteGenerationService', () => {
 
     const content =
       createDrop.mock.calls[0][0].createDropRequest.parts[0].content;
-    expect(content).toContain('— Services: api, pushNotificationsHandler');
-    expect(content).not.toContain('\nRuns:');
+    expect(content).toContain(
+      '- Services: [api #45](https://github.com/6529-Collections/6529seize-backend/actions/runs/123), pushNotificationsHandler'
+    );
+    expect(content).not.toContain('Runs:');
   });
 
   it('neutralizes model-supplied markdown and mention syntax', async () => {

--- a/src/release-notes/release-note-generation.service.test.ts
+++ b/src/release-notes/release-note-generation.service.test.ts
@@ -233,6 +233,104 @@ describe('ReleaseNoteGenerationService', () => {
     );
   });
 
+  it('renders multi-PR backend notes as paragraphs with adjacent service bullets', async () => {
+    const multiPullRequestContext: GitHubReleaseContext = {
+      ...context,
+      pull_requests: [
+        context.pull_requests[0],
+        {
+          ...context.pull_requests[0],
+          number: 43,
+          url: 'https://github.com/6529-Collections/6529seize-backend/pull/43',
+          title: 'Improve push notifications',
+          contributors: [],
+          candidate_services: ['pushNotificationsHandler']
+        }
+      ]
+    };
+    const createDrop = jest.fn().mockResolvedValue({});
+    const service = new ReleaseNoteGenerationService(
+      {
+        getReleaseContext: jest.fn().mockResolvedValue(multiPullRequestContext),
+        getReleasePrompt: jest.fn().mockResolvedValue('Repository prompt.')
+      } as unknown as ReleaseNoteGitHubService,
+      {
+        promptAndGetReply: jest.fn().mockResolvedValue(
+          JSON.stringify({
+            pull_requests: [
+              {
+                number: 42,
+                summary: 'Made notification delivery more reliable.'
+              },
+              {
+                number: 43,
+                summary: 'Improved push notification delivery.'
+              }
+            ]
+          })
+        )
+      },
+      { createDrop } as unknown as DropCreationApiService,
+      {
+        getIdsByHandles: jest.fn().mockResolvedValue({})
+      } as unknown as IdentitiesDb,
+      {},
+      createDropsRepository()
+    );
+
+    await service.generateAndPost(request, {});
+
+    const content =
+      createDrop.mock.calls[0][0].createDropRequest.parts[0].content;
+    expect(content).toContain(
+      '[PR #42](https://github.com/6529-Collections/6529seize-backend/pull/42): Made notification delivery more reliable. - [@Alice](https://github.com/Alice)\n- Service: [api #45](https://github.com/6529-Collections/6529seize-backend/actions/runs/123)\n\n[PR #43](https://github.com/6529-Collections/6529seize-backend/pull/43): Improved push notification delivery.\n- Service: [pushNotificationsHandler #46](https://github.com/6529-Collections/6529seize-backend/actions/runs/456)'
+    );
+  });
+
+  it('falls back to grouped service run links when service candidates are empty', async () => {
+    const createDrop = jest.fn().mockResolvedValue({});
+    const service = new ReleaseNoteGenerationService(
+      {
+        getReleaseContext: jest.fn().mockResolvedValue({
+          ...context,
+          pull_requests: [
+            {
+              ...context.pull_requests[0],
+              candidate_services: []
+            }
+          ]
+        }),
+        getReleasePrompt: jest.fn().mockResolvedValue('Repository prompt.')
+      } as unknown as ReleaseNoteGitHubService,
+      {
+        promptAndGetReply: jest.fn().mockResolvedValue(
+          JSON.stringify({
+            pull_requests: [
+              {
+                number: 42,
+                summary: 'Made notification delivery more reliable.'
+              }
+            ]
+          })
+        )
+      },
+      { createDrop } as unknown as DropCreationApiService,
+      {
+        getIdsByHandles: jest.fn().mockResolvedValue({})
+      } as unknown as IdentitiesDb,
+      {},
+      createDropsRepository()
+    );
+
+    await service.generateAndPost(request, {});
+
+    const content =
+      createDrop.mock.calls[0][0].createDropRequest.parts[0].content;
+    expect(content).toContain(
+      '- Services: [api #45](https://github.com/6529-Collections/6529seize-backend/actions/runs/123), [pushNotificationsHandler #46](https://github.com/6529-Collections/6529seize-backend/actions/runs/456)'
+    );
+  });
+
   it('rejects a model response that omits a pull request', async () => {
     const service = new ReleaseNoteGenerationService(
       {

--- a/src/release-notes/release-note-generation.service.ts
+++ b/src/release-notes/release-note-generation.service.ts
@@ -91,6 +91,10 @@ function getRepoName(repo: string): string {
   return repo.split('/').pop() ?? repo;
 }
 
+function isFrontendRelease(request: ReleaseNoteGenerationRequest): boolean {
+  return getRepoName(request.repo) === '6529seize-frontend';
+}
+
 function buildReleaseNotePublicationId(
   request: ReleaseNoteGenerationRequest
 ): string {
@@ -107,8 +111,7 @@ function getReleaseHeading(request: ReleaseNoteGenerationRequest): string {
   const repository = request.repo.includes('/')
     ? request.repo
     : `6529-Collections/${request.repo}`;
-  const surface =
-    getRepoName(request.repo) === '6529seize-frontend' ? 'Frontend' : 'Backend';
+  const surface = isFrontendRelease(request) ? 'Frontend' : 'Backend';
   const shortSha = request.sha.slice(0, 8);
   const commit = formatMarkdownLink(
     shortSha,
@@ -126,40 +129,47 @@ function getReleaseHeading(request: ReleaseNoteGenerationRequest): string {
     timeZone: 'UTC',
     timeZoneName: 'short'
   }).format(deployedAt);
-  if (request.release_group_services.length === 1) {
+  if (surface === 'Frontend' && request.release_group_services.length === 1) {
     const runNumber = request.run_number || request.run_id;
-    const runLabel =
-      surface === 'Frontend'
-        ? `#${runNumber}`
-        : `${request.service?.trim() || request.release_group_services[0]} #${runNumber}`;
-    const run = formatMarkdownLink(runLabel, request.run_url);
+    const run = formatMarkdownLink(`#${runNumber}`, request.run_url);
     return `### ${surface} deploy ${run} · commit ${commit} — ${formattedDate}`;
   }
   return `### ${surface} deploy · commit ${commit} — ${formattedDate}`;
 }
 
-function getGroupedRunLine(
-  request: ReleaseNoteGenerationRequest
+function getBackendServiceLine(
+  request: ReleaseNoteGenerationRequest,
+  services: string[]
 ): string | null {
-  if (request.release_group_services.length === 1) {
+  if (!services.length) {
     return null;
   }
   const runs = request.release_group_runs ?? [];
   const runsByService = new Map(runs.map((run) => [run.service, run]));
-  if (
-    runsByService.size !== request.release_group_services.length ||
-    request.release_group_services.some(
-      (service) => !runsByService.has(service)
-    )
-  ) {
-    return null;
+  const currentService =
+    request.service?.trim() ||
+    (request.release_group_services.length === 1
+      ? request.release_group_services[0]
+      : null);
+  if (currentService && !runsByService.has(currentService)) {
+    runsByService.set(currentService, {
+      service: currentService,
+      run_id: request.run_id,
+      run_number: request.run_number,
+      run_url: request.run_url
+    });
   }
-  const runLinks = request.release_group_services.map((service) => {
-    const run = runsByService.get(service)!;
+
+  const runLinks = services.map((service) => {
+    const run = runsByService.get(service);
+    if (!run) {
+      return service;
+    }
     const runNumber = run.run_number || run.run_id;
     return formatMarkdownLink(`${run.service} #${runNumber}`, run.run_url);
   });
-  return `Runs: ${runLinks.join(', ')}`;
+  const serviceLabel = services.length === 1 ? 'Service' : 'Services';
+  return `- ${serviceLabel}: ${runLinks.join(', ')}`;
 }
 
 function sanitizeContext(context: GitHubReleaseContext) {
@@ -440,7 +450,8 @@ export class ReleaseNoteGenerationService {
         pullRequest
       ])
     );
-    const lines = generatedNotes.map((note) => {
+    const frontendRelease = isFrontendRelease(request);
+    const releaseNoteBlocks = generatedNotes.map((note) => {
       const pullRequest = contextsByNumber.get(note.number);
       if (!pullRequest) {
         throw new Error(`Missing release context for PR ${note.number}`);
@@ -457,18 +468,23 @@ export class ReleaseNoteGenerationService {
       const services = Array.from(new Set(pullRequest.candidate_services)).sort(
         (a, b) => a.localeCompare(b)
       );
+      const pullRequestLine = `${pullRequestLink}: ${note.summary}${contributorSuffix}`;
+      if (!frontendRelease) {
+        const serviceLine = getBackendServiceLine(request, services);
+        return serviceLine
+          ? `${pullRequestLine}\n${serviceLine}`
+          : pullRequestLine;
+      }
       const serviceLabel = services.length === 1 ? 'Service' : 'Services';
       const serviceSuffix = services.length
         ? ` — ${serviceLabel}: ${services.join(', ')}`
         : '';
-      return `- ${pullRequestLink}: ${note.summary}${contributorSuffix}${serviceSuffix}`;
+      return `- ${pullRequestLine}${serviceSuffix}`;
     });
-    const groupedRunLine = getGroupedRunLine(request);
     const content = [
       getReleaseHeading(request),
-      ...(groupedRunLine ? [groupedRunLine] : []),
       '',
-      ...lines
+      releaseNoteBlocks.join(frontendRelease ? '\n' : '\n\n')
     ].join('\n');
 
     return {

--- a/src/release-notes/release-note-generation.service.ts
+++ b/src/release-notes/release-note-generation.service.ts
@@ -20,7 +20,10 @@ import {
   ReleaseNoteGitHubService,
   ReleasePullRequestContext
 } from './release-note-github.service';
-import { ReleaseNoteGenerationRequest } from './release-note-generation-queue';
+import {
+  ReleaseNoteGenerationRequest,
+  ReleaseNoteRunReference
+} from './release-note-generation-queue';
 
 interface GeneratedReleaseNote {
   readonly number: number;
@@ -137,13 +140,9 @@ function getReleaseHeading(request: ReleaseNoteGenerationRequest): string {
   return `### ${surface} deploy · commit ${commit} — ${formattedDate}`;
 }
 
-function getBackendServiceLine(
-  request: ReleaseNoteGenerationRequest,
-  services: string[]
-): string | null {
-  if (!services.length) {
-    return null;
-  }
+function getBackendRunsByService(
+  request: ReleaseNoteGenerationRequest
+): ReadonlyMap<string, ReleaseNoteRunReference> {
   const runs = request.release_group_runs ?? [];
   const runsByService = new Map(runs.map((run) => [run.service, run]));
   const currentService =
@@ -159,7 +158,16 @@ function getBackendServiceLine(
       run_url: request.run_url
     });
   }
+  return runsByService;
+}
 
+function getBackendServiceLine(
+  services: string[],
+  runsByService: ReadonlyMap<string, ReleaseNoteRunReference>
+): string | null {
+  if (!services.length) {
+    return null;
+  }
   const runLinks = services.map((service) => {
     const run = runsByService.get(service);
     if (!run) {
@@ -451,6 +459,10 @@ export class ReleaseNoteGenerationService {
       ])
     );
     const frontendRelease = isFrontendRelease(request);
+    const backendRunsByService = getBackendRunsByService(request);
+    const backendFallbackServices = Array.from(
+      new Set(request.release_group_services)
+    ).sort((a, b) => a.localeCompare(b));
     const releaseNoteBlocks = generatedNotes.map((note) => {
       const pullRequest = contextsByNumber.get(note.number);
       if (!pullRequest) {
@@ -470,7 +482,13 @@ export class ReleaseNoteGenerationService {
       );
       const pullRequestLine = `${pullRequestLink}: ${note.summary}${contributorSuffix}`;
       if (!frontendRelease) {
-        const serviceLine = getBackendServiceLine(request, services);
+        const backendServices = services.length
+          ? services
+          : backendFallbackServices;
+        const serviceLine = getBackendServiceLine(
+          backendServices,
+          backendRunsByService
+        );
         return serviceLine
           ? `${pullRequestLine}\n${serviceLine}`
           : pullRequestLine;

--- a/src/release-notes/release-note-generation.service.ts
+++ b/src/release-notes/release-note-generation.service.ts
@@ -180,6 +180,31 @@ function getBackendServiceLine(
   return `- ${serviceLabel}: ${runLinks.join(', ')}`;
 }
 
+function formatReleaseNoteBlock(
+  pullRequestLine: string,
+  services: string[],
+  frontendRelease: boolean,
+  backendRunsByService: ReadonlyMap<string, ReleaseNoteRunReference>,
+  backendFallbackServices: string[]
+): string {
+  if (!frontendRelease) {
+    const backendServices = services.length
+      ? services
+      : backendFallbackServices;
+    const serviceLine = getBackendServiceLine(
+      backendServices,
+      backendRunsByService
+    );
+    return serviceLine ? `${pullRequestLine}\n${serviceLine}` : pullRequestLine;
+  }
+
+  const serviceLabel = services.length === 1 ? 'Service' : 'Services';
+  const serviceSuffix = services.length
+    ? ` — ${serviceLabel}: ${services.join(', ')}`
+    : '';
+  return `- ${pullRequestLine}${serviceSuffix}`;
+}
+
 function sanitizeContext(context: GitHubReleaseContext) {
   return {
     previous_sha: context.previous_sha,
@@ -481,23 +506,13 @@ export class ReleaseNoteGenerationService {
         (a, b) => a.localeCompare(b)
       );
       const pullRequestLine = `${pullRequestLink}: ${note.summary}${contributorSuffix}`;
-      if (!frontendRelease) {
-        const backendServices = services.length
-          ? services
-          : backendFallbackServices;
-        const serviceLine = getBackendServiceLine(
-          backendServices,
-          backendRunsByService
-        );
-        return serviceLine
-          ? `${pullRequestLine}\n${serviceLine}`
-          : pullRequestLine;
-      }
-      const serviceLabel = services.length === 1 ? 'Service' : 'Services';
-      const serviceSuffix = services.length
-        ? ` — ${serviceLabel}: ${services.join(', ')}`
-        : '';
-      return `- ${pullRequestLine}${serviceSuffix}`;
+      return formatReleaseNoteBlock(
+        pullRequestLine,
+        services,
+        frontendRelease,
+        backendRunsByService,
+        backendFallbackServices
+      );
     });
     const content = [
       getReleaseHeading(request),


### PR DESCRIPTION
## Summary

- make backend release headings commit-centric
- render each PR as a paragraph followed immediately by a service/run list item
- link each affected service to its own workflow run
- preserve the existing frontend release-note layout

## Why

Backend release notes currently repeat service names between the heading, grouped run line, and PR line. This keeps the deployment metadata while presenting it once, directly beneath the relevant PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved release note formatting for frontend and backend releases.
  * Added linked service and run details where applicable.
  * Added clearer per-PR service information for backend deployments.
  * Added fallback service links when run information is unavailable.
  * Improved formatting for releases containing multiple pull requests or services.

* **Bug Fixes**
  * Removed outdated service and run formatting from generated release notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->