### PR TITLE
Make backend test evidence identities unambiguous

### DIFF
--- a/src/api-serverless/src/drops/drops-api-service.test.ts
+++ b/src/api-serverless/src/drops/drops-api-service.test.ts
@@ -697,7 +697,7 @@ describe('DropsApiService', () => {
     { page: 0, page_size: 2 },
     { page: 1, page_size: 0 }
   ])(
-    'rejects invalid curation drops pagination before querying drops',
+    'rejects invalid curation drops pagination before querying drops (page=$page, page_size=$page_size)',
     async ({ page, page_size }) => {
       const { service, dropsDb, dropsMappers, curationsDb, ctx } =
         createService();

--- a/src/profiles/profile-level.test.ts
+++ b/src/profiles/profile-level.test.ts
@@ -1,25 +1,5 @@
 import { calculateLevel } from './profile-level';
 
-function generateRandomAddress() {
-  const hexCharacters = '0123456789abcdef';
-  let hexCode = '';
-
-  for (let i = 0; i < 40; i++) {
-    const randomIndex = Math.floor(Math.random() * hexCharacters.length);
-    hexCode += hexCharacters[randomIndex];
-  }
-
-  return `0x${hexCode}`;
-}
-
-function createRandomWallets(numberOfWallets: number): string[] {
-  const wallets = [];
-  for (let i = 0; i < numberOfWallets; i++) {
-    wallets.push(generateRandomAddress());
-  }
-  return wallets;
-}
-
 describe('Profile Level', () => {
   it('resolves when tdh is negative', () => {
     expect(calculateLevel({ tdh: -1, rep: 0 })).toBe(0);
@@ -51,20 +31,5 @@ describe('Profile Level', () => {
 
   it('negative rep is subtracted from TDH', () => {
     expect(calculateLevel({ tdh: 10000, rep: -9900 })).toBe(3);
-  });
-
-  it.skip('generates random wallets', () => {
-    // eslint-disable-next-line
-    console.log(
-      JSON.stringify(
-        createRandomWallets(200).map((address) => ({
-          address,
-          amount: 2,
-          category: 'love'
-        })),
-        null,
-        2
-      )
-    );
   });
 });

--- a/src/tests/user-groups.integration.test.ts
+++ b/src/tests/user-groups.integration.test.ts
@@ -522,14 +522,14 @@ describeWithSeed(
           ]
         );
       });
-      it('identities of minTdh10AndTdh11Identity1ExcludedGroup ', async () => {
+      it('excludes an identity that is also explicitly included', async () => {
         await expectGroupToContainExactIdentities(
           onlyInclusionAndExclusionGroupWhereSameIdentityIsIncludedAndExcluded,
           []
         );
       });
 
-      it('identities of minTdh10AndTdh11Identity1ExcludedGroup ', async () => {
+      it('keeps the minimum TDH group when one identity is included and excluded', async () => {
         await expectGroupToContainExactIdentities(
           minTdh10GroupWhereTdh11Identity1IsIncludedAndExcluded,
           [


### PR DESCRIPTION
## Issue
- The strict Release Bus backend evidence gate ran all suites successfully but correctly rejected one legacy skipped utility block and repeated assertion identities.

## Fix
- Remove the non-test random-wallet generator that was permanently skipped.
- Give parameterized and copied tests deterministic, distinct display identities while preserving every behavioral assertion.

## Changes
- Add pagination values to the parameterized drops test title.
- Correct two copied user-group test titles.
- Remove the skipped console-output helper and its unused random-data helpers.

## Validation
- Affected suites: 3 suites, 48/48 tests, zero skipped and zero duplicate identities.
- Full bounded evidence replay: 275/275 suites, 2,453/2,453 tests, zero failed/skipped/missing/unexpected/duplicate files or test identities.
- `npm run lint`
- TypeScript project check
- `git diff --check`

## Risk
- Level: Low
- Why: test metadata and a permanently skipped utility block only; production code is unchanged.
- Rollback: revert this commit.

## Review Notes
- The strict evidence policy remains unchanged and fail-closed.