### PR TITLE
Fix v2 PR check evidence identity

### DIFF
--- a/src/releaseBus/release-bus.github-app.test.ts
+++ b/src/releaseBus/release-bus.github-app.test.ts
@@ -1,10 +1,101 @@
+import fetch, { Response } from 'node-fetch';
 import {
+  ReleaseBusGitHubApp,
   releaseBusPullRequestMergeStateEligible,
   safeGitHubWorkflowLabel,
   sanitizeGitHubWorkflowJobs,
   workflowRunMatchesOperation,
   type GitHubWorkflowJob
 } from '@/releaseBus/release-bus.github-app';
+
+jest.mock('node-fetch', () => {
+  const actual = jest.requireActual('node-fetch');
+  return { ...actual, __esModule: true, default: jest.fn() };
+});
+
+describe('GitHub pull request qualification evidence', () => {
+  it('reads checks from the PR head and binds the artifact to its merge tree', async () => {
+    const headSha = 'a'.repeat(40);
+    const baseSha = 'b'.repeat(40);
+    const mergeSha = 'c'.repeat(40);
+    const runId = 12345;
+    const app = new ReleaseBusGitHubApp();
+    (
+      app as unknown as {
+        cachedToken: { value: string; expiresAt: number };
+      }
+    ).cachedToken = { value: 'test-token', expiresAt: Date.now() + 120_000 };
+    const fetchMock = fetch as jest.MockedFunction<typeof fetch>;
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            number: 42,
+            state: 'open',
+            mergeable: true,
+            mergeable_state: 'blocked',
+            head: { sha: headSha, ref: 'agent/test' },
+            base: { sha: baseSha, ref: 'main' },
+            merge_commit_sha: mergeSha
+          })
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            check_runs: [
+              {
+                id: 99,
+                name: 'Build backend and API',
+                status: 'completed',
+                conclusion: 'success',
+                completed_at: '2026-07-23T04:00:00Z',
+                details_url: `https://github.com/6529-Collections/6529seize-backend/actions/runs/${runId}/job/7`
+              }
+            ]
+          })
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            artifacts: [
+              {
+                id: 100,
+                name: `release-bus-v2-pr-${mergeSha}`,
+                digest: `sha256:${'d'.repeat(64)}`,
+                expired: false,
+                workflow_run: { id: runId, head_sha: headSha }
+              }
+            ]
+          })
+        )
+      );
+
+    try {
+      const qualification = await app.getPullRequestQualification(
+        'backend',
+        42,
+        headSha
+      );
+
+      expect(String(fetchMock.mock.calls[1]?.[0])).toContain(
+        `/commits/${headSha}/check-runs`
+      );
+      expect(String(fetchMock.mock.calls[1]?.[0])).not.toContain(mergeSha);
+      expect(qualification).toMatchObject({
+        baseSha,
+        mergeSha,
+        checksRunId: String(runId),
+        artifactRunId: String(runId),
+        artifactName: `release-bus-v2-pr-${mergeSha}`,
+        artifactDigest: 'd'.repeat(64)
+      });
+    } finally {
+      fetchMock.mockReset();
+    }
+  });
+});
 
 describe('GitHub pull request release eligibility', () => {
   it('accepts a ruleset-blocked but explicitly mergeable exact tree', () => {

--- a/src/releaseBus/release-bus.github-app.ts
+++ b/src/releaseBus/release-bus.github-app.ts
@@ -411,7 +411,7 @@ export class ReleaseBusGitHubApp {
 
     const checksResponse = await this.request(
       repository,
-      `/commits/${mergeSha}/check-runs?per_page=100`
+      `/commits/${headSha}/check-runs?per_page=100`
     );
     await this.assertOk(
       checksResponse,
@@ -421,7 +421,7 @@ export class ReleaseBusGitHubApp {
       ((await checksResponse.json()) as { check_runs?: GitHubCheckRun[] })
         .check_runs ?? [];
     if (checks.length === 0)
-      throw new Error('Pull request merge tree has no check evidence');
+      throw new Error('Pull request head has no check evidence');
     const incomplete = checks.filter((check) => check.status !== 'completed');
     if (incomplete.length > 0)
       throw new Error(


### PR DESCRIPTION
Live staging-beta registration found that GitHub attaches pull-request check runs to the PR head SHA even though Actions checks out the synthetic merge-tree SHA.

This reads terminal-green check evidence from the exact head SHA, while preserving the stronger artifact binding: artifact name and manifest use the exact merge-tree SHA, and the artifact source run must be one of those green head check runs.

Validation: mocked GitHub qualification suite 10/10; targeted lint clean.

Release notes: do not publish.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request qualification by checking evidence against the pull request’s head commit.
  * Updated error messaging when no check-run evidence is available.

* **Tests**
  * Added coverage validating check-run and workflow artifact qualification, including commit references, run and artifact identifiers, names, and digests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->