### PR TITLE
Fix Release Bus backend preflight dependencies

### DIFF
--- a/.github/workflows/release-bus-isolate-candidate.yml
+++ b/.github/workflows/release-bus-isolate-candidate.yml
@@ -92,7 +92,7 @@ jobs:
               git -c core.hooksPath=/dev/null commit -m "Isolation merge $sha"
             done < <(jq -r '.[]' <<< "$CANDIDATE_SHAS")
             npm ci
-            npm --prefix src/api-serverless ci
+            npm --prefix src/api-serverless ci --ignore-scripts
             npx eslint "src/**/*.ts" --max-warnings=0
             NODE_OPTIONS=--max-old-space-size=8192 ./node_modules/.bin/tsc -p tsconfig.json --pretty false
             npm test -- --runInBand

--- a/.github/workflows/release-bus-isolate-candidate.yml
+++ b/.github/workflows/release-bus-isolate-candidate.yml
@@ -92,6 +92,7 @@ jobs:
               git -c core.hooksPath=/dev/null commit -m "Isolation merge $sha"
             done < <(jq -r '.[]' <<< "$CANDIDATE_SHAS")
             npm ci
+            npm --prefix src/api-serverless ci
             npx eslint "src/**/*.ts" --max-warnings=0
             NODE_OPTIONS=--max-old-space-size=8192 ./node_modules/.bin/tsc -p tsconfig.json --pretty false
             npm test -- --runInBand

--- a/.github/workflows/release-bus-preflight.yml
+++ b/.github/workflows/release-bus-preflight.yml
@@ -66,7 +66,9 @@ jobs:
             jq -e --arg unit "$unit" '.services | any(.name == $unit)' src/config/deploy-services.json >/dev/null
           done < <(jq -r '.[]' <<< "$DEPLOY_UNITS")
       - name: Install dependencies
-        run: npm ci
+        run: |
+          npm ci
+          npm --prefix src/api-serverless ci
       - name: Lint and typecheck
         run: |
           npx eslint "src/**/*.ts" --max-warnings=0

--- a/.github/workflows/release-bus-preflight.yml
+++ b/.github/workflows/release-bus-preflight.yml
@@ -66,9 +66,9 @@ jobs:
             jq -e --arg unit "$unit" '.services | any(.name == $unit)' src/config/deploy-services.json >/dev/null
           done < <(jq -r '.[]' <<< "$DEPLOY_UNITS")
       - name: Install dependencies
-        run: |
-          npm ci
-          npm --prefix src/api-serverless ci
+        run: npm ci
+      - name: Install API type dependencies without lifecycle scripts
+        run: npm --prefix src/api-serverless ci --ignore-scripts
       - name: Lint and typecheck
         run: |
           npx eslint "src/**/*.ts" --max-warnings=0

--- a/src/releaseBus/release-bus-infrastructure.test.ts
+++ b/src/releaseBus/release-bus-infrastructure.test.ts
@@ -3,6 +3,14 @@ import stateMachine from '@/releaseBus/state-machine.asl.json';
 import { e2eSourceRef } from '@/releaseBus/worker';
 
 const deployWorkflow = readFileSync('.github/workflows/deploy.yml', 'utf8');
+const preflightWorkflow = readFileSync(
+  '.github/workflows/release-bus-preflight.yml',
+  'utf8'
+);
+const isolationWorkflow = readFileSync(
+  '.github/workflows/release-bus-isolate-candidate.yml',
+  'utf8'
+);
 const releaseBusServerless = readFileSync(
   'src/releaseBus/serverless.yaml',
   'utf8'
@@ -32,6 +40,15 @@ describe('release bus infrastructure contract', () => {
     expect(
       e2eSourceRef('release-bus/train', 'staging', 'release-bus/train')
     ).toBe('release-bus/train');
+  });
+
+  it('installs API dependencies before root typechecking', () => {
+    expect(preflightWorkflow).toContain(
+      'npm --prefix src/api-serverless ci\n      - name: Lint and typecheck'
+    );
+    expect(isolationWorkflow).toContain(
+      'npm --prefix src/api-serverless ci\n            npx eslint'
+    );
   });
 
   it('injects the GitHub App identity into every Release Bus Lambda', () => {

--- a/src/releaseBus/release-bus-infrastructure.test.ts
+++ b/src/releaseBus/release-bus-infrastructure.test.ts
@@ -43,11 +43,18 @@ describe('release bus infrastructure contract', () => {
   });
 
   it('installs API dependencies before root typechecking', () => {
-    expect(preflightWorkflow).toContain(
-      'npm --prefix src/api-serverless ci\n      - name: Lint and typecheck'
+    const installCommand =
+      'npm --prefix src/api-serverless ci --ignore-scripts';
+    const preflightInstallIndex = preflightWorkflow.indexOf(installCommand);
+    const isolationInstallIndex = isolationWorkflow.indexOf(installCommand);
+
+    expect(preflightInstallIndex).toBeGreaterThan(-1);
+    expect(preflightWorkflow.indexOf('npx eslint')).toBeGreaterThan(
+      preflightInstallIndex
     );
-    expect(isolationWorkflow).toContain(
-      'npm --prefix src/api-serverless ci\n            npx eslint'
+    expect(isolationInstallIndex).toBeGreaterThan(-1);
+    expect(isolationWorkflow.indexOf('npx eslint')).toBeGreaterThan(
+      isolationInstallIndex
     );
   });
 


### PR DESCRIPTION
## What changed

- install the API package dependencies before the root Release Bus preflight typecheck
- mirror the same setup in deterministic candidate isolation
- add a regression assertion covering both workflows

## Root cause

The Release Bus preflight ran the root TypeScript project after installing only root dependencies. That project includes API sources, whose module declarations live under `src/api-serverless/node_modules`, so the first live train failed before deployment with missing-module/type errors.

## Impact

Backend Release Bus preflight and isolation now use the same two dependency trees as normal backend PR CI. No application runtime behavior or database schema changes.

## Validation

- exact failed ESLint + TypeScript preflight commands
- `npm run lint`
- `npm test -- src/releaseBus/release-bus-infrastructure.test.ts --runInBand`
- Prettier checks for both workflows and the regression test