### PR TITLE
Wire GitHub App identity into production API

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -188,11 +188,15 @@ jobs:
         if: github.event.inputs.service == 'api' && github.event.inputs.environment == 'prod'
         shell: bash
         env:
+          RELEASE_BUS_GITHUB_APP_ID: ${{ vars.RELEASE_BUS_GITHUB_APP_ID }}
+          RELEASE_BUS_GITHUB_PRIVATE_KEY: ${{ secrets.RELEASE_BUS_GITHUB_PRIVATE_KEY }}
           RELEASE_BUS_GITHUB_WEBHOOK_SECRET: ${{ secrets.RELEASE_BUS_GITHUB_WEBHOOK_SECRET }}
           RELEASE_BUS_WORKFLOW_AUTH_TOKEN: ${{ secrets.RELEASE_BUS_WORKFLOW_AUTH_TOKEN }}
         run: |
           set -euo pipefail
           [[ "$RELEASE_BUS_MODE" =~ ^(OFF|SHADOW|STAGING|PRODUCTION)$ ]]
+          [[ "$RELEASE_BUS_GITHUB_APP_ID" =~ ^[1-9][0-9]*$ ]]
+          test -n "$RELEASE_BUS_GITHUB_PRIVATE_KEY"
           test -n "$RELEASE_BUS_GITHUB_WEBHOOK_SECRET"
           test -n "$RELEASE_BUS_WORKFLOW_AUTH_TOKEN"
       - name: Check production preconditions
@@ -254,7 +258,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Resolve Release Bus GitHub App installation
-        if: github.event.inputs.service == 'releaseBus'
+        if: github.event.inputs.service == 'releaseBus' || (github.event.inputs.service == 'api' && github.event.inputs.environment == 'prod')
         id: release_bus_app
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
@@ -471,8 +475,17 @@ jobs:
           pushd src/releaseBus && npm run sls-deploy:${{ github.event.inputs.environment }} && popd
       - name: Deploy API
         if: github.event.inputs.service == 'api'
+        env:
+          RELEASE_BUS_GITHUB_APP_ID: ${{ vars.RELEASE_BUS_GITHUB_APP_ID }}
+          RELEASE_BUS_GITHUB_INSTALLATION_ID: ${{ steps.release_bus_app.outputs.installation-id }}
+          RELEASE_BUS_MODE: ${{ vars.RELEASE_BUS_MODE || 'OFF' }}
         run: |
+          set -euo pipefail
           set +x
+          if [ "${{ github.event.inputs.environment }}" = prod ]; then
+            [[ "$RELEASE_BUS_GITHUB_APP_ID" =~ ^[1-9][0-9]*$ ]]
+            test -n "$RELEASE_BUS_GITHUB_INSTALLATION_ID"
+          fi
           GIT_COMMIT=$(git rev-parse HEAD)
           VERSION_DESCRIPTION="$(git rev-parse --short HEAD) - $(date) - $(git rev-parse --abbrev-ref HEAD) - $(git show -s --format=%s)"
           DEPLOY_REGION="${{ github.event.inputs.environment == 'prod' && 'us-east-1' || 'eu-west-1' }}"
@@ -484,9 +497,9 @@ jobs:
           aws lambda get-function-configuration --function-name seizeAPI --query 'Environment.Variables' --output json --no-cli-pager > /tmp/current_env.json 2>/dev/null || echo '{}' > /tmp/current_env.json
           jq --arg commit "$GIT_COMMIT" --arg claimsMediaArweaveUploadSqsUrl "$CLAIMS_MEDIA_ARWEAVE_UPLOAD_SQS_URL" --arg attachmentsIngestS3Bucket "$ATTACHMENTS_INGEST_S3_BUCKET" --arg dropMediaSanitizeImages "$DROP_MEDIA_SANITIZE_IMAGES" --arg dropMediaIngestS3Bucket "$DROP_MEDIA_INGEST_S3_BUCKET" --arg dropMediaIngestS3Region "$DROP_MEDIA_INGEST_S3_REGION" --arg dropMediaIngestStage "$DROP_MEDIA_INGEST_STAGE" --arg dropMediaSanitizerSqsQueueName "$DROP_MEDIA_SANITIZER_SQS_QUEUE_NAME" --arg apiGatewayWsEndpoint "$API_GATEWAY_WS_ENDPOINT" '. + {GIT_COMMIT: $commit, CLAIMS_MEDIA_ARWEAVE_UPLOAD_SQS_URL: $claimsMediaArweaveUploadSqsUrl, ATTACHMENTS_INGEST_S3_BUCKET: $attachmentsIngestS3Bucket, DROP_MEDIA_SANITIZE_IMAGES: $dropMediaSanitizeImages, DROP_MEDIA_INGEST_S3_BUCKET: $dropMediaIngestS3Bucket, DROP_MEDIA_INGEST_S3_REGION: $dropMediaIngestS3Region, DROP_MEDIA_INGEST_STAGE: $dropMediaIngestStage, DROP_MEDIA_SANITIZER_SQS_QUEUE_NAME: $dropMediaSanitizerSqsQueueName, API_GATEWAY_WS_ENDPOINT: $apiGatewayWsEndpoint}' /tmp/current_env.json > /tmp/app_env.json
           if [ "${{ github.event.inputs.environment }}" = prod ]; then
