### PR TITLE
Clarify OFF manual deployment policy

### DIFF
--- a/.agents/skills/deploy-6529/SKILL.md
+++ b/.agents/skills/deploy-6529/SKILL.md
@@ -18,13 +18,13 @@ description: Route and execute 6529 backend, frontend, or coupled staging and pr
 
 | Mode | Staging | Production |
 | --- | --- | --- |
-| `OFF` | Serialized manual fallback | Serialized manual fallback with explicit owner authorization and exact staging evidence |
+| `OFF` | Serialized manual fallback | Serialized manual fallback with explicit owner authorization; staging evidence is not required |
 | `STAGING` | Register the exact candidate with v2 | Manual fallback only; production automation is disabled |
 | `PRODUCTION` | Register the exact candidate with v2 | Explicitly mark an exact `STAGING_VALIDATED` candidate ready for v2 production |
 
-When mode is active, stop if `ALL` or the target lane is paused. A pause while
-mode is `OFF` intentionally disables v2 and does not prohibit the documented
-manual fallback.
+When mode is active, stop if `ALL` or the target lane is paused. In `OFF`, v2
+controls are non-authoritative and do not prohibit manual staging or production
+through the documented fallback.
 
 ## V2 readiness
 
@@ -67,9 +67,11 @@ qualification and never publishes release notes.
    frontend.
 6. Record exact deployed frontend/backend SHAs before E2E and freeze staging
    until E2E is terminal.
-7. Production requires explicit owner authorization and successful validation
-   of the intended exact release set. Re-fetch `main`, preserve dependency
-   order, and never publish a release note manually.
+7. In `OFF`, production requires explicit owner authorization but not prior
+   staging deployment or validation. Re-fetch `main` and preserve dependency
+   order. Pass the same merged PR number and full canonical service set to every
+   backend production run; set `release_note_publish=true` only on the final
+   sequential service. Never author or post the note—the autonomous bot owns it.
 
 ## Monitoring and recovery
 

--- a/.agents/skills/deploy-6529/SKILL.md
+++ b/.agents/skills/deploy-6529/SKILL.md
@@ -59,8 +59,10 @@ qualification and never publishes release notes.
 3. Re-fetch immediately before pushing. If a shared ref moved, recompute from
    the new head. Never force-push.
 4. Merge the development branch into current `1a-staging`. Deploy required
-   backend units in DAG order; independent frontier units may run concurrently
-   only when workflow concurrency cannot cancel siblings.
+   backend units in DAG order through `Deploy a service`. Dispatch exactly one
+   service at a time and wait for exact success before dispatching the next;
+   shared workflow concurrency can cancel sibling runs, even for independent
+   DAG-frontier units.
 5. For coupled work, verify required backend units before merging/deploying
    frontend.
 6. Record exact deployed frontend/backend SHAs before E2E and freeze staging

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,15 +10,18 @@
 - While `OFF`, dispatch backend `Deploy a service` workflows one at a time and
   wait for exact success before starting the next. Its shared concurrency can
   cancel sibling service runs, including independent DAG-frontier units.
-- Stop an active v2 lane when `ALL` or that lane is paused. Paused controls in
-  `OFF` intentionally disable v2 and do not block the documented manual route.
+- Stop an active v2 lane when `ALL` or that lane is paused. In `OFF`, v2
+  controls are non-authoritative and do not block manual staging or production.
+  Explicit owner production authorization is sufficient; prior staging
+  deployment or validation is not required.
 - For coupled work, declare backend dependencies and preserve backend-before-
   frontend ordering. Within v2, only independent backend DAG frontier units run
   together.
 - `STAGING_DEPLOYED` is not validation. Do not mutate staging during manifest-
   bound E2E, and never infer production readiness from staging validation.
-- Never cancel another actor's workflow, force-push a shared ref, bypass exact
-  SHA/artifact checks, or publish a release note manually.
+- Never cancel another actor's workflow, force-push a shared ref, or bypass exact
+  SHA/artifact checks. Never author or post release notes manually; preserve the
+  autonomous bot's complete grouping metadata and finalize signal.
 
 # Commiting to Git
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,10 +7,14 @@
   `false`. `STAGING` routes staging readiness through v2. `PRODUCTION` routes
   staging through v2 and requires a separate explicit exact-SHA production
   action after `STAGING_VALIDATED`.
+- While `OFF`, dispatch backend `Deploy a service` workflows one at a time and
+  wait for exact success before starting the next. Its shared concurrency can
+  cancel sibling service runs, including independent DAG-frontier units.
 - Stop an active v2 lane when `ALL` or that lane is paused. Paused controls in
   `OFF` intentionally disable v2 and do not block the documented manual route.
 - For coupled work, declare backend dependencies and preserve backend-before-
-  frontend ordering. Only independent backend DAG frontier units run together.
+  frontend ordering. Within v2, only independent backend DAG frontier units run
+  together.
 - `STAGING_DEPLOYED` is not validation. Do not mutate staging during manifest-
   bound E2E, and never infer production readiness from staging validation.
 - Never cancel another actor's workflow, force-push a shared ref, bypass exact

--- a/ops/deployment-bus/simple-release-bus-v2.md
+++ b/ops/deployment-bus/simple-release-bus-v2.md
@@ -17,13 +17,14 @@ to the v1 endpoint only before the additive v2 API exists.
 
 | Mode | Staging | Production |
 | --- | --- | --- |
-| `OFF` | Serialized legacy manual route | Serialized manual route with explicit owner authority and exact staging evidence |
+| `OFF` | Serialized legacy manual route | Serialized manual route with explicit owner authority; no staging evidence gate |
 | `STAGING` | V2 readiness | Production remains manual/disabled |
 | `PRODUCTION` | V2 readiness | Separate explicit v2 action for an exact `STAGING_VALIDATED` candidate |
 
