### PR TITLE
Fix release bus shadow dependency handling

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -462,6 +462,10 @@ builds immutable artifacts and deploys backend services in registry DAG order
 before dependent frontend code. The API's `/deploy/ui/bus` page is the
 readiness queue and pause/resume control plane. Modes `OFF`, `SHADOW`,
 `STAGING`, and `PRODUCTION` permit a backward-compatible rollout.
+Shadow evaluation writes evidence and audit state only, never GitHub statuses or
+other GitHub mutations. When dependency candidates are evaluated in separate
+shadow trains, successful shadow evidence satisfies their dependants for later
+shadow scheduling without satisfying the live staging or production gates.
 The generated backend deployment workflow resolves the installed GitHub App's
 installation ID and injects only the non-secret App identity into all three
 Release Bus Lambdas. The App private key, webhook verification secret, and

--- a/src/releaseBus/index.ts
+++ b/src/releaseBus/index.ts
@@ -243,7 +243,8 @@ const starter: Handler = async () =>
           frontendBaseSha:
             lane === 'PRODUCTION' ? frontendMain : frontendStaging,
           backendBaseSha: lane === 'PRODUCTION' ? backendMain : backendStaging,
-          excludedCandidateIds
+          excludedCandidateIds,
+          allowShadowDependencyEvidence: mode === 'SHADOW'
         });
       }
       if (!train) return { mode, started: false };

--- a/src/releaseBus/release-bus.service.test.ts
+++ b/src/releaseBus/release-bus.service.test.ts
@@ -224,6 +224,136 @@ describe('ReleaseBusService readiness', () => {
   });
 });
 