-            jq --arg mode "$RELEASE_BUS_MODE" '. + {RELEASE_BUS_MODE: $mode} | del(.RELEASE_BUS_WORKFLOW_AUTH_TOKEN, .RELEASE_BUS_GITHUB_WEBHOOK_SECRET)' /tmp/app_env.json > /tmp/runtime_env.json
+            jq --arg mode "$RELEASE_BUS_MODE" --arg appId "$RELEASE_BUS_GITHUB_APP_ID" --arg installationId "$RELEASE_BUS_GITHUB_INSTALLATION_ID" '. + {RELEASE_BUS_MODE: $mode, RELEASE_BUS_GITHUB_APP_ID: $appId, RELEASE_BUS_GITHUB_INSTALLATION_ID: $installationId} | del(.RELEASE_BUS_WORKFLOW_AUTH_TOKEN, .RELEASE_BUS_GITHUB_WEBHOOK_SECRET)' /tmp/app_env.json > /tmp/runtime_env.json
           else
-            jq '. + {RELEASE_BUS_MODE: "OFF"} | del(.RELEASE_BUS_WORKFLOW_AUTH_TOKEN, .RELEASE_BUS_GITHUB_WEBHOOK_SECRET)' /tmp/app_env.json > /tmp/runtime_env.json
+            jq '. + {RELEASE_BUS_MODE: "OFF"} | del(.RELEASE_BUS_GITHUB_APP_ID, .RELEASE_BUS_GITHUB_INSTALLATION_ID, .RELEASE_BUS_WORKFLOW_AUTH_TOKEN, .RELEASE_BUS_GITHUB_WEBHOOK_SECRET)' /tmp/app_env.json > /tmp/runtime_env.json
           fi
           jq '{Variables: .}' /tmp/runtime_env.json > /tmp/env_config.json
           aws lambda update-function-configuration --function-name seizeAPI --description "$VERSION_DESCRIPTION" --environment file:///tmp/env_config.json --memory-size "$API_MEMORY_SIZE" --timeout "$API_TIMEOUT" --no-cli-pager > /dev/null 2>&1

--- a/scripts/generate-deploy-config.mjs
+++ b/scripts/generate-deploy-config.mjs
@@ -206,11 +206,15 @@ jobs:
         if: github.event.inputs.service == 'api' && github.event.inputs.environment == 'prod'
         shell: bash
         env:
+          RELEASE_BUS_GITHUB_APP_ID: \${{ vars.RELEASE_BUS_GITHUB_APP_ID }}
+          RELEASE_BUS_GITHUB_PRIVATE_KEY: \${{ secrets.RELEASE_BUS_GITHUB_PRIVATE_KEY }}
           RELEASE_BUS_GITHUB_WEBHOOK_SECRET: \${{ secrets.RELEASE_BUS_GITHUB_WEBHOOK_SECRET }}
           RELEASE_BUS_WORKFLOW_AUTH_TOKEN: \${{ secrets.RELEASE_BUS_WORKFLOW_AUTH_TOKEN }}
         run: |
           set -euo pipefail
           [[ "$RELEASE_BUS_MODE" =~ ^(OFF|SHADOW|STAGING|PRODUCTION)$ ]]
+          [[ "$RELEASE_BUS_GITHUB_APP_ID" =~ ^[1-9][0-9]*$ ]]
+          test -n "$RELEASE_BUS_GITHUB_PRIVATE_KEY"
           test -n "$RELEASE_BUS_GITHUB_WEBHOOK_SECRET"
           test -n "$RELEASE_BUS_WORKFLOW_AUTH_TOKEN"
       - name: Check production preconditions
@@ -283,7 +287,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Resolve Release Bus GitHub App installation
-        if: github.event.inputs.service == 'releaseBus'
+        if: github.event.inputs.service == 'releaseBus' || (github.event.inputs.service == 'api' && github.event.inputs.environment == 'prod')
         id: release_bus_app
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
         with:
