### PR TITLE
Restore CI wave alerts after early deploy failures

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -599,9 +599,6 @@ jobs:
           done
           echo "API did not report healthy exact commit $INPUT_EXPECTED_SHA" >&2
           exit 1
-      # Early validation failures skip the normal checkout. The remaining local
-      # failure notifier needs only this script; Discord uses an external action.
-      # Pin it to the trusted running workflow rather than the deploy target ref.
       - name: Checkout CI wave notifier after early failure
         if: failure() && hashFiles('scripts/notify-ci-wave.mjs') == ''
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -599,6 +599,14 @@ jobs:
           done
           echo "API did not report healthy exact commit $INPUT_EXPECTED_SHA" >&2
           exit 1
+      - name: Checkout CI wave notifier after early failure
+        if: failure() && hashFiles('scripts/notify-ci-wave.mjs') == ''
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+          sparse-checkout: scripts/notify-ci-wave.mjs
+          sparse-checkout-cone-mode: false
       - name: Notify about failure
         uses: sarisia/actions-status-discord@v1
         if: failure()

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -599,6 +599,9 @@ jobs:
           done
           echo "API did not report healthy exact commit $INPUT_EXPECTED_SHA" >&2
           exit 1
+      # Early validation failures skip the normal checkout. The remaining local
+      # failure notifier needs only this script; Discord uses an external action.
+      # Pin it to the trusted running workflow rather than the deploy target ref.
       - name: Checkout CI wave notifier after early failure
         if: failure() && hashFiles('scripts/notify-ci-wave.mjs') == ''
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/scripts/generate-deploy-config.mjs
+++ b/scripts/generate-deploy-config.mjs
@@ -677,6 +677,14 @@ jobs:
           done
           echo "API did not report healthy exact commit $INPUT_EXPECTED_SHA" >&2
           exit 1
+      - name: Checkout CI wave notifier after early failure
+        if: failure() && hashFiles('scripts/notify-ci-wave.mjs') == ''
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: \${{ github.workflow_sha }}
+          persist-credentials: false
+          sparse-checkout: scripts/notify-ci-wave.mjs
+          sparse-checkout-cone-mode: false
       - name: Notify about failure
         uses: sarisia/actions-status-discord@v1
         if: failure()

--- a/scripts/generate-deploy-config.mjs
+++ b/scripts/generate-deploy-config.mjs
@@ -677,6 +677,9 @@ jobs:
           done
           echo "API did not report healthy exact commit $INPUT_EXPECTED_SHA" >&2
           exit 1
+      # Early validation failures skip the normal checkout. The remaining local
+      # failure notifier needs only this script; Discord uses an external action.
+      # Pin it to the trusted running workflow rather than the deploy target ref.
       - name: Checkout CI wave notifier after early failure
         if: failure() && hashFiles('scripts/notify-ci-wave.mjs') == ''
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/scripts/generate-deploy-config.mjs
+++ b/scripts/generate-deploy-config.mjs
@@ -677,9 +677,6 @@ jobs:
           done
           echo "API did not report healthy exact commit $INPUT_EXPECTED_SHA" >&2
           exit 1
-      # Early validation failures skip the normal checkout. The remaining local
-      # failure notifier needs only this script; Discord uses an external action.
-      # Pin it to the trusted running workflow rather than the deploy target ref.
       - name: Checkout CI wave notifier after early failure
         if: failure() && hashFiles('scripts/notify-ci-wave.mjs') == ''
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3


### PR DESCRIPTION
## Issue
- Early deploy validation failures occur before the repository checkout step.
- The Discord failure action remains available, but the repository-local `scripts/notify-ci-wave.mjs` file is absent, so the Waves notification cannot run.

## Fix
- Add a failure-only recovery checkout when the notifier script is missing.
- Check out the trusted workflow commit with persisted credentials disabled and sparse checkout limited to the notifier script.

## Changes
- Update the deploy workflow generator.
- Regenerate `.github/workflows/deploy.yml`.

## Validation
- Regenerated the deploy workflow successfully.
- Verified the generator with `node --check`.
- Parsed the generated workflow as YAML.
- Verified the diff with `git diff --check`.
- Full lint was not completed because the clean worktree lacked dependencies and the locked install remained silent; it was stopped rather than delaying publication.

## Risk
- Level: Low
- Why: The added checkout runs only after a failure and only when the notifier script is unavailable.
- Rollback: Revert this commit to restore the previous notification behavior.

## Deployment
- None. This changes the GitHub Actions workflow only.

## Review Notes
- Confirm that the failure-only sparse checkout remains pinned to `github.workflow_sha` and does not persist credentials.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved deployment workflow reliability when failures occur early, ensuring completion/failure notifications still run.
  - Notification steps now automatically recover when the required notification script isn’t available after an early termination.

- **Chores**
  - Updated deployment automation to conditionally fetch only the notification script when needed.
  - Applied the same recovery behavior to generated deployment configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->