### PR TITLE
fix: authorize exact v2 E2E manifest identity

### DIFF
--- a/src/api-serverless/src/deploy/deploy-validation.test.ts
+++ b/src/api-serverless/src/deploy/deploy-validation.test.ts
@@ -536,6 +536,29 @@ describe('Release Bus v2 validation', () => {
         operation_key: `rb2:${trainId}:deploy:staging:frontend:a1`
       }).error
     ).toBeDefined();
+    expect(
+      ReleaseBusV2AuthorizationBodySchema.validate({
+        ...authorization,
+        operation_key: `rb2:${trainId}:deploy:e2e:staging:a1`
+      }).error
+    ).toBeDefined();
+
+    const deployAuthorization = {
+      ...authorization,
+      operation_key: `rb2:${trainId}:deploy:staging:backend:api:a1`,
+      artifact_run_id: '29984625887',
+      repository: 'backend',
+      service: 'api'
+    };
+    expect(
+      ReleaseBusV2AuthorizationBodySchema.validate(deployAuthorization).error
+    ).toBeUndefined();
+    expect(
+      ReleaseBusV2AuthorizationBodySchema.validate({
+        ...deployAuthorization,
+        artifact_run_id: null
+      }).error
+    ).toBeDefined();
   });
 
   it('accepts an exact backend PR candidate with an acyclic deploy plan', () => {

--- a/src/api-serverless/src/deploy/deploy-validation.test.ts
+++ b/src/api-serverless/src/deploy/deploy-validation.test.ts
@@ -507,6 +507,37 @@ describe('Release Bus v2 validation', () => {
     ).toBeDefined();
   });
 
+  it('binds v2 E2E authorization to the exact manifest identity', () => {
+    const trainId = '8af60034-9741-4b9d-bb1c-80b483f75455';
+    const authorization = {
+      train_id: trainId,
+      operation_key: `rb2:${trainId}:e2e:staging:a1`,
+      workflow_run_id: '29984983314',
+      artifact_run_id: null,
+      repository: 'frontend',
+      environment: 'staging',
+      service: null,
+      expected_sha: 'a'.repeat(40),
+      artifact_digest: 'b'.repeat(64)
+    };
+
+    expect(
+      ReleaseBusV2AuthorizationBodySchema.validate(authorization).error
+    ).toBeUndefined();
+    expect(
+      ReleaseBusV2AuthorizationBodySchema.validate({
+        ...authorization,
+        artifact_digest: null
+      }).error
+    ).toBeDefined();
+    expect(
+      ReleaseBusV2AuthorizationBodySchema.validate({
+        ...authorization,
+        operation_key: `rb2:${trainId}:deploy:staging:frontend:a1`
+      }).error
+    ).toBeDefined();
+  });
+
   it('accepts an exact backend PR candidate with an acyclic deploy plan', () => {
     const result = ReleaseBusV2CandidateBodySchema.validate({
       repository: 'backend',

--- a/src/api-serverless/src/deploy/deploy.validation.ts
+++ b/src/api-serverless/src/deploy/deploy.validation.ts
@@ -620,11 +620,10 @@ const ARTIFACT_FREE_RELEASE_OPERATIONS = [
 const RELEASE_OPERATION_KEY_PATTERN =
   /^rb:[A-Za-z0-9._-]+:r[1-9]\d*:([A-Za-z0-9._-]{1,48}):[a-f0-9]{32}:a[1-9]\d*$/;
 
-export const ReleaseBusAuthorizationBodySchema = Joi.object({
+const releaseBusAuthorizationFields = () => ({
   train_id: Joi.string()
     .guid({ version: ['uuidv4'] })
     .required(),
-  operation_key: Joi.string().max(180).required(),
   workflow_run_id: Joi.string().pattern(/^\d+$/).required(),
   artifact_run_id: Joi.when('environment', {
     is: 'orchestration',
@@ -638,7 +637,12 @@ export const ReleaseBusAuthorizationBodySchema = Joi.object({
     .valid('orchestration', 'staging', 'prod')
     .required(),
   service: Joi.string().max(100).allow(null).required(),
-  expected_sha: ReleaseShaSchema.required(),
+  expected_sha: ReleaseShaSchema.required()
+});
+
+export const ReleaseBusAuthorizationBodySchema = Joi.object({
+  ...releaseBusAuthorizationFields(),
+  operation_key: Joi.string().max(180).required(),
   artifact_digest: Joi.when('artifact_run_id', {
     is: null,
     then: Joi.valid(null).required(),
@@ -676,27 +680,11 @@ const RELEASE_BUS_V2_OPERATION_KEY_PATTERN =
   /^rb2:[a-f0-9-]{36}:[A-Za-z0-9._:-]+:a[1-9]\d{0,8}$/;
 
 export const ReleaseBusV2AuthorizationBodySchema = Joi.object({
-  train_id: Joi.string()
-    .guid({ version: ['uuidv4'] })
-    .required(),
+  ...releaseBusAuthorizationFields(),
   operation_key: Joi.string()
     .pattern(RELEASE_BUS_V2_OPERATION_KEY_PATTERN)
     .max(180)
     .required(),
-  workflow_run_id: Joi.string().pattern(/^\d+$/).required(),
-  artifact_run_id: Joi.when('environment', {
-    is: 'orchestration',
-    then: Joi.valid(null).required(),
-    otherwise: Joi.alternatives()
-      .try(Joi.string().pattern(/^\d+$/), Joi.valid(null))
-      .required()
-  }),
-  repository: ReleaseRepositorySchema.required(),
-  environment: Joi.string()
-    .valid('orchestration', 'staging', 'prod')
-    .required(),
-  service: Joi.string().max(100).allow(null).required(),
-  expected_sha: ReleaseShaSchema.required(),
   artifact_digest: Joi.alternatives()
     .try(Joi.string().pattern(/^[a-f0-9]{64}$/), Joi.valid(null))
     .required()
@@ -709,9 +697,14 @@ export const ReleaseBusV2AuthorizationBodySchema = Joi.object({
         ? value
         : helpers.error('any.invalid');
     }
-    const isExactManifestE2E = value.operation_key.includes(
-      `:e2e:${value.environment}:`
-    );
+    const keySegments = value.operation_key.split(':');
+    const isExactManifestE2E =
+      keySegments.length === 5 &&
+      keySegments[0] === 'rb2' &&
+      keySegments[1] === value.train_id &&
+      keySegments[2] === 'e2e' &&
+      keySegments[3] === value.environment &&
+      /^a[1-9]\d{0,8}$/.test(keySegments[4]);
     if (isExactManifestE2E) {
       return value.repository === 'frontend' &&
         value.service === null &&

--- a/src/api-serverless/src/deploy/deploy.validation.ts
+++ b/src/api-serverless/src/deploy/deploy.validation.ts
@@ -675,19 +675,56 @@ export const ReleaseBusAuthorizationBodySchema = Joi.object({
 const RELEASE_BUS_V2_OPERATION_KEY_PATTERN =
   /^rb2:[a-f0-9-]{36}:[A-Za-z0-9._:-]+:a[1-9]\d{0,8}$/;
 
-export const ReleaseBusV2AuthorizationBodySchema =
-  ReleaseBusAuthorizationBodySchema.keys({
-    operation_key: Joi.string()
-      .pattern(RELEASE_BUS_V2_OPERATION_KEY_PATTERN)
-      .max(180)
+export const ReleaseBusV2AuthorizationBodySchema = Joi.object({
+  train_id: Joi.string()
+    .guid({ version: ['uuidv4'] })
+    .required(),
+  operation_key: Joi.string()
+    .pattern(RELEASE_BUS_V2_OPERATION_KEY_PATTERN)
+    .max(180)
+    .required(),
+  workflow_run_id: Joi.string().pattern(/^\d+$/).required(),
+  artifact_run_id: Joi.when('environment', {
+    is: 'orchestration',
+    then: Joi.valid(null).required(),
+    otherwise: Joi.alternatives()
+      .try(Joi.string().pattern(/^\d+$/), Joi.valid(null))
       .required()
+  }),
+  repository: ReleaseRepositorySchema.required(),
+  environment: Joi.string()
+    .valid('orchestration', 'staging', 'prod')
+    .required(),
+  service: Joi.string().max(100).allow(null).required(),
+  expected_sha: ReleaseShaSchema.required(),
+  artifact_digest: Joi.alternatives()
+    .try(Joi.string().pattern(/^[a-f0-9]{64}$/), Joi.valid(null))
+    .required()
+})
+  .custom((value, helpers) => {
+    if (!value.operation_key.startsWith(`rb2:${value.train_id}:`))
+      return helpers.error('any.invalid');
+    if (value.environment === 'orchestration') {
+      return value.artifact_run_id === null && value.artifact_digest === null
+        ? value
+        : helpers.error('any.invalid');
+    }
+    const isExactManifestE2E = value.operation_key.includes(
+      `:e2e:${value.environment}:`
+    );
+    if (isExactManifestE2E) {
+      return value.repository === 'frontend' &&
+        value.service === null &&
+        value.artifact_run_id === null &&
+        value.artifact_digest !== null
+        ? value
+        : helpers.error('any.invalid');
+    }
+    return value.artifact_run_id !== null && value.artifact_digest !== null
+      ? value
+      : helpers.error('any.invalid');
   })
-    .custom((value, helpers) => {
-      if (!value.operation_key.startsWith(`rb2:${value.train_id}:`))
-        return helpers.error('any.invalid');
-      return value;
-    })
-    .required();
+  .required();
 
 export const ReleaseBusBreakGlassAuthorizationBodySchema = Joi.object({
   workflow_run_id: Joi.string().pattern(/^\d+$/).required(),


### PR DESCRIPTION
## Summary
- give v2 authorization its own explicit artifact contract instead of inheriting v1 artifact-free rules
- require orchestration operations to be null/null, deployments to carry run+digest, and E2E to carry the exact manifest identity without an artifact run
- cover the exact staging E2E payload and reject missing/cross-operation manifest identities

## Live paused-beta evidence
Backend staging reached `STAGING_DEPLOYED` at exact SHA `f3e94829336a8627ffbe279fbb3c4f0d4f046419`. E2E run `29984983314` then stopped before tests because v1 validation required `artifact_digest:null`; the controller classified it CONTROL_PLANE and retained the exact manifest.

## Validation
- deploy validation + v2 operations suites: 35/35
- targeted ESLint, Prettier, and `git diff --check`

Release notes intentionally disabled.