@@ -537,8 +541,17 @@ jobs:
           pushd src/releaseBus && npm run sls-deploy:\${{ github.event.inputs.environment }} && popd
       - name: Deploy API
         if: github.event.inputs.service == 'api'
+        env:
+          RELEASE_BUS_GITHUB_APP_ID: \${{ vars.RELEASE_BUS_GITHUB_APP_ID }}
+          RELEASE_BUS_GITHUB_INSTALLATION_ID: \${{ steps.release_bus_app.outputs.installation-id }}
+          RELEASE_BUS_MODE: \${{ vars.RELEASE_BUS_MODE || 'OFF' }}
         run: |
+          set -euo pipefail
           set +x
+          if [ "\${{ github.event.inputs.environment }}" = prod ]; then
+            [[ "$RELEASE_BUS_GITHUB_APP_ID" =~ ^[1-9][0-9]*$ ]]
+            test -n "$RELEASE_BUS_GITHUB_INSTALLATION_ID"
+          fi
           GIT_COMMIT=$(git rev-parse HEAD)
           VERSION_DESCRIPTION="$(git rev-parse --short HEAD) - $(date) - $(git rev-parse --abbrev-ref HEAD) - $(git show -s --format=%s)"
           DEPLOY_REGION="\${{ github.event.inputs.environment == 'prod' && 'us-east-1' || 'eu-west-1' }}"
@@ -550,9 +563,9 @@ jobs:
           aws lambda get-function-configuration --function-name seizeAPI --query 'Environment.Variables' --output json --no-cli-pager > /tmp/current_env.json 2>/dev/null || echo '{}' > /tmp/current_env.json
           jq --arg commit "$GIT_COMMIT" --arg claimsMediaArweaveUploadSqsUrl "$CLAIMS_MEDIA_ARWEAVE_UPLOAD_SQS_URL" --arg attachmentsIngestS3Bucket "$ATTACHMENTS_INGEST_S3_BUCKET" --arg dropMediaSanitizeImages "$DROP_MEDIA_SANITIZE_IMAGES" --arg dropMediaIngestS3Bucket "$DROP_MEDIA_INGEST_S3_BUCKET" --arg dropMediaIngestS3Region "$DROP_MEDIA_INGEST_S3_REGION" --arg dropMediaIngestStage "$DROP_MEDIA_INGEST_STAGE" --arg dropMediaSanitizerSqsQueueName "$DROP_MEDIA_SANITIZER_SQS_QUEUE_NAME" --arg apiGatewayWsEndpoint "$API_GATEWAY_WS_ENDPOINT" '. + {GIT_COMMIT: $commit, CLAIMS_MEDIA_ARWEAVE_UPLOAD_SQS_URL: $claimsMediaArweaveUploadSqsUrl, ATTACHMENTS_INGEST_S3_BUCKET: $attachmentsIngestS3Bucket, DROP_MEDIA_SANITIZE_IMAGES: $dropMediaSanitizeImages, DROP_MEDIA_INGEST_S3_BUCKET: $dropMediaIngestS3Bucket, DROP_MEDIA_INGEST_S3_REGION: $dropMediaIngestS3Region, DROP_MEDIA_INGEST_STAGE: $dropMediaIngestStage, DROP_MEDIA_SANITIZER_SQS_QUEUE_NAME: $dropMediaSanitizerSqsQueueName, API_GATEWAY_WS_ENDPOINT: $apiGatewayWsEndpoint}' /tmp/current_env.json > /tmp/app_env.json
           if [ "\${{ github.event.inputs.environment }}" = prod ]; then
-            jq --arg mode "$RELEASE_BUS_MODE" '. + {RELEASE_BUS_MODE: $mode} | del(.RELEASE_BUS_WORKFLOW_AUTH_TOKEN, .RELEASE_BUS_GITHUB_WEBHOOK_SECRET)' /tmp/app_env.json > /tmp/runtime_env.json
+            jq --arg mode "$RELEASE_BUS_MODE" --arg appId "$RELEASE_BUS_GITHUB_APP_ID" --arg installationId "$RELEASE_BUS_GITHUB_INSTALLATION_ID" '. + {RELEASE_BUS_MODE: $mode, RELEASE_BUS_GITHUB_APP_ID: $appId, RELEASE_BUS_GITHUB_INSTALLATION_ID: $installationId} | del(.RELEASE_BUS_WORKFLOW_AUTH_TOKEN, .RELEASE_BUS_GITHUB_WEBHOOK_SECRET)' /tmp/app_env.json > /tmp/runtime_env.json
           else
