### PR TITLE
Beta: validate Release Bus v2 coupled DAG path

### DIFF
--- a/ops/deployment-bus/rb2-beta-coupled.md
+++ b/ops/deployment-bus/rb2-beta-coupled.md
@@ -1,0 +1,5 @@
+# Release Bus v2 coupled DAG acceptance marker
+
+This documentation-only marker is the backend half of the coupled acceptance
+candidate. The deployment manifest exercises the `api -> teamLoop` dependency
+edge without changing runtime behavior.


### PR DESCRIPTION
Synthetic backend half of the authorized Simple Release Bus v2 coupled acceptance case.

- runtime change: none (documentation marker only)
- staging deploy plan: `api -> teamLoop`
- frontend dependency: paired after both PRs are green
- release notes: do not publish