### PR TITLE
Fix v2 API reconciler invoke permission

### DIFF
--- a/src/releaseBus/release-bus-infrastructure.test.ts
+++ b/src/releaseBus/release-bus-infrastructure.test.ts
@@ -178,6 +178,17 @@ describe('release bus infrastructure contract', () => {
     );
   });
 
+  it('allows the shared API role to nudge only the v2 reconciler Lambda', () => {
+    const policy = releaseBusServerless.slice(
+      releaseBusServerless.indexOf('ReleaseBusV2ReconcilerInvokePolicy:'),
+      releaseBusServerless.indexOf('ReleaseBusWorkerVersionReadPolicy:')
+    );
+    expect(policy).toContain('Roles:\n          - lambda-vpc-role');
+    expect(policy).toContain('Action: lambda:InvokeFunction');
+    expect(policy).toContain('!GetAtt V2ReconcilerLambdaFunction.Arn');
+    expect(policy).not.toContain("Resource: '*'");
+  });
+
   it('ships fail-closed base evidence controls to the worker', () => {
     expect(releaseBusServerless).toContain(
       "RELEASE_BUS_BASE_EVIDENCE_REUSE: ${env:RELEASE_BUS_BASE_EVIDENCE_REUSE, 'false'}"

--- a/src/releaseBus/release-bus.github-app.test.ts
+++ b/src/releaseBus/release-bus.github-app.test.ts
@@ -1,9 +1,29 @@
 import {
+  releaseBusPullRequestMergeStateEligible,
   safeGitHubWorkflowLabel,
   sanitizeGitHubWorkflowJobs,
   workflowRunMatchesOperation,
   type GitHubWorkflowJob
 } from '@/releaseBus/release-bus.github-app';
+
+describe('GitHub pull request release eligibility', () => {
+  it('accepts a ruleset-blocked but explicitly mergeable exact tree', () => {
+    expect(releaseBusPullRequestMergeStateEligible(true, 'blocked')).toBe(true);
+  });
+
+  it.each(['dirty', 'draft', 'unknown', undefined])(
+    'rejects an unresolved %s merge state',
+    (state) => {
+      expect(releaseBusPullRequestMergeStateEligible(true, state)).toBe(false);
+    }
+  );
+
+  it('rejects a known merge conflict regardless of state label', () => {
+    expect(releaseBusPullRequestMergeStateEligible(false, 'blocked')).toBe(
+      false
+    );
+  });
+});
 
 describe('GitHub workflow operation identity', () => {
   it('matches only the exact bracketed operation key', () => {

--- a/src/releaseBus/release-bus.github-app.ts
+++ b/src/releaseBus/release-bus.github-app.ts
@@ -144,6 +144,20 @@ export function sanitizeGitHubWorkflowJobs(
   }));
 }
 
+export function releaseBusPullRequestMergeStateEligible(
+  mergeable: boolean | null | undefined,
+  mergeableState: string | undefined
+): boolean {
+  if (mergeable === false) return false;
+  if (['clean', 'unstable', 'behind'].includes(mergeableState ?? ''))
+    return true;
+  // The Release Bus GitHub App is a pull-request-mode ruleset bypass actor.
+  // GitHub still reports `blocked` for maintainer-review requirements, so only
+  // accept that state when the merge tree itself is explicitly mergeable. The
+  // exact merge-tree checks are independently required below.
+  return mergeable === true && mergeableState === 'blocked';
+}
+
 function base64Url(value: string | Buffer): string {
   return Buffer.from(value).toString('base64url');
 }
@@ -386,8 +400,10 @@ export class ReleaseBusGitHubApp {
     if (!mergeSha || !/^[a-f0-9]{40}$/.test(mergeSha))
       throw new Error('Pull request has no exact merge-tree SHA');
     if (
-      pull.mergeable === false ||
-      !['clean', 'unstable', 'behind'].includes(pull.mergeable_state ?? '')
+      !releaseBusPullRequestMergeStateEligible(
+        pull.mergeable,
+        pull.mergeable_state
+      )
     )
       throw new Error(
         `Pull request is not eligible against its current base (${pull.mergeable_state ?? 'unknown'}); required checks or mergeability are unresolved`

--- a/src/releaseBus/serverless.yaml
+++ b/src/releaseBus/serverless.yaml
@@ -115,6 +115,20 @@ resources:
             - Effect: Allow
               Action: states:DescribeExecution
               Resource: '*'
+    ReleaseBusV2ReconcilerInvokePolicy:
+      Type: AWS::IAM::Policy
+      Properties:
+        PolicyName: !Sub '${AWS::StackName}-invoke-v2-reconciler'
+        Roles:
+          - lambda-vpc-role
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+            - Effect: Allow
+              Action: lambda:InvokeFunction
+              Resource:
+                - !GetAtt V2ReconcilerLambdaFunction.Arn
+                - !Join [':', [!GetAtt V2ReconcilerLambdaFunction.Arn, '*']]
     ReleaseBusWorkerVersionReadPolicy:
       Type: AWS::IAM::Policy
       Properties:


### PR DESCRIPTION
Live staging-beta validation found two integration gaps before any candidate was created:

1. `seizeAPI` could not asynchronously invoke `releaseBusV2Reconciler`; add a dedicated least-privilege IAM policy scoped to that Lambda ARN and aliases.
2. GitHub REST keeps reporting `mergeable_state=blocked` for the authorized Release Bus App even after the app is configured as a pull-request-mode ruleset bypass actor; accept that label only when the merge tree is explicitly mergeable, then retain the existing requirement that every exact merge-tree check is terminal-green. Dirty/unknown/conflicting states remain rejected.

Validation: targeted infrastructure/GitHub App suites 20/20; targeted lint clean.

Release notes: do not publish.