-            jq '. + {RELEASE_BUS_MODE: "OFF"} | del(.RELEASE_BUS_WORKFLOW_AUTH_TOKEN, .RELEASE_BUS_GITHUB_WEBHOOK_SECRET)' /tmp/app_env.json > /tmp/runtime_env.json
+            jq '. + {RELEASE_BUS_MODE: "OFF"} | del(.RELEASE_BUS_GITHUB_APP_ID, .RELEASE_BUS_GITHUB_INSTALLATION_ID, .RELEASE_BUS_WORKFLOW_AUTH_TOKEN, .RELEASE_BUS_GITHUB_WEBHOOK_SECRET)' /tmp/app_env.json > /tmp/runtime_env.json
           fi
           jq '{Variables: .}' /tmp/runtime_env.json > /tmp/env_config.json
           aws lambda update-function-configuration --function-name seizeAPI --description "$VERSION_DESCRIPTION" --environment file:///tmp/env_config.json --memory-size "$API_MEMORY_SIZE" --timeout "$API_TIMEOUT" --no-cli-pager > /dev/null 2>&1

--- a/src/releaseBus/release-bus-infrastructure.test.ts
+++ b/src/releaseBus/release-bus-infrastructure.test.ts
@@ -47,6 +47,21 @@ describe('release bus infrastructure contract', () => {
     expect(deployWorkflow).toContain(
       'RELEASE_BUS_GITHUB_INSTALLATION_ID: ${{ steps.release_bus_app.outputs.installation-id }}'
     );
+    expect(deployWorkflow).toContain(
+      "github.event.inputs.service == 'releaseBus' || (github.event.inputs.service == 'api' && github.event.inputs.environment == 'prod')"
+    );
+    expect(deployWorkflow).toContain(
+      'RELEASE_BUS_GITHUB_APP_ID: $appId, RELEASE_BUS_GITHUB_INSTALLATION_ID: $installationId'
+    );
+    expect(deployWorkflow).toContain(
+      "- name: Deploy API\n        if: github.event.inputs.service == 'api'\n        env:\n          RELEASE_BUS_GITHUB_APP_ID: ${{ vars.RELEASE_BUS_GITHUB_APP_ID }}\n          RELEASE_BUS_GITHUB_INSTALLATION_ID: ${{ steps.release_bus_app.outputs.installation-id }}\n          RELEASE_BUS_MODE: ${{ vars.RELEASE_BUS_MODE || 'OFF' }}"
+    );
+    expect(deployWorkflow).not.toContain(
+      "RELEASE_BUS_MODE: ${{ vars.RELEASE_BUS_MODE || 'OFF' }}\n          RELEASE_BUS_MODE: ${{ vars.RELEASE_BUS_MODE || 'OFF' }}"
+    );
+    expect(deployWorkflow).toContain(
+      'del(.RELEASE_BUS_GITHUB_APP_ID, .RELEASE_BUS_GITHUB_INSTALLATION_ID, .RELEASE_BUS_WORKFLOW_AUTH_TOKEN, .RELEASE_BUS_GITHUB_WEBHOOK_SECRET)'
+    );
   });
 
   it('stores production credentials outside Lambda configuration', () => {


### PR DESCRIPTION
## What changed

- resolve the Release Bus GitHub App installation for production API deployments
- inject the App ID and installation ID into `seizeAPI`
- validate the App configuration before deploying
- remove the production-only identity from staging API configuration
- add an infrastructure contract test covering the wiring

## Why

The Release Bus pause/resume endpoints returned HTTP 500 because `seizeAPI` loaded the private key but had no `RELEASE_BUS_GITHUB_APP_ID` or `RELEASE_BUS_GITHUB_INSTALLATION_ID`. The request failed before reaching GitHub or checking operator membership.

## Impact

Production API redeployment will make operator pause/resume authorization able to mint a GitHub App installation token. No database or public API schema changes are involved.

## Validation

- `npm run lint`
- `npm run build` (253 suites, 2,234 tests passed; TypeScript compilation passed)
- generated workflow parsed as YAML
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Production API deployments now support Release Bus integration through GitHub App credentials.
  * Release Bus installation details are automatically configured during eligible production deployments.

* **Bug Fixes**
  * Added validation to catch missing or incorrectly formatted Release Bus credentials before deployment.
  * Non-production deployments now reliably disable Release Bus integration and remove production-only settings.
  * Improved deployment configuration checks to prevent incomplete runtime setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->