-For an active mode, `ALL` and the target lane must be running. In `OFF`, paused
-v2 controls are expected and the manual fallback remains available when
-`RELEASE_BUS_ENFORCEMENT` is absent or `false`.
+For an active mode, `ALL` and the target lane must be running. In `OFF`, v2
+controls are non-authoritative and the manual fallback remains available when
+`RELEASE_BUS_ENFORCEMENT` is absent or `false`, including owner-authorized
+production without prior staging evidence.
 
 ## Candidate contract
 
@@ -79,7 +80,10 @@ from current `main`:
   verify exact versions, run production-safe read-only E2E, and mark
   `PRODUCTION_DEPLOYED`.
 
-V2 does not publish release notes.
+V2 never authors or posts release notes itself. Production operations must feed
+the existing autonomous release-note bot complete, canonical grouping metadata
+and an idempotent finalize signal. Internal operational candidates may opt out
+explicitly.
 
 ## Failure behavior
 

--- a/ops/deployment-bus/simple-release-bus-v2.md
+++ b/ops/deployment-bus/simple-release-bus-v2.md
@@ -108,7 +108,8 @@ Rollback:
 1. pause v2 `ALL` and set mode `OFF`;
 2. allow any already-dispatched exact operation to reach a safe terminal state;
 3. verify no v2 train owns staging or production;
-4. use the serialized manual fallback;
+4. use the serialized manual fallback, dispatching backend `Deploy a service`
+   workflows one at a time because shared concurrency can cancel sibling runs;
 5. preserve v2 rows and v1 code for diagnosis—do not destructively delete them.
 
 Never cancel another actor's shared workflow or force-push a shared ref.

--- a/ops/skills/deploy-6529/SKILL.md
+++ b/ops/skills/deploy-6529/SKILL.md
@@ -18,13 +18,13 @@ description: Route and execute 6529 backend, frontend, or coupled staging and pr
 
 | Mode | Staging | Production |
 | --- | --- | --- |
-| `OFF` | Serialized manual fallback | Serialized manual fallback with explicit owner authorization and exact staging evidence |
+| `OFF` | Serialized manual fallback | Serialized manual fallback with explicit owner authorization; staging evidence is not required |
 | `STAGING` | Register the exact candidate with v2 | Manual fallback only; production automation is disabled |
 | `PRODUCTION` | Register the exact candidate with v2 | Explicitly mark an exact `STAGING_VALIDATED` candidate ready for v2 production |
 
-When mode is active, stop if `ALL` or the target lane is paused. A pause while
-mode is `OFF` intentionally disables v2 and does not prohibit the documented
-manual fallback.
+When mode is active, stop if `ALL` or the target lane is paused. In `OFF`, v2
+controls are non-authoritative and do not prohibit manual staging or production
+through the documented fallback.
 
 ## V2 readiness
 
@@ -67,9 +67,11 @@ qualification and never publishes release notes.
    frontend.
 6. Record exact deployed frontend/backend SHAs before E2E and freeze staging
    until E2E is terminal.
-7. Production requires explicit owner authorization and successful validation
-   of the intended exact release set. Re-fetch `main`, preserve dependency
-   order, and never publish a release note manually.
+7. In `OFF`, production requires explicit owner authorization but not prior
+   staging deployment or validation. Re-fetch `main` and preserve dependency
+   order. Pass the same merged PR number and full canonical service set to every
+   backend production run; set `release_note_publish=true` only on the final
+   sequential service. Never author or post the note—the autonomous bot owns it.
 
 ## Monitoring and recovery
 

--- a/ops/skills/deploy-6529/SKILL.md
+++ b/ops/skills/deploy-6529/SKILL.md
@@ -59,8 +59,10 @@ qualification and never publishes release notes.
 3. Re-fetch immediately before pushing. If a shared ref moved, recompute from
    the new head. Never force-push.
 4. Merge the development branch into current `1a-staging`. Deploy required
-   backend units in DAG order; independent frontier units may run concurrently
-   only when workflow concurrency cannot cancel siblings.
+   backend units in DAG order through `Deploy a service`. Dispatch exactly one
+   service at a time and wait for exact success before dispatching the next;
+   shared workflow concurrency can cancel sibling runs, even for independent
+   DAG-frontier units.
 5. For coupled work, verify required backend units before merging/deploying
    frontend.
 6. Record exact deployed frontend/backend SHAs before E2E and freeze staging


### PR DESCRIPTION
## Issue
- OFF-mode manual guidance could allow concurrent backend service dispatches even though shared workflow concurrency can cancel siblings.
- It also incorrectly required staging evidence for owner-authorized production and blurred autonomous release-note metadata with manual note authoring.

## Fix
- Make OFF-mode staging and production independent of v2 controls, remove the temporary staging-evidence gate, serialize backend services, and preserve the autonomous release-note pipeline.

## Changes
- Require one backend Deploy-a-service run at a time, with exact success before the next.
- State that explicit owner authorization is sufficient for production while mode is OFF, even without staging evidence.
- Require the same PR number and canonical service set on every production unit, with publish enabled only on the final sequential unit.
- Distinguish never manually author/post from supplying metadata to the autonomous bot.
- Align repository instructions, both deploy-6529 skill copies, and the v2 operator runbook.

## Validation
- Official skill quick validator passed for both backend skill copies.
- Backend skill copies are byte-identical.
- `git diff --check` passed.

## Risk
- Level: Low
- Why: Operational documentation and agent guidance only; it reflects the current OFF maintenance policy.
- Rollback: Revert after an explicitly authorized automated bus cutover replaces this temporary policy.

## Review Notes
- Confirm OFF-mode controls/staging evidence are not manual gates and release-note metadata remains mandatory.
