### PR TITLE
Document the Release Bus v2 maintenance route

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,14 +1,17 @@
 # Temporary Release Bus v2 Maintenance
 
 This section overrides the deployment skill and older Release Bus documentation
-until the v2 cutover is complete.
+until the v2 production cutover and rollback observation criteria in branch
+`agent/simple-release-bus-v2-plan` at commit `0d8fb5e726279b4a80592b3dc7d4ec3db75065e9`
+are complete and this section is deliberately removed.
 
 - Do not register a candidate with Release Bus v1.
 - Before any staging or production mutation, run
   `node ops/scripts/release-bus-status.mjs`. Continue only when it reports
   `mode: OFF`; otherwise wait and retry.
 - For a manual route, require `RELEASE_BUS_ENFORCEMENT` to be absent or exactly
-  `false`. Stop on `true`, any other value, or a failed variable lookup.
+  `false`. The `OFF` result and this enforcement result are one AND gate: both
+  must pass. Stop on disagreement, `true`, any other value, or a failed lookup.
 - Inspect active frontend and backend staging/production workflows and fetch the
   exact remote target ref before merging or dispatching. Wait for other actors;
   never cancel their workflows or force-push a shared branch.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,28 @@
+# Temporary Release Bus v2 Maintenance
+
+This section overrides the deployment skill and older Release Bus documentation
+until the v2 cutover is complete.
+
+- Do not register a candidate with Release Bus v1.
+- Before any staging or production mutation, run
+  `node ops/scripts/release-bus-status.mjs`. Continue only when it reports
+  `mode: OFF`; otherwise wait and retry.
+- For a manual route, require `RELEASE_BUS_ENFORCEMENT` to be absent or exactly
+  `false`. Stop on `true`, any other value, or a failed variable lookup.
+- Inspect active frontend and backend staging/production workflows and fetch the
+  exact remote target ref before merging or dispatching. Wait for other actors;
+  never cancel their workflows or force-push a shared branch.
+- Re-fetch immediately before pushing. If the target moved, recompute the merge
+  from its new head.
+- Deploy required backend units before dependent frontend work. Dispatch only
+  independent backend DAG units concurrently, and only with
+  `cancel-in-progress: false`.
+- Record exact deployed frontend/backend SHAs before E2E and do not mutate
+  staging until that E2E run is terminal.
+- Production still requires explicit owner authorization and successful staging
+  validation of the intended exact release set. Do not publish a release note
+  manually.
+
 # Commiting to Git
 
 Use DCO signoff commits. Before committing, verify `git config user.name` and `git config user.email`; for GitHub commits, `user.email` should be the matching `accountcode+username@users.noreply.github.com` address unless the user explicitly wants another verified email. Commit with `git commit -s -m "<message>"` so Git appends `Signed-off-by: <user.name> <user.email>`.

--- a/ops/skills/deploy-6529/SKILL.md
+++ b/ops/skills/deploy-6529/SKILL.md
@@ -5,6 +5,33 @@ description: Determine the live 6529 Release Bus mode through authenticated gh, 
 
 # Deploy 6529 Backend
 
+## Temporary v2 maintenance override
+
+Until this section is removed after Release Bus v2 cutover:
+
+1. Do not submit readiness to Release Bus v1.
+2. Run `node ops/scripts/release-bus-status.mjs` before any staging or
+   production mutation and continue only when it reports `mode: OFF`. If it is
+   not `OFF`, wait and retry; do not use break glass to bypass the transition.
+3. Require `RELEASE_BUS_ENFORCEMENT` to be absent or exactly `false` in every
+   repository in the release set. Stop on `true`, any other value, or lookup
+   failure.
+4. Fetch the exact remote target head and inspect active frontend and backend
+   staging/production workflows. Wait for every other actor; never cancel their
+   workflow or force-push a shared branch. Re-fetch immediately before pushing
+   and recompute the merge if the target moved.
+5. Deploy required backend units before dependent frontend work. Dispatch only
+   independent backend DAG units concurrently, and only when their workflows
+   use `cancel-in-progress: false`.
+6. Record exact deployed frontend/backend SHAs before E2E and freeze staging
+   until that E2E run is terminal.
+7. Require explicit owner authorization and successful exact staging validation
+   for production. Do not publish a release note manually.
+
+When the helper reports `OFF`, use the legacy manual route described below.
+The older pause and mode-routing text remains rollback documentation, but it
+does not authorize v1 readiness during this maintenance window.
+
 Determine the live Release Bus mode before choosing either the bus or a manual
 path. The frontend repository's
 `ops/docs/developer/deployment-bus-process.md` is the lifecycle authority and

--- a/ops/skills/deploy-6529/SKILL.md
+++ b/ops/skills/deploy-6529/SKILL.md
@@ -1,13 +1,16 @@
 ---
 name: deploy-6529
-description: Determine the live 6529 Release Bus mode through authenticated gh, then route exact backend SHAs and allowlisted service DAGs through the required manual, shadow, staging-bus, production-bus, or operator break-glass path. Use when Codex is asked to stage, deploy, promote, merge for release, validate, pause, resume, recover, or coordinate a backend or combined frontend/backend release.
+description: During the temporary Release Bus v2 maintenance window, require authenticated live mode OFF plus disabled enforcement and use only the serialized manual route for exact backend SHAs and allowlisted service DAGs. Retained v1 shadow, bus, and break-glass routes are rollback reference only. Use when Codex is asked to stage, deploy, promote, merge for release, validate, pause, resume, recover, or coordinate a backend or combined frontend/backend release.
 ---
 
 # Deploy 6529 Backend
 
 ## Temporary v2 maintenance override
 
-Until this section is removed after Release Bus v2 cutover:
+Until the v2 production cutover and rollback observation criteria tracked by
+branch `agent/simple-release-bus-v2-plan` at commit
+`0d8fb5e726279b4a80592b3dc7d4ec3db75065e9` are complete and this section is
+deliberately removed:
 
 1. Do not submit readiness to Release Bus v1.
 2. Run `node ops/scripts/release-bus-status.mjs` before any staging or
@@ -15,7 +18,8 @@ Until this section is removed after Release Bus v2 cutover:
    not `OFF`, wait and retry; do not use break glass to bypass the transition.
 3. Require `RELEASE_BUS_ENFORCEMENT` to be absent or exactly `false` in every
    repository in the release set. Stop on `true`, any other value, or lookup
-   failure.
+   failure. Steps 2 and 3 are one fail-closed AND gate: both must pass, and any
+   disagreement stops the release.
 4. Fetch the exact remote target head and inspect active frontend and backend
    staging/production workflows. Wait for every other actor; never cancel their
    workflow or force-push a shared branch. Re-fetch immediately before pushing
@@ -69,6 +73,10 @@ operator deliberately follows the audited break-glass procedure.
 
 ## Mode routing
 
+> **Suspended during v2 maintenance:** only the `OFF` row is authorized. The
+> other rows are v1 rollback reference and must not be actioned until the
+> temporary override is deliberately removed.
+
 | Live mode    | Staging behavior                                                 | Production behavior                                                         |
 | ------------ | ---------------------------------------------------------------- | --------------------------------------------------------------------------- |
 | `OFF`        | Use the legacy manual path; do not queue in the bus              | Use the legacy manual path                                                  |
@@ -80,6 +88,10 @@ After an active bus lane accepts a candidate, never launch a parallel manual
 deployment because the lane appears slow.
 
 ## Manual-route enforcement gate
+
+> **Maintenance authority:** this gate is AND-combined with a fresh `mode:
+> OFF` helper result. Legacy enforcement or break-glass text below cannot
+> authorize a non-`OFF` mutation during v2 maintenance.
 
 For every repository affected by a manual route, inspect its live Actions
 variable with authenticated `gh`:
@@ -180,6 +192,9 @@ once only after every required backend unit succeeds.
   operator.
 
 ## Operator break glass
+
+> **Suspended during v2 maintenance:** this section is v1 rollback reference
+> only and cannot bypass the temporary `OFF` protocol.
 
 Members of `release-bus-operators` and organization owners may:
 


### PR DESCRIPTION
## Issue
- Release Bus v1 is being disabled while the authorized v2 replacement is implemented.
- Backend developers and agents need one deterministic manual staging/production route during the maintenance window.

## Fix
- Add a temporary maintenance override that forbids v1 readiness and permits manual release mutations only after the live helper reports `OFF`.
- Require serialized shared-ref and environment ownership, dependency-DAG deployment, backend-before-frontend ordering, exact-SHA E2E evidence, and explicit production authorization.

## Changes
- Update repository agent instructions.
- Update the backend deployment skill with the temporary manual route and v1 registration prohibition.

## Validation
- `git diff --check`
- Skill Creator `quick_validate.py` against `ops/skills/deploy-6529`

## Risk
- Level: Low
- Why: documentation and agent-instruction only; no runtime or workflow behavior changes.
- Rollback: revert this PR after v2 cutover replaces the temporary route.

## Deployment
- None.

## Review Notes
- Confirm the override is unambiguous about `OFF`, enforcement, shared workflow serialization, dependency ordering, and staging freeze during E2E.
- No release note should be published.