### PR TITLE
Close Release Bus preflight dependency graph

### DIFF
--- a/.github/workflows/release-bus-isolate-candidate.yml
+++ b/.github/workflows/release-bus-isolate-candidate.yml
@@ -95,7 +95,7 @@ jobs:
             npm --prefix src/api-serverless ci --ignore-scripts
             npx eslint "src/**/*.ts" --max-warnings=0
             NODE_OPTIONS=--max-old-space-size=8192 ./node_modules/.bin/tsc -p tsconfig.json --pretty false
-            npm test -- --runInBand
+            npm test -- --maxWorkers=2
             while IFS= read -r unit; do
               if [ "$unit" = api ]; then
                 (cd src/api-serverless && npm ci && npm run build)

--- a/.github/workflows/release-bus-preflight.yml
+++ b/.github/workflows/release-bus-preflight.yml
@@ -152,6 +152,8 @@ jobs:
       - *setup-node-root
       - *activate-npm
       - *install-root
+      - name: Install API test dependencies without lifecycle scripts
+        run: npm --prefix src/api-serverless ci --ignore-scripts
       - name: Stage immutable evidence contract and tool
         env:
           CONTRACT: ${{ needs.authorize.outputs.contract }}
@@ -215,8 +217,19 @@ jobs:
         with:
           node-version: '22'
           cache: npm
-          cache-dependency-path: ${{ matrix.unit == 'api' && 'src/api-serverless/package-lock.json' || format('src/{0}/package-lock.json', matrix.unit) }}
+          cache-dependency-path: |
+            package-lock.json
+            ${{ matrix.unit == 'api' && 'src/api-serverless/package-lock.json' || format('src/{0}/package-lock.json', matrix.unit) }}
       - *activate-npm
+      - *install-root
+      - name: Install frozen selected-unit dependencies without lifecycle scripts
+        env:
+          UNIT: ${{ matrix.unit }}
+        run: |
+          set -euo pipefail
+          package_dir="src/$UNIT"
+          if [ "$UNIT" = api ]; then package_dir=src/api-serverless; fi
+          npm --prefix "$package_dir" ci --ignore-scripts
       - name: Build selected unit once and record its immutable digest
         env:
           CONTRACT: ${{ needs.authorize.outputs.contract }}
@@ -225,7 +238,7 @@ jobs:
           set -euo pipefail
           package_dir="src/$UNIT"
           if [ "$UNIT" = api ]; then package_dir=src/api-serverless; fi
-          (cd "$package_dir" && npm ci --ignore-scripts && npm run build)
+          npm --prefix "$package_dir" run build
           test -z "$(git status --porcelain --untracked-files=no)"
           mkdir -p "release-bus-unit/packages/$UNIT" release-bus-unit/evidence
           cp "$package_dir/dist/index.zip" "release-bus-unit/packages/$UNIT/index.zip"

--- a/src/releaseBus/release-bus-infrastructure.test.ts
+++ b/src/releaseBus/release-bus-infrastructure.test.ts
@@ -68,6 +68,14 @@ describe('release bus infrastructure contract', () => {
       preflightWorkflow.indexOf('\n  typecheck:'),
       preflightWorkflow.indexOf('\n  tests:')
     );
+    const testsJob = preflightWorkflow.slice(
+      preflightWorkflow.indexOf('\n  tests:'),
+      preflightWorkflow.indexOf('\n  package:')
+    );
+    const packageJob = preflightWorkflow.slice(
+      preflightWorkflow.indexOf('\n  package:'),
+      preflightWorkflow.indexOf('\n  aggregate:')
+    );
     const aggregateJob = preflightWorkflow.slice(
       preflightWorkflow.indexOf('\n  aggregate:')
     );
@@ -93,6 +101,22 @@ describe('release bus infrastructure contract', () => {
       'npm test -- --maxWorkers=2 --json --outputFile='
     );
     expect(preflightWorkflow).not.toContain('--runInBand');
+    expect(isolationWorkflow).toContain('npm test -- --maxWorkers=2');
+    expect(isolationWorkflow).not.toContain('--runInBand');
+    expect(testsJob.indexOf(installCommand)).toBeGreaterThan(-1);
+    expect(testsJob.indexOf('npm test -- --maxWorkers=2')).toBeGreaterThan(
+      testsJob.indexOf(installCommand)
+    );
+    expect(packageJob).toContain('package-lock.json');
+    expect(packageJob.indexOf('- *install-root')).toBeGreaterThan(-1);
+    expect(
+      packageJob.indexOf('Install frozen selected-unit dependencies')
+    ).toBeGreaterThan(packageJob.indexOf('- *install-root'));
+    expect(
+      packageJob.indexOf('npm --prefix "$package_dir" run build')
+    ).toBeGreaterThan(
+      packageJob.indexOf('Install frozen selected-unit dependencies')
+    );
     expect(preflightWorkflow).toContain(
       'test "$TEST_RESULT" = success -a "$PACKAGE_RESULT" = success'
     );

--- a/src/releaseBus/release-bus-infrastructure.test.ts
+++ b/src/releaseBus/release-bus-infrastructure.test.ts
@@ -103,11 +103,21 @@ describe('release bus infrastructure contract', () => {
     expect(preflightWorkflow).not.toContain('--runInBand');
     expect(isolationWorkflow).toContain('npm test -- --maxWorkers=2');
     expect(isolationWorkflow).not.toContain('--runInBand');
-    expect(testsJob.indexOf(installCommand)).toBeGreaterThan(-1);
-    expect(testsJob.indexOf('npm test -- --maxWorkers=2')).toBeGreaterThan(
-      testsJob.indexOf(installCommand)
-    );
+    expect(testsJob).toContain('npm test -- --maxWorkers=2');
+    expect(testsJob).not.toContain('--runInBand');
+    const testsInstallIndex = testsJob.indexOf(installCommand);
+    expect(testsInstallIndex).toBeGreaterThan(-1);
+    for (const marker of [
+      'Stage immutable evidence contract and tool',
+      'Capture complete Jest file inventory',
+      'npm test -- --maxWorkers=2'
+    ]) {
+      expect(testsJob.indexOf(marker)).toBeGreaterThan(testsInstallIndex);
+    }
     expect(packageJob).toContain('package-lock.json');
+    expect(packageJob).toContain(
+      'npm --prefix "$package_dir" ci --ignore-scripts'
+    );
     expect(packageJob.indexOf('- *install-root')).toBeGreaterThan(-1);
     expect(
       packageJob.indexOf('Install frozen selected-unit dependencies')


### PR DESCRIPTION
## Summary
- install API-local dependencies before the backend Release Bus test gate
- install root and selected-unit frozen dependencies before each once-only unit build
- replace the remaining isolation `--runInBand` with bounded workers and lock the invariants in infrastructure tests

## Live failure proof
- preflight run 29939623226 failed only because shared root/API dependencies were absent
- bounded baseline, combined, and candidate isolation runs 29940294636, 29940296380, and 29940298263 all passed with complete dependencies
- the candidate was returned to READY and the staging control is paused at an idle boundary

## Local validation
- focused Release Bus infrastructure tests: 10/10 passed
- Prettier and `git diff --check` passed
- exact API, attachmentsOrchestrator, and attachmentsProcessor package builds succeeded without tracked-source mutation

Operational rollout only; do not publish release notes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Release validation now runs with controlled parallelism, improving feedback speed while preserving test coverage.
  * Preflight checks more consistently verify dependencies are installed before testing and packaging.
  * Additional safeguards confirm that builds use the intended locked dependencies and complete required checks before release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->