### PR TITLE
fix: install API dependencies in v2 test shards

### DIFF
--- a/.github/workflows/release-bus-v2-preflight.yml
+++ b/.github/workflows/release-bus-v2-preflight.yml
@@ -186,9 +186,14 @@ jobs:
         with:
           node-version: '22'
           cache: npm
-          cache-dependency-path: package-lock.json
+          cache-dependency-path: |
+            package-lock.json
+            src/api-serverless/package-lock.json
       - name: Install frozen root dependencies
         run: npm ci --ignore-scripts
+      - name: Install frozen API dependencies for API-aware shards
+        if: matrix.shard == 'typecheck' || startsWith(matrix.shard, 'tests-')
+        run: npm --prefix src/api-serverless ci --ignore-scripts
       - name: Run shard
         env:
           SHARD: ${{ matrix.shard }}
@@ -197,7 +202,6 @@ jobs:
           case "$SHARD" in
             lint) ./node_modules/.bin/eslint "src/**/*.ts" --max-warnings=0 ;;
             typecheck)
-              npm --prefix src/api-serverless ci --ignore-scripts
               ./node_modules/.bin/tsc -p tsconfig.json --pretty false
               ;;
             inventory)
@@ -246,7 +250,12 @@ jobs:
           persist-credentials: false
       - name: Install Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with: { node-version: '22', cache: npm, cache-dependency-path: package-lock.json }
+        with:
+          {
+            node-version: '22',
+            cache: npm,
+            cache-dependency-path: package-lock.json
+          }
       - name: Build selected unit exactly once
         env:
           UNIT: ${{ matrix.unit }}

--- a/src/releaseBusV2/release-bus-v2.acceptance.test.ts
+++ b/src/releaseBusV2/release-bus-v2.acceptance.test.ts
@@ -826,6 +826,12 @@ describe('Release Bus v2 offline acceptance harness', () => {
     expect(workflow).toContain(
       'shard: [lint, typecheck, inventory, tests-1, tests-2, tests-3, tests-4]'
     );
+    expect(workflow).toContain(
+      "matrix.shard == 'typecheck' || startsWith(matrix.shard, 'tests-')"
+    );
+    expect(workflow).toContain(
+      'npm --prefix src/api-serverless ci --ignore-scripts'
+    );
     expect(workflow).toContain('uniq -d shards.sorted');
     expect(workflow).toContain('diff -u complete.sorted shards.sorted');
     expect(workflow).toContain("steps.inventory_verify.outcome == 'success'");


### PR DESCRIPTION
## Summary
- install frozen `src/api-serverless` dependencies in all API-aware typecheck/test shards
- include the nested lockfile in the setup-node npm cache key
- assert the dependency boundary in the v2 offline acceptance harness

## Live paused-beta evidence
Combined preflight run `29983424916` failed only because shard 4 could not resolve `serverless-http`; the other 505 tests in that shard passed. ALL/STAGING were paused before controller disposition, the candidate remains unheld, and no staging mutation occurred.

## Validation
- v2 acceptance suite: 10/10
- exact formerly failing shard after nested install: 70 suites / 513 tests
- targeted ESLint, Prettier, and `git diff --check`

Release notes intentionally disabled.