### PR TITLE
fix: accept Release Bus App workflow actors

### DIFF
--- a/src/releaseBus/release-bus.github-app.test.ts
+++ b/src/releaseBus/release-bus.github-app.test.ts
@@ -121,8 +121,47 @@ describe('GitHub workflow operation identity', () => {
   it('accepts human and GitHub App workflow actors', () => {
     expect(isValidGitHubWorkflowActor('GelatoGenesis')).toBe(true);
     expect(isValidGitHubWorkflowActor('6529-release-bus[bot]')).toBe(true);
+    expect(isValidGitHubWorkflowActor('github-actions[bot]')).toBe(false);
     expect(isValidGitHubWorkflowActor('release-bus[admin]')).toBe(false);
     expect(isValidGitHubWorkflowActor(`${'a'.repeat(40)}`)).toBe(false);
+  });
+
+  it('reads the exact Release Bus App actor from a workflow run', async () => {
+    const app = new ReleaseBusGitHubApp();
+    (
+      app as unknown as {
+        cachedToken: { value: string; expiresAt: number };
+      }
+    ).cachedToken = { value: 'test-token', expiresAt: Date.now() + 120_000 };
+    const fetchMock = fetch as jest.MockedFunction<typeof fetch>;
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          id: 12345,
+          name: 'Release Bus v2 - Compose Backend',
+          path: '.github/workflows/release-bus-v2-compose.yml',
+          display_title: 'Compose backend v2 train beta [rb2:beta:a1]',
+          status: 'in_progress',
+          conclusion: null,
+          head_sha: 'a'.repeat(40),
+          html_url: 'https://github.com/example/actions/runs/12345',
+          event: 'workflow_dispatch',
+          actor: { login: '6529-release-bus[bot]' }
+        })
+      )
+    );
+
+    try {
+      await expect(
+        app.getWorkflowRunIdentity('backend', '12345')
+      ).resolves.toMatchObject({
+        actor: '6529-release-bus[bot]',
+        event: 'workflow_dispatch',
+        headSha: 'a'.repeat(40)
+      });
+    } finally {
+      fetchMock.mockReset();
+    }
   });
 
   it('matches only the exact bracketed operation key', () => {

--- a/src/releaseBus/release-bus.github-app.test.ts
+++ b/src/releaseBus/release-bus.github-app.test.ts
@@ -1,5 +1,6 @@
 import fetch, { Response } from 'node-fetch';
 import {
+  isValidGitHubWorkflowActor,
   ReleaseBusGitHubApp,
   releaseBusPullRequestMergeStateEligible,
   safeGitHubWorkflowLabel,
@@ -117,6 +118,13 @@ describe('GitHub pull request release eligibility', () => {
 });
 
 describe('GitHub workflow operation identity', () => {
+  it('accepts human and GitHub App workflow actors', () => {
+    expect(isValidGitHubWorkflowActor('GelatoGenesis')).toBe(true);
+    expect(isValidGitHubWorkflowActor('6529-release-bus[bot]')).toBe(true);
+    expect(isValidGitHubWorkflowActor('release-bus[admin]')).toBe(false);
+    expect(isValidGitHubWorkflowActor(`${'a'.repeat(40)}`)).toBe(false);
+  });
+
   it('matches only the exact bracketed operation key', () => {
     const operationKey = 'rb:train-1:r1:preflight:aabbcc:a2';
 

--- a/src/releaseBus/release-bus.github-app.ts
+++ b/src/releaseBus/release-bus.github-app.ts
@@ -25,6 +25,15 @@ export function workflowRunMatchesOperation(
 ): boolean {
   return displayTitle.includes(`[${operationKey}]`);
 }
+
+export function isValidGitHubWorkflowActor(actor: string): boolean {
+  // GitHub App workflow actors use the app slug followed by the literal
+  // `[bot]` suffix. Human logins retain GitHub's 39-character limit.
+  return (
+    /^[A-Za-z0-9-]{1,39}$/.test(actor) ||
+    /^[A-Za-z0-9-]{1,100}\[bot\]$/.test(actor)
+  );
+}
 export type GitHubWorkflowJob = {
   readonly id: number;
   readonly name: string;
@@ -716,7 +725,7 @@ export class ReleaseBusGitHubApp {
     await this.assertOk(response, `read ${repository} workflow run`);
     const run = (await response.json()) as GitHubRun;
     const actor = run.actor?.login ?? '';
-    if (!/^[A-Za-z0-9-]{1,39}$/.test(actor))
+    if (!isValidGitHubWorkflowActor(actor))
       throw new Error('GitHub workflow run has no valid actor');
     if (!/^[a-f0-9]{40}$/i.test(run.head_sha))
       throw new Error('GitHub workflow run has no valid head SHA');

--- a/src/releaseBus/release-bus.github-app.ts
+++ b/src/releaseBus/release-bus.github-app.ts
@@ -28,10 +28,10 @@ export function workflowRunMatchesOperation(
 
 export function isValidGitHubWorkflowActor(actor: string): boolean {
   // GitHub App workflow actors use the app slug followed by the literal
-  // `[bot]` suffix. Human logins retain GitHub's 39-character limit.
+  // `[bot]` suffix. Only the Release Bus App may drive automated operations;
+  // human logins retain GitHub's 39-character limit for manual attribution.
   return (
-    /^[A-Za-z0-9-]{1,39}$/.test(actor) ||
-    /^[A-Za-z0-9-]{1,100}\[bot\]$/.test(actor)
+    /^[A-Za-z0-9-]{1,39}$/.test(actor) || actor === '6529-release-bus[bot]'
   );
 }
 export type GitHubWorkflowJob = {


### PR DESCRIPTION
## Summary
- recognize GitHub App `[bot]` logins when binding exact workflow-run identity
- retain the existing GitHub human-login length constraint
- cover both actor forms and invalid bracketed/overlong values

## Live beta evidence
The paused v2 staging beta dispatched compose run `29981702843` as `6529-release-bus[bot]`. The workflow stopped at its authorization boundary with `GitHub workflow run has no valid actor`; no shared ref or environment was mutated. ALL and STAGING remain paused.

## Validation
- `npm test -- --runInBand src/releaseBus/release-bus.github-app.test.ts src/releaseBusV2/release-bus-v2.operations.test.ts` (21/21)
- targeted ESLint
- `git diff --check`

Release notes intentionally disabled for this control-plane hotfix.