### PR TITLE
Bound Release Bus experimental history

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -494,8 +494,9 @@ endpoint is reserved for the controlled pre-go-live clean slate: every control
 must already be paused, and the transaction locks and rejects any active train,
 operation, or lane lease before deleting only Release Bus journal rows in
 dependency-safe order. Schema, controls, lane rows, secrets, and application
-data remain intact; controls remain deterministically paused until a fresh
-operator handshake resumes them.
+data remain intact. A required UUID reset id makes lost-response retries
+idempotent, and controls remain deterministically paused until a fresh operator
+handshake resumes them.
 Backend units whose registry policy is `production-only` are built and tested
 in preflight but cannot be runtime-deployed to staging; their staging gate is
 the combined application E2E suite plus the immutable artifact evidence. The

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -485,7 +485,17 @@ mode in Lambda configuration, while the staging API is explicitly forced to
 `RELEASE_BUS_MODE` intentionally controls the production-region API, starter,
 and worker; the orchestrator is not deployed separately in staging. The
 cleaner shares the App identity because it lists and deletes expired temporary
-branches in both repositories.
+branches in both repositories. It also prunes terminal Release Bus trains and
+unreferenced terminal candidates in transactionally bounded batches after
+`RELEASE_BUS_HISTORY_RETENTION_DAYS` (30 days by default, constrained to
+1–365 days). Retained train membership always keeps its candidate rows.
+The operator-only `POST /deploy/release-bus/reset-experimental-history`
+endpoint is reserved for the controlled pre-go-live clean slate: every control
+must already be paused, and the transaction locks and rejects any active train,
+operation, or lane lease before deleting only Release Bus journal rows in
+dependency-safe order. Schema, controls, lane rows, secrets, and application
+data remain intact; controls remain deterministically paused until a fresh
+operator handshake resumes them.
 Backend units whose registry policy is `production-only` are built and tested
 in preflight but cannot be runtime-deployed to staging; their staging gate is
 the combined application E2E suite plus the immutable artifact evidence. The