+describe('ReleaseBusService shadow dependencies', () => {
+  function repositoryWithShadowedDependency() {
+    let dependency: ReleaseCandidateRecord = {
+      ...candidate('READY_FOR_STAGING'),
+      id: 'backend-dependency',
+      repository: 'backend',
+      branch_name: 'feature/backend',
+      head_sha: 'b'.repeat(40),
+      staging_ready_at: 1,
+      deploy_plan_json: { units: ['api'], edges: [] }
+    };
+    let dependant: ReleaseCandidateRecord = {
+      ...candidate('BLOCKED'),
+      id: 'frontend-dependant',
+      staging_ready_at: 2,
+      hold_reason: 'WAITING_FOR_DEPENDENCY:STAGING'
+    };
+    const edge = {
+      id: 'dependency-edge',
+      candidate_id: dependant.id,
+      depends_on_candidate_id: dependency.id,
+      required_state: 'STAGING_VALIDATED' as const,
+      created_at: 1,
+      updated_at: 1
+    };
+    const createdCandidateIds: string[][] = [];
+    const repository = {
+      executeNativeQueriesInTransaction: async (
+        fn: (value: unknown) => unknown
+      ) => fn({}),
+      listControls: async () => [],
+      acquireLane: async () => ({ lease_token: 'lease-token' }),
+      releaseLane: async () => true,
+      listCandidates: async (
+        statuses: ReleaseCandidateRecord['status'][] | null
+      ) =>
+        [dependency, dependant].filter(
+          (item) => !statuses || statuses.includes(item.status)
+        ),
+      listDependencies: async (candidateIds: readonly string[]) =>
+        candidateIds.includes(dependant.id) ? [edge] : [],
+      findCandidateById: async (id: string) =>
+        [dependency, dependant].find((item) => item.id === id) ?? null,
+      hasCandidateEvidence: async (_candidateId: string, type: string) =>
+        type === 'CANDIDATE_SHADOW_EVALUATED_STAGING',
+      updateCandidateLifecycle: async (
+        id: string,
+        _version: number,
+        fields: {
+          status: ReleaseCandidateRecord['status'];
+          holdReason?: string | null;
+          currentTrainId?: string | null;
+        }
+      ) => {
+        const update = (item: ReleaseCandidateRecord) => ({
+          ...item,
+          status: fields.status,
+          hold_reason:
+            fields.holdReason === undefined
+              ? item.hold_reason
+              : fields.holdReason,
+          current_train_id:
+            fields.currentTrainId === undefined
+              ? item.current_train_id
+              : fields.currentTrainId,
+          row_version: item.row_version + 1
+        });
+        if (id === dependency.id) dependency = update(dependency);
+        if (id === dependant.id) dependant = update(dependant);
+      },
+      createTrain: async (_train: unknown, candidateIds: readonly string[]) => {
+        createdCandidateIds.push([...candidateIds]);
+      },
+      appendEvent: async () => undefined
+    } as unknown as ReleaseBusRepository;
+    return {
+      repository,
+      createdCandidateIds,
+      dependant: () => dependant,
+      dependency
+    };
+  }
+
+  it('releases a shadow hold after the dependency was evaluated in an earlier shadow train', async () => {
+    const state = repositoryWithShadowedDependency();
+
+    const train = await new ReleaseBusService(state.repository).freezeNextTrain(
+      {
+        lane: 'STAGING',
+        owner: 'shadow-starter',
+        frontendBaseSha: 'c'.repeat(40),
+        backendBaseSha: 'd'.repeat(40),
+        cutoffAt: 10,
+        excludedCandidateIds: [state.dependency.id],
+        allowShadowDependencyEvidence: true
+      }
+    );
+
+    expect(train).not.toBeNull();
+    expect(state.createdCandidateIds).toEqual([['frontend-dependant']]);
+    expect(state.dependant()).toMatchObject({
+      status: 'STAGING_CLAIMED',
+      hold_reason: null,
+      current_train_id: train?.id
+    });
+  });
+
+  it('does not use shadow evidence to release a live dependency hold', async () => {
+    const state = repositoryWithShadowedDependency();
+
+    const train = await new ReleaseBusService(state.repository).freezeNextTrain(
+      {
+        lane: 'STAGING',
+        owner: 'live-starter',
+        frontendBaseSha: 'c'.repeat(40),
+        backendBaseSha: 'd'.repeat(40),
+        cutoffAt: 10,
+        excludedCandidateIds: [state.dependency.id]
+      }
+    );
+
+    expect(train).toBeNull();
+    expect(state.createdCandidateIds).toEqual([]);
+    expect(state.dependant()).toMatchObject({
+      status: 'BLOCKED',
+      hold_reason: 'WAITING_FOR_DEPENDENCY:STAGING'
+    });
+  });
+});
+
 describe('ReleaseBusService break glass', () => {
   it('does not pause when a train is active', async () => {
     const activeTrain = { id: 'active-train' };

--- a/src/releaseBus/release-bus.service.ts
+++ b/src/releaseBus/release-bus.service.ts
@@ -49,6 +49,7 @@ export type FreezeTrainInput = {
   readonly backendBaseSha: string | null;
   readonly cutoffAt?: number;
   readonly excludedCandidateIds?: readonly string[];
+  readonly allowShadowDependencyEvidence?: boolean;
 };
 
 function normalizeDeployPlan(
@@ -591,7 +592,11 @@ export class ReleaseBusService {
         );
         if (!lane) return null;
 
-        await this.refreshSatisfiedDependencyHolds(input.lane, ctx);
+        await this.refreshSatisfiedDependencyHolds(
+          input.lane,
+          Boolean(input.allowShadowDependencyEvidence),
+          ctx
+        );
         const readyStatus = readyStatusForLane(input.lane);
         const excludedCandidateIds = new Set(input.excludedCandidateIds ?? []);
         const candidates = (
@@ -633,7 +638,13 @@ export class ReleaseBusService {
                 dependency.depends_on_candidate_id,
                 `CANDIDATE_${dependency.required_state}`,
                 ctx
-              )));
+              )) ||
+              (Boolean(input.allowShadowDependencyEvidence) &&
+                (await this.repository.hasCandidateEvidence(
+                  dependency.depends_on_candidate_id,
+                  `CANDIDATE_SHADOW_EVALUATED_${input.lane}`,
+                  ctx
+                ))));
           if (!satisfied) blockedRoots.add(dependency.candidate_id);
         }
         const internalEdges = dependencies
