### PR TITLE
Require release metadata for manual production deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -247,20 +247,28 @@ jobs:
           exit 1
       - name: Check production release-note preconditions
         shell: bash
-        if: github.event.inputs.environment == 'prod' && github.event.inputs.release_pull_request == '' && !startsWith(github.event.inputs.operation_key, 'rb2:')
-        run: |
-          echo "A merged release_pull_request is required for production deploys" >&2
-          exit 1
-      - name: Validate production release PR
-        shell: bash
         if: github.event.inputs.environment == 'prod' && !startsWith(github.event.inputs.operation_key, 'rb2:')
         env:
           RELEASE_PULL_REQUEST: ${{ github.event.inputs.release_pull_request }}
+          RELEASE_GROUP_SERVICES: ${{ github.event.inputs.release_group_services }}
+          RELEASE_SERVICE: ${{ github.event.inputs.service }}
         run: |
+          set -euo pipefail
           if ! [[ "$RELEASE_PULL_REQUEST" =~ ^[1-9][0-9]*$ ]]; then
             echo "release_pull_request must be a positive PR number" >&2
             exit 1
           fi
+          if [ -z "$RELEASE_GROUP_SERVICES" ]; then
+            echo "release_group_services must contain the full canonical production service set" >&2
+            exit 1
+          fi
+          case ",${RELEASE_GROUP_SERVICES}," in
+            *,"${RELEASE_SERVICE}",*) ;;
+            *)
+              echo "release_group_services must include the deployed service ${RELEASE_SERVICE}" >&2
+              exit 1
+              ;;
+          esac
       - name: Authorize operator break glass
         if: github.event.inputs.operation_key == '' && vars.RELEASE_BUS_ENFORCEMENT == 'true'
         shell: bash

--- a/scripts/generate-deploy-config.mjs
+++ b/scripts/generate-deploy-config.mjs
@@ -265,20 +265,28 @@ jobs:
           exit 1
       - name: Check production release-note preconditions
         shell: bash
-        if: github.event.inputs.environment == 'prod' && github.event.inputs.release_pull_request == '' && !startsWith(github.event.inputs.operation_key, 'rb2:')
-        run: |
-          echo "A merged release_pull_request is required for production deploys" >&2
-          exit 1
-      - name: Validate production release PR
-        shell: bash
         if: github.event.inputs.environment == 'prod' && !startsWith(github.event.inputs.operation_key, 'rb2:')
         env:
           RELEASE_PULL_REQUEST: \${{ github.event.inputs.release_pull_request }}
+          RELEASE_GROUP_SERVICES: \${{ github.event.inputs.release_group_services }}
+          RELEASE_SERVICE: \${{ github.event.inputs.service }}
         run: |
+          set -euo pipefail
           if ! [[ "$RELEASE_PULL_REQUEST" =~ ^[1-9][0-9]*$ ]]; then
             echo "release_pull_request must be a positive PR number" >&2
             exit 1
           fi
+          if [ -z "$RELEASE_GROUP_SERVICES" ]; then
+            echo "release_group_services must contain the full canonical production service set" >&2
+            exit 1
+          fi
+          case ",\${RELEASE_GROUP_SERVICES}," in
+            *,"\${RELEASE_SERVICE}",*) ;;
+            *)
+              echo "release_group_services must include the deployed service \${RELEASE_SERVICE}" >&2
+              exit 1
+              ;;
+          esac
       - name: Authorize operator break glass
         if: github.event.inputs.operation_key == '' && vars.RELEASE_BUS_ENFORCEMENT == 'true'
         shell: bash

--- a/src/releaseBus/release-bus-infrastructure.test.ts
+++ b/src/releaseBus/release-bus-infrastructure.test.ts
@@ -23,6 +23,7 @@ const releaseBusGitHubApp = readFileSync(
   'src/releaseBus/release-bus.github-app.ts',
   'utf8'
 );
+const ciWaveNotifier = readFileSync('scripts/notify-ci-wave.mjs', 'utf8');
 const forceFreshMigration = readFileSync(
   'migrations/20260721114000-add-release-bus-force-fresh-base-canary.js',
   'utf8'
@@ -247,6 +248,13 @@ describe('release bus infrastructure contract', () => {
     expect(deployWorkflow).toContain(
       'CI_RELEASE_GROUP_SERVICES: ${{ github.event.inputs.release_group_services }}'
     );
+    expect(deployWorkflow).toContain(
+      'release_group_services must contain the full canonical production service set'
+    );
+    expect(deployWorkflow).toContain(
+      'release_group_services must include the deployed service'
+    );
+    expect(ciWaveNotifier).toContain("targetEnvironment === 'prod'");
     expect(deployWorkflow).toContain(
       'del(.RELEASE_BUS_WORKFLOW_AUTH_TOKEN, .RELEASE_BUS_GITHUB_WEBHOOK_SECRET)'
     );


### PR DESCRIPTION
## Issue
Manual production deploys could omit the canonical release service group, causing the autonomous release-note consumer to pin an incomplete group.

## Fix
Require a positive merged PR number and a nonempty release_group_services value containing the deployed service before any non-v2 production deploy starts. Staging remains release-note ineligible.

## Validation
- npm run generate:deploy-config
- npm test -- --runInBand src/releaseBus/release-bus-infrastructure.test.ts (11 passed)
- git diff --check

## Risk
- Level: Low
- Rollback: revert the workflow guard commit.

## Deployment
None. Merging updates the GitHub Actions workflow immediately.