### PR TITLE
Harden private wave push notification access

### DIFF
--- a/src/drops/create-or-update-drop-use-case.test.ts
+++ b/src/drops/create-or-update-drop-use-case.test.ts
@@ -1094,6 +1094,126 @@ describe('CreateOrUpdateDropUseCase', () => {
     );
   });
 
+  it('filters direct mentions to identities eligible for a private wave', async () => {
+    const userGroupsService = {
+      findIdentitiesInGroups: jest.fn().mockResolvedValue(['eligible-mention'])
+    };
+    const identitySubscriptionsDb = {
+      findWaveFollowersEligibleForDropNotifications: jest
+        .fn()
+        .mockResolvedValue([]),
+      countWaveSubscribers: jest.fn().mockResolvedValue(0),
+      findMutedWaveReaders: jest.fn().mockResolvedValue([])
+    };
+    const userNotifier = {
+      notifyWaveDropCreatedRecipients: jest.fn().mockResolvedValue([101])
+    };
+    const useCase = createUseCaseWithMocks({
+      userGroupsService,
+      identitySubscriptionsDb,
+      userNotifier
+    });
+
+    await expect(
+      (useCase as any).notifyWaveDropRecipients(
+        {
+          model: {
+            drop_id: 'drop-1',
+            author_id: 'author-1',
+            mentioned_groups: []
+          },
+          wave: {
+            id: 'wave-1',
+            visibility_group_id: 'private-group',
+            parent_wave_id: null
+          },
+          directlyMentionedIdentityIds: [
+            'eligible-mention',
+            'ineligible-mention'
+          ]
+        },
+        { connection: {} }
+      )
+    ).resolves.toEqual([101]);
+
+    expect(userGroupsService.findIdentitiesInGroups).toHaveBeenCalledWith(
+      ['private-group'],
+      { timer: undefined, connection: {} }
+    );
+    expect(identitySubscriptionsDb.findMutedWaveReaders).toHaveBeenCalledWith(
+      'wave-1',
+      ['eligible-mention'],
+      {}
+    );
+    expect(userNotifier.notifyWaveDropCreatedRecipients).toHaveBeenCalledWith(
+      {
+        waveId: 'wave-1',
+        dropId: 'drop-1',
+        relatedIdentityId: 'author-1',
+        mentionedIdentityIds: ['eligible-mention'],
+        allDropsSubscriberIds: []
+      },
+      'private-group',
+      { timer: undefined, connection: {} }
+    );
+  });
+
+  it('requires direct mentions to access both child and parent waves', async () => {
+    const userGroupsService = {
+      findIdentitiesInGroups: jest
+        .fn()
+        .mockResolvedValueOnce(['child-and-parent', 'child-only'])
+        .mockResolvedValueOnce(['child-and-parent'])
+    };
+    const wavesApiDb = {
+      findWaveById: jest.fn().mockResolvedValue({
+        id: 'parent-wave',
+        visibility_group_id: 'parent-group'
+      })
+    };
+    const identitySubscriptionsDb = {
+      findWaveFollowersEligibleForDropNotifications: jest
+        .fn()
+        .mockResolvedValue([]),
+      countWaveSubscribers: jest.fn().mockResolvedValue(0),
+      findMutedWaveReaders: jest.fn().mockResolvedValue([])
+    };
+    const userNotifier = {
+      notifyWaveDropCreatedRecipients: jest.fn().mockResolvedValue([102])
+    };
+    const useCase = createUseCaseWithMocks({
+      userGroupsService,
+      wavesApiDb,
+      identitySubscriptionsDb,
+      userNotifier
+    });
+
+    await (useCase as any).notifyWaveDropRecipients(
+      {
+        model: {
+          drop_id: 'drop-1',
+          author_id: 'author-1',
+          mentioned_groups: []
+        },
+        wave: {
+          id: 'child-wave',
+          visibility_group_id: 'child-group',
+          parent_wave_id: 'parent-wave'
+        },
+        directlyMentionedIdentityIds: ['child-and-parent', 'child-only']
+      },
+      { connection: {} }
+    );
+
+    expect(userNotifier.notifyWaveDropCreatedRecipients).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mentionedIdentityIds: ['child-and-parent']
+      }),
+      'child-group',
+      { timer: undefined, connection: {} }
+    );
+  });
+
   it('keeps all-drops notifications below the subscriber cap while deduplicating @all mentions', async () => {
     jest.spyOn(env, 'getIntOrNull').mockReturnValue(15);
     const identitySubscriptionsDb = {

--- a/src/drops/create-or-update-drop-use-case.test.ts
+++ b/src/drops/create-or-update-drop-use-case.test.ts
@@ -1158,6 +1158,57 @@ describe('CreateOrUpdateDropUseCase', () => {
     );
   });
 
+  it('deduplicates direct mentions for a public wave without group lookups', async () => {
+    const userGroupsService = {
+      findIdentitiesInGroups: jest.fn()
+    };
+    const identitySubscriptionsDb = {
+      findWaveFollowersEligibleForDropNotifications: jest
+        .fn()
+        .mockResolvedValue([]),
+      countWaveSubscribers: jest.fn().mockResolvedValue(0),
+      findMutedWaveReaders: jest.fn().mockResolvedValue([])
+    };
+    const userNotifier = {
+      notifyWaveDropCreatedRecipients: jest.fn().mockResolvedValue([103])
+    };
+    const useCase = createUseCaseWithMocks({
+      userGroupsService,
+      identitySubscriptionsDb,
+      userNotifier
+    });
+
+    await (useCase as any).notifyWaveDropRecipients(
+      {
+        model: {
+          drop_id: 'drop-1',
+          author_id: 'author-1',
+          mentioned_groups: []
+        },
+        wave: {
+          id: 'public-wave',
+          visibility_group_id: null,
+          parent_wave_id: null
+        },
+        directlyMentionedIdentityIds: ['public-mention', 'public-mention']
+      },
+      { connection: {} }
+    );
+
+    expect(userGroupsService.findIdentitiesInGroups).not.toHaveBeenCalled();
+    expect(userNotifier.notifyWaveDropCreatedRecipients).toHaveBeenCalledWith(
+      {
+        waveId: 'public-wave',
+        dropId: 'drop-1',
+        relatedIdentityId: 'author-1',
+        mentionedIdentityIds: ['public-mention'],
+        allDropsSubscriberIds: []
+      },
+      null,
+      { timer: undefined, connection: {} }
+    );
+  });
+
   it('requires direct mentions to access both child and parent waves', async () => {
     const userGroupsService = {
       findIdentitiesInGroups: jest
@@ -1205,10 +1256,25 @@ describe('CreateOrUpdateDropUseCase', () => {
       { connection: {} }
     );
 
+    expect(wavesApiDb.findWaveById).toHaveBeenCalledWith('parent-wave', {});
+    expect(userGroupsService.findIdentitiesInGroups).toHaveBeenNthCalledWith(
+      1,
+      ['child-group'],
+      { timer: undefined, connection: {} }
+    );
+    expect(userGroupsService.findIdentitiesInGroups).toHaveBeenNthCalledWith(
+      2,
+      ['parent-group'],
+      { timer: undefined, connection: {} }
+    );
     expect(userNotifier.notifyWaveDropCreatedRecipients).toHaveBeenCalledWith(
-      expect.objectContaining({
-        mentionedIdentityIds: ['child-and-parent']
-      }),
+      {
+        waveId: 'child-wave',
+        dropId: 'drop-1',
+        relatedIdentityId: 'author-1',
+        mentionedIdentityIds: ['child-and-parent'],
+        allDropsSubscriberIds: []
+      },
       'child-group',
       { timer: undefined, connection: {} }
     );

--- a/src/drops/create-or-update-drop.use-case.ts
+++ b/src/drops/create-or-update-drop.use-case.ts
@@ -98,6 +98,7 @@ import {
 } from '@/waves/wave-chat-slow-mode.helpers';
 import { isWaveCreatorOrAdmin } from '@/waves/wave-admin.helpers';
 import { parseDecentralizedMediaRef } from '@/decentralized-media/decentralized-media';
+import { Logger } from '@/logging';
 
 const TENOR_CHAT_LINK_ORIGIN = 'https://media.tenor.com';
 const GIPHY_CHAT_LINK_HOST_REGEX = /^media\d*\.giphy\.com$/;
@@ -209,6 +210,8 @@ export function sanitizeDropStructuredFields(
 }
 
 export class CreateOrUpdateDropUseCase {
+  private readonly logger = Logger.get(CreateOrUpdateDropUseCase.name);
+
   public constructor(
     private readonly dropsDb: DropsDb,
     private readonly dropVotingDb: DropVotingDb,
@@ -2039,14 +2042,18 @@ export class CreateOrUpdateDropUseCase {
         connection
       );
       if (!parentWave) {
+        this.logger.warn(
+          `Cannot resolve parent wave ${wave.parent_wave_id} while filtering direct mention recipients for wave ${wave.id}`
+        );
         return [];
       }
       if (parentWave.visibility_group_id) {
         visibilityGroupIds.push(parentWave.visibility_group_id);
       }
     }
-    if (!visibilityGroupIds.length || !identityIds.length) {
-      return identityIds;
+    const distinctIdentityIds = collections.distinct(identityIds);
+    if (!visibilityGroupIds.length || !distinctIdentityIds.length) {
+      return distinctIdentityIds;
     }
 
     const eligibleIdentitySets = await Promise.all(
@@ -2059,11 +2066,9 @@ export class CreateOrUpdateDropUseCase {
         return new Set(eligibleIdentityIds);
       })
     );
-    return collections
-      .distinct(identityIds)
-      .filter((identityId) =>
-        eligibleIdentitySets.every((eligibleIds) => eligibleIds.has(identityId))
-      );
+    return distinctIdentityIds.filter((identityId) =>
+      eligibleIdentitySets.every((eligibleIds) => eligibleIds.has(identityId))
+    );
   }
 }
 

--- a/src/drops/create-or-update-drop.use-case.ts
+++ b/src/drops/create-or-update-drop.use-case.ts
@@ -1971,15 +1971,21 @@ export class CreateOrUpdateDropUseCase {
       ),
       this.identitySubscriptionsDb.countWaveSubscribers(wave.id, connection)
     ]);
+    const eligibleDirectMentionedIdentityIds =
+      await this.filterIdentityIdsEligibleToReadWave(
+        wave,
+        directlyMentionedIdentityIds,
+        { timer, connection }
+      );
     const mutedDirectMentionedIdentityIds = new Set(
       await this.identitySubscriptionsDb.findMutedWaveReaders(
         wave.id,
-        directlyMentionedIdentityIds,
+        eligibleDirectMentionedIdentityIds,
         connection
       )
     );
     const directMentionIdentityIds = collections.distinct(
-      directlyMentionedIdentityIds.filter(
+      eligibleDirectMentionedIdentityIds.filter(
         (identityId) =>
           identityId !== authorId &&
           !mutedDirectMentionedIdentityIds.has(identityId)
@@ -2017,6 +2023,47 @@ export class CreateOrUpdateDropUseCase {
       );
     timer?.stop(`${CreateOrUpdateDropUseCase.name}->notifyWaveDropRecipients`);
     return pendingPushNotificationIds;
+  }
+
+  private async filterIdentityIdsEligibleToReadWave(
+    wave: WaveEntity,
+    identityIds: string[],
+    { timer, connection }: { timer?: Timer; connection: ConnectionWrapper<any> }
+  ): Promise<string[]> {
+    const visibilityGroupIds = [wave.visibility_group_id].filter(
+      (groupId): groupId is string => groupId !== null
+    );
+    if (wave.parent_wave_id) {
+      const parentWave = await this.wavesApiDb.findWaveById(
+        wave.parent_wave_id,
+        connection
+      );
+      if (!parentWave) {
+        return [];
+      }
+      if (parentWave.visibility_group_id) {
+        visibilityGroupIds.push(parentWave.visibility_group_id);
+      }
+    }
+    if (!visibilityGroupIds.length || !identityIds.length) {
+      return identityIds;
+    }
+
+    const eligibleIdentitySets = await Promise.all(
+      collections.distinct(visibilityGroupIds).map(async (groupId) => {
+        const eligibleIdentityIds =
+          await this.userGroupsService.findIdentitiesInGroups([groupId], {
+            timer,
+            connection
+          });
+        return new Set(eligibleIdentityIds);
+      })
+    );
+    return collections
+      .distinct(identityIds)
+      .filter((identityId) =>
+        eligibleIdentitySets.every((eligibleIds) => eligibleIds.has(identityId))
+      );
   }
 }
 

--- a/src/notifications/identity-notifications.db.test.ts
+++ b/src/notifications/identity-notifications.db.test.ts
@@ -169,4 +169,29 @@ describe('IdentityNotificationsDb mute filtering', () => {
     );
     expect(sendIdentityPushNotification).toHaveBeenCalledWith(401);
   });
+
+  it('counts only unread notifications visible to the recipient', async () => {
+    const db = {
+      oneOrNull: jest.fn().mockResolvedValue({ cnt: 2 })
+    };
+    const repo = new IdentityNotificationsDb(() => db as any);
+
+    await expect(
+      repo.countUnreadNotificationsForIdentity(
+        'recipient-1',
+        ['private-group'],
+        undefined,
+        { enabledCauses: [IdentityNotificationCause.IDENTITY_MENTIONED] }
+      )
+    ).resolves.toBe(2);
+
+    expect(db.oneOrNull).toHaveBeenCalledWith(
+      expect.not.stringContaining('includeNotificationId'),
+      expect.objectContaining({
+        identity_id: 'recipient-1',
+        eligibleGroupIds: ['private-group']
+      }),
+      undefined
+    );
+  });
 });

--- a/src/notifications/identity-notifications.db.ts
+++ b/src/notifications/identity-notifications.db.ts
@@ -389,17 +389,10 @@ export class IdentityNotificationsDb extends LazyDbAccessCompatibleService {
     eligibleGroupIds: string[],
     connection?: ConnectionWrapper<any>,
     options?: {
-      includeNotificationId?: number;
       enabledCauses?: IdentityNotificationCause[];
     }
   ): Promise<number> {
-    const includeId = options?.includeNotificationId;
-    const hasIncludeNotificationId =
-      includeId !== undefined && includeId !== null;
     const enabledCauses = options?.enabledCauses;
-    const includeClause = hasIncludeNotificationId
-      ? ` OR (n.id = :includeNotificationId AND n.identity_id = :identity_id)`
-      : '';
     const hasEnabledCauses =
       enabledCauses !== undefined && enabledCauses.length > 0;
     const causeClause = hasEnabledCauses
@@ -409,15 +402,11 @@ export class IdentityNotificationsDb extends LazyDbAccessCompatibleService {
     const queryParams: {
       identity_id: string;
       eligibleGroupIds: string[];
-      includeNotificationId?: number;
       enabledCauses?: IdentityNotificationCause[];
     } = {
       identity_id,
       eligibleGroupIds
     };
-    if (hasIncludeNotificationId) {
-      queryParams.includeNotificationId = includeId;
-    }
     if (hasEnabledCauses) {
       queryParams.enabledCauses = enabledCauses;
     }
@@ -444,7 +433,7 @@ export class IdentityNotificationsDb extends LazyDbAccessCompatibleService {
             })
             AND COALESCE(r.muted, FALSE) = FALSE
             AND m.id IS NULL
-          )${includeClause}
+          )
         )${causeClause}
       `,
         queryParams,

--- a/src/pushNotificationsHandler/identity-push-notification-access.test.ts
+++ b/src/pushNotificationsHandler/identity-push-notification-access.test.ts
@@ -1,4 +1,7 @@
-import { IdentityNotificationEntity } from '@/entities/IIdentityNotification';
+import {
+  IdentityNotificationCause,
+  IdentityNotificationEntity
+} from '@/entities/IIdentityNotification';
 import { IdentityPushNotificationAccess } from './identity-push-notification-access';
 
 describe('IdentityPushNotificationAccess', () => {
@@ -39,7 +42,7 @@ describe('IdentityPushNotificationAccess', () => {
       findWavesByIds: jest.fn().mockResolvedValue(visibleWaves)
     };
     const dropRepository = {
-      findBy: jest.fn().mockResolvedValue(relatedDrops)
+      find: jest.fn().mockResolvedValue(relatedDrops)
     };
     const dataSourceSupplier = jest.fn(() => ({
       getRepository: jest.fn(() => dropRepository)
@@ -90,22 +93,65 @@ describe('IdentityPushNotificationAccess', () => {
     expect(dataSourceSupplier).not.toHaveBeenCalled();
   });
 
-  it('allows related drops only when they belong to the visible wave', async () => {
-    const { access } = createAccess({
-      relatedDrops: [
-        { id: 'drop-1', wave_id: 'wave-1' },
-        { id: 'drop-2', wave_id: 'wave-1' }
-      ]
+  it('allows a public wave without eligible groups', async () => {
+    const { access, groupsService, wavesDb } = createAccess({
+      eligibleGroupIds: [],
+      visibleWaves: [{ id: 'public-wave' }],
+      relatedDrops: [{ id: 'drop-1', wave_id: 'public-wave' }]
     });
 
     await expect(
       access.canRecipientReadRelatedContent(
-        createNotification({ related_drop_2_id: 'drop-2' })
+        createNotification({
+          wave_id: 'public-wave',
+          visibility_group_id: null
+        })
+      )
+    ).resolves.toBe(true);
+
+    expect(groupsService.getGroupsUserIsEligibleFor).toHaveBeenCalledWith(
+      'recipient-1'
+    );
+    expect(wavesDb.findWavesByIds).toHaveBeenCalledWith(['public-wave'], []);
+  });
+
+  it('caches wave eligibility while checking multiple notifications in one batch', async () => {
+    const { access, groupsService, wavesDb } = createAccess();
+    const waveAccessCache = new Map<string, Promise<boolean>>();
+
+    await expect(
+      access.canRecipientReadRelatedContent(
+        createNotification(),
+        waveAccessCache
+      )
+    ).resolves.toBe(true);
+    await expect(
+      access.canRecipientReadRelatedContent(
+        createNotification({ related_drop_id: 'drop-2' }),
+        waveAccessCache
+      )
+    ).resolves.toBe(false);
+
+    expect(groupsService.getGroupsUserIsEligibleFor).toHaveBeenCalledTimes(1);
+    expect(wavesDb.findWavesByIds).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows the primary drop when a cross-wave secondary drop is referenced', async () => {
+    const { access } = createAccess({
+      relatedDrops: [{ id: 'drop-1', wave_id: 'wave-1' }]
+    });
+
+    await expect(
+      access.canRecipientReadRelatedContent(
+        createNotification({
+          cause: IdentityNotificationCause.DROP_QUOTED,
+          related_drop_2_id: 'private-wave-2-drop'
+        })
       )
     ).resolves.toBe(true);
   });
 
-  it('denies related content from a different wave', async () => {
+  it('denies primary related content from a different wave', async () => {
     const { access } = createAccess({
       relatedDrops: [{ id: 'drop-1', wave_id: 'private-wave-2' }]
     });

--- a/src/pushNotificationsHandler/identity-push-notification-access.test.ts
+++ b/src/pushNotificationsHandler/identity-push-notification-access.test.ts
@@ -1,0 +1,125 @@
+import { IdentityNotificationEntity } from '@/entities/IIdentityNotification';
+import { IdentityPushNotificationAccess } from './identity-push-notification-access';
+
+describe('IdentityPushNotificationAccess', () => {
+  function createNotification(
+    overrides: Partial<IdentityNotificationEntity> = {}
+  ): IdentityNotificationEntity {
+    return {
+      id: 1,
+      identity_id: 'recipient-1',
+      additional_identity_id: 'actor-1',
+      related_drop_id: 'drop-1',
+      related_drop_part_no: null,
+      related_drop_2_id: null,
+      related_drop_2_part_no: null,
+      cause: 'IDENTITY_MENTIONED',
+      additional_data: '{}',
+      created_at: 1,
+      read_at: null,
+      visibility_group_id: 'private-group',
+      wave_id: 'wave-1',
+      ...overrides
+    } as IdentityNotificationEntity;
+  }
+
+  function createAccess({
+    eligibleGroupIds = ['private-group'],
+    visibleWaves = [{ id: 'wave-1' }],
+    relatedDrops = [{ id: 'drop-1', wave_id: 'wave-1' }]
+  }: {
+    eligibleGroupIds?: string[];
+    visibleWaves?: Array<{ id: string }>;
+    relatedDrops?: Array<{ id: string; wave_id: string }>;
+  } = {}) {
+    const groupsService = {
+      getGroupsUserIsEligibleFor: jest.fn().mockResolvedValue(eligibleGroupIds)
+    };
+    const wavesDb = {
+      findWavesByIds: jest.fn().mockResolvedValue(visibleWaves)
+    };
+    const dropRepository = {
+      findBy: jest.fn().mockResolvedValue(relatedDrops)
+    };
+    const dataSourceSupplier = jest.fn(() => ({
+      getRepository: jest.fn(() => dropRepository)
+    }));
+    return {
+      access: new IdentityPushNotificationAccess(
+        groupsService as any,
+        wavesDb as any,
+        dataSourceSupplier as any
+      ),
+      groupsService,
+      wavesDb,
+      dropRepository,
+      dataSourceSupplier
+    };
+  }
+
+  it('allows notifications without wave-scoped content', async () => {
+    const { access, groupsService, wavesDb, dataSourceSupplier } =
+      createAccess();
+
+    await expect(
+      access.canRecipientReadRelatedContent(
+        createNotification({
+          wave_id: null,
+          visibility_group_id: null,
+          related_drop_id: null
+        })
+      )
+    ).resolves.toBe(true);
+
+    expect(groupsService.getGroupsUserIsEligibleFor).not.toHaveBeenCalled();
+    expect(wavesDb.findWavesByIds).not.toHaveBeenCalled();
+    expect(dataSourceSupplier).not.toHaveBeenCalled();
+  });
+
+  it('denies a notification when the recipient cannot read its wave', async () => {
+    const { access, wavesDb, dataSourceSupplier } = createAccess({
+      eligibleGroupIds: [],
+      visibleWaves: []
+    });
+
+    await expect(
+      access.canRecipientReadRelatedContent(createNotification())
+    ).resolves.toBe(false);
+
+    expect(wavesDb.findWavesByIds).toHaveBeenCalledWith(['wave-1'], []);
+    expect(dataSourceSupplier).not.toHaveBeenCalled();
+  });
+
+  it('allows related drops only when they belong to the visible wave', async () => {
+    const { access } = createAccess({
+      relatedDrops: [
+        { id: 'drop-1', wave_id: 'wave-1' },
+        { id: 'drop-2', wave_id: 'wave-1' }
+      ]
+    });
+
+    await expect(
+      access.canRecipientReadRelatedContent(
+        createNotification({ related_drop_2_id: 'drop-2' })
+      )
+    ).resolves.toBe(true);
+  });
+
+  it('denies related content from a different wave', async () => {
+    const { access } = createAccess({
+      relatedDrops: [{ id: 'drop-1', wave_id: 'private-wave-2' }]
+    });
+
+    await expect(
+      access.canRecipientReadRelatedContent(createNotification())
+    ).resolves.toBe(false);
+  });
+
+  it('denies a notification when a related drop no longer exists', async () => {
+    const { access } = createAccess({ relatedDrops: [] });
+
+    await expect(
+      access.canRecipientReadRelatedContent(createNotification())
+    ).resolves.toBe(false);
+  });
+});

--- a/src/pushNotificationsHandler/identity-push-notification-access.test.ts
+++ b/src/pushNotificationsHandler/identity-push-notification-access.test.ts
@@ -2,6 +2,7 @@ import {
   IdentityNotificationCause,
   IdentityNotificationEntity
 } from '@/entities/IIdentityNotification';
+import type { DataSource } from 'typeorm';
 import { IdentityPushNotificationAccess } from './identity-push-notification-access';
 
 describe('IdentityPushNotificationAccess', () => {
@@ -35,6 +36,9 @@ describe('IdentityPushNotificationAccess', () => {
     visibleWaves?: Array<{ id: string }>;
     relatedDrops?: Array<{ id: string; wave_id: string }>;
   } = {}) {
+    type DropFindOptions = {
+      where: { id: { _value: string[] } };
+    };
     const groupsService = {
       getGroupsUserIsEligibleFor: jest.fn().mockResolvedValue(eligibleGroupIds)
     };
@@ -42,16 +46,20 @@ describe('IdentityPushNotificationAccess', () => {
       findWavesByIds: jest.fn().mockResolvedValue(visibleWaves)
     };
     const dropRepository = {
-      find: jest.fn().mockResolvedValue(relatedDrops)
+      find: jest
+        .fn()
+        .mockImplementation(({ where }: DropFindOptions) =>
+          relatedDrops.filter((drop) => where.id._value.includes(drop.id))
+        )
     };
     const dataSourceSupplier = jest.fn(() => ({
       getRepository: jest.fn(() => dropRepository)
     }));
     return {
       access: new IdentityPushNotificationAccess(
-        groupsService as any,
-        wavesDb as any,
-        dataSourceSupplier as any
+        groupsService,
+        wavesDb,
+        dataSourceSupplier as unknown as () => Pick<DataSource, 'getRepository'>
       ),
       groupsService,
       wavesDb,

--- a/src/pushNotificationsHandler/identity-push-notification-access.test.ts
+++ b/src/pushNotificationsHandler/identity-push-notification-access.test.ts
@@ -127,10 +127,10 @@ describe('IdentityPushNotificationAccess', () => {
     ).resolves.toBe(true);
     await expect(
       access.canRecipientReadRelatedContent(
-        createNotification({ related_drop_id: 'drop-2' }),
+        createNotification({ related_drop_id: 'drop-1' }),
         waveAccessCache
       )
-    ).resolves.toBe(false);
+    ).resolves.toBe(true);
 
     expect(groupsService.getGroupsUserIsEligibleFor).toHaveBeenCalledTimes(1);
     expect(wavesDb.findWavesByIds).toHaveBeenCalledTimes(1);

--- a/src/pushNotificationsHandler/identity-push-notification-access.ts
+++ b/src/pushNotificationsHandler/identity-push-notification-access.ts
@@ -1,0 +1,64 @@
+import { In, type DataSource } from 'typeorm';
+import {
+  userGroupsService,
+  UserGroupsService
+} from '@/api/community-members/user-groups.service';
+import { wavesApiDb, WavesApiDb } from '@/api/waves/waves.api.db';
+import { getDataSource } from '@/db';
+import { DropEntity } from '@/entities/IDrop';
+import { IdentityNotificationEntity } from '@/entities/IIdentityNotification';
+
+export class IdentityPushNotificationAccess {
+  constructor(
+    private readonly groupsService: UserGroupsService,
+    private readonly wavesDb: WavesApiDb,
+    private readonly dataSourceSupplier: () => DataSource
+  ) {}
+
+  async canRecipientReadRelatedContent(
+    notification: IdentityNotificationEntity
+  ): Promise<boolean> {
+    const waveId = notification.wave_id;
+    if (!waveId) {
+      return true;
+    }
+
+    const eligibleGroupIds =
+      await this.groupsService.getGroupsUserIsEligibleFor(
+        notification.identity_id
+      );
+    const visibleWaves = await this.wavesDb.findWavesByIds(
+      [waveId],
+      eligibleGroupIds
+    );
+    if (!visibleWaves.some((wave) => wave.id === waveId)) {
+      return false;
+    }
+
+    const relatedDropIds = Array.from(
+      new Set(
+        [notification.related_drop_id, notification.related_drop_2_id].filter(
+          (dropId): dropId is string => dropId !== null
+        )
+      )
+    );
+    if (!relatedDropIds.length) {
+      return true;
+    }
+
+    const relatedDrops = await this.dataSourceSupplier()
+      .getRepository(DropEntity)
+      .findBy({ id: In(relatedDropIds) });
+    return (
+      relatedDrops.length === relatedDropIds.length &&
+      relatedDrops.every((drop) => drop.wave_id === waveId)
+    );
+  }
+}
+
+export const identityPushNotificationAccess =
+  new IdentityPushNotificationAccess(
+    userGroupsService,
+    wavesApiDb,
+    getDataSource
+  );

--- a/src/pushNotificationsHandler/identity-push-notification-access.ts
+++ b/src/pushNotificationsHandler/identity-push-notification-access.ts
@@ -10,9 +10,12 @@ import { IdentityNotificationEntity } from '@/entities/IIdentityNotification';
 
 export class IdentityPushNotificationAccess {
   constructor(
-    private readonly groupsService: UserGroupsService,
-    private readonly wavesDb: WavesApiDb,
-    private readonly dataSourceSupplier: () => DataSource
+    private readonly groupsService: Pick<
+      UserGroupsService,
+      'getGroupsUserIsEligibleFor'
+    >,
+    private readonly wavesDb: Pick<WavesApiDb, 'findWavesByIds'>,
+    private readonly dataSourceSupplier: () => Pick<DataSource, 'getRepository'>
   ) {}
 
   async canRecipientReadWave(

--- a/src/pushNotificationsHandler/identity-push-notification-access.ts
+++ b/src/pushNotificationsHandler/identity-push-notification-access.ts
@@ -15,40 +15,54 @@ export class IdentityPushNotificationAccess {
     private readonly dataSourceSupplier: () => DataSource
   ) {}
 
+  async canRecipientReadWave(
+    identityId: string,
+    waveId: string
+  ): Promise<boolean> {
+    const eligibleGroupIds =
+      await this.groupsService.getGroupsUserIsEligibleFor(identityId);
+    const visibleWaves = await this.wavesDb.findWavesByIds(
+      [waveId],
+      eligibleGroupIds
+    );
+    return visibleWaves.some((wave) => wave.id === waveId);
+  }
+
   async canRecipientReadRelatedContent(
-    notification: IdentityNotificationEntity
+    notification: IdentityNotificationEntity,
+    waveAccessCache?: Map<string, Promise<boolean>>
   ): Promise<boolean> {
     const waveId = notification.wave_id;
     if (!waveId) {
       return true;
     }
 
-    const eligibleGroupIds =
-      await this.groupsService.getGroupsUserIsEligibleFor(
-        notification.identity_id
-      );
-    const visibleWaves = await this.wavesDb.findWavesByIds(
-      [waveId],
-      eligibleGroupIds
-    );
-    if (!visibleWaves.some((wave) => wave.id === waveId)) {
+    const waveAccessKey = `${notification.identity_id}:${waveId}`;
+    let canReadWave = waveAccessCache?.get(waveAccessKey);
+    if (!canReadWave) {
+      canReadWave = this.canRecipientReadWave(notification.identity_id, waveId);
+      waveAccessCache?.set(waveAccessKey, canReadWave);
+    }
+    if (!(await canReadWave)) {
       return false;
     }
 
-    const relatedDropIds = Array.from(
-      new Set(
-        [notification.related_drop_id, notification.related_drop_2_id].filter(
-          (dropId): dropId is string => dropId !== null
-        )
-      )
-    );
+    // Push bodies are rendered from the primary related drop. Secondary drops
+    // may legitimately belong to another wave for cross-wave quote/reply
+    // notifications, so they are not part of this content-access check.
+    const relatedDropIds = notification.related_drop_id
+      ? [notification.related_drop_id]
+      : [];
     if (!relatedDropIds.length) {
       return true;
     }
 
     const relatedDrops = await this.dataSourceSupplier()
       .getRepository(DropEntity)
-      .findBy({ id: In(relatedDropIds) });
+      .find({
+        where: { id: In(relatedDropIds) },
+        select: { id: true, wave_id: true }
+      });
     return (
       relatedDrops.length === relatedDropIds.length &&
       relatedDrops.every((drop) => drop.wave_id === waveId)

--- a/src/pushNotificationsHandler/identityPushNotifications.ts
+++ b/src/pushNotificationsHandler/identityPushNotifications.ts
@@ -47,6 +47,7 @@ import {
 } from '@/pushNotificationsHandler/sendPushNotifications';
 import { identityMutesDb } from '../api-serverless/src/identity-mutes/identity-mutes.db';
 import { wsListenersNotifier } from '../api-serverless/src/ws/ws-listeners-notifier';
+import { identityPushNotificationAccess } from '@/pushNotificationsHandler/identity-push-notification-access';
 
 const CAUSE_TO_SETTING_KEY: Partial<
   Record<IdentityNotificationCause, keyof PushNotificationSettingsData>
@@ -346,6 +347,17 @@ async function buildIdentityNotificationMessages(
     return [];
   }
 
+  const canRecipientReadRelatedContent =
+    await identityPushNotificationAccess.canRecipientReadRelatedContent(
+      notification
+    );
+  if (!canRecipientReadRelatedContent) {
+    logger.warn(
+      `[ID ${notification.id}] Skipping push because identity ${notification.identity_id} cannot read wave ${notification.wave_id}`
+    );
+    return [];
+  }
+
   if (notification.wave_id) {
     const readerMetric = await getDataSource()
       .getRepository(WaveReaderMetricEntity)
@@ -443,12 +455,8 @@ async function buildIdentityNotificationMessages(
               const eligibleGroupIds =
                 await userGroupsService.getGroupsUserIsEligibleFor(profileId);
               const options: {
-                includeNotificationId?: number;
                 enabledCauses?: IdentityNotificationCause[];
               } = { enabledCauses };
-              if (profileId === notification.identity_id) {
-                options.includeNotificationId = notification.id;
-              }
               return identityNotificationsDb.countUnreadNotificationsForIdentity(
                 profileId,
                 eligibleGroupIds,

--- a/src/pushNotificationsHandler/identityPushNotifications.ts
+++ b/src/pushNotificationsHandler/identityPushNotifications.ts
@@ -352,18 +352,6 @@ async function buildIdentityNotificationMessages(
     return [];
   }
 
-  const canRecipientReadRelatedContent =
-    await identityPushNotificationAccess.canRecipientReadRelatedContent(
-      notification,
-      waveAccessCache
-    );
-  if (!canRecipientReadRelatedContent) {
-    logger.warn(
-      `[ID ${notification.id}] Skipping push because identity ${notification.identity_id} cannot read the related content in wave ${notification.wave_id}`
-    );
-    return [];
-  }
-
   if (notification.wave_id) {
     const readerMetric = await getDataSource()
       .getRepository(WaveReaderMetricEntity)
@@ -410,6 +398,18 @@ async function buildIdentityNotificationMessages(
   let multiProfileTitlePrefix: string | null = null;
   if (sharedDeviceTokenKeys.size > 0) {
     multiProfileTitlePrefix = buildMultiProfileTitlePrefix(targetProfileHandle);
+  }
+
+  const canRecipientReadRelatedContent =
+    await identityPushNotificationAccess.canRecipientReadRelatedContent(
+      notification,
+      waveAccessCache
+    );
+  if (!canRecipientReadRelatedContent) {
+    logger.warn(
+      `[ID ${notification.id}] Skipping push because identity ${notification.identity_id} cannot read the related content in wave ${notification.wave_id}`
+    );
+    return [];
   }
 
   const notificationData = await generateNotificationData(notification);

--- a/src/pushNotificationsHandler/identityPushNotifications.ts
+++ b/src/pushNotificationsHandler/identityPushNotifications.ts
@@ -268,6 +268,7 @@ export async function sendIdentityNotificationsBatch(
     .forEach((id) => logger.error(`Notification not found: ${id}`));
 
   const failedIds: number[] = [];
+  const waveAccessCache = new Map<string, Promise<boolean>>();
   const messagesByNotification = await Promise.all(
     uniqueIds.map(async (id) => {
       const notification = notificationsById.get(id);
@@ -281,7 +282,10 @@ export async function sendIdentityNotificationsBatch(
         return [];
       }
       try {
-        return await buildIdentityNotificationMessages(notification);
+        return await buildIdentityNotificationMessages(
+          notification,
+          waveAccessCache
+        );
       } catch (error) {
         logger.error(`Failed to build notification ${id}: ${error}`);
         failedIds.push(id);
@@ -338,7 +342,8 @@ async function findMutedNotificationIds(
 }
 
 async function buildIdentityNotificationMessages(
-  notification: IdentityNotificationEntity
+  notification: IdentityNotificationEntity,
+  waveAccessCache?: Map<string, Promise<boolean>>
 ): Promise<IdentityPushNotificationMessage[]> {
   if (notification.read_at) {
     logger.info(
@@ -349,11 +354,12 @@ async function buildIdentityNotificationMessages(
 
   const canRecipientReadRelatedContent =
     await identityPushNotificationAccess.canRecipientReadRelatedContent(
-      notification
+      notification,
+      waveAccessCache
     );
   if (!canRecipientReadRelatedContent) {
     logger.warn(
-      `[ID ${notification.id}] Skipping push because identity ${notification.identity_id} cannot read wave ${notification.wave_id}`
+      `[ID ${notification.id}] Skipping push because identity ${notification.identity_id} cannot read the related content in wave ${notification.wave_id}`
     );
     return [];
   }


### PR DESCRIPTION
## Summary
- filter direct mention recipients to identities eligible for the wave and parent wave
- re-check wave and related-drop access immediately before push generation
- remove the unread badge visibility bypass for the current notification

## Validation
- Scoped ESLint passes.
- Jest/Testcontainers was not run locally because the configured Colima runtime was unavailable; CI should run the focused and existing backend tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification targeting for private waves, including correct direct-mention filtering and parent/child wave eligibility handling.
  * Push notifications are now withheld when recipients can’t access the relevant wave or (when applicable) the referenced drop content.
  * Improved unread notification counts by removing outdated “include specific notification” counting logic.
* **Tests**
  * Added/expanded unit tests covering recipient selection, wave/drop access decisions (including cached checks), and visible-only unread counting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->