### PR TITLE
Add initiator mentions to CI alerts

### DIFF
--- a/scripts/notify-ci-wave.mjs
+++ b/scripts/notify-ci-wave.mjs
@@ -81,10 +81,7 @@ const repository = requireValue('GITHUB_REPOSITORY', GITHUB_REPOSITORY);
 const runId = requireValue('GITHUB_RUN_ID', GITHUB_RUN_ID);
 const status = requireValue('CI_PIPELINES_STATUS', CI_PIPELINES_STATUS);
 const title = requireValue('CI_PIPELINES_TITLE', CI_PIPELINES_TITLE);
-const triggeredByGithubLogin = requireValue(
-  'GITHUB_TRIGGERING_ACTOR or GITHUB_ACTOR',
-  GITHUB_TRIGGERING_ACTOR || GITHUB_ACTOR
-);
+const triggeredByGithubLogin = GITHUB_TRIGGERING_ACTOR || GITHUB_ACTOR || null;
 const isReleaseNotesEligible =
   status === 'success' &&
   targetEnvironment === 'prod' &&

--- a/scripts/notify-ci-wave.mjs
+++ b/scripts/notify-ci-wave.mjs
@@ -23,7 +23,9 @@ const {
   GITHUB_RUN_NUMBER,
   GITHUB_SERVER_URL = 'https://github.com',
   GITHUB_SHA,
-  GITHUB_REF_NAME
+  GITHUB_REF_NAME,
+  GITHUB_TRIGGERING_ACTOR,
+  GITHUB_ACTOR
 } = process.env;
 
 function requireValue(name, value) {
@@ -79,6 +81,10 @@ const repository = requireValue('GITHUB_REPOSITORY', GITHUB_REPOSITORY);
 const runId = requireValue('GITHUB_RUN_ID', GITHUB_RUN_ID);
 const status = requireValue('CI_PIPELINES_STATUS', CI_PIPELINES_STATUS);
 const title = requireValue('CI_PIPELINES_TITLE', CI_PIPELINES_TITLE);
+const triggeredByGithubLogin = requireValue(
+  'GITHUB_TRIGGERING_ACTOR or GITHUB_ACTOR',
+  GITHUB_TRIGGERING_ACTOR || GITHUB_ACTOR
+);
 const isReleaseNotesEligible =
   status === 'success' &&
   targetEnvironment === 'prod' &&
@@ -128,6 +134,7 @@ const payload = {
   status,
   title,
   description: CI_PIPELINES_DESCRIPTION || null,
+  triggered_by_github_login: triggeredByGithubLogin,
   run_id: runId,
   run_number: GITHUB_RUN_NUMBER || null,
   run_url: `${GITHUB_SERVER_URL}/${repository}/actions/runs/${runId}`,

--- a/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.routes.test.ts
+++ b/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.routes.test.ts
@@ -55,6 +55,7 @@ function makeAlertRequest(body: Record<string, unknown> = {}) {
     workflow: 'Deploy a service',
     status: 'failure',
     title: 'Backend deploy failed',
+    triggered_by_github_login: 'prxt6529',
     run_id: '123',
     run_url:
       'https://github.com/6529-Collections/6529seize-backend/actions/runs/123',
@@ -103,6 +104,7 @@ const ciPipelineAlertChangedFields = [
   'status',
   'title',
   'description',
+  'triggered_by_github_login',
   'sha',
   'branch',
   'environment',
@@ -115,6 +117,7 @@ const ciPipelineAlertRequestArbitrary = fc
     workflow: alertTextArbitrary,
     status: fc.constantFrom('success' as const, 'failure' as const),
     title: alertTextArbitrary,
+    triggered_by_github_login: alertTextArbitrary,
     run_id: alertTextArbitrary,
     run_number: optionalAlertTextArbitrary,
     run_url: alertTextArbitrary.map(

--- a/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.routes.ts
+++ b/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.routes.ts
@@ -28,6 +28,12 @@ const CiPipelineAlertRequestSchema: Joi.ObjectSchema<CiPipelineAlertRequest> =
     status: Joi.string().valid('success', 'failure').required(),
     title: Joi.string().trim().min(1).max(250).required(),
     description: Joi.string().trim().max(5000).allow(null, '').optional(),
+    triggered_by_github_login: Joi.string()
+      .trim()
+      .min(1)
+      .max(100)
+      .allow(null, '')
+      .optional(),
     run_id: Joi.string().trim().min(1).max(100).required(),
     run_number: Joi.string().trim().max(100).allow(null, '').optional(),
     run_url: Joi.string()
@@ -200,6 +206,7 @@ export function buildCiPipelineAlertDedupeKey(
         request.status,
         request.title,
         request.description ?? '',
+        request.triggered_by_github_login ?? '',
         request.sha ?? '',
         request.branch ?? '',
         request.environment ?? '',

--- a/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.test.ts
+++ b/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.test.ts
@@ -340,36 +340,71 @@ describe('CiPipelineAlertService', () => {
     expect(dropCreationApiService.toggleHideLinkPreview).not.toHaveBeenCalled();
   });
 
-  it('rejects initiators without a 6529 profile mapping', async () => {
+  it('posts with an unknown initiator when the 6529 mapping is missing', async () => {
     const service = new CiPipelineAlertService(
       dropCreationApiService as any,
       identitiesRepository as any
     );
 
-    await expect(
-      service.postAlert(
-        { ...baseRequest, triggered_by_github_login: 'unknown-user' },
-        {}
-      )
-    ).rejects.toThrow(
-      'Missing 6529 profile mapping for CI workflow initiator: unknown-user'
+    await service.postAlert(
+      {
+        ...baseRequest,
+        status: 'success',
+        triggered_by_github_login: 'unknown-user'
+      },
+      {}
     );
 
-    expect(dropCreationApiService.createDrop).not.toHaveBeenCalled();
+    expect(identitiesRepository.getIdsByHandles).not.toHaveBeenCalled();
+    expect(
+      dropCreationApiService.createDrop.mock.calls[0][0].createDropRequest
+        .parts[0].content
+    ).toContain('Triggered by: unknown');
+    expect(
+      dropCreationApiService.createDrop.mock.calls[0][0].createDropRequest
+        .mentioned_users
+    ).toEqual([]);
   });
 
-  it('rejects mapped initiators without a matching 6529 profile', async () => {
+  it('posts with an unknown initiator when the mapped profile is missing', async () => {
     identitiesRepository.getIdsByHandles.mockResolvedValue({});
     const service = new CiPipelineAlertService(
       dropCreationApiService as any,
       identitiesRepository as any
     );
 
-    await expect(service.postAlert(baseRequest, {})).rejects.toThrow(
-      'Missing 6529 profile for CI workflow initiator: prxt0'
+    await service.postAlert({ ...baseRequest, status: 'success' }, {});
+
+    expect(
+      dropCreationApiService.createDrop.mock.calls[0][0].createDropRequest
+        .parts[0].content
+    ).toContain('Triggered by: unknown');
+    expect(
+      dropCreationApiService.createDrop.mock.calls[0][0].createDropRequest
+        .mentioned_users
+    ).toEqual([]);
+  });
+
+  it('posts with an unknown initiator when actor metadata is absent', async () => {
+    const service = new CiPipelineAlertService(
+      dropCreationApiService as any,
+      identitiesRepository as any
     );
 
-    expect(dropCreationApiService.createDrop).not.toHaveBeenCalled();
+    await service.postAlert(
+      {
+        ...baseRequest,
+        status: 'success',
+        triggered_by_github_login: null
+      },
+      {}
+    );
+
+    expect(identitiesRepository.getIdsByHandles).not.toHaveBeenCalled();
+    expect(
+      dropCreationApiService.createDrop.mock.calls[0][0].createDropRequest
+        .parts[0].content
+    ).toContain('Triggered by: unknown');
   });
 
   it('enqueues release-note generation after posting an eligible production success', async () => {

--- a/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.test.ts
+++ b/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.test.ts
@@ -238,7 +238,7 @@ describe('CiPipelineAlertService', () => {
                   'Workflow: Web Deploy - PROD',
                   'Branch: main',
                   'Commit: [abc12345](https://github.com/6529-Collections/6529seize-frontend/commit/abc1234567890)',
-                  'Triggered by: @[prxt0]',
+                  'Initiated by: @[prxt0]',
                   'Run: [#6082](https://github.com/6529-Collections/6529seize-frontend/actions/runs/12345)',
                   '',
                   'cc @[prxt0] @[ALICE] @[Bob]'
@@ -301,7 +301,7 @@ describe('CiPipelineAlertService', () => {
                   'Workflow: Web Deploy - PROD',
                   'Branch: main',
                   'Commit: [abc12345](https://github.com/6529-Collections/6529seize-frontend/commit/abc1234567890)',
-                  'Triggered by: @[prxt0]',
+                  'Initiated by: @[prxt0]',
                   'Run: [#6082](https://github.com/6529-Collections/6529seize-frontend/actions/runs/12345)'
                 ].join('\n')
               )
@@ -324,7 +324,7 @@ describe('CiPipelineAlertService', () => {
         'Workflow: Web Deploy - PROD',
         'Branch: main',
         'Commit: [abc12345](https://github.com/6529-Collections/6529seize-frontend/commit/abc1234567890)',
-        'Triggered by: @[prxt0]',
+        'Initiated by: @[prxt0]',
         'Run: [#6082](https://github.com/6529-Collections/6529seize-frontend/actions/runs/12345)'
       ].join('\n')
     );
@@ -359,7 +359,7 @@ describe('CiPipelineAlertService', () => {
     expect(
       dropCreationApiService.createDrop.mock.calls[0][0].createDropRequest
         .parts[0].content
-    ).toContain('Triggered by: unknown');
+    ).toContain('Initiated by: unknown');
     expect(
       dropCreationApiService.createDrop.mock.calls[0][0].createDropRequest
         .mentioned_users
@@ -378,7 +378,7 @@ describe('CiPipelineAlertService', () => {
     expect(
       dropCreationApiService.createDrop.mock.calls[0][0].createDropRequest
         .parts[0].content
-    ).toContain('Triggered by: unknown');
+    ).toContain('Initiated by: unknown');
     expect(
       dropCreationApiService.createDrop.mock.calls[0][0].createDropRequest
         .mentioned_users
@@ -404,7 +404,7 @@ describe('CiPipelineAlertService', () => {
     expect(
       dropCreationApiService.createDrop.mock.calls[0][0].createDropRequest
         .parts[0].content
-    ).toContain('Triggered by: unknown');
+    ).toContain('Initiated by: unknown');
   });
 
   it('enqueues release-note generation after posting an eligible production success', async () => {
@@ -549,7 +549,7 @@ describe('CiPipelineAlertService', () => {
         'Workflow: Publish',
         'Branch: v0.3.11',
         'Commit: [abc12345](https://github.com/6529-Collections/6529-core/commit/abc1234567890)',
-        'Triggered by: @[prxt0]',
+        'Initiated by: @[prxt0]',
         'Run: [#6082](https://github.com/6529-Collections/6529-core/actions/runs/12345)'
       ].join('\n')
     );

--- a/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.test.ts
+++ b/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.test.ts
@@ -26,6 +26,7 @@ const baseRequest = {
   status: 'failure' as const,
   title: 'Seize PROD WEB DEPLOY: CI pipeline is broken!!!',
   description: 'abc123 - Fix deploy',
+  triggered_by_github_login: 'prxt6529',
   run_id: '12345',
   run_number: '6082',
   run_url:
@@ -57,13 +58,14 @@ describe('CiPipelineAlertService', () => {
     process.env.CI_PIPELINES_PROD_WAVE_ID = 'prod-wave';
     process.env.CI_PIPELINES_BOT_PROFILE_ID = 'bot-profile';
     process.env.CI_PIPELINES_FAILURE_MENTION_PROFILE_HANDLES =
-      '@alice, @[Bob], alice, missing';
+      '@prxt0, @alice, @[Bob], alice, missing';
     dropCreationApiService = {
       createDrop: jest.fn().mockResolvedValue({ id: 'drop-1' }),
       toggleHideLinkPreview: jest.fn().mockResolvedValue({})
     };
     identitiesRepository = {
       getIdsByHandles: jest.fn().mockResolvedValue({
+        prxt0: 'profile-initiator',
         ALICE: 'profile-1',
         Bob: 'profile-2'
       })
@@ -196,6 +198,7 @@ describe('CiPipelineAlertService', () => {
     await service.postAlert(baseRequest, ctx as any);
 
     expect(identitiesRepository.getIdsByHandles).toHaveBeenCalledWith([
+      'prxt0',
       'alice',
       'Bob',
       'missing'
@@ -211,6 +214,10 @@ describe('CiPipelineAlertService', () => {
           metadata: [],
           mentioned_users: [
             {
+              mentioned_profile_id: 'profile-initiator',
+              handle_in_content: 'prxt0'
+            },
+            {
               mentioned_profile_id: 'profile-1',
               handle_in_content: 'ALICE'
             },
@@ -223,17 +230,18 @@ describe('CiPipelineAlertService', () => {
             expect.objectContaining({
               content: expect.stringContaining(
                 [
-                  '[PROD] Seize PROD WEB DEPLOY: CI pipeline is broken!!! ❌',
+                  '[PROD] Seize PROD WEB DEPLOY: CI pipeline is broken!!! 🚨',
                   '',
                   'abc123 - Fix deploy',
-                  '',
-                  'cc @[ALICE] @[Bob]',
                   '',
                   'Service: Frontend - web',
                   'Workflow: Web Deploy - PROD',
                   'Branch: main',
                   'Commit: [abc12345](https://github.com/6529-Collections/6529seize-frontend/commit/abc1234567890)',
-                  'Run: [#6082](https://github.com/6529-Collections/6529seize-frontend/actions/runs/12345)'
+                  'Triggered by: @[prxt0]',
+                  'Run: [#6082](https://github.com/6529-Collections/6529seize-frontend/actions/runs/12345)',
+                  '',
+                  'cc @[prxt0] @[ALICE] @[Bob]'
                 ].join('\n')
               )
             })
@@ -249,7 +257,7 @@ describe('CiPipelineAlertService', () => {
     expect(dropCreationApiService.toggleHideLinkPreview).not.toHaveBeenCalled();
   });
 
-  it('routes staging successes without resolving or adding mentions', async () => {
+  it('routes staging successes with an initiator mention', async () => {
     const service = new CiPipelineAlertService(
       dropCreationApiService as any,
       identitiesRepository as any
@@ -265,7 +273,9 @@ describe('CiPipelineAlertService', () => {
       {}
     );
 
-    expect(identitiesRepository.getIdsByHandles).not.toHaveBeenCalled();
+    expect(identitiesRepository.getIdsByHandles).toHaveBeenCalledWith([
+      'prxt0'
+    ]);
     expect(dropCreationApiService.createDrop).toHaveBeenCalledWith(
       expect.objectContaining({
         hideLinkPreview: true,
@@ -273,7 +283,12 @@ describe('CiPipelineAlertService', () => {
           wave_id: 'staging-wave',
           title: null,
           metadata: [],
-          mentioned_users: [],
+          mentioned_users: [
+            {
+              mentioned_profile_id: 'profile-initiator',
+              handle_in_content: 'prxt0'
+            }
+          ],
           parts: [
             expect.objectContaining({
               content: expect.stringContaining(
@@ -286,6 +301,7 @@ describe('CiPipelineAlertService', () => {
                   'Workflow: Web Deploy - PROD',
                   'Branch: main',
                   'Commit: [abc12345](https://github.com/6529-Collections/6529seize-frontend/commit/abc1234567890)',
+                  'Triggered by: @[prxt0]',
                   'Run: [#6082](https://github.com/6529-Collections/6529seize-frontend/actions/runs/12345)'
                 ].join('\n')
               )
@@ -308,6 +324,7 @@ describe('CiPipelineAlertService', () => {
         'Workflow: Web Deploy - PROD',
         'Branch: main',
         'Commit: [abc12345](https://github.com/6529-Collections/6529seize-frontend/commit/abc1234567890)',
+        'Triggered by: @[prxt0]',
         'Run: [#6082](https://github.com/6529-Collections/6529seize-frontend/actions/runs/12345)'
       ].join('\n')
     );
@@ -321,6 +338,38 @@ describe('CiPipelineAlertService', () => {
         .parts[0].content
     ).not.toContain('cc @[');
     expect(dropCreationApiService.toggleHideLinkPreview).not.toHaveBeenCalled();
+  });
+
+  it('rejects initiators without a 6529 profile mapping', async () => {
+    const service = new CiPipelineAlertService(
+      dropCreationApiService as any,
+      identitiesRepository as any
+    );
+
+    await expect(
+      service.postAlert(
+        { ...baseRequest, triggered_by_github_login: 'unknown-user' },
+        {}
+      )
+    ).rejects.toThrow(
+      'Missing 6529 profile mapping for CI workflow initiator: unknown-user'
+    );
+
+    expect(dropCreationApiService.createDrop).not.toHaveBeenCalled();
+  });
+
+  it('rejects mapped initiators without a matching 6529 profile', async () => {
+    identitiesRepository.getIdsByHandles.mockResolvedValue({});
+    const service = new CiPipelineAlertService(
+      dropCreationApiService as any,
+      identitiesRepository as any
+    );
+
+    await expect(service.postAlert(baseRequest, {})).rejects.toThrow(
+      'Missing 6529 profile for CI workflow initiator: prxt0'
+    );
+
+    expect(dropCreationApiService.createDrop).not.toHaveBeenCalled();
   });
 
   it('enqueues release-note generation after posting an eligible production success', async () => {
@@ -465,6 +514,7 @@ describe('CiPipelineAlertService', () => {
         'Workflow: Publish',
         'Branch: v0.3.11',
         'Commit: [abc12345](https://github.com/6529-Collections/6529-core/commit/abc1234567890)',
+        'Triggered by: @[prxt0]',
         'Run: [#6082](https://github.com/6529-Collections/6529-core/actions/runs/12345)'
       ].join('\n')
     );
@@ -482,7 +532,7 @@ describe('CiPipelineAlertService', () => {
 
       expect(
         dropCreationApiService.createDrop.mock.calls[0][0].createDropRequest.parts[0].content.startsWith(
-          '[PROD] Web Deploy - PROD ❌'
+          '[PROD] Web Deploy - PROD 🚨'
         )
       ).toBe(true);
     }
@@ -495,7 +545,7 @@ describe('CiPipelineAlertService', () => {
     );
 
     await service.postAlert(
-      { ...baseRequest, title: 'Build succeeded ✅ ❌', status: 'success' },
+      { ...baseRequest, title: 'Build succeeded ✅ ❌ 🚨', status: 'success' },
       {}
     );
 
@@ -503,7 +553,7 @@ describe('CiPipelineAlertService', () => {
       dropCreationApiService.createDrop.mock.calls[0][0].createDropRequest
         .parts[0].content;
     expect(content.startsWith('[PROD] Build succeeded ✅')).toBe(true);
-    expect(content.startsWith('[PROD] Build succeeded ✅ ❌')).toBe(false);
+    expect(content.startsWith('[PROD] Build succeeded ✅ ❌ 🚨')).toBe(false);
   });
 
   it('preserves the outcome and run metadata when text is long', async () => {
@@ -525,7 +575,7 @@ describe('CiPipelineAlertService', () => {
       dropCreationApiService.createDrop.mock.calls[0][0].createDropRequest
         .parts[0].content;
     const heading = content.split('\n')[0];
-    expect(heading.endsWith('❌')).toBe(true);
+    expect(heading.endsWith('🚨')).toBe(true);
     expect(heading.length).toBeLessThanOrEqual(250);
     expect(Buffer.from(heading, 'utf8').toString('utf8')).toBe(heading);
     expect(content).toContain(

--- a/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.ts
+++ b/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.ts
@@ -13,6 +13,7 @@ import {
   releaseNoteGenerationQueue,
   ReleaseNoteGenerationQueue
 } from '@/release-notes/release-note-generation-queue';
+import { GITHUB_TO_6529_HANDLES } from '@/release-notes/release-note-contributors.config';
 import { isAllowedReleaseNotesPrompt } from '@/release-notes/release-note-prompts.config';
 
 export type CiPipelineAlertStatus = 'success' | 'failure';
@@ -23,6 +24,7 @@ export interface CiPipelineAlertRequest {
   readonly status: CiPipelineAlertStatus;
   readonly title: string;
   readonly description?: string | null;
+  readonly triggered_by_github_login?: string | null;
   readonly run_id: string;
   readonly run_number?: string | null;
   readonly run_url: string;
@@ -41,6 +43,12 @@ export interface CiPipelineAlertRequest {
 interface MentionedProfile {
   readonly profileId: string;
   readonly handle: string;
+}
+
+interface AlertMentions {
+  readonly triggeredBy: MentionedProfile | null;
+  readonly failureCc: MentionedProfile[];
+  readonly all: MentionedProfile[];
 }
 
 const MAX_DROP_CONTENT_LENGTH = 30000;
@@ -104,7 +112,7 @@ export function normalizeTargetEnvironment(value: string | null | undefined) {
 }
 
 function formatStatusEmoji(status: CiPipelineAlertStatus): string {
-  return status === 'success' ? '✅' : '❌';
+  return status === 'success' ? '✅' : '🚨';
 }
 
 function sanitizeAlertText(value: string): string {
@@ -121,7 +129,7 @@ function formatAlertHeading(request: CiPipelineAlertRequest): string {
   const title = sanitizeAlertText(
     normalizeOptionalValue(request.title) ?? request.workflow
   )
-    .replace(/[✅❌]/g, '')
+    .replace(/✅|❌|🚨/g, '')
     .replace(/\s+/g, ' ')
     .trim();
   const truncatedTitle = truncate(
@@ -238,8 +246,7 @@ export class CiPipelineAlertService {
   ): Promise<void> {
     const waveId = this.resolveWaveId(request);
     const botProfileId = env.getStringOrThrow('CI_PIPELINES_BOT_PROFILE_ID');
-    const mentions =
-      request.status === 'failure' ? await this.resolveFailureMentions() : [];
+    const mentions = await this.resolveAlertMentions(request);
 
     const createDropRequest = this.buildCreateDropRequest({
       request,
@@ -318,16 +325,42 @@ export class CiPipelineAlertService {
     });
   }
 
-  private async resolveFailureMentions(): Promise<MentionedProfile[]> {
-    const configuredHandles = parseProfileHandles(
-      env.getStringOrNull('CI_PIPELINES_FAILURE_MENTION_PROFILE_HANDLES')
+  private async resolveAlertMentions(
+    request: CiPipelineAlertRequest
+  ): Promise<AlertMentions> {
+    const triggeredByGithubLogin = normalizeOptionalValue(
+      request.triggered_by_github_login
     );
-    if (!configuredHandles.length) {
-      return [];
+    const triggeredByHandle = triggeredByGithubLogin
+      ? GITHUB_TO_6529_HANDLES[triggeredByGithubLogin.toLowerCase()]
+      : null;
+    if (triggeredByGithubLogin && !triggeredByHandle) {
+      throw new Error(
+        `Missing 6529 profile mapping for CI workflow initiator: ${triggeredByGithubLogin}`
+      );
+    }
+
+    const failureHandles =
+      request.status === 'failure'
+        ? parseProfileHandles(
+            env.getStringOrNull('CI_PIPELINES_FAILURE_MENTION_PROFILE_HANDLES')
+          )
+        : [];
+    const handlesToResolve = [
+      ...(triggeredByHandle ? [triggeredByHandle] : []),
+      ...failureHandles
+    ].filter(
+      (handle, index, handles) =>
+        handles.findIndex(
+          (candidate) => candidate.toLowerCase() === handle.toLowerCase()
+        ) === index
+    );
+    if (!handlesToResolve.length) {
+      return { triggeredBy: null, failureCc: [], all: [] };
     }
 
     const profileIdsByHandle =
-      await this.identitiesRepository.getIdsByHandles(configuredHandles);
+      await this.identitiesRepository.getIdsByHandles(handlesToResolve);
     const mentionsByNormalizedHandle = new Map(
       Object.entries(profileIdsByHandle).map(([handle, profileId]) => [
         handle.toLowerCase(),
@@ -337,7 +370,17 @@ export class CiPipelineAlertService {
         }
       ])
     );
-    const missingHandles = configuredHandles.filter(
+    const triggeredBy = triggeredByHandle
+      ? (mentionsByNormalizedHandle.get(triggeredByHandle.toLowerCase()) ??
+        null)
+      : null;
+    if (triggeredByHandle && !triggeredBy) {
+      throw new Error(
+        `Missing 6529 profile for CI workflow initiator: ${triggeredByHandle}`
+      );
+    }
+
+    const missingHandles = failureHandles.filter(
       (handle) => !mentionsByNormalizedHandle.has(handle.toLowerCase())
     );
     if (missingHandles.length) {
@@ -345,10 +388,17 @@ export class CiPipelineAlertService {
         `Skipping CI pipeline alert mentions with missing profiles: ${missingHandles.join(', ')}`
       );
     }
-
-    return configuredHandles
+    const failureCc = failureHandles
       .map((handle) => mentionsByNormalizedHandle.get(handle.toLowerCase()))
       .filter((mention): mention is MentionedProfile => !!mention);
+    const all = [...(triggeredBy ? [triggeredBy] : []), ...failureCc].filter(
+      (mention, index, mentions) =>
+        mentions.findIndex(
+          (candidate) => candidate.profileId === mention.profileId
+        ) === index
+    );
+
+    return { triggeredBy, failureCc, all };
   }
 
   private resolveWaveId(request: CiPipelineAlertRequest): string {
@@ -371,7 +421,7 @@ export class CiPipelineAlertService {
   }: {
     readonly request: CiPipelineAlertRequest;
     readonly waveId: string;
-    readonly mentions: MentionedProfile[];
+    readonly mentions: AlertMentions;
   }): ApiCreateDropRequest {
     const content = this.formatContent(request, mentions);
     return {
@@ -384,7 +434,7 @@ export class CiPipelineAlertService {
           media: []
         }
       ],
-      mentioned_users: mentions.map((mention) => ({
+      mentioned_users: mentions.all.map((mention) => ({
         mentioned_profile_id: mention.profileId,
         handle_in_content: mention.handle
       })),
@@ -399,12 +449,14 @@ export class CiPipelineAlertService {
 
   private formatContent(
     request: CiPipelineAlertRequest,
-    mentions: MentionedProfile[]
+    mentions: AlertMentions
   ): string {
-    const mentionHandles = mentions
+    const failureMentionHandles = mentions.failureCc
       .map((mention) => '@[' + mention.handle + ']')
       .join(' ');
-    const mentionLines = mentions.length ? [`cc ${mentionHandles}`] : [];
+    const failureMentionLines = failureMentionHandles
+      ? ['', `cc ${failureMentionHandles}`]
+      : [];
 
     const branch = normalizeOptionalValue(request.branch);
     const commit = formatCommit(request);
@@ -416,13 +468,15 @@ export class CiPipelineAlertService {
       formatAlertHeading(request),
       '',
       ...(formattedDescription ? [formattedDescription, ''] : []),
-      ...mentionLines,
-      ...(mentionLines.length ? [''] : []),
       `Service: ${formatServiceLabel(request)}`,
       `Workflow: ${request.workflow}`,
       ...(branch ? [`Branch: ${branch}`] : []),
       ...(commit ? [`Commit: ${commit}`] : []),
-      `Run: ${formatRun(request)}`
+      ...(mentions.triggeredBy
+        ? [`Triggered by: @[${mentions.triggeredBy.handle}]`]
+        : []),
+      `Run: ${formatRun(request)}`,
+      ...failureMentionLines
     ];
 
     return truncate(lines.join('\n'), MAX_DROP_CONTENT_LENGTH);

--- a/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.ts
+++ b/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.ts
@@ -469,6 +469,9 @@ export class CiPipelineAlertService {
     const formattedDescription = description
       ? truncate(sanitizeAlertText(description), MAX_ALERT_DESCRIPTION_LENGTH)
       : null;
+    const triggeredBy = mentions.triggeredBy
+      ? '@[' + mentions.triggeredBy.handle + ']'
+      : 'unknown';
     const lines = [
       formatAlertHeading(request),
       '',
@@ -477,7 +480,7 @@ export class CiPipelineAlertService {
       `Workflow: ${request.workflow}`,
       ...(branch ? [`Branch: ${branch}`] : []),
       ...(commit ? [`Commit: ${commit}`] : []),
-      `Triggered by: ${mentions.triggeredBy ? `@[${mentions.triggeredBy.handle}]` : 'unknown'}`,
+      `Triggered by: ${triggeredBy}`,
       `Run: ${formatRun(request)}`,
       ...failureMentionLines
     ];

--- a/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.ts
+++ b/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.ts
@@ -334,9 +334,13 @@ export class CiPipelineAlertService {
     const triggeredByHandle = triggeredByGithubLogin
       ? GITHUB_TO_6529_HANDLES[triggeredByGithubLogin.toLowerCase()]
       : null;
-    if (triggeredByGithubLogin && !triggeredByHandle) {
-      throw new Error(
-        `Missing 6529 profile mapping for CI workflow initiator: ${triggeredByGithubLogin}`
+    if (!triggeredByGithubLogin) {
+      this.logger.warn(
+        'Unable to resolve CI workflow initiator: GitHub login is missing'
+      );
+    } else if (!triggeredByHandle) {
+      this.logger.warn(
+        `Unable to resolve CI workflow initiator ${triggeredByGithubLogin}: 6529 profile mapping is missing`
       );
     }
 
@@ -375,8 +379,8 @@ export class CiPipelineAlertService {
         null)
       : null;
     if (triggeredByHandle && !triggeredBy) {
-      throw new Error(
-        `Missing 6529 profile for CI workflow initiator: ${triggeredByHandle}`
+      this.logger.warn(
+        `Unable to resolve CI workflow initiator ${triggeredByGithubLogin}: 6529 profile ${triggeredByHandle} is missing`
       );
     }
 
@@ -391,6 +395,7 @@ export class CiPipelineAlertService {
     const failureCc = failureHandles
       .map((handle) => mentionsByNormalizedHandle.get(handle.toLowerCase()))
       .filter((mention): mention is MentionedProfile => !!mention);
+    // Profile IDs collapse handle aliases while preserving initiator-first order.
     const all = [...(triggeredBy ? [triggeredBy] : []), ...failureCc].filter(
       (mention, index, mentions) =>
         mentions.findIndex(
@@ -472,9 +477,7 @@ export class CiPipelineAlertService {
       `Workflow: ${request.workflow}`,
       ...(branch ? [`Branch: ${branch}`] : []),
       ...(commit ? [`Commit: ${commit}`] : []),
-      ...(mentions.triggeredBy
-        ? [`Triggered by: @[${mentions.triggeredBy.handle}]`]
-        : []),
+      `Triggered by: ${mentions.triggeredBy ? `@[${mentions.triggeredBy.handle}]` : 'unknown'}`,
       `Run: ${formatRun(request)}`,
       ...failureMentionLines
     ];

--- a/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.ts
+++ b/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.ts
@@ -480,7 +480,7 @@ export class CiPipelineAlertService {
       `Workflow: ${request.workflow}`,
       ...(branch ? [`Branch: ${branch}`] : []),
       ...(commit ? [`Commit: ${commit}`] : []),
-      `Triggered by: ${triggeredBy}`,
+      `Initiated by: ${triggeredBy}`,
       `Run: ${formatRun(request)}`,
       ...failureMentionLines
     ];


### PR DESCRIPTION
## Summary

- accept the GitHub triggering actor in signed CI alert payloads
- map the actor to the canonical 6529 profile and create a real profile mention on success and failure posts
- fall back to `Initiated by: unknown` without suppressing the alert when actor metadata, mappings, or profiles are unavailable
- keep failure escalation recipients in a bottom `cc` row while deduplicating mention metadata
- use 🚨 as the CI failure status marker
- send the triggering actor from backend deployment workflows

## Root cause

CI alerts carried run metadata and optional descriptions but no workflow initiator. Failure recipients were rendered before the operational fields, and frontend merge commit subjects could become empty or unhelpful Markdown bullets.

## Impact

CI Wave posts now identify and notify the 6529 profile that initiated the current workflow attempt when it can be resolved. Initiator attribution is best effort: missing or unresolved actors render as `Initiated by: unknown`, ensuring a real CI alert is never dropped because enrichment failed.

Deploy this backend receiver before the coordinated sender PRs:

- [frontend PR #3312](https://github.com/6529-Collections/6529seize-frontend/pull/3312)
- [Core PR #219](https://github.com/6529-Collections/6529-core/pull/219)

## Validation

- 32 focused CI pipeline alert service and route tests
- backend ESLint
- signed sender payload execution checks with and without actor metadata

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CI pipeline alerts now include the GitHub login that triggered the workflow.
  * Alert messages display an “Initiated by” line and notify the corresponding profile when available.
  * Duplicate-alert detection now accounts for the workflow initiator.

* **Bug Fixes**
  * Improved mention handling prevents duplicate notifications and validates profile mappings.
  * Updated failure alerts use consistent 🚨 formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->