@@ -795,6 +806,7 @@ export class ReleaseBusService {
 
   private async refreshSatisfiedDependencyHolds(
     lane: ReleaseLane,
+    allowShadowDependencyEvidence: boolean,
     ctx: RequestContext
   ): Promise<void> {
     const blocked = (
@@ -819,7 +831,15 @@ export class ReleaseBusService {
             dependency.depends_on_candidate_id,
             `CANDIDATE_${dependency.required_state}`,
             ctx
-          ))
+          )) &&
+          !(
+            allowShadowDependencyEvidence &&
+            (await this.repository.hasCandidateEvidence(
+              dependency.depends_on_candidate_id,
+              `CANDIDATE_SHADOW_EVALUATED_${lane}`,
+              ctx
+            ))
+          )
         ) {
           satisfied = false;
           break;

--- a/src/releaseBus/worker.test.ts
+++ b/src/releaseBus/worker.test.ts
@@ -1,5 +1,6 @@
 const mockFindCandidateById = jest.fn();
 const mockUpdateCandidateLifecycle = jest.fn();
+const mockAddEvidence = jest.fn();
 const mockEnsureCommitStatus = jest.fn();
 const mockCommentOnPullRequest = jest.fn();
 const mockRefContainsCommit = jest.fn();
@@ -20,6 +21,7 @@ jest.mock('@/releaseBus/release-bus.repository', () => ({
     findCandidateById: (...args: unknown[]) => mockFindCandidateById(...args),
     updateCandidateLifecycle: (...args: unknown[]) =>
       mockUpdateCandidateLifecycle(...args),
+    addEvidence: (...args: unknown[]) => mockAddEvidence(...args),
     updateTrain: (...args: unknown[]) => mockUpdateTrain(...args),
     getLane: (...args: unknown[]) => mockGetLane(...args),
     releaseLane: (...args: unknown[]) => mockReleaseLane(...args),
@@ -251,5 +253,29 @@ describe('finishIncompleteComposition', () => {
     });
 
     expect(mockResolveRef).not.toHaveBeenCalled();
+  });
+
+  it('completes shadow evaluation without publishing a GitHub status', async () => {
+    process.env.RELEASE_BUS_MODE = 'SHADOW';
+    const shadowTrain = { ...train, status: 'FROZEN' as const };
+    mockFindTrain.mockResolvedValue(shadowTrain);
+    mockListTrainItems.mockResolvedValue([
+      { candidate_id: candidates[0].id, sequence: 1 }
+    ]);
+
+    await expect(advanceReleaseTrain(shadowTrain.id)).resolves.toMatchObject({
+      decision: 'COMPLETE',
+      status: 'COMPLETED'
+    });
+
+    expect(mockAddEvidence).toHaveBeenCalledWith(
+      expect.objectContaining({
+        candidateId: candidates[0].id,
+        evidenceType: 'CANDIDATE_SHADOW_EVALUATED_STAGING',
+        status: 'SUCCEEDED'
+      }),
+      {}
+    );
+    expect(mockEnsureCommitStatus).not.toHaveBeenCalled();
   });
 });

--- a/src/releaseBus/worker.ts
+++ b/src/releaseBus/worker.ts
@@ -1701,12 +1701,6 @@ async function shadowComplete(
       },
       {}
     );
-    await publishCandidateStatus(
-      train,
-      candidate,
-      'pending',
-      `Shadow evaluated; waiting for live mode (${train.id})`
-    );
   }
   await releaseBusRepository.addEvidence(
     {


### PR DESCRIPTION
## What changed

- Let successful dependency evidence from an earlier shadow train satisfy later shadow-only scheduling.
- Keep live staging and production dependency gates unchanged.
- Stop publishing pending GitHub commit statuses when a shadow train completes.
- Document the shadow-mode guarantees.

## Root cause

Shadowed candidates are intentionally excluded from later shadow trains, but their dependants only accepted live validation evidence. This left cross-repository dependants blocked. Shadow completion also called the normal commit-status publisher even though shadow mode is intended to avoid GitHub mutations.

## Validation

- npm run lint
- npm test -- --runInBand src/releaseBus
- npm run build
- 252 suites passed; 2,226 tests passed; one skipped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Shadow evaluations now record candidate evidence without publishing GitHub statuses or making other GitHub changes.
  * Successful dependency evaluations in shadow trains can unblock later shadow scheduling when enabled.
  * Shadow evidence no longer satisfies live staging or production dependency gates.

* **Documentation**
  * Clarified shadow-mode behavior and dependency-evidence rules.

* **Tests**
  * Added coverage for shadow dependency handling and evidence recording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->