### PR TITLE
Recover release trains from E2E infrastructure failures

### DIFF
--- a/src/releaseBus/worker.test.ts
+++ b/src/releaseBus/worker.test.ts
@@ -1279,6 +1279,126 @@ describe('frontend base canary', () => {
   });
 });
 
+describe('staging E2E infrastructure recovery', () => {
+  const e2eCandidate = candidate('candidate-e2e', 'backend', SHA_A, 1776);
+  const e2eTrain: ReleaseTrainRecord = {
+    id: 'train-1',
+    revision: 1,
+    target_lane: 'STAGING',
+    status: 'E2E_RUNNING',
+    cutoff_at: 1,
+    frontend_base_sha: 'd'.repeat(40),
+    backend_base_sha: 'e'.repeat(40),
+    frontend_release_branch: null,
+    backend_release_branch: 'release-bus/staging-train-train-1-r1',
+    frontend_pr_number: null,
+    backend_pr_number: null,
+    state_machine_execution_arn: null,
+    worker_version: '11',
+    failure_reason: null,
+    started_at: 1,
+    completed_at: null,
+    created_at: 1,
+    updated_at: 1,
+    row_version: 1
+  };
+  const failedOperation = {
+    id: 'operation-e2e-attempt-1',
+    operation_key: 'train-1:r1:e2e-staging:a1',
+    train_id: e2eTrain.id,
+    revision: e2eTrain.revision,
+    operation_type: 'e2e-staging',
+    repository: 'frontend',
+    environment: 'staging',
+    service: null,
+    expected_sha: SHA_B,
+    artifact_digest: null,
+    attempt: 1,
+    status: 'FAILED',
+    external_id: '29920703076',
+    request_metadata_json: {
+      workflow: 'staging-e2e.yml',
+      ref: 'main',
+      inputs: { pack: 'all', source_ref: '1a-staging' }
+    },
+    result_metadata_json: {
+      url: 'https://github.com/6529-Collections/6529seize-frontend/actions/runs/29920703076',
+      workflow_conclusion: 'failure',
+      failed_job: 'Staging E2E packs',
+      failed_step: 'Install Playwright browser'
+    },
+    started_at: 1,
+    completed_at: 2,
+    created_at: 1,
+    updated_at: 2,
+    row_version: 2
+  } as const;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.RELEASE_BUS_MODE = 'STAGING';
+    mockFindTrain.mockResolvedValue(e2eTrain);
+    mockListTrainItems.mockResolvedValue([
+      { candidate_id: e2eCandidate.id, sequence: 1 }
+    ]);
+    mockFindCandidateById.mockResolvedValue(e2eCandidate);
+    mockHeartbeatLane.mockResolvedValue(true);
+    mockListControls.mockResolvedValue([]);
+    mockListTrainOperations.mockResolvedValue([failedOperation]);
+    mockListTrainEvents.mockResolvedValue([]);
+    mockGetOrCreateOperation.mockImplementation(async (operation) => operation);
+    mockFindWorkflowRun.mockResolvedValue(null);
+    mockDispatchWorkflow.mockResolvedValue(undefined);
+    mockUpdateOperation.mockResolvedValue(undefined);
+    mockFindOperation.mockResolvedValue({
+      ...failedOperation,
+      operation_key: 'train-1:r1:e2e-staging:a2',
+      attempt: 2,
+      status: 'DISPATCHED'
+    });
+    mockAppendEvent.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    delete process.env.RELEASE_BUS_MODE;
+  });
+
+  it('retries a legacy E2E setup failure without redeploying or pausing', async () => {
+    await expect(advanceReleaseTrain(e2eTrain.id)).resolves.toMatchObject({
+      decision: 'WAIT',
+      status: 'E2E_RUNNING',
+      wait_reason: {
+        code: 'INFRASTRUCTURE_RETRY_BACKOFF',
+        summary: expect.stringContaining('retry automatically')
+      }
+    });
+
+    expect(mockDispatchWorkflow).toHaveBeenCalledWith(
+      'frontend',
+      'staging-e2e.yml',
+      'main',
+      expect.objectContaining({
+        pack: 'all',
+        source_ref: '1a-staging',
+        operation_key: expect.stringMatching(/:a2$/)
+      })
+    );
+    expect(mockSetControl).not.toHaveBeenCalled();
+    expect(mockUpdateCandidateLifecycle).not.toHaveBeenCalled();
+    expect(mockAppendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: 'OPERATION_INFRASTRUCTURE_RETRY_DISPATCHED',
+        payload: expect.objectContaining({
+          failed_attempt: 1,
+          next_attempt: 2,
+          lane_paused: false
+        })
+      }),
+      {}
+    );
+  });
+});
+
 function candidate(
   id: string,
   repository: 'backend' | 'frontend',

--- a/src/releaseBus/worker.ts
+++ b/src/releaseBus/worker.ts
@@ -51,7 +51,27 @@ export type WorkerResult = {
   readonly current_operation?: ReleaseOperationView | null;
 };
 
-class TerminalReleaseTrainError extends Error {}
+class TerminalReleaseTrainError extends Error {
+  public readonly releaseBusTerminalError = true;
+
+  public constructor(message: string) {
+    super(message);
+    this.name = 'TerminalReleaseTrainError';
+    Object.setPrototypeOf(this, TerminalReleaseTrainError.prototype);
+  }
+}
+
+function isTerminalReleaseTrainError(
+  error: unknown
+): error is TerminalReleaseTrainError {
+  return (
+    error instanceof TerminalReleaseTrainError ||
+    (error !== null &&
+      typeof error === 'object' &&
+      'releaseBusTerminalError' in error &&
+      error.releaseBusTerminalError === true)
+  );
+}
 
 class ConcurrentReleaseTrainPhaseError extends Error {
   public constructor(message: string) {
@@ -258,6 +278,26 @@ function retryableInfrastructureFailure(
   return (
     gateReport.failure_class === 'INFRASTRUCTURE_TRANSIENT' &&
     gateReport.retryable === true
+  );
+}
+
+const E2E_INFRASTRUCTURE_SETUP_STEPS = new Set([
+  'Install Socket Firewall',
+  'Install and verify frozen dependencies',
+  'Install dependencies',
+  'Install Playwright browser'
+]);
+
+function retryableE2eInfrastructureFailure(
+  operation: ReleaseOperationRecord
+): boolean {
+  if (retryableInfrastructureFailure(operation)) return true;
+  if (!operation.operation_type.startsWith('e2e-')) return false;
+  const result = metadata(operation.result_metadata_json);
+  return (
+    result.workflow_conclusion === 'failure' &&
+    typeof result.failed_step === 'string' &&
+    E2E_INFRASTRUCTURE_SETUP_STEPS.has(result.failed_step)
   );
 }
 
@@ -705,8 +745,7 @@ async function retryInfrastructureFailures(
   const rejected = retryResults.find(
     (result): result is PromiseRejectedResult => result.status === 'rejected'
   );
-  if (rejected?.reason instanceof TerminalReleaseTrainError)
-    throw rejected.reason;
+  if (isTerminalReleaseTrainError(rejected?.reason)) throw rejected.reason;
   if (rejected) {
     await releaseBusRepository.appendEvent(
       {
@@ -730,7 +769,10 @@ async function retryInfrastructureFailures(
 async function pollPhase(
   train: ReleaseTrainRecord,
   candidates: readonly ReleaseCandidateRecord[],
-  prefix: string
+  prefix: string,
+  isRetryableInfrastructureFailure: (
+    operation: ReleaseOperationRecord
+  ) => boolean = retryableInfrastructureFailure
 ): Promise<
   'PASS' | 'WAIT' | 'INFRASTRUCTURE_WAIT' | 'INFRASTRUCTURE_EXHAUSTED' | 'FAIL'
 > {
@@ -745,7 +787,7 @@ async function pollPhase(
     (operation) => workflowResult(operation) === 'FAIL'
   );
   if (failed.length > 0) {
-    if (failed.every(retryableInfrastructureFailure)) {
+    if (failed.every(isRetryableInfrastructureFailure)) {
       return retryInfrastructureFailures(train, candidates, failed, prefix);
     }
     return 'FAIL';
@@ -2393,11 +2435,20 @@ async function heartbeatOwnedTrainLanes(
 
 async function advanceE2e(
   train: ReleaseTrainRecord,
+  candidates: readonly ReleaseCandidateRecord[],
   environment: 'staging' | 'prod'
-): Promise<'PASS' | 'WAIT' | 'FAIL'> {
+): Promise<
+  'PASS' | 'WAIT' | 'INFRASTRUCTURE_WAIT' | 'INFRASTRUCTURE_EXHAUSTED' | 'FAIL'
+> {
   const type = `e2e-${environment}`;
-  const existing = (await phaseOperations(train.id, type))[0];
-  if (existing) return workflowResult(await reconcile(existing));
+  const existing = await phaseOperations(train.id, type);
+  if (existing.length > 0)
+    return pollPhase(
+      train,
+      candidates,
+      type,
+      retryableE2eInfrastructureFailure
+    );
   const ref = e2eSourceRef(
     train.frontend_release_branch,
     environment,
@@ -3239,13 +3290,19 @@ export async function advanceReleaseTrain(
       });
     }
     if (train.status === 'E2E_RUNNING') {
-      return advanceGuardedPhase({
+      const laneWait = await waitForRequiredLane(train, 'global-staging');
+      if (laneWait) return laneWait;
+      const result = await advanceE2e(train, candidates, 'staging');
+      const infrastructure = await infrastructurePhaseResult(
         train,
-        lane: 'global-staging',
-        run: () => advanceE2e(train, 'staging'),
-        failureMessage: 'Staging E2E failed',
-        nextStatus: 'VALIDATING_STAGING'
-      });
+        result,
+        'staging E2E'
+      );
+      if (infrastructure) return infrastructure;
+      if (result === 'FAIL')
+        throw new TerminalReleaseTrainError('Staging E2E failed');
+      if (result === 'WAIT') return waitFor(train, train.status);
+      return continueAtPhase(train, 'VALIDATING_STAGING');
     }
     if (train.status === 'VALIDATING_STAGING') {
       const stagingLaneWait = await waitForRequiredLane(
@@ -3379,13 +3436,22 @@ export async function advanceReleaseTrain(
     }
     if (train.status === 'PRODUCTION_E2E_RUNNING') {
       const latest = await reloadTrain(train.id);
-      return advanceGuardedPhase({
-        train: latest,
-        lane: 'global-production',
-        run: () => advanceE2e(latest, 'prod'),
-        failureMessage: 'Production E2E failed',
-        nextStatus: 'VALIDATING_PRODUCTION'
-      });
+      const productionLaneWait = await waitForRequiredLane(
+        latest,
+        'global-production'
+      );
+      if (productionLaneWait) return productionLaneWait;
+      const result = await advanceE2e(latest, candidates, 'prod');
+      const infrastructure = await infrastructurePhaseResult(
+        latest,
+        result,
+        'production E2E'
+      );
+      if (infrastructure) return infrastructure;
+      if (result === 'FAIL')
+        throw new TerminalReleaseTrainError('Production E2E failed');
+      if (result === 'WAIT') return waitFor(latest, latest.status);
+      return continueAtPhase(latest, 'VALIDATING_PRODUCTION');
     }
     if (train.status === 'VALIDATING_PRODUCTION') {
       const productionLaneWait = await waitForRequiredLane(
@@ -3434,7 +3500,7 @@ export async function advanceReleaseTrain(
         summary: `Train phase changed concurrently to ${latest.status}; waiting for the next guarded worker tick.`
       });
     }
-    if (!(error instanceof TerminalReleaseTrainError)) throw error;
+    if (!isTerminalReleaseTrainError(error)) throw error;
     const message =
       error instanceof Error
         ? error.message


### PR DESCRIPTION
## What changed
- classify E2E setup-step failures as transient infrastructure
- retry only E2E while preserving completed deployments
- keep the lane running and candidates attached during bounded retries
- harden terminal-error recognition

## Why
The worker repeatedly threw on a failed E2E setup run instead of terminalizing or retrying, leaving the train stuck in E2E_RUNNING.

## Impact
The current and future trains can recover from dependency/Playwright setup outages without rebuilding, redeploying, quarantining candidates, or pausing the lane.

## Validation
- 28 focused worker tests
- Prettier, targeted ESLint, diff check
- full TypeScript check was attempted but the existing local dependency checkout lacks unrelated API declarations; the focused ts-jest compile passed