### PR TITLE
test: v2 backend fast-path acceptance

### DIFF
--- a/ops/deployment-bus/rb2-beta-backend-fastpath.md
+++ b/ops/deployment-bus/rb2-beta-backend-fastpath.md
@@ -1,0 +1,5 @@
+# Release Bus v2 backend fast-path acceptance marker
+
+This documentation-only marker is an immutable latest-main candidate used to
+measure exact green PR evidence and artifact reuse. It does not change runtime
+behavior.


### PR DESCRIPTION
Synthetic Release Bus v2 backend-only acceptance candidate from exact latest main.

- documentation-only marker; no runtime behavior change
- intended to prove reuse of the exact green PR merge tree and API artifact
- will not publish a release note

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a marker documenting Release Bus v2 backend fast-path acceptance.
  * Clarified that the marker does not affect runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->