--- a/src/api-serverless/src/deploy/deploy-release-bus-routes.test.ts
+++ b/src/api-serverless/src/deploy/deploy-release-bus-routes.test.ts
@@ -70,6 +70,7 @@ jest.mock('@/releaseBus/release-bus.github-app', () => ({
 }));
 
 jest.mock('@/releaseBus/release-bus.service', () => ({
+  ...jest.requireActual('@/releaseBus/release-bus.service'),
   releaseBusService: {
     pauseForBreakGlass: (...args: unknown[]) => mockPauseForBreakGlass(...args),
     markReady: (...args: unknown[]) => mockMarkReady(...args),
@@ -83,11 +84,13 @@ import express, { NextFunction, Request, Response } from 'express';
 import { Server } from 'node:http';
 import { ApiCompliantException } from '@/exceptions';
 import deployRoutes from '@/api/deploy/deploy.routes';
+import { ReleaseBusHistoryResetBlockedError } from '@/releaseBus/release-bus.service';
 
 const WORKFLOW_TOKEN = 'release-bus-workflow-token';
 const TRAIN_ID = '123e4567-e89b-42d3-a456-426614174000';
 const SHA = 'a'.repeat(40);
 const DIGEST = 'b'.repeat(64);
+const RESET_ID = '123e4567-e89b-42d3-a456-426614174001';
 
 function candidate(status: 'READY_FOR_STAGING' | 'CANCELLED') {
   return {
@@ -800,7 +803,8 @@ describe('release-bus experimental history reset', () => {
     mockIsOrganizationOperator.mockResolvedValue(true);
     mockResetExperimentalHistory.mockResolvedValue({
       reset_at: 123456,
-      actor: 'operator'
+      actor: 'operator',
+      reused: false
     });
     mockListControls.mockResolvedValue([
       { scope: 'ALL', paused: 1 },
@@ -815,6 +819,7 @@ describe('release-bus experimental history reset', () => {
     const response = await post(
       '/deploy/release-bus/reset-experimental-history',
       {
+        reset_id: RESET_ID,
         confirmation: 'RESET_RELEASE_BUS_EXPERIMENTAL_HISTORY',
         reason: 'Controlled go-live reset after all operations are quiescent'
       }
@@ -828,6 +833,7 @@ describe('release-bus experimental history reset', () => {
     const response = await post(
       '/deploy/release-bus/reset-experimental-history',
       {
+        reset_id: RESET_ID,
         confirmation: 'reset',
         reason: 'Controlled go-live reset after all operations are quiescent'
       }
@@ -839,12 +845,15 @@ describe('release-bus experimental history reset', () => {
 
   it('reports a quiescence race as a conflict', async () => {
     mockResetExperimentalHistory.mockRejectedValue(
-      new Error('An active release operation blocks history reset')
+      new ReleaseBusHistoryResetBlockedError(
+        'An active release operation blocks history reset'
+      )
     );
 
     const response = await post(
       '/deploy/release-bus/reset-experimental-history',
       {
+        reset_id: RESET_ID,
         confirmation: 'RESET_RELEASE_BUS_EXPERIMENTAL_HISTORY',
         reason: 'Controlled go-live reset after all operations are quiescent'
       }
@@ -859,6 +868,7 @@ describe('release-bus experimental history reset', () => {
     const response = await post(
       '/deploy/release-bus/reset-experimental-history',
       {
+        reset_id: RESET_ID,
         confirmation: 'RESET_RELEASE_BUS_EXPERIMENTAL_HISTORY',
         reason: 'Controlled go-live reset after all operations are quiescent'
       }
@@ -869,6 +879,7 @@ describe('release-bus experimental history reset', () => {
       reset: true,
       reset_at: 123456,
       actor: 'operator',
+      reused: false,
       controls: [
         { scope: 'ALL', paused: 1 },
         { scope: 'STAGING', paused: 1 },
@@ -877,8 +888,46 @@ describe('release-bus experimental history reset', () => {
     });
     expect(mockResetExperimentalHistory).toHaveBeenCalledWith(
       'Controlled go-live reset after all operations are quiescent',
-      'operator'
+      'operator',
+      RESET_ID
     );
+  });
+
+  it('does not invite a retry when the post-reset controls read fails', async () => {
+    mockListControls.mockRejectedValue(new Error('database read failed'));
+
+    const response = await post(
+      '/deploy/release-bus/reset-experimental-history',
+      {
+        reset_id: RESET_ID,
+        confirmation: 'RESET_RELEASE_BUS_EXPERIMENTAL_HISTORY',
+        reason: 'Controlled go-live reset after all operations are quiescent'
+      }
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      reset: true,
+      controls: null,
+      controls_status: 'unavailable'
+    });
+  });
+
+  it('does not mask an unexpected reset failure as a conflict', async () => {
+    mockResetExperimentalHistory.mockRejectedValue(
+      new Error('database transaction failed')
+    );
+
+    const response = await post(
+      '/deploy/release-bus/reset-experimental-history',
+      {
+        reset_id: RESET_ID,
+        confirmation: 'RESET_RELEASE_BUS_EXPERIMENTAL_HISTORY',
+        reason: 'Controlled go-live reset after all operations are quiescent'
+      }
+    );
+
+    expect(response.status).toBe(500);
   });
 });
 

--- a/src/api-serverless/src/deploy/deploy-release-bus-routes.test.ts
+++ b/src/api-serverless/src/deploy/deploy-release-bus-routes.test.ts
@@ -20,6 +20,8 @@ const mockListTrains = jest.fn();
 const mockFindTrain = jest.fn();
 const mockListTrainItems = jest.fn();
 const mockGetReleaseTrainOverview = jest.fn();
+const mockListControls = jest.fn();
+const mockResetExperimentalHistory = jest.fn();
 
 jest.mock('@/releaseBus/release-bus.repository', () => ({
   releaseBusRepository: {
@@ -34,7 +36,8 @@ jest.mock('@/releaseBus/release-bus.repository', () => ({
     findCandidateById: (...args: unknown[]) => mockFindCandidateById(...args),
     listTrains: (...args: unknown[]) => mockListTrains(...args),
     findTrain: (...args: unknown[]) => mockFindTrain(...args),
-    listTrainItems: (...args: unknown[]) => mockListTrainItems(...args)
+    listTrainItems: (...args: unknown[]) => mockListTrainItems(...args),
+    listControls: (...args: unknown[]) => mockListControls(...args)
   }
 }));
 
@@ -70,7 +73,9 @@ jest.mock('@/releaseBus/release-bus.service', () => ({
   releaseBusService: {
     pauseForBreakGlass: (...args: unknown[]) => mockPauseForBreakGlass(...args),
     markReady: (...args: unknown[]) => mockMarkReady(...args),
-    cancel: (...args: unknown[]) => mockCancel(...args)
+    cancel: (...args: unknown[]) => mockCancel(...args),
+    resetExperimentalHistory: (...args: unknown[]) =>
+      mockResetExperimentalHistory(...args)
   }
 }));
 
@@ -785,6 +790,95 @@ describe('release-bus progress reporting', () => {
     expect(response.body.error).toContain('terminal progress report');
     expect(mockUpdateOperation).not.toHaveBeenCalled();
     expect(mockAppendEvent).not.toHaveBeenCalled();
+  });
+});
+
+describe('release-bus experimental history reset', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetViewer.mockResolvedValue({ login: 'operator' });
+    mockIsOrganizationOperator.mockResolvedValue(true);
+    mockResetExperimentalHistory.mockResolvedValue({
+      reset_at: 123456,
+      actor: 'operator'
+    });
+    mockListControls.mockResolvedValue([
+      { scope: 'ALL', paused: 1 },
+      { scope: 'STAGING', paused: 1 },
+      { scope: 'PRODUCTION', paused: 1 }
+    ]);
+  });
+
+  it('requires Release Bus operator authorization', async () => {
+    mockIsOrganizationOperator.mockResolvedValue(false);
+
+    const response = await post(
+      '/deploy/release-bus/reset-experimental-history',
+      {
+        confirmation: 'RESET_RELEASE_BUS_EXPERIMENTAL_HISTORY',
+        reason: 'Controlled go-live reset after all operations are quiescent'
+      }
+    );
+
+    expect(response.status).toBe(403);
+    expect(mockResetExperimentalHistory).not.toHaveBeenCalled();
+  });
+
+  it('rejects an inexact destructive confirmation', async () => {
+    const response = await post(
+      '/deploy/release-bus/reset-experimental-history',
+      {
+        confirmation: 'reset',
+        reason: 'Controlled go-live reset after all operations are quiescent'
+      }
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockResetExperimentalHistory).not.toHaveBeenCalled();
+  });
+
+  it('reports a quiescence race as a conflict', async () => {
+    mockResetExperimentalHistory.mockRejectedValue(
+      new Error('An active release operation blocks history reset')
+    );
+
+    const response = await post(
+      '/deploy/release-bus/reset-experimental-history',
+      {
+        confirmation: 'RESET_RELEASE_BUS_EXPERIMENTAL_HISTORY',
+        reason: 'Controlled go-live reset after all operations are quiescent'
+      }
+    );
+
+    expect(response.status).toBe(409);
+    expect(response.body.error).toContain('active release operation');
+    expect(mockListControls).not.toHaveBeenCalled();
+  });
+
+  it('returns the deterministic paused controls after a reset', async () => {
+    const response = await post(
+      '/deploy/release-bus/reset-experimental-history',
+      {
+        confirmation: 'RESET_RELEASE_BUS_EXPERIMENTAL_HISTORY',
+        reason: 'Controlled go-live reset after all operations are quiescent'
+      }
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      reset: true,
+      reset_at: 123456,
+      actor: 'operator',
+      controls: [
+        { scope: 'ALL', paused: 1 },
+        { scope: 'STAGING', paused: 1 },
+        { scope: 'PRODUCTION', paused: 1 }
+      ]
+    });
+    expect(mockResetExperimentalHistory).toHaveBeenCalledWith(
+      'Controlled go-live reset after all operations are quiescent',
+      'operator'
+    );
   });
 });
 

--- a/src/api-serverless/src/deploy/deploy-validation.test.ts
+++ b/src/api-serverless/src/deploy/deploy-validation.test.ts
@@ -188,20 +188,30 @@ describe('deploy.validation', () => {
   it('requires an exact destructive reset confirmation and bounded reason', () => {
     expect(
       ReleaseBusExperimentalResetBodySchema.validate({
+        reset_id: '123e4567-e89b-42d3-a456-426614174001',
         confirmation: 'RESET_RELEASE_BUS_EXPERIMENTAL_HISTORY',
         reason: 'Release Bus go-live clean-slate reset after full quiescence'
       }).error
     ).toBeUndefined();
     expect(
       ReleaseBusExperimentalResetBodySchema.validate({
+        reset_id: '123e4567-e89b-42d3-a456-426614174001',
         confirmation: 'reset',
         reason: 'Release Bus go-live clean-slate reset after full quiescence'
       }).error
     ).toBeDefined();
     expect(
       ReleaseBusExperimentalResetBodySchema.validate({
+        reset_id: '123e4567-e89b-42d3-a456-426614174001',
         confirmation: 'RESET_RELEASE_BUS_EXPERIMENTAL_HISTORY',
         reason: 'too short'
+      }).error
+    ).toBeDefined();
+    expect(
+      ReleaseBusExperimentalResetBodySchema.validate({
+        reset_id: 'not-a-uuid',
+        confirmation: 'RESET_RELEASE_BUS_EXPERIMENTAL_HISTORY',
+        reason: 'Release Bus go-live clean-slate reset after full quiescence'
       }).error
     ).toBeDefined();
   });

--- a/src/api-serverless/src/deploy/deploy-validation.test.ts
+++ b/src/api-serverless/src/deploy/deploy-validation.test.ts
@@ -2,6 +2,7 @@ import {
   DeployDispatchBodySchema,
   ReleaseBusAuthorizationBodySchema,
   ReleaseBusBreakGlassAuthorizationBodySchema,
+  ReleaseBusExperimentalResetBodySchema,
   ReleaseBusProgressReportBodySchema,
   ReleaseCandidateReadyBodySchema
 } from '@/api/deploy/deploy.validation';
@@ -180,6 +181,27 @@ describe('deploy.validation', () => {
         service: null,
         expected_sha: 'd'.repeat(40),
         reason: ''
+      }).error
+    ).toBeDefined();
+  });
+
+  it('requires an exact destructive reset confirmation and bounded reason', () => {
+    expect(
+      ReleaseBusExperimentalResetBodySchema.validate({
+        confirmation: 'RESET_RELEASE_BUS_EXPERIMENTAL_HISTORY',
+        reason: 'Release Bus go-live clean-slate reset after full quiescence'
+      }).error
+    ).toBeUndefined();
+    expect(
+      ReleaseBusExperimentalResetBodySchema.validate({
+        confirmation: 'reset',
+        reason: 'Release Bus go-live clean-slate reset after full quiescence'
+      }).error
+    ).toBeDefined();
+    expect(
+      ReleaseBusExperimentalResetBodySchema.validate({
+        confirmation: 'RESET_RELEASE_BUS_EXPERIMENTAL_HISTORY',
+        reason: 'too short'
       }).error
     ).toBeDefined();
   });

--- a/src/api-serverless/src/deploy/deploy.routes.ts
+++ b/src/api-serverless/src/deploy/deploy.routes.ts
@@ -38,7 +38,10 @@ import {
   getReleaseBusMode,
   RELEASE_BUS_OPERATOR_TEAM
 } from '@/releaseBus/release-bus.config';
-import { releaseBusService } from '@/releaseBus/release-bus.service';
+import {
+  ReleaseBusHistoryResetBlockedError,
+  releaseBusService
+} from '@/releaseBus/release-bus.service';
 import { getReleaseTrainOverview } from '@/releaseBus/release-bus-status.service';
 import type {
   MarkReleaseReadyInput,
@@ -502,26 +505,34 @@ deployRoutes.post(
     const token = getGitHubTokenOrThrow(req);
     const actor = await requireOperator(token);
     const body = getValidatedByJoiOrThrow<{
+      reset_id: string;
       confirmation: 'RESET_RELEASE_BUS_EXPERIMENTAL_HISTORY';
       reason: string;
     }>(req.body, ReleaseBusExperimentalResetBodySchema);
     try {
       const result = await releaseBusService.resetExperimentalHistory(
         body.reason,
-        actor
+        actor,
+        body.reset_id
       );
+      let controls = null;
+      try {
+        controls = await releaseBusRepository.listControls({});
+      } catch {
+        // The reset transaction has already committed. Return its terminal
+        // result so a transient read failure cannot invite a destructive retry.
+      }
       setNoStoreHeaders(res);
       return res.json({
         reset: true,
         ...result,
-        controls: await releaseBusRepository.listControls({}),
+        controls,
+        controls_status: controls ? 'available' : 'unavailable',
         mode: getReleaseBusMode()
       });
     } catch (error) {
-      throw new CustomApiCompliantException(
-        409,
-        error instanceof Error ? error.message : 'Release Bus reset was blocked'
-      );
+      if (!(error instanceof ReleaseBusHistoryResetBlockedError)) throw error;
+      throw new CustomApiCompliantException(409, error.message);
     }
   }
 );

--- a/src/api-serverless/src/deploy/deploy.routes.ts
+++ b/src/api-serverless/src/deploy/deploy.routes.ts
@@ -24,6 +24,7 @@ import {
   DeployRunsQuerySchema,
   ReleaseBusBreakGlassAuthorizationBodySchema,
   ReleaseBusControlBodySchema,
+  ReleaseBusExperimentalResetBodySchema,
   ReleaseBusAuthorizationBodySchema,
   ReleaseBusProgressReportBodySchema,
   ReleaseCandidateListQuerySchema,
@@ -494,6 +495,36 @@ deployRoutes.post('/release-bus/resume', async (req, res) => {
   setNoStoreHeaders(res);
   return res.json(await updateBusControl(req, false));
 });
+
+deployRoutes.post(
+  '/release-bus/reset-experimental-history',
+  async (req, res) => {
+    const token = getGitHubTokenOrThrow(req);
+    const actor = await requireOperator(token);
+    const body = getValidatedByJoiOrThrow<{
+      confirmation: 'RESET_RELEASE_BUS_EXPERIMENTAL_HISTORY';
+      reason: string;
+    }>(req.body, ReleaseBusExperimentalResetBodySchema);
+    try {
+      const result = await releaseBusService.resetExperimentalHistory(
+        body.reason,
+        actor
+      );
+      setNoStoreHeaders(res);
+      return res.json({
+        reset: true,
+        ...result,
+        controls: await releaseBusRepository.listControls({}),
+        mode: getReleaseBusMode()
+      });
+    } catch (error) {
+      throw new CustomApiCompliantException(
+        409,
+        error instanceof Error ? error.message : 'Release Bus reset was blocked'
+      );
+    }
+  }
+);
 
 deployRoutes.post('/release-bus/authorize', async (req, res) => {
   requireWorkflowCredential(req);

--- a/src/api-serverless/src/deploy/deploy.validation.ts
+++ b/src/api-serverless/src/deploy/deploy.validation.ts
@@ -153,6 +153,9 @@ export const ReleaseBusControlBodySchema = Joi.object({
 }).required();
 
 export const ReleaseBusExperimentalResetBodySchema = Joi.object({
+  reset_id: Joi.string()
+    .guid({ version: ['uuidv4'] })
+    .required(),
   confirmation: Joi.string()
     .valid('RESET_RELEASE_BUS_EXPERIMENTAL_HISTORY')
     .required(),

--- a/src/api-serverless/src/deploy/deploy.validation.ts
+++ b/src/api-serverless/src/deploy/deploy.validation.ts
@@ -152,6 +152,13 @@ export const ReleaseBusControlBodySchema = Joi.object({
   reason: Joi.string().trim().min(3).max(1000).required()
 }).required();
 
+export const ReleaseBusExperimentalResetBodySchema = Joi.object({
+  confirmation: Joi.string()
+    .valid('RESET_RELEASE_BUS_EXPERIMENTAL_HISTORY')
+    .required(),
+  reason: Joi.string().trim().min(20).max(1000).required()
+}).required();
+
 const ReleaseBusReportPathSchema = Joi.string()
   .trim()
   .min(1)

--- a/src/releaseBus/index.ts
+++ b/src/releaseBus/index.ts
@@ -359,6 +359,16 @@ const cleaner: Handler = async () =>
         1000;
       if (!Number.isFinite(retentionMs) || retentionMs < 24 * 60 * 60 * 1000)
         throw new Error('Invalid release-bus branch retention');
+      const historyRetentionDays = Number(
+        process.env.RELEASE_BUS_HISTORY_RETENTION_DAYS ?? '30'
+      );
+      if (
+        !Number.isSafeInteger(historyRetentionDays) ||
+        historyRetentionDays < 1 ||
+        historyRetentionDays > 365
+      )
+        throw new Error('Invalid release-bus history retention');
+      const historyRetentionMs = historyRetentionDays * 24 * 60 * 60 * 1000;
       const trains = await releaseBusRepository.listTrains(500, {});
       const protectedRefs = new Set(
         trains
@@ -383,7 +393,10 @@ const cleaner: Handler = async () =>
           deleted.push(`${repository}:${ref.ref}`);
         }
       }
-      return { deleted };
+      const history = await releaseBusService.pruneTerminalHistory(
+        Date.now() - historyRetentionMs
+      );
+      return { deleted, history };
     },
     { logger, entities, skipRedis: true }
   );

--- a/src/releaseBus/index.ts
+++ b/src/releaseBus/index.ts
@@ -351,14 +351,16 @@ const worker: Handler<{ train_id: string; worker_arn: string }> = async (
 const cleaner: Handler = async () =>
   doInDbContext(
     async () => {
-      const retentionMs =
-        Number(process.env.RELEASE_BUS_BRANCH_RETENTION_DAYS ?? '7') *
-        24 *
-        60 *
-        60 *
-        1000;
-      if (!Number.isFinite(retentionMs) || retentionMs < 24 * 60 * 60 * 1000)
+      const branchRetentionDays = Number(
+        process.env.RELEASE_BUS_BRANCH_RETENTION_DAYS ?? '7'
+      );
+      if (
+        !Number.isSafeInteger(branchRetentionDays) ||
+        branchRetentionDays < 1 ||
+        branchRetentionDays > 365
+      )
         throw new Error('Invalid release-bus branch retention');
+      const retentionMs = branchRetentionDays * 24 * 60 * 60 * 1000;
       const historyRetentionDays = Number(
         process.env.RELEASE_BUS_HISTORY_RETENTION_DAYS ?? '30'
       );

--- a/src/releaseBus/release-bus-handler-secret-order.test.ts
+++ b/src/releaseBus/release-bus-handler-secret-order.test.ts
@@ -16,6 +16,12 @@ const mockListReleaseBusRefs = jest.fn(async () => {
   expect(process.env.RELEASE_BUS_GITHUB_PRIVATE_KEY).toBe('private-key');
   return [];
 });
+const mockPruneTerminalHistory = jest.fn(async (cutoffAt: number) => {
+  callOrder.push('history');
+  expect(cutoffAt).toBeGreaterThan(0);
+  expect(cutoffAt).toBeLessThan(Date.now());
+  return { trains: 0, candidates: 0 };
+});
 
 jest.mock('@/env', () => ({ prepEnvironment: mockPrepEnvironment }));
 jest.mock('@/db', () => ({
@@ -42,7 +48,9 @@ jest.mock('@/releaseBus/release-bus.github-app', () => ({
   }
 }));
 jest.mock('@/releaseBus/release-bus.service', () => ({
-  releaseBusService: {}
+  releaseBusService: {
+    pruneTerminalHistory: mockPruneTerminalHistory
+  }
 }));
 jest.mock('@/releaseBus/release-bus.metrics', () => ({
   publishReleaseBusMetrics: jest.fn()
@@ -73,7 +81,8 @@ describe('Release Bus handler secret ordering', () => {
       'database',
       'repository',
       'github',
-      'github'
+      'github',
+      'history'
     ]);
   });
 });

--- a/src/releaseBus/release-bus-idempotency.test.ts
+++ b/src/releaseBus/release-bus-idempotency.test.ts
@@ -303,7 +303,38 @@ describe('release operation idempotency', () => {
     expect(sql[candidateSelect]).toContain(
       'not exists ( select 1 from release_train_items item where item.candidate_id = candidate.id )'
     );
+    expect(sql[candidateSelect]).toContain(
+      'where dependency.depends_on_candidate_id = candidate.id'
+    );
     expect(candidateDelete).toBeGreaterThan(candidateSelect);
+    const dependencyDelete = sql.find((statement) =>
+      statement.startsWith('delete from release_candidate_dependencies')
+    );
+    expect(dependencyDelete).toContain('where candidate_id in (:candidateIds)');
+    expect(dependencyDelete).not.toContain('depends_on_candidate_id in');
+  });
+
+  it('loads an experimental reset by its idempotency key under lock', async () => {
+    const execute = jest.fn().mockResolvedValue([]);
+    const oneOrNull = jest.fn().mockResolvedValue({
+      event_type: 'EXPERIMENTAL_HISTORY_RESET'
+    });
+    const repository = new ReleaseBusRepository(
+      () => ({ execute, oneOrNull }) as unknown as SqlExecutor
+    );
+
+    await expect(
+      repository.findExperimentalHistoryReset(
+        '123e4567-e89b-42d3-a456-426614174001',
+        {}
+      )
+    ).resolves.toMatchObject({ event_type: 'EXPERIMENTAL_HISTORY_RESET' });
+    expect(
+      oneOrNull.mock.calls[0]?.[0].trim().split(/\s+/).join(' ')
+    ).toContain(
+      "json_unquote(json_extract(payload_json, '$.reset_id')) = :resetId"
+    );
+    expect(oneOrNull.mock.calls[0]?.[0]).toContain('for update');
   });
 
   it('resets experimental rows in dependency-safe order and retains an audit event', async () => {
@@ -315,6 +346,7 @@ describe('release operation idempotency', () => {
     await repository.resetExperimentalHistory(
       'Controlled go-live reset',
       'operator',
+      '123e4567-e89b-42d3-a456-426614174001',
       {}
     );
 
@@ -336,7 +368,10 @@ describe('release operation idempotency', () => {
     expect(sql.at(-1)).toContain('insert into release_train_events');
     expect(execute.mock.calls.at(-1)?.[1]).toMatchObject({
       eventType: 'EXPERIMENTAL_HISTORY_RESET',
-      githubActor: 'operator'
+      githubActor: 'operator',
+      trainId: null,
+      candidateId: null,
+      payload: expect.stringContaining('123e4567-e89b-42d3-a456-426614174001')
     });
   });
 });

--- a/src/releaseBus/release-bus-idempotency.test.ts
+++ b/src/releaseBus/release-bus-idempotency.test.ts
@@ -261,4 +261,82 @@ describe('release operation idempotency', () => {
     ).rejects.toThrow('exceeds the maximum 50');
     expect(execute).not.toHaveBeenCalled();
   });
+
+  it('prunes terminal trains before unreferenced terminal candidates', async () => {
+    const execute = jest.fn(async (sql: string) => {
+      const normalized = sql.trim().split(/\s+/).join(' ');
+      if (normalized.startsWith('select id from release_trains'))
+        return [{ id: 'train-old' }];
+      if (
+        normalized.startsWith(
+          'select candidate.id from release_ready_deployments candidate'
+        )
+      )
+        return [{ id: 'candidate-old' }];
+      return { affectedRows: 1 };
+    });
+    const repository = new ReleaseBusRepository(
+      () => ({ execute }) as unknown as SqlExecutor
+    );
+
+    await expect(
+      repository.pruneTerminalHistory(123456, 500, {})
+    ).resolves.toEqual({ trains: 1, candidates: 1 });
+
+    const sql = execute.mock.calls.map(([statement]) =>
+      statement.trim().split(/\s+/).join(' ')
+    );
+    const trainItemDelete = sql.findIndex((statement) =>
+      statement.startsWith('delete from release_train_items')
+    );
+    const candidateSelect = sql.findIndex((statement) =>
+      statement.startsWith(
+        'select candidate.id from release_ready_deployments candidate'
+      )
+    );
+    const candidateDelete = sql.findIndex((statement) =>
+      statement.startsWith('delete from release_ready_deployments')
+    );
+    expect(sql[0]).toContain('limit 100');
+    expect(trainItemDelete).toBeGreaterThan(0);
+    expect(candidateSelect).toBeGreaterThan(trainItemDelete);
+    expect(sql[candidateSelect]).toContain(
+      'not exists ( select 1 from release_train_items item where item.candidate_id = candidate.id )'
+    );
+    expect(candidateDelete).toBeGreaterThan(candidateSelect);
+  });
+
+  it('resets experimental rows in dependency-safe order and retains an audit event', async () => {
+    const execute = jest.fn().mockResolvedValue({ affectedRows: 1 });
+    const repository = new ReleaseBusRepository(
+      () => ({ execute }) as unknown as SqlExecutor
+    );
+
+    await repository.resetExperimentalHistory(
+      'Controlled go-live reset',
+      'operator',
+      {}
+    );
+
+    const sql = execute.mock.calls.map(([statement]) =>
+      statement.trim().split(/\s+/).join(' ')
+    );
+    expect(sql.slice(0, 7)).toEqual([
+      'delete from release_train_events',
+      'delete from release_train_evidence',
+      'delete from release_train_operations',
+      'delete from release_train_items',
+      'delete from release_candidate_dependencies',
+      'delete from release_ready_deployments',
+      'delete from release_trains'
+    ]);
+    expect(sql[7]).toContain(
+      'update release_deployment_lanes set train_id = null, lease_owner = null, lease_token = null'
+    );
+    expect(sql.at(-1)).toContain('insert into release_train_events');
+    expect(execute.mock.calls.at(-1)?.[1]).toMatchObject({
+      eventType: 'EXPERIMENTAL_HISTORY_RESET',
+      githubActor: 'operator'
+    });
+  });
 });

--- a/src/releaseBus/release-bus.repository.ts
+++ b/src/releaseBus/release-bus.repository.ts
@@ -120,6 +120,11 @@ export type ReleaseTrainEvidenceRecord = {
   readonly created_at: number | string;
 };
 
+export type ReleaseBusPruneResult = {
+  readonly trains: number;
+  readonly candidates: number;
+};
+
 function dbOptions(ctx: RequestContext) {
   return ctx.connection ? { wrappedConnection: ctx.connection } : undefined;
 }
@@ -860,6 +865,18 @@ export class ReleaseBusRepository extends LazyDbAccessCompatibleService {
     );
   }
 
+  public async findActiveOperation(
+    ctx: RequestContext
+  ): Promise<ReleaseOperationRecord | null> {
+    return this.db.oneOrNull<ReleaseOperationRecord>(
+      `select * from ${RELEASE_TRAIN_OPERATIONS_TABLE}
+       where status in ('PENDING', 'DISPATCHED', 'RUNNING')
+       order by created_at limit 1 for update`,
+      undefined,
+      dbOptions(ctx)
+    );
+  }
+
   public async setControl(
     scope: ReleaseControlScope,
     paused: boolean,
@@ -926,11 +943,152 @@ export class ReleaseBusRepository extends LazyDbAccessCompatibleService {
     );
   }
 
-  public async listLanes(ctx: RequestContext): Promise<ReleaseLaneRecord[]> {
+  public async listLanes(
+    ctx: RequestContext,
+    forUpdate = false
+  ): Promise<ReleaseLaneRecord[]> {
     return this.db.execute<ReleaseLaneRecord>(
-      `select * from ${RELEASE_DEPLOYMENT_LANES_TABLE} order by name`,
+      `select * from ${RELEASE_DEPLOYMENT_LANES_TABLE} order by name${forUpdate ? ' for update' : ''}`,
       undefined,
       dbOptions(ctx)
+    );
+  }
+
+  public async pruneTerminalHistory(
+    cutoffAt: number,
+    batchSize: number,
+    ctx: RequestContext
+  ): Promise<ReleaseBusPruneResult> {
+    if (!Number.isSafeInteger(cutoffAt) || cutoffAt <= 0)
+      throw new Error('Invalid release-bus history cutoff');
+    const boundedBatchSize = Math.max(1, Math.min(Math.trunc(batchSize), 100));
+    const terminalCandidateStatuses: ReleaseCandidateStatus[] = [
+      'PRODUCTION_VALIDATED',
+      'STAGING_FAILED',
+      'SUPERSEDED',
+      'QUARANTINED',
+      'CANCELLED'
+    ];
+    const trainRows = await this.db.execute<{ id: string }>(
+      `select id from ${RELEASE_TRAINS_TABLE}
+       where status in ('COMPLETED', 'FAILED', 'ROLLED_BACK', 'CANCELLED')
+         and completed_at is not null and completed_at < :cutoffAt
+       order by completed_at, id limit ${boundedBatchSize}`,
+      { cutoffAt },
+      dbOptions(ctx)
+    );
+    const trainIds = trainRows.map((row) => row.id);
+    if (trainIds.length > 0) {
+      await this.db.execute(
+        `update ${RELEASE_READY_DEPLOYMENTS_TABLE}
+         set current_train_id = null, updated_at = :now, row_version = row_version + 1
+         where current_train_id in (:trainIds)`,
+        { trainIds, now: Date.now() },
+        dbOptions(ctx)
+      );
+      for (const table of [
+        RELEASE_TRAIN_EVENTS_TABLE,
+        RELEASE_TRAIN_EVIDENCE_TABLE,
+        RELEASE_TRAIN_OPERATIONS_TABLE,
+        RELEASE_TRAIN_ITEMS_TABLE
+      ]) {
+        await this.db.execute(
+          `delete from ${table} where train_id in (:trainIds)`,
+          { trainIds },
+          dbOptions(ctx)
+        );
+      }
+      await this.db.execute(
+        `delete from ${RELEASE_TRAINS_TABLE} where id in (:trainIds)`,
+        { trainIds },
+        dbOptions(ctx)
+      );
+    }
+
+    // Candidate history is pruned only after its terminal train items have
+    // been removed. This keeps every retained train membership resolvable even
+    // when train and candidate retention batches are cut at different points.
+    const candidateRows = await this.db.execute<{ id: string }>(
+      `select candidate.id from ${RELEASE_READY_DEPLOYMENTS_TABLE} candidate
+       where candidate.status in (:terminalCandidateStatuses)
+         and candidate.updated_at < :cutoffAt
+         and not exists (
+           select 1 from ${RELEASE_TRAIN_ITEMS_TABLE} item
+           where item.candidate_id = candidate.id
+         )
+         and not exists (
+           select 1 from ${RELEASE_CANDIDATE_DEPENDENCIES_TABLE} dependency
+           join ${RELEASE_READY_DEPLOYMENTS_TABLE} dependant
+             on dependant.id = dependency.candidate_id
+           where dependency.depends_on_candidate_id = candidate.id
+             and dependant.status not in (:terminalCandidateStatuses)
+         )
+       order by candidate.updated_at, candidate.id limit ${boundedBatchSize}`,
+      { cutoffAt, terminalCandidateStatuses },
+      dbOptions(ctx)
+    );
+    const candidateIds = candidateRows.map((row) => row.id);
+    if (candidateIds.length > 0) {
+      await this.db.execute(
+        `delete from ${RELEASE_CANDIDATE_DEPENDENCIES_TABLE}
+         where candidate_id in (:candidateIds)
+            or depends_on_candidate_id in (:candidateIds)`,
+        { candidateIds },
+        dbOptions(ctx)
+      );
+      await this.db.execute(
+        `delete from ${RELEASE_TRAIN_EVENTS_TABLE} where candidate_id in (:candidateIds)`,
+        { candidateIds },
+        dbOptions(ctx)
+      );
+      await this.db.execute(
+        `delete from ${RELEASE_TRAIN_EVIDENCE_TABLE} where candidate_id in (:candidateIds)`,
+        { candidateIds },
+        dbOptions(ctx)
+      );
+      await this.db.execute(
+        `delete from ${RELEASE_READY_DEPLOYMENTS_TABLE} where id in (:candidateIds)`,
+        { candidateIds },
+        dbOptions(ctx)
+      );
+    }
+    return { trains: trainIds.length, candidates: candidateIds.length };
+  }
+
+  public async resetExperimentalHistory(
+    reason: string,
+    actor: string,
+    ctx: RequestContext
+  ): Promise<void> {
+    for (const table of [
+      RELEASE_TRAIN_EVENTS_TABLE,
+      RELEASE_TRAIN_EVIDENCE_TABLE,
+      RELEASE_TRAIN_OPERATIONS_TABLE,
+      RELEASE_TRAIN_ITEMS_TABLE,
+      RELEASE_CANDIDATE_DEPENDENCIES_TABLE,
+      RELEASE_READY_DEPLOYMENTS_TABLE,
+      RELEASE_TRAINS_TABLE
+    ]) {
+      await this.db.execute(`delete from ${table}`, undefined, dbOptions(ctx));
+    }
+    await this.db.execute(
+      `update ${RELEASE_DEPLOYMENT_LANES_TABLE}
+       set train_id = null, lease_owner = null, lease_token = null,
+           heartbeat_at = null, expires_at = null, updated_at = :now,
+           row_version = row_version + 1`,
+      { now: Date.now() },
+      dbOptions(ctx)
+    );
+    for (const scope of ['ALL', 'STAGING', 'PRODUCTION'] as const) {
+      await this.setControl(scope, true, reason, actor, ctx);
+    }
+    await this.appendEvent(
+      {
+        eventType: 'EXPERIMENTAL_HISTORY_RESET',
+        githubActor: actor,
+        payload: { reason }
+      },
+      ctx
     );
   }
 

--- a/src/releaseBus/release-bus.repository.ts
+++ b/src/releaseBus/release-bus.repository.ts
@@ -877,6 +877,20 @@ export class ReleaseBusRepository extends LazyDbAccessCompatibleService {
     );
   }
 
+  public async findExperimentalHistoryReset(
+    resetId: string,
+    ctx: RequestContext
+  ): Promise<ReleaseTrainEventRecord | null> {
+    return this.db.oneOrNull<ReleaseTrainEventRecord>(
+      `select * from ${RELEASE_TRAIN_EVENTS_TABLE}
+       where event_type = 'EXPERIMENTAL_HISTORY_RESET'
+         and json_unquote(json_extract(payload_json, '$.reset_id')) = :resetId
+       order by created_at desc limit 1 for update`,
+      { resetId },
+      dbOptions(ctx)
+    );
+  }
+
   public async setControl(
     scope: ReleaseControlScope,
     paused: boolean,
@@ -1018,10 +1032,7 @@ export class ReleaseBusRepository extends LazyDbAccessCompatibleService {
          )
          and not exists (
            select 1 from ${RELEASE_CANDIDATE_DEPENDENCIES_TABLE} dependency
-           join ${RELEASE_READY_DEPLOYMENTS_TABLE} dependant
-             on dependant.id = dependency.candidate_id
            where dependency.depends_on_candidate_id = candidate.id
-             and dependant.status not in (:terminalCandidateStatuses)
          )
        order by candidate.updated_at, candidate.id limit ${boundedBatchSize}`,
       { cutoffAt, terminalCandidateStatuses },
@@ -1031,8 +1042,7 @@ export class ReleaseBusRepository extends LazyDbAccessCompatibleService {
     if (candidateIds.length > 0) {
       await this.db.execute(
         `delete from ${RELEASE_CANDIDATE_DEPENDENCIES_TABLE}
-         where candidate_id in (:candidateIds)
-            or depends_on_candidate_id in (:candidateIds)`,
+         where candidate_id in (:candidateIds)`,
         { candidateIds },
         dbOptions(ctx)
       );
@@ -1058,8 +1068,10 @@ export class ReleaseBusRepository extends LazyDbAccessCompatibleService {
   public async resetExperimentalHistory(
     reason: string,
     actor: string,
+    resetId: string,
     ctx: RequestContext
-  ): Promise<void> {
+  ): Promise<number> {
+    const resetAt = Date.now();
     for (const table of [
       RELEASE_TRAIN_EVENTS_TABLE,
       RELEASE_TRAIN_EVIDENCE_TABLE,
@@ -1076,7 +1088,7 @@ export class ReleaseBusRepository extends LazyDbAccessCompatibleService {
        set train_id = null, lease_owner = null, lease_token = null,
            heartbeat_at = null, expires_at = null, updated_at = :now,
            row_version = row_version + 1`,
-      { now: Date.now() },
+      { now: resetAt },
       dbOptions(ctx)
     );
     for (const scope of ['ALL', 'STAGING', 'PRODUCTION'] as const) {
@@ -1086,10 +1098,12 @@ export class ReleaseBusRepository extends LazyDbAccessCompatibleService {
       {
         eventType: 'EXPERIMENTAL_HISTORY_RESET',
         githubActor: actor,
-        payload: { reason }
+        payload: { reason, reset_id: resetId },
+        createdAt: resetAt
       },
       ctx
     );
+    return resetAt;
   }
 
   public async releaseLane(
@@ -1212,6 +1226,7 @@ export class ReleaseBusRepository extends LazyDbAccessCompatibleService {
       readonly eventType: string;
       readonly githubActor?: string | null;
       readonly payload?: unknown;
+      readonly createdAt?: number;
     },
     ctx: RequestContext
   ): Promise<void> {
@@ -1226,7 +1241,7 @@ export class ReleaseBusRepository extends LazyDbAccessCompatibleService {
         eventType: event.eventType,
         githubActor: event.githubActor ?? null,
         payload: event.payload ? JSON.stringify(event.payload) : null,
-        now: Date.now()
+        now: event.createdAt ?? Date.now()
       },
       dbOptions(ctx)
     );

--- a/src/releaseBus/release-bus.service.test.ts
+++ b/src/releaseBus/release-bus.service.test.ts
@@ -456,6 +456,7 @@ describe('ReleaseBusService history lifecycle', () => {
         calls.push(`controls:${forUpdate}`);
         return pausedControls;
       },
+      findExperimentalHistoryReset: async () => null,
       findActiveTrain: async () => {
         calls.push('active-train');
         return null;
@@ -478,14 +479,20 @@ describe('ReleaseBusService history lifecycle', () => {
       },
       resetExperimentalHistory: async () => {
         calls.push('reset');
+        return 123456;
       }
     } as unknown as ReleaseBusRepository;
 
     const result = await new ReleaseBusService(
       repository
-    ).resetExperimentalHistory('Controlled final go-live reset', 'operator');
+    ).resetExperimentalHistory(
+      'Controlled final go-live reset',
+      'operator',
+      '123e4567-e89b-42d3-a456-426614174001'
+    );
 
     expect(result.actor).toBe('operator');
+    expect(result.reused).toBe(false);
     expect(Number.isSafeInteger(result.reset_at)).toBe(true);
     expect(calls).toEqual([
       'controls:true',
@@ -544,6 +551,7 @@ describe('ReleaseBusService history lifecycle', () => {
         callback: (value: unknown) => unknown
       ) => callback({ transaction: true }),
       listControls: async () => scenario.controls,
+      findExperimentalHistoryReset: async () => null,
       findActiveTrain: async () => scenario.activeTrain,
       findActiveOperation: async () => scenario.activeOperation,
       listLanes: async () => scenario.lanes,
@@ -553,9 +561,38 @@ describe('ReleaseBusService history lifecycle', () => {
     await expect(
       new ReleaseBusService(repository).resetExperimentalHistory(
         'Controlled final go-live reset',
-        'operator'
+        'operator',
+        '123e4567-e89b-42d3-a456-426614174001'
       )
     ).rejects.toThrow(scenario.error);
+    expect(resetExperimentalHistory).not.toHaveBeenCalled();
+  });
+
+  it('returns an already committed reset before rechecking mutable lane state', async () => {
+    const resetExperimentalHistory = jest.fn();
+    const repository = {
+      executeNativeQueriesInTransaction: async (
+        callback: (value: unknown) => unknown
+      ) => callback({ transaction: true }),
+      listControls: async () => [{ scope: 'STAGING', paused: false }],
+      findExperimentalHistoryReset: async () => ({
+        created_at: 123456,
+        github_actor: 'original-operator'
+      }),
+      resetExperimentalHistory
+    } as unknown as ReleaseBusRepository;
+
+    await expect(
+      new ReleaseBusService(repository).resetExperimentalHistory(
+        'Retry after lost response',
+        'retrying-operator',
+        '123e4567-e89b-42d3-a456-426614174001'
+      )
+    ).resolves.toEqual({
+      reset_at: 123456,
+      actor: 'original-operator',
+      reused: true
+    });
     expect(resetExperimentalHistory).not.toHaveBeenCalled();
   });
 });

--- a/src/releaseBus/release-bus.service.test.ts
+++ b/src/releaseBus/release-bus.service.test.ts
@@ -417,3 +417,145 @@ describe('ReleaseBusService break glass', () => {
     expect(calls).toEqual(['lock-controls', 'pause', 'audit']);
   });
 });
+
+describe('ReleaseBusService history lifecycle', () => {
+  const pausedControls = [
+    { scope: 'ALL', paused: 1 },
+    { scope: 'STAGING', paused: true },
+    { scope: 'PRODUCTION', paused: 1 }
+  ];
+
+  it('prunes terminal history in one transaction', async () => {
+    const connection = { transaction: true };
+    const pruneTerminalHistory = jest.fn().mockResolvedValue({
+      trains: 2,
+      candidates: 3
+    });
+    const repository = {
+      executeNativeQueriesInTransaction: async (
+        callback: (value: unknown) => unknown
+      ) => callback(connection),
+      pruneTerminalHistory
+    } as unknown as ReleaseBusRepository;
+
+    await expect(
+      new ReleaseBusService(repository).pruneTerminalHistory(1234, 25)
+    ).resolves.toEqual({ trains: 2, candidates: 3 });
+    expect(pruneTerminalHistory).toHaveBeenCalledWith(1234, 25, {
+      connection
+    });
+  });
+
+  it('resets experimental history only after a locked quiescence proof', async () => {
+    const calls: string[] = [];
+    const repository = {
+      executeNativeQueriesInTransaction: async (
+        callback: (value: unknown) => unknown
+      ) => callback({ transaction: true }),
+      listControls: async (_ctx: unknown, forUpdate: boolean) => {
+        calls.push(`controls:${forUpdate}`);
+        return pausedControls;
+      },
+      findActiveTrain: async () => {
+        calls.push('active-train');
+        return null;
+      },
+      findActiveOperation: async () => {
+        calls.push('active-operation');
+        return null;
+      },
+      listLanes: async (_ctx: unknown, forUpdate: boolean) => {
+        calls.push(`lanes:${forUpdate}`);
+        return [
+          {
+            train_id: null,
+            lease_owner: null,
+            lease_token: null,
+            heartbeat_at: null,
+            expires_at: null
+          }
+        ];
+      },
+      resetExperimentalHistory: async () => {
+        calls.push('reset');
+      }
+    } as unknown as ReleaseBusRepository;
+
+    const result = await new ReleaseBusService(
+      repository
+    ).resetExperimentalHistory('Controlled final go-live reset', 'operator');
+
+    expect(result.actor).toBe('operator');
+    expect(Number.isSafeInteger(result.reset_at)).toBe(true);
+    expect(calls).toEqual([
+      'controls:true',
+      'active-train',
+      'active-operation',
+      'lanes:true',
+      'reset'
+    ]);
+  });
+
+  it.each([
+    {
+      name: 'an unpaused control',
+      controls: [{ scope: 'STAGING', paused: false }],
+      activeTrain: null,
+      activeOperation: null,
+      lanes: [],
+      error: 'controls must be paused'
+    },
+    {
+      name: 'an active train',
+      controls: pausedControls,
+      activeTrain: { id: 'train-active' },
+      activeOperation: null,
+      lanes: [],
+      error: 'active release train'
+    },
+    {
+      name: 'an active operation',
+      controls: pausedControls,
+      activeTrain: null,
+      activeOperation: { id: 'operation-active' },
+      lanes: [],
+      error: 'active release operation'
+    },
+    {
+      name: 'an owned lane',
+      controls: pausedControls,
+      activeTrain: null,
+      activeOperation: null,
+      lanes: [
+        {
+          train_id: 'train-old',
+          lease_owner: null,
+          lease_token: null,
+          heartbeat_at: null,
+          expires_at: null
+        }
+      ],
+      error: 'owned Release Bus lane'
+    }
+  ])('fails closed on $name', async (scenario) => {
+    const resetExperimentalHistory = jest.fn();
+    const repository = {
+      executeNativeQueriesInTransaction: async (
+        callback: (value: unknown) => unknown
+      ) => callback({ transaction: true }),
+      listControls: async () => scenario.controls,
+      findActiveTrain: async () => scenario.activeTrain,
+      findActiveOperation: async () => scenario.activeOperation,
+      listLanes: async () => scenario.lanes,
+      resetExperimentalHistory
+    } as unknown as ReleaseBusRepository;
+
+    await expect(
+      new ReleaseBusService(repository).resetExperimentalHistory(
+        'Controlled final go-live reset',
+        'operator'
+      )
+    ).rejects.toThrow(scenario.error);
+    expect(resetExperimentalHistory).not.toHaveBeenCalled();
+  });
+});

--- a/src/releaseBus/release-bus.service.ts
+++ b/src/releaseBus/release-bus.service.ts
@@ -804,6 +804,56 @@ export class ReleaseBusService {
     );
   }
 
+  public async pruneTerminalHistory(
+    cutoffAt: number,
+    batchSize = 100
+  ): Promise<{ trains: number; candidates: number }> {
+    return this.repository.executeNativeQueriesInTransaction(
+      async (connection) =>
+        this.repository.pruneTerminalHistory(cutoffAt, batchSize, {
+          connection
+        })
+    );
+  }
+
+  public async resetExperimentalHistory(
+    reason: string,
+    actor: string
+  ): Promise<{ reset_at: number; actor: string }> {
+    return this.repository.executeNativeQueriesInTransaction(
+      async (connection) => {
+        const ctx = { connection };
+        const controls = await this.repository.listControls(ctx, true);
+        if (!controls.every((control) => Boolean(control.paused))) {
+          throw new Error(
+            'All Release Bus controls must be paused before reset'
+          );
+        }
+        if (await this.repository.findActiveTrain(ctx)) {
+          throw new Error('An active release train blocks history reset');
+        }
+        if (await this.repository.findActiveOperation(ctx)) {
+          throw new Error('An active release operation blocks history reset');
+        }
+        const lanes = await this.repository.listLanes(ctx, true);
+        if (
+          lanes.some(
+            (lane) =>
+              lane.train_id !== null ||
+              lane.lease_owner !== null ||
+              lane.lease_token !== null ||
+              lane.heartbeat_at !== null ||
+              lane.expires_at !== null
+          )
+        ) {
+          throw new Error('An owned Release Bus lane blocks history reset');
+        }
+        await this.repository.resetExperimentalHistory(reason, actor, ctx);
+        return { reset_at: Date.now(), actor };
+      }
+    );
+  }
+
   public async pauseForBreakGlass(
     scope: ReleaseControlScope,
     reason: string,

--- a/src/releaseBus/release-bus.service.ts
+++ b/src/releaseBus/release-bus.service.ts
@@ -52,6 +52,14 @@ export type FreezeTrainInput = {
   readonly allowShadowDependencyEvidence?: boolean;
 };
 
+export class ReleaseBusHistoryResetBlockedError extends Error {
+  public constructor(message: string) {
+    super(message);
+    this.name = 'ReleaseBusHistoryResetBlockedError';
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
 function normalizeDeployPlan(
   plan: ReleaseDeployPlan | null
 ): ReleaseDeployPlan | null {
@@ -818,22 +826,38 @@ export class ReleaseBusService {
 
   public async resetExperimentalHistory(
     reason: string,
-    actor: string
-  ): Promise<{ reset_at: number; actor: string }> {
+    actor: string,
+    resetId: string
+  ): Promise<{ reset_at: number; actor: string; reused: boolean }> {
     return this.repository.executeNativeQueriesInTransaction(
       async (connection) => {
         const ctx = { connection };
         const controls = await this.repository.listControls(ctx, true);
+        const priorReset = await this.repository.findExperimentalHistoryReset(
+          resetId,
+          ctx
+        );
+        if (priorReset) {
+          return {
+            reset_at: Number(priorReset.created_at),
+            actor: priorReset.github_actor ?? actor,
+            reused: true
+          };
+        }
         if (!controls.every((control) => Boolean(control.paused))) {
-          throw new Error(
+          throw new ReleaseBusHistoryResetBlockedError(
             'All Release Bus controls must be paused before reset'
           );
         }
         if (await this.repository.findActiveTrain(ctx)) {
-          throw new Error('An active release train blocks history reset');
+          throw new ReleaseBusHistoryResetBlockedError(
+            'An active release train blocks history reset'
+          );
         }
         if (await this.repository.findActiveOperation(ctx)) {
-          throw new Error('An active release operation blocks history reset');
+          throw new ReleaseBusHistoryResetBlockedError(
+            'An active release operation blocks history reset'
+          );
         }
         const lanes = await this.repository.listLanes(ctx, true);
         if (
@@ -846,10 +870,17 @@ export class ReleaseBusService {
               lane.expires_at !== null
           )
         ) {
-          throw new Error('An owned Release Bus lane blocks history reset');
+          throw new ReleaseBusHistoryResetBlockedError(
+            'An owned Release Bus lane blocks history reset'
+          );
         }
-        await this.repository.resetExperimentalHistory(reason, actor, ctx);
-        return { reset_at: Date.now(), actor };
+        const resetAt = await this.repository.resetExperimentalHistory(
+          reason,
+          actor,
+          resetId,
+          ctx
+        );
+        return { reset_at: resetAt, actor, reused: false };
       }
     );
   }


### PR DESCRIPTION
## Summary
- prune terminal Release Bus trains and unreferenced terminal candidates in transactionally bounded batches while preserving retained train membership and dependency lineage
- add an operator-only fail-closed clean-slate reset: all controls paused, no active train/operation/lane ownership under row locks, and a required UUID reset id for lost-response idempotency
- preserve schema, controls, lane rows, secrets, and application data; retain one durable reset event and leave controls paused for the final handshake

## Validation
- Exact signed/DCO head: `ea2b221fd1929baf6290521722c859e13e96d863` from backend main `5f18dbcf9836c55510d4c22588ddaafc85156c6b`
- 77 focused Jest tests pass, including cleaner handler ordering, API/auth/error semantics, idempotency, pruning SQL, and service quiescence
- full `tsc --noEmit`, changed TypeScript ESLint, Prettier, and diff checks pass
- 6529bot exact-head follow-up: no new findings

## Deployment
Deploy backend `api` first, then `releaseBus` (registry default dependency); no schema migration or frontend runtime dependency. Do not invoke reset until the combined follow-up rollout is terminal in production and the lane/operator proves full quiescence. `release_note_publish=false`.

## Rollback
Revert the code commit; pruning defaults to 30 days and is bounded to 100 rows per type per cleaner invocation. The destructive reset has no automatic caller and requires an exact operator request.