### PR TITLE
Fix active wave participant badges

### DIFF
--- a/src/api-serverless/openapi.yaml
+++ b/src/api-serverless/openapi.yaml
@@ -14764,8 +14764,12 @@ components:
       properties:
         is_participant:
           type: boolean
+          description: >-
+            Whether the identity currently has at least one active PARTICIPATORY
+            drop in the wave.
         is_winner:
           type: boolean
+          description: Whether the identity has at least one WINNER drop in the wave.
     ApiIncomingIdentitySubscriptionsPage:
       type: object
       required:

--- a/src/api-serverless/src/generated/models/ApiIdentityWaveParticipation.ts
+++ b/src/api-serverless/src/generated/models/ApiIdentityWaveParticipation.ts
@@ -13,7 +13,13 @@
 import { HttpFile } from '../http/http';
 
 export class ApiIdentityWaveParticipation {
+    /**
+    * Whether the identity currently has at least one active PARTICIPATORY drop in the wave.
+    */
     'is_participant': boolean;
+    /**
+    * Whether the identity has at least one WINNER drop in the wave.
+    */
     'is_winner': boolean;
 
     static readonly discriminator: string | undefined = undefined;

--- a/src/drops/drops-db.test.ts
+++ b/src/drops/drops-db.test.ts
@@ -27,12 +27,18 @@ describe('DropsDb', () => {
       {
         wave_id: 'wave-1',
         author_id: 'author-1',
-        is_participant: 1,
+        is_participant: 0,
         is_winner: 1
       },
       {
         wave_id: 'wave-2',
         author_id: 'author-outside-requested-pair',
+        is_participant: 1,
+        is_winner: 1
+      },
+      {
+        wave_id: 'wave-3',
+        author_id: 'author-1',
         is_participant: 1,
         is_winner: 1
       }
@@ -49,7 +55,8 @@ describe('DropsDb', () => {
         { wave_id: 'wave-1', author_id: 'author-1' },
         { wave_id: 'wave-1', author_id: 'author-1' },
         { wave_id: 'wave-2', author_id: 'author-1' },
-        { wave_id: 'wave-2', author_id: 'author-2' }
+        { wave_id: 'wave-2', author_id: 'author-2' },
+        { wave_id: 'wave-3', author_id: 'author-1' }
       ],
       {
         connection: { connection } as any,
@@ -60,7 +67,7 @@ describe('DropsDb', () => {
     expect(result).toEqual({
       'wave-1': {
         'author-1': {
-          is_participant: true,
+          is_participant: false,
           is_winner: true
         }
       },
@@ -73,12 +80,18 @@ describe('DropsDb', () => {
           is_participant: false,
           is_winner: false
         }
+      },
+      'wave-3': {
+        'author-1': {
+          is_participant: true,
+          is_winner: true
+        }
       }
     });
     expect(execute).toHaveBeenCalledTimes(1);
     const [sql, params, options] = execute.mock.calls[0];
     expect(sql).toContain(
-      'max(case when drop_type in (:participant_type, :winner_type)'
+      'max(case when drop_type = :participant_type then 1 else 0 end)'
     );
     expect(sql).toContain('max(case when drop_type = :winner_type');
     expect(sql).toContain('wave_id in (:wave_ids)');
@@ -87,7 +100,7 @@ describe('DropsDb', () => {
     expect(sql).not.toContain('exists(');
     expect(sql).not.toContain('union all');
     expect(params).toEqual({
-      wave_ids: ['wave-1', 'wave-2'],
+      wave_ids: ['wave-1', 'wave-2', 'wave-3'],
       author_ids: ['author-1', 'author-2'],
       participant_type: DropType.PARTICIPATORY,
       winner_type: DropType.WINNER
@@ -95,12 +108,12 @@ describe('DropsDb', () => {
     expect(options).toEqual({ wrappedConnection: { connection } });
   });
 
-  it('treats a promoted winner row as both participant and winner', async () => {
+  it('does not treat a promoted winner row as an active participant', async () => {
     const execute = jest.fn().mockResolvedValue([
       {
         wave_id: 'wave-1',
         author_id: 'author-1',
-        is_participant: 1,
+        is_participant: 0,
         is_winner: 1
       }
     ]);
@@ -120,11 +133,11 @@ describe('DropsDb', () => {
     );
 
     expect(result['wave-1']?.['author-1']).toEqual({
-      is_participant: true,
+      is_participant: false,
       is_winner: true
     });
     expect(execute.mock.calls[0]?.[0]).toContain(
-      'drop_type in (:participant_type, :winner_type)'
+      'max(case when drop_type = :participant_type then 1 else 0 end)'
     );
   });
 

--- a/src/drops/drops.db.ts
+++ b/src/drops/drops.db.ts
@@ -181,7 +181,7 @@ export class DropsDb extends LazyDbAccessCompatibleService {
         `
           select wave_id,
                  author_id,
-                 max(case when drop_type in (:participant_type, :winner_type) then 1 else 0 end) as is_participant,
+                 max(case when drop_type = :participant_type then 1 else 0 end) as is_participant,
                  max(case when drop_type = :winner_type then 1 else 0 end) as is_winner
           from ${DROPS_TABLE}
           where wave_id in (:wave_ids)


### PR DESCRIPTION
## Issue
- Winner-only profiles were still marked as active wave participants after their PARTICIPATORY drop transitioned to WINNER.

## Fix
- Calculate active participation only from current PARTICIPATORY drops.
- Keep winner status independent so winner-only, active-only, and mixed profiles receive the correct booleans.

## Changes
- Update the wave participation aggregation query.
- Add regression coverage for winner-only and mixed active-plus-winning states.
- Document the boolean semantics in OpenAPI and regenerate the model.
- No schema, migration, queue, loop, dependency, or architecture change. No architecture-doc update is needed.

## Validation
- Focused DropsDb tests: 14/14 passed using the repository Jest configuration without container-only global hooks.
- npm run lint
- Root TypeScript compilation with no emit
- API OpenAPI generation and packaged build
- Full local Jest could not start because the required container runtime was unavailable; CI provides the full container-backed test gate.

## Risk
- Level: Low
- Why: one boolean aggregation condition changes without altering the response shape or query structure.
- Rollback: redeploy the prior API commit.

## Deployment
1. api

## Review Notes
- Confirm winner-only authors return is_participant=false and is_winner=true.
- Confirm authors with separate active and winning drops still return both booleans as true.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected wave participation status so winner entries are no longer incorrectly counted as active participants.
  - Updated participation results to accurately distinguish participants from winners across multiple waves.

- **Documentation**
  - Clarified API descriptions for participant and winner status indicators in wave participation responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->