### PR TITLE
Refine subscription notification emojis

### DIFF
--- a/src/subscription-wave-notifier.test.ts
+++ b/src/subscription-wave-notifier.test.ts
@@ -100,7 +100,7 @@ describe('subscription wave notifier message formatting', () => {
         hash: '0xabc',
         adminHandles: ['admin1', 'admin2']
       })
-    ).toBe('Top up 0xabc already processed\n\n@[admin1] @[admin2]');
+    ).toBe('⚠️ Top up 0xabc already processed\n\n@[admin1] @[admin2]');
   });
 
   it('builds normal top-up posts with an optional profile mention', () => {
@@ -116,7 +116,7 @@ describe('subscription wave notifier message formatting', () => {
       })
     ).toBe(
       [
-        '🔝 Subscription Top Up of 0.06529 ETH from 0x1234.',
+        '💰 Subscription Top Up of 0.06529 ETH from 0x1234.',
         '',
         'Profile: @[6529er]',
         '',
@@ -137,7 +137,7 @@ describe('subscription wave notifier message formatting', () => {
       })
     ).toBe(
       [
-        'No subscription found for airdrop address:',
+        '🚨 No subscription found for airdrop address:',
         '',
         '0xairdrop',
         '',
@@ -154,7 +154,7 @@ describe('subscription wave notifier message formatting', () => {
       })
     ).toBe(
       [
-        'No balance found for consolidation key:',
+        '🚨 No balance found for consolidation key:',
         '',
         '0xkey',
         '',
@@ -171,7 +171,7 @@ describe('subscription wave notifier message formatting', () => {
       })
     ).toBe(
       [
-        'Insufficient balance for consolidation key:',
+        '🚨 Insufficient balance for consolidation key:',
         '',
         '0xkey',
         '',

--- a/src/subscription-wave-notifier.ts
+++ b/src/subscription-wave-notifier.ts
@@ -110,7 +110,7 @@ export function buildProcessedTopUpWaveMessage({
   hash: string;
   adminHandles: string[];
 }): string {
-  return withMentions(`Top up ${hash} already processed`, adminHandles);
+  return withMentions(`⚠️ Top up ${hash} already processed`, adminHandles);
 }
 
 export function buildSubscriptionTopUpWaveMessage({
@@ -125,7 +125,7 @@ export function buildSubscriptionTopUpWaveMessage({
   profileHandle?: string | null;
 }): string {
   const lines = [
-    `🔝 Subscription Top Up of ${topUp.amount} ETH from ${topUp.from_wallet}.`
+    `💰 Subscription Top Up of ${topUp.amount} ETH from ${topUp.from_wallet}.`
   ];
   if (profileHandle) {
     lines.push('', `Profile: @[${profileHandle}]`);
@@ -152,7 +152,7 @@ export function buildNoSubscriptionFoundWaveMessage({
 }): string {
   return withMentions(
     [
-      'No subscription found for airdrop address:',
+      '🚨 No subscription found for airdrop address:',
       '',
       airdropAddress,
       '',
@@ -173,7 +173,7 @@ export function buildNoBalanceFoundWaveMessage({
 }): string {
   return withMentions(
     [
-      'No balance found for consolidation key:',
+      '🚨 No balance found for consolidation key:',
       '',
       consolidationKey,
       '',
@@ -194,7 +194,7 @@ export function buildInsufficientBalanceWaveMessage({
 }): string {
   return withMentions(
     [
-      'Insufficient balance for consolidation key:',
+      '🚨 Insufficient balance for consolidation key:',
       '',
       consolidationKey,
       '',

--- a/src/subscriptionsTopUpLoop/db.subscriptions_topup.ts
+++ b/src/subscriptionsTopUpLoop/db.subscriptions_topup.ts
@@ -35,7 +35,7 @@ export async function persistTopUps(topUps: SubscriptionTopUp[]) {
     for (const topUp of topUps) {
       const isProcessed = await isTopUpProcessed(topUp.hash, manager);
       if (isProcessed) {
-        const message = `Top up ${topUp.hash} already processed`;
+        const message = `⚠️ Top up ${topUp.hash} already processed`;
         logger.warn(message);
         await sendDiscordUpdate(
           process.env.SUBSCRIPTIONS_DISCORD_WEBHOOK as string,
@@ -98,7 +98,7 @@ export async function persistTopUps(topUps: SubscriptionTopUp[]) {
   for (const topUp of processedTopUps) {
     const seizeDomain =
       process.env.NODE_ENV === 'development' ? 'staging.6529' : '6529';
-    let discordMessage = `🔝 Subscription Top Up of ${topUp.amount} ETH from ${topUp.from_wallet}.`;
+    let discordMessage = `💰 Subscription Top Up of ${topUp.amount} ETH from ${topUp.from_wallet}.`;
     const link = ethTools.toEtherScanTransactionLink(
       parseInt(process.env.SUBSCRIPTIONS_CHAIN_ID ?? '1'),
       topUp.hash

--- a/src/tests/subscriptions.test.ts
+++ b/src/tests/subscriptions.test.ts
@@ -567,6 +567,9 @@ describe('SubscriptionTests', () => {
         'Subscriptions',
         'warn'
       );
+      expect(mockSendDiscordUpdate.mock.calls[0][1]).toContain(
+        '🚨 No subscription found for airdrop address'
+      );
       expect(waveNotifications).toContainEqual({
         kind: 'no-subscription-found',
         airdropAddress: transaction.to_address,
@@ -628,7 +631,7 @@ describe('SubscriptionTests', () => {
       expect(mockFetchBalance).toHaveBeenCalledTimes(2);
       expect(mockSendDiscordUpdate).toHaveBeenCalledWith(
         'https://test-discord-webhook',
-        expect.stringContaining('Insufficient balance'),
+        expect.stringContaining('🚨 Insufficient balance'),
         'Subscriptions',
         'error'
       );
@@ -681,7 +684,7 @@ describe('SubscriptionTests', () => {
       expect(mockFetchBalance).toHaveBeenCalledTimes(1);
       expect(mockSendDiscordUpdate).toHaveBeenCalledWith(
         'https://test-discord-webhook',
-        expect.stringContaining('No balance found'),
+        expect.stringContaining('🚨 No balance found'),
         'Subscriptions',
         'error'
       );

--- a/src/transactionsProcessingLoop/subscriptions.ts
+++ b/src/transactionsProcessingLoop/subscriptions.ts
@@ -234,7 +234,7 @@ async function processSubscription(
 
   if (!finalSubscription) {
     const transactionLink = buildTransactionLink(transaction.transaction);
-    const message = `No subscription found for airdrop address: ${transaction.to_address} \nTransaction: ${transactionLink}`;
+    const message = `🚨 No subscription found for airdrop address: ${transaction.to_address} \nTransaction: ${transactionLink}`;
     logger.warn(message);
     await sendDiscordUpdate(
       process.env.SUBSCRIPTIONS_DISCORD_WEBHOOK as string,
@@ -256,7 +256,7 @@ async function processSubscription(
   );
   if (!balance) {
     const transactionLink = buildTransactionLink(transaction.transaction);
-    const message = `No balance found for consolidation key: ${finalSubscription.consolidation_key} \nTransaction: ${transactionLink}`;
+    const message = `🚨 No balance found for consolidation key: ${finalSubscription.consolidation_key} \nTransaction: ${transactionLink}`;
     logger.error(message);
     await sendDiscordUpdate(
       process.env.SUBSCRIPTIONS_DISCORD_WEBHOOK as string,
@@ -275,7 +275,7 @@ async function processSubscription(
     };
   } else if (MEMES_MINT_PRICE > balance.balance) {
     const transactionLink = buildTransactionLink(transaction.transaction);
-    const message = `Insufficient balance for consolidation key: ${finalSubscription.consolidation_key} \nTransaction: ${transactionLink}`;
+    const message = `🚨 Insufficient balance for consolidation key: ${finalSubscription.consolidation_key} \nTransaction: ${transactionLink}`;
     logger.error(message);
     await sendDiscordUpdate(
       process.env.SUBSCRIPTIONS_DISCORD_WEBHOOK as string,


### PR DESCRIPTION
## Issue
- Subscription top-up and error notifications need clearer visual severity cues in both Discord and Waves.

## Fix
- Align the emoji prefixes across both notification transports while preserving the existing message content, links, mentions, and delivery behavior.

## Changes
- Replace the successful top-up emoji with `💰`.
- Prefix duplicate top-up warnings with `⚠️`.
- Prefix missing-subscription, missing-balance, and insufficient-balance notifications with `🚨`.
- Update Wave formatter expectations and Discord redemption assertions.
- No API, schema, entity, migration, dependency, configuration, or architecture changes.

## Validation
- `npm run lint`
- Focused Jest suites: 25 tests passed across `src/subscription-wave-notifier.test.ts` and `src/tests/subscriptions.test.ts`.
- `git diff --check`
- The repository-wide `npm run build` was attempted but its Jest phase is blocked by an unrelated existing missing `js-yaml` declaration in `src/api-serverless/generate-openapi-routes.ts`.

## Risk
- Level: Low
- Why: Copy-only changes to established notification templates and their assertions.
- Rollback: Revert this commit to restore the previous emoji prefixes.

## Deployment
1. `subscriptionsTopUpLoop`
2. `transactionsProcessingLoop`

No dependency exists between the two deployment steps.

## Review Notes
- Confirm the chosen emoji severity matches operational expectations in both Discord and Waves.