### PR TITLE
Beta: validate Release Bus v2 backend-only path

### DIFF
--- a/ops/deployment-bus/rb2-beta-backend-only.md
+++ b/ops/deployment-bus/rb2-beta-backend-only.md
@@ -1,0 +1,5 @@
+# Release Bus v2 backend-only acceptance marker
+
+This documentation-only marker is the immutable candidate used to validate the
+backend-only staging and production fast paths. It does not change runtime
+behavior.


### PR DESCRIPTION
Synthetic acceptance candidate for the authorized Simple Release Bus v2 cutover.

- runtime change: none (documentation marker only)
- staging deploy plan: `api`
- production readiness: explicit only after all staging beta cases pass
- release notes: do not publish