### PR TITLE
Add fail-closed operator-only v2 beta isolation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -147,6 +147,7 @@ env:
   SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
   RELEASE_BUS_MODE: ${{ vars.RELEASE_BUS_MODE || 'OFF' }}
   RELEASE_BUS_V2_MODE: ${{ vars.RELEASE_BUS_V2_MODE || 'OFF' }}
+  RELEASE_BUS_V2_BETA_ALLOWLIST: ${{ vars.RELEASE_BUS_V2_BETA_ALLOWLIST || '' }}
   RELEASE_BUS_BASE_EVIDENCE_REUSE: ${{ vars.RELEASE_BUS_BASE_EVIDENCE_REUSE || 'false' }}
   RELEASE_BUS_BASE_EVIDENCE_REUSE_SHADOW: ${{ vars.RELEASE_BUS_BASE_EVIDENCE_REUSE_SHADOW || 'false' }}
   RELEASE_BUS_BASE_EVIDENCE_MAX_AGE_HOURS: ${{ vars.RELEASE_BUS_BASE_EVIDENCE_MAX_AGE_HOURS || '24' }}
@@ -221,6 +222,9 @@ jobs:
           set -euo pipefail
           [[ "$RELEASE_BUS_MODE" =~ ^(OFF|SHADOW|STAGING|PRODUCTION)$ ]]
           [[ "$RELEASE_BUS_V2_MODE" =~ ^(OFF|STAGING|PRODUCTION)$ ]]
+          if [ -n "$RELEASE_BUS_V2_BETA_ALLOWLIST" ]; then
+            jq -e 'type == "array" and length > 0' <<< "$RELEASE_BUS_V2_BETA_ALLOWLIST" > /dev/null
+          fi
           [[ "$RELEASE_BUS_BASE_EVIDENCE_REUSE" =~ ^(false|true)$ ]]
           [[ "$RELEASE_BUS_BASE_EVIDENCE_REUSE_SHADOW" =~ ^(false|true)$ ]]
           [[ "$RELEASE_BUS_BASE_EVIDENCE_MAX_AGE_HOURS" =~ ^([1-9]|[1-9][0-9]|1[0-5][0-9]|16[0-8])$ ]]
@@ -238,6 +242,9 @@ jobs:
           set -euo pipefail
           [[ "$RELEASE_BUS_MODE" =~ ^(OFF|SHADOW|STAGING|PRODUCTION)$ ]]
           [[ "$RELEASE_BUS_V2_MODE" =~ ^(OFF|STAGING|PRODUCTION)$ ]]
+          if [ -n "$RELEASE_BUS_V2_BETA_ALLOWLIST" ]; then
+            jq -e 'type == "array" and length > 0' <<< "$RELEASE_BUS_V2_BETA_ALLOWLIST" > /dev/null
+          fi
           [[ "$RELEASE_BUS_GITHUB_APP_ID" =~ ^[1-9][0-9]*$ ]]
           test -n "$RELEASE_BUS_GITHUB_PRIVATE_KEY"
           test -n "$RELEASE_BUS_GITHUB_WEBHOOK_SECRET"
@@ -557,6 +564,7 @@ jobs:
           RELEASE_BUS_GITHUB_INSTALLATION_ID: ${{ steps.release_bus_app.outputs.installation-id }}
           RELEASE_BUS_MODE: ${{ vars.RELEASE_BUS_MODE || 'OFF' }}
           RELEASE_BUS_V2_MODE: ${{ vars.RELEASE_BUS_V2_MODE || 'OFF' }}
+          RELEASE_BUS_V2_BETA_ALLOWLIST: ${{ vars.RELEASE_BUS_V2_BETA_ALLOWLIST || '' }}
         run: |
           set -euo pipefail
           test -n "$RELEASE_BUS_GITHUB_INSTALLATION_ID"
@@ -570,6 +578,7 @@ jobs:
           RELEASE_BUS_GITHUB_INSTALLATION_ID: ${{ steps.release_bus_app.outputs.installation-id }}
           RELEASE_BUS_MODE: ${{ vars.RELEASE_BUS_MODE || 'OFF' }}
           RELEASE_BUS_V2_MODE: ${{ vars.RELEASE_BUS_V2_MODE || 'OFF' }}
+          RELEASE_BUS_V2_BETA_ALLOWLIST: ${{ vars.RELEASE_BUS_V2_BETA_ALLOWLIST || '' }}
         run: |
           set -euo pipefail
           set +x
@@ -588,9 +597,9 @@ jobs:
           aws lambda get-function-configuration --function-name seizeAPI --query 'Environment.Variables' --output json --no-cli-pager > /tmp/current_env.json 2>/dev/null || echo '{}' > /tmp/current_env.json
           jq --arg commit "$GIT_COMMIT" --arg claimsMediaArweaveUploadSqsUrl "$CLAIMS_MEDIA_ARWEAVE_UPLOAD_SQS_URL" --arg attachmentsIngestS3Bucket "$ATTACHMENTS_INGEST_S3_BUCKET" --arg dropMediaSanitizeImages "$DROP_MEDIA_SANITIZE_IMAGES" --arg dropMediaIngestS3Bucket "$DROP_MEDIA_INGEST_S3_BUCKET" --arg dropMediaIngestS3Region "$DROP_MEDIA_INGEST_S3_REGION" --arg dropMediaIngestStage "$DROP_MEDIA_INGEST_STAGE" --arg dropMediaSanitizerSqsQueueName "$DROP_MEDIA_SANITIZER_SQS_QUEUE_NAME" --arg apiGatewayWsEndpoint "$API_GATEWAY_WS_ENDPOINT" '. + {GIT_COMMIT: $commit, CLAIMS_MEDIA_ARWEAVE_UPLOAD_SQS_URL: $claimsMediaArweaveUploadSqsUrl, ATTACHMENTS_INGEST_S3_BUCKET: $attachmentsIngestS3Bucket, DROP_MEDIA_SANITIZE_IMAGES: $dropMediaSanitizeImages, DROP_MEDIA_INGEST_S3_BUCKET: $dropMediaIngestS3Bucket, DROP_MEDIA_INGEST_S3_REGION: $dropMediaIngestS3Region, DROP_MEDIA_INGEST_STAGE: $dropMediaIngestStage, DROP_MEDIA_SANITIZER_SQS_QUEUE_NAME: $dropMediaSanitizerSqsQueueName, API_GATEWAY_WS_ENDPOINT: $apiGatewayWsEndpoint}' /tmp/current_env.json > /tmp/app_env.json
           if [ "${{ github.event.inputs.environment }}" = prod ]; then
-            jq --arg mode "$RELEASE_BUS_MODE" --arg v2Mode "$RELEASE_BUS_V2_MODE" --arg appId "$RELEASE_BUS_GITHUB_APP_ID" --arg installationId "$RELEASE_BUS_GITHUB_INSTALLATION_ID" '. + {RELEASE_BUS_MODE: $mode, RELEASE_BUS_V2_MODE: $v2Mode, RELEASE_BUS_GITHUB_APP_ID: $appId, RELEASE_BUS_GITHUB_INSTALLATION_ID: $installationId} | del(.RELEASE_BUS_WORKFLOW_AUTH_TOKEN, .RELEASE_BUS_GITHUB_WEBHOOK_SECRET)' /tmp/app_env.json > /tmp/runtime_env.json
+            jq --arg mode "$RELEASE_BUS_MODE" --arg v2Mode "$RELEASE_BUS_V2_MODE" --arg v2BetaAllowlist "$RELEASE_BUS_V2_BETA_ALLOWLIST" --arg appId "$RELEASE_BUS_GITHUB_APP_ID" --arg installationId "$RELEASE_BUS_GITHUB_INSTALLATION_ID" '. + {RELEASE_BUS_MODE: $mode, RELEASE_BUS_V2_MODE: $v2Mode, RELEASE_BUS_V2_BETA_ALLOWLIST: $v2BetaAllowlist, RELEASE_BUS_GITHUB_APP_ID: $appId, RELEASE_BUS_GITHUB_INSTALLATION_ID: $installationId} | del(.RELEASE_BUS_WORKFLOW_AUTH_TOKEN, .RELEASE_BUS_GITHUB_WEBHOOK_SECRET)' /tmp/app_env.json > /tmp/runtime_env.json
           else
-            jq '. + {RELEASE_BUS_MODE: "OFF", RELEASE_BUS_V2_MODE: "OFF"} | del(.RELEASE_BUS_GITHUB_APP_ID, .RELEASE_BUS_GITHUB_INSTALLATION_ID, .RELEASE_BUS_WORKFLOW_AUTH_TOKEN, .RELEASE_BUS_GITHUB_WEBHOOK_SECRET)' /tmp/app_env.json > /tmp/runtime_env.json
+            jq '. + {RELEASE_BUS_MODE: "OFF", RELEASE_BUS_V2_MODE: "OFF"} | del(.RELEASE_BUS_V2_BETA_ALLOWLIST, .RELEASE_BUS_GITHUB_APP_ID, .RELEASE_BUS_GITHUB_INSTALLATION_ID, .RELEASE_BUS_WORKFLOW_AUTH_TOKEN, .RELEASE_BUS_GITHUB_WEBHOOK_SECRET)' /tmp/app_env.json > /tmp/runtime_env.json
           fi
           jq '{Variables: .}' /tmp/runtime_env.json > /tmp/env_config.json
           aws lambda update-function-configuration --function-name seizeAPI --description "$VERSION_DESCRIPTION" --environment file:///tmp/env_config.json --memory-size "$API_MEMORY_SIZE" --timeout "$API_TIMEOUT" --no-cli-pager > /dev/null 2>&1

--- a/ops/deployment-bus/simple-release-bus-v2.md
+++ b/ops/deployment-bus/simple-release-bus-v2.md
@@ -40,6 +40,15 @@ An exact available PR artifact is accepted only from the same green workflow run
 and digest. A new head supersedes the older immutable candidate and explains the
 old GitHub status.
 
+While global mode is `OFF`, the public contract above remains disabled. The
+operator beta is a fail-closed exception available only when the deployed API
+and reconciler share a valid `RELEASE_BUS_V2_BETA_ALLOWLIST`. Each registration
+must supply the exact preassigned UUIDv4 `candidate_id`; repository, branch,
+requesting GitHub operator, and lane must all match the configuration. Entries
+for one bounded test share one `test_id` and one operator. Ordinary developers,
+unlisted candidates, and malformed configuration remain on the `OFF` manual
+route.
+
 Backend candidates cannot require frontend-first deployment. For coupled work,
 register backend first and declare it as the frontend prerequisite.
 
@@ -102,14 +111,84 @@ operation identities and never repeat completed mutations.
 ## Operator rollout and rollback
 
 Deploy additive changes in this order: database migrations, API/UI, then the v2
-reconciler. Keep `RELEASE_BUS_V2_MODE=OFF` and controls paused during offline
-and synthetic validation. For staging beta, set mode `STAGING`, resume
-`STAGING` and `ALL`, and keep `PRODUCTION` paused. Enable `PRODUCTION`
-only after the staging acceptance cases pass; production remains explicit.
+reconciler. Keep `RELEASE_BUS_V2_MODE=OFF` throughout offline, shadow, staging
+beta, and production beta validation. The status helpers must continue to
+report `OFF`; manual fallback remains authoritative for everyone except the
+exact operator beta entries below.
+
+### Operator-only OFF beta
+
+`RELEASE_BUS_V2_BETA_ALLOWLIST` is a GitHub Actions variable containing a JSON
+array. It is not a mode and never changes the helper result:
+
+```json
+[
+  {
+    "test_id": "backend-only-1",
+    "candidate_id": "11111111-1111-4111-8111-111111111111",
+    "repository": "backend",
+    "branch_name": "agent/rb2-beta-backend-one",
+    "operator": "exact-github-login",
+    "lanes": ["STAGING"]
+  }
+]
+```
+
+The parser rejects unknown fields, duplicate candidate IDs, duplicate
+repository/branch pairs, mixed operators/test IDs, invalid UUIDs, and unknown
+lanes. An empty variable disables all beta automation. Invalid nonempty
+configuration pauses `ALL` while mode remains `OFF`; OFF-mode manual fallback
+continues to ignore v2 controls.
+
+Before any allowlist is installed, exhaust local integration tests and
+read-only shadow checks. Shadow checks may resolve exact refs, PR qualification,
+current locks, and active workflow state, but must not update a shared ref,
+dispatch a deploy/E2E workflow, or create/claim a live candidate. With the
+allowlist absent, a worker invocation must claim and advance nothing.
+
+For each single bounded staging test:
+
+1. Prove both helpers report `OFF`, controls are understood, no lock is owned,
+   and no frontend/backend staging deploy, staging E2E, or shared-ref mutation
+   is active. Never cancel or supersede unrelated work.
+2. Install only that test's exact allowlist. Deploy the production API first
+   and `releaseBus` second, both with v1/v2 modes still `OFF`; use explicit
+   release-note opt-out for these internal operations.
+3. Register only the preassigned synthetic IDs and exact branches. The
+   reconciler snapshots both `1a-staging` refs and active workflows, acquires
+   `staging-environment`, repeats the snapshot, and records
+   `BETA_STAGING_IDLE_HANDSHAKE` before mutation. A busy workflow or changed ref
+   releases the lock without mutation.
+4. Run exactly one case to a terminal state. Record ready-to-deployed timing;
+   report E2E separately. Verify transparent checks, exact artifacts/manifests,
+   one build per artifact, and no duplicate workflow dispatch.
+5. Clear the allowlist, deploy API then `releaseBus` with the empty value, and
+   prove helpers still report `OFF`, the train is terminal, all related
+   workflows are terminal, and the staging lock is free before the next case.
+
+The required staging cases are backend-only, frontend-only, coupled backend
+DAG/frontend, unrelated manual-work concurrency, and one injected
+infrastructure failure with an idempotent retry. Backend ready-to-deployed must
+be 3–5 minutes and frontend 10–15 minutes. Any reliability or timing miss keeps
+the allowlist empty and automation globally `OFF` until repaired.
+
+Production beta is a separate allowlist installation after all staging cases
+pass. Use only exact `STAGING_VALIDATED` candidate IDs, list only the explicit
+production subset, and require the operator's separate mark-ready action. The
+first production beta must reuse exact qualification; if a qualification train
+appears, stop with mode `OFF` and do not mutate staging. Before production
+mutation the reconciler performs the analogous double active-workflow/main-ref
+snapshot under `production-environment` and records
+`BETA_PRODUCTION_IDLE_HANDSHAKE`. Prove 3–5 minute backend or 10–15 minute
+frontend promotion, then clear/deploy the empty allowlist and return to idle.
+
+General `STAGING` or `PRODUCTION` mode enablement is forbidden until every case
+above passes and the owner explicitly authorizes cutover.
 
 Rollback:
 
-1. pause v2 `ALL` and set mode `OFF`;
+1. clear the beta allowlist, pause v2 `ALL` if state is uncertain, and keep mode
+   `OFF`;
 2. allow any already-dispatched exact operation to reach a safe terminal state;
 3. verify no v2 train owns staging or production;
 4. use the serialized manual fallback, dispatching backend `Deploy a service`

--- a/scripts/generate-deploy-config.mjs
+++ b/scripts/generate-deploy-config.mjs
@@ -165,6 +165,7 @@ env:
   SENTRY_AUTH_TOKEN: \${{ secrets.SENTRY_AUTH_TOKEN }}
   RELEASE_BUS_MODE: \${{ vars.RELEASE_BUS_MODE || 'OFF' }}
   RELEASE_BUS_V2_MODE: \${{ vars.RELEASE_BUS_V2_MODE || 'OFF' }}
+  RELEASE_BUS_V2_BETA_ALLOWLIST: \${{ vars.RELEASE_BUS_V2_BETA_ALLOWLIST || '' }}
   RELEASE_BUS_BASE_EVIDENCE_REUSE: \${{ vars.RELEASE_BUS_BASE_EVIDENCE_REUSE || 'false' }}
   RELEASE_BUS_BASE_EVIDENCE_REUSE_SHADOW: \${{ vars.RELEASE_BUS_BASE_EVIDENCE_REUSE_SHADOW || 'false' }}
   RELEASE_BUS_BASE_EVIDENCE_MAX_AGE_HOURS: \${{ vars.RELEASE_BUS_BASE_EVIDENCE_MAX_AGE_HOURS || '24' }}
@@ -239,6 +240,9 @@ jobs:
           set -euo pipefail
           [[ "$RELEASE_BUS_MODE" =~ ^(OFF|SHADOW|STAGING|PRODUCTION)$ ]]
           [[ "$RELEASE_BUS_V2_MODE" =~ ^(OFF|STAGING|PRODUCTION)$ ]]
+          if [ -n "$RELEASE_BUS_V2_BETA_ALLOWLIST" ]; then
+            jq -e 'type == "array" and length > 0' <<< "$RELEASE_BUS_V2_BETA_ALLOWLIST" > /dev/null
+          fi
           [[ "$RELEASE_BUS_BASE_EVIDENCE_REUSE" =~ ^(false|true)$ ]]
           [[ "$RELEASE_BUS_BASE_EVIDENCE_REUSE_SHADOW" =~ ^(false|true)$ ]]
           [[ "$RELEASE_BUS_BASE_EVIDENCE_MAX_AGE_HOURS" =~ ^([1-9]|[1-9][0-9]|1[0-5][0-9]|16[0-8])$ ]]
@@ -256,6 +260,9 @@ jobs:
           set -euo pipefail
           [[ "$RELEASE_BUS_MODE" =~ ^(OFF|SHADOW|STAGING|PRODUCTION)$ ]]
           [[ "$RELEASE_BUS_V2_MODE" =~ ^(OFF|STAGING|PRODUCTION)$ ]]
+          if [ -n "$RELEASE_BUS_V2_BETA_ALLOWLIST" ]; then
+            jq -e 'type == "array" and length > 0' <<< "$RELEASE_BUS_V2_BETA_ALLOWLIST" > /dev/null
+          fi
           [[ "$RELEASE_BUS_GITHUB_APP_ID" =~ ^[1-9][0-9]*$ ]]
           test -n "$RELEASE_BUS_GITHUB_PRIVATE_KEY"
           test -n "$RELEASE_BUS_GITHUB_WEBHOOK_SECRET"
@@ -623,6 +630,7 @@ jobs:
           RELEASE_BUS_GITHUB_INSTALLATION_ID: \${{ steps.release_bus_app.outputs.installation-id }}
           RELEASE_BUS_MODE: \${{ vars.RELEASE_BUS_MODE || 'OFF' }}
           RELEASE_BUS_V2_MODE: \${{ vars.RELEASE_BUS_V2_MODE || 'OFF' }}
+          RELEASE_BUS_V2_BETA_ALLOWLIST: \${{ vars.RELEASE_BUS_V2_BETA_ALLOWLIST || '' }}
         run: |
           set -euo pipefail
           test -n "$RELEASE_BUS_GITHUB_INSTALLATION_ID"
@@ -636,6 +644,7 @@ jobs:
           RELEASE_BUS_GITHUB_INSTALLATION_ID: \${{ steps.release_bus_app.outputs.installation-id }}
           RELEASE_BUS_MODE: \${{ vars.RELEASE_BUS_MODE || 'OFF' }}
           RELEASE_BUS_V2_MODE: \${{ vars.RELEASE_BUS_V2_MODE || 'OFF' }}
+          RELEASE_BUS_V2_BETA_ALLOWLIST: \${{ vars.RELEASE_BUS_V2_BETA_ALLOWLIST || '' }}
         run: |
           set -euo pipefail
           set +x
@@ -654,9 +663,9 @@ jobs:
           aws lambda get-function-configuration --function-name seizeAPI --query 'Environment.Variables' --output json --no-cli-pager > /tmp/current_env.json 2>/dev/null || echo '{}' > /tmp/current_env.json
           jq --arg commit "$GIT_COMMIT" --arg claimsMediaArweaveUploadSqsUrl "$CLAIMS_MEDIA_ARWEAVE_UPLOAD_SQS_URL" --arg attachmentsIngestS3Bucket "$ATTACHMENTS_INGEST_S3_BUCKET" --arg dropMediaSanitizeImages "$DROP_MEDIA_SANITIZE_IMAGES" --arg dropMediaIngestS3Bucket "$DROP_MEDIA_INGEST_S3_BUCKET" --arg dropMediaIngestS3Region "$DROP_MEDIA_INGEST_S3_REGION" --arg dropMediaIngestStage "$DROP_MEDIA_INGEST_STAGE" --arg dropMediaSanitizerSqsQueueName "$DROP_MEDIA_SANITIZER_SQS_QUEUE_NAME" --arg apiGatewayWsEndpoint "$API_GATEWAY_WS_ENDPOINT" '. + {GIT_COMMIT: $commit, CLAIMS_MEDIA_ARWEAVE_UPLOAD_SQS_URL: $claimsMediaArweaveUploadSqsUrl, ATTACHMENTS_INGEST_S3_BUCKET: $attachmentsIngestS3Bucket, DROP_MEDIA_SANITIZE_IMAGES: $dropMediaSanitizeImages, DROP_MEDIA_INGEST_S3_BUCKET: $dropMediaIngestS3Bucket, DROP_MEDIA_INGEST_S3_REGION: $dropMediaIngestS3Region, DROP_MEDIA_INGEST_STAGE: $dropMediaIngestStage, DROP_MEDIA_SANITIZER_SQS_QUEUE_NAME: $dropMediaSanitizerSqsQueueName, API_GATEWAY_WS_ENDPOINT: $apiGatewayWsEndpoint}' /tmp/current_env.json > /tmp/app_env.json
           if [ "\${{ github.event.inputs.environment }}" = prod ]; then
-            jq --arg mode "$RELEASE_BUS_MODE" --arg v2Mode "$RELEASE_BUS_V2_MODE" --arg appId "$RELEASE_BUS_GITHUB_APP_ID" --arg installationId "$RELEASE_BUS_GITHUB_INSTALLATION_ID" '. + {RELEASE_BUS_MODE: $mode, RELEASE_BUS_V2_MODE: $v2Mode, RELEASE_BUS_GITHUB_APP_ID: $appId, RELEASE_BUS_GITHUB_INSTALLATION_ID: $installationId} | del(.RELEASE_BUS_WORKFLOW_AUTH_TOKEN, .RELEASE_BUS_GITHUB_WEBHOOK_SECRET)' /tmp/app_env.json > /tmp/runtime_env.json
+            jq --arg mode "$RELEASE_BUS_MODE" --arg v2Mode "$RELEASE_BUS_V2_MODE" --arg v2BetaAllowlist "$RELEASE_BUS_V2_BETA_ALLOWLIST" --arg appId "$RELEASE_BUS_GITHUB_APP_ID" --arg installationId "$RELEASE_BUS_GITHUB_INSTALLATION_ID" '. + {RELEASE_BUS_MODE: $mode, RELEASE_BUS_V2_MODE: $v2Mode, RELEASE_BUS_V2_BETA_ALLOWLIST: $v2BetaAllowlist, RELEASE_BUS_GITHUB_APP_ID: $appId, RELEASE_BUS_GITHUB_INSTALLATION_ID: $installationId} | del(.RELEASE_BUS_WORKFLOW_AUTH_TOKEN, .RELEASE_BUS_GITHUB_WEBHOOK_SECRET)' /tmp/app_env.json > /tmp/runtime_env.json
           else
-            jq '. + {RELEASE_BUS_MODE: "OFF", RELEASE_BUS_V2_MODE: "OFF"} | del(.RELEASE_BUS_GITHUB_APP_ID, .RELEASE_BUS_GITHUB_INSTALLATION_ID, .RELEASE_BUS_WORKFLOW_AUTH_TOKEN, .RELEASE_BUS_GITHUB_WEBHOOK_SECRET)' /tmp/app_env.json > /tmp/runtime_env.json
+            jq '. + {RELEASE_BUS_MODE: "OFF", RELEASE_BUS_V2_MODE: "OFF"} | del(.RELEASE_BUS_V2_BETA_ALLOWLIST, .RELEASE_BUS_GITHUB_APP_ID, .RELEASE_BUS_GITHUB_INSTALLATION_ID, .RELEASE_BUS_WORKFLOW_AUTH_TOKEN, .RELEASE_BUS_GITHUB_WEBHOOK_SECRET)' /tmp/app_env.json > /tmp/runtime_env.json
           fi
           jq '{Variables: .}' /tmp/runtime_env.json > /tmp/env_config.json
           aws lambda update-function-configuration --function-name seizeAPI --description "$VERSION_DESCRIPTION" --environment file:///tmp/env_config.json --memory-size "$API_MEMORY_SIZE" --timeout "$API_TIMEOUT" --no-cli-pager > /dev/null 2>&1

--- a/src/api-serverless/openapi.yaml
+++ b/src/api-serverless/openapi.yaml
@@ -23826,6 +23826,10 @@ components:
         - branch_name
         - expected_head_sha
       properties:
+        candidate_id:
+          type: string
+          format: uuid
+          description: Exact synthetic candidate id required only for the operator-only beta while global mode is OFF.
         repository:
           type: string
           enum:

--- a/src/api-serverless/src/deploy/deploy-release-bus-routes.test.ts
+++ b/src/api-serverless/src/deploy/deploy-release-bus-routes.test.ts
@@ -46,6 +46,8 @@ jest.mock('@aws-sdk/client-lambda', () => ({
 }));
 const mockV2MarkReadyForProduction = jest.fn();
 const mockV2Cancel = jest.fn();
+const mockV2Register = jest.fn();
+const mockV2IsBetaTrainAllowed = jest.fn();
 const mockV2Authorize = jest.fn();
 const mockV2ReportProgress = jest.fn();
 
@@ -126,13 +128,15 @@ jest.mock('@/releaseBusV2/release-bus-v2.repository', () => ({
 
 jest.mock('@/releaseBusV2/release-bus-v2.service', () => ({
   releaseBusV2Service: {
-    register: jest.fn(),
+    register: (...args: unknown[]) => mockV2Register(...args),
     markReadyForProduction: (...args: unknown[]) =>
       mockV2MarkReadyForProduction(...args),
     revokeProductionReadiness: jest.fn(),
     cancel: (...args: unknown[]) => mockV2Cancel(...args),
     setPaused: jest.fn(),
-    invalidateBranch: jest.fn()
+    invalidateBranch: jest.fn(),
+    isBetaTrainAllowed: (...args: unknown[]) =>
+      mockV2IsBetaTrainAllowed(...args)
   }
 }));
 
@@ -1158,6 +1162,7 @@ describe('Release Bus v2 route authorization and exact actions', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     process.env.RELEASE_BUS_V2_MODE = 'PRODUCTION';
+    delete process.env.RELEASE_BUS_V2_BETA_ALLOWLIST;
     process.env.RELEASE_BUS_WORKFLOW_AUTH_TOKEN = WORKFLOW_TOKEN;
     mockGetViewer.mockResolvedValue({ login: 'developer' });
     mockAssertRepositoryWriteAccess.mockResolvedValue(undefined);
@@ -1189,10 +1194,12 @@ describe('Release Bus v2 route authorization and exact actions', () => {
     mockV2ListTrainCandidates.mockResolvedValue([]);
     mockV2ListOperations.mockResolvedValue([]);
     mockV2ListEvents.mockResolvedValue([]);
+    mockV2IsBetaTrainAllowed.mockResolvedValue(true);
   });
 
   afterAll(() => {
     delete process.env.RELEASE_BUS_V2_MODE;
+    delete process.env.RELEASE_BUS_V2_BETA_ALLOWLIST;
     delete process.env.RELEASE_BUS_WORKFLOW_AUTH_TOKEN;
   });
 
@@ -1286,6 +1293,81 @@ describe('Release Bus v2 route authorization and exact actions', () => {
         })
       })
     );
+  });
+
+  it('keeps ordinary candidate registration disabled while global mode is OFF', async () => {
+    process.env.RELEASE_BUS_V2_MODE = 'OFF';
+    mockIsOrganizationOperator.mockResolvedValue(false);
+
+    const response = await post('/deploy/release-bus-v2/candidates', {
+      candidate_id: candidateId,
+      repository: 'frontend',
+      pr_number: 321,
+      branch_name: 'agent/rb2-beta-frontend-one',
+      expected_head_sha: SHA,
+      deploy_plan: null,
+      dependencies: []
+    });
+
+    expect(response.status).toBe(403);
+    expect(mockV2Register).not.toHaveBeenCalled();
+    expect(mockAssertRepositoryWriteAccess).not.toHaveBeenCalled();
+  });
+
+  it('queues an operator-only beta reconciliation while reporting global OFF', async () => {
+    process.env.RELEASE_BUS_V2_MODE = 'OFF';
+    process.env.RELEASE_BUS_V2_BETA_ALLOWLIST = JSON.stringify([
+      {
+        test_id: 'frontend-only-1',
+        candidate_id: candidateId,
+        repository: 'frontend',
+        branch_name: 'agent/rb2-beta-frontend-one',
+        operator: 'developer',
+        lanes: ['STAGING']
+      }
+    ]);
+
+    const response = await post('/deploy/release-bus-v2/reconcile', {});
+
+    expect(response.status).toBe(202);
+    expect(response.body).toMatchObject({
+      accepted: true,
+      mode: 'OFF',
+      execution: 'queued_operator_beta'
+    });
+    expect(mockLambdaSend).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails closed when an OFF workflow train is not beta-allowlisted', async () => {
+    process.env.RELEASE_BUS_V2_MODE = 'OFF';
+    process.env.RELEASE_BUS_V2_BETA_ALLOWLIST = JSON.stringify([
+      {
+        test_id: 'frontend-only-1',
+        candidate_id: candidateId,
+        repository: 'frontend',
+        branch_name: 'agent/rb2-beta-frontend-one',
+        operator: 'developer',
+        lanes: ['STAGING']
+      }
+    ]);
+    mockV2FindTrain.mockResolvedValue({ id: TRAIN_ID, lane: 'STAGING' });
+    mockV2IsBetaTrainAllowed.mockResolvedValue(false);
+    const body = {
+      train_id: TRAIN_ID,
+      operation_key: `rb2:${TRAIN_ID}:prepare:frontend:a1`,
+      workflow_run_id: '12345',
+      artifact_run_id: null,
+      repository: 'frontend',
+      environment: 'orchestration',
+      service: null,
+      expected_sha: SHA,
+      artifact_digest: null
+    };
+
+    const response = await post('/deploy/release-bus-v2/authorize', body);
+
+    expect(response.status).toBe(403);
+    expect(mockV2Authorize).not.toHaveBeenCalled();
   });
 
   it('reports a reconciliation dispatch failure without claiming it was queued', async () => {

--- a/src/api-serverless/src/deploy/deploy-release-bus-routes.test.ts
+++ b/src/api-serverless/src/deploy/deploy-release-bus-routes.test.ts
@@ -1338,6 +1338,26 @@ describe('Release Bus v2 route authorization and exact actions', () => {
     expect(mockLambdaSend).toHaveBeenCalledTimes(1);
   });
 
+  it('rejects an allowlisted beta actor who is no longer an org operator', async () => {
+    process.env.RELEASE_BUS_V2_MODE = 'OFF';
+    process.env.RELEASE_BUS_V2_BETA_ALLOWLIST = JSON.stringify([
+      {
+        test_id: 'frontend-only-1',
+        candidate_id: candidateId,
+        repository: 'frontend',
+        branch_name: 'agent/rb2-beta-frontend-one',
+        operator: 'developer',
+        lanes: ['STAGING']
+      }
+    ]);
+    mockIsOrganizationOperator.mockResolvedValue(false);
+
+    const response = await post('/deploy/release-bus-v2/reconcile', {});
+
+    expect(response.status).toBe(403);
+    expect(mockLambdaSend).not.toHaveBeenCalled();
+  });
+
   it('fails closed when an OFF workflow train is not beta-allowlisted', async () => {
     process.env.RELEASE_BUS_V2_MODE = 'OFF';
     process.env.RELEASE_BUS_V2_BETA_ALLOWLIST = JSON.stringify([
@@ -1352,6 +1372,27 @@ describe('Release Bus v2 route authorization and exact actions', () => {
     ]);
     mockV2FindTrain.mockResolvedValue({ id: TRAIN_ID, lane: 'STAGING' });
     mockV2IsBetaTrainAllowed.mockResolvedValue(false);
+    const body = {
+      train_id: TRAIN_ID,
+      operation_key: `rb2:${TRAIN_ID}:prepare:frontend:a1`,
+      workflow_run_id: '12345',
+      artifact_run_id: null,
+      repository: 'frontend',
+      environment: 'orchestration',
+      service: null,
+      expected_sha: SHA,
+      artifact_digest: null
+    };
+
+    const response = await post('/deploy/release-bus-v2/authorize', body);
+
+    expect(response.status).toBe(403);
+    expect(mockV2Authorize).not.toHaveBeenCalled();
+  });
+
+  it('returns a uniform 403 when an OFF workflow train lookup fails', async () => {
+    process.env.RELEASE_BUS_V2_MODE = 'OFF';
+    mockV2FindTrain.mockRejectedValue(new Error('database unavailable'));
     const body = {
       train_id: TRAIN_ID,
       operation_key: `rb2:${TRAIN_ID}:prepare:frontend:a1`,

--- a/src/api-serverless/src/deploy/deploy.routes.ts
+++ b/src/api-serverless/src/deploy/deploy.routes.ts
@@ -965,9 +965,9 @@ deployRoutes.post('/release-bus-v2/reconcile', async (req, res) => {
 
 async function requireV2TrainAutomationAllowed(trainId: string) {
   if (getReleaseBusV2Mode() !== 'OFF') return;
-  const train = await releaseBusV2Repository.findTrain(trainId, {});
   let allowed = false;
   try {
+    const train = await releaseBusV2Repository.findTrain(trainId, {});
     allowed = Boolean(
       train && (await releaseBusV2Service.isBetaTrainAllowed(train))
     );

--- a/src/api-serverless/src/deploy/deploy.routes.ts
+++ b/src/api-serverless/src/deploy/deploy.routes.ts
@@ -61,7 +61,11 @@ import type {
   ReleaseControlScope,
   ReleaseRepository
 } from '@/releaseBus/release-bus.types';
-import { getReleaseBusV2Mode } from '@/releaseBusV2/release-bus-v2.config';
+import {
+  getReleaseBusV2BetaAllowlist,
+  getReleaseBusV2Mode,
+  releaseBusV2BetaAllowsCandidate
+} from '@/releaseBusV2/release-bus-v2.config';
 import {
   releaseBusV2Operations,
   type ReleaseBusV2Progress
@@ -126,8 +130,13 @@ function targetForRepository(repository: ReleaseRepository) {
 
 async function requireOperator(token: string): Promise<string> {
   const viewer = await gitHubDeployService.getViewer(token);
+  await requireOperatorLogin(viewer.login);
+  return viewer.login;
+}
+
+async function requireOperatorLogin(login: string): Promise<void> {
   const allowed = await releaseBusGitHubApp.isOrganizationOperator(
-    viewer.login,
+    login,
     RELEASE_BUS_OPERATOR_TEAM
   );
   if (!allowed)
@@ -135,7 +144,6 @@ async function requireOperator(token: string): Promise<string> {
       403,
       'Release-bus operator permission is required'
     );
-  return viewer.login;
 }
 
 async function requireAuthenticatedViewer(req: Request): Promise<string> {
@@ -158,6 +166,28 @@ async function requireV2CandidateWriteAccess(
       404,
       'Release Bus v2 candidate not found'
     );
+  if (getReleaseBusV2Mode() === 'OFF') {
+    await requireOperatorLogin(viewer.login);
+    let allowed = false;
+    try {
+      const betaAllowlist = getReleaseBusV2BetaAllowlist();
+      allowed =
+        candidate.requested_by.toLowerCase() === viewer.login.toLowerCase() &&
+        (releaseBusV2BetaAllowsCandidate(betaAllowlist, candidate, 'STAGING') ||
+          releaseBusV2BetaAllowsCandidate(
+            betaAllowlist,
+            candidate,
+            'PRODUCTION'
+          ));
+    } catch {
+      allowed = false;
+    }
+    if (!allowed)
+      throw new CustomApiCompliantException(
+        403,
+        'This candidate is not enabled for the operator-only OFF beta'
+      );
+  }
   await gitHubDeployService.assertRepositoryWriteAccess(
     token,
     targetForRepository(candidate.repository)
@@ -601,7 +631,10 @@ deployRoutes.post(
 
 deployRoutes.post('/release-bus-v2/candidates', async (req, res) => {
   const token = getGitHubTokenOrThrow(req);
-  const actor = (await gitHubDeployService.getViewer(token)).login;
+  const actor =
+    getReleaseBusV2Mode() === 'OFF'
+      ? await requireOperator(token)
+      : (await gitHubDeployService.getViewer(token)).login;
   const body = getValidatedByJoiOrThrow<ReleaseBusV2RegisterInput>(
     req.body,
     ReleaseBusV2CandidateBodySchema
@@ -870,7 +903,20 @@ deployRoutes.post('/release-bus-v2/reconcile', async (req, res) => {
     {}
   );
   const mode = getReleaseBusV2Mode();
-  if (mode !== 'OFF') {
+  let betaEnabledForActor = false;
+  if (mode === 'OFF') {
+    try {
+      betaEnabledForActor = getReleaseBusV2BetaAllowlist().some(
+        (entry) => entry.operator === actor.toLowerCase()
+      );
+    } catch {
+      throw new CustomApiCompliantException(
+        409,
+        'Release Bus v2 beta allowlist is invalid; automation remains OFF'
+      );
+    }
+  }
+  if (mode !== 'OFF' || betaEnabledForActor) {
     try {
       await lambdaClient.send(
         new InvokeCommand({
@@ -905,13 +951,35 @@ deployRoutes.post('/release-bus-v2/reconcile', async (req, res) => {
     }
   }
   setNoStoreHeaders(res);
+  let execution = 'queued_on_reserved_worker';
+  if (mode === 'OFF') {
+    execution = betaEnabledForActor ? 'queued_operator_beta' : 'disabled';
+  }
   return res.status(202).json({
-    accepted: mode !== 'OFF',
+    accepted: mode !== 'OFF' || betaEnabledForActor,
     mode,
     requested_by: actor,
-    execution: mode === 'OFF' ? 'disabled' : 'queued_on_reserved_worker'
+    execution
   });
 });
+
+async function requireV2TrainAutomationAllowed(trainId: string) {
+  if (getReleaseBusV2Mode() !== 'OFF') return;
+  const train = await releaseBusV2Repository.findTrain(trainId, {});
+  let allowed = false;
+  try {
+    allowed = Boolean(
+      train && (await releaseBusV2Service.isBetaTrainAllowed(train))
+    );
+  } catch {
+    allowed = false;
+  }
+  if (!allowed)
+    throw new CustomApiCompliantException(
+      403,
+      'Release Bus v2 workflow is not allowlisted for the OFF beta'
+    );
+}
 
 deployRoutes.post('/release-bus-v2/authorize', async (req, res) => {
   requireWorkflowCredential(req);
@@ -928,6 +996,7 @@ deployRoutes.post('/release-bus-v2/authorize', async (req, res) => {
     expected_sha: string;
     artifact_digest: string | null;
   }>(req.body, ReleaseBusV2AuthorizationBodySchema);
+  await requireV2TrainAutomationAllowed(authorization.train_id);
   try {
     const result = await releaseBusV2Operations.authorize(authorization);
     setNoStoreHeaders(res);
@@ -952,6 +1021,7 @@ deployRoutes.post('/release-bus-v2/report-progress', async (req, res) => {
     req.body,
     ReleaseBusV2ProgressBodySchema
   );
+  await requireV2TrainAutomationAllowed(body.train_id);
   try {
     const result = await releaseBusV2Operations.reportProgress(body);
     setNoStoreHeaders(res);

--- a/src/api-serverless/src/deploy/deploy.validation.ts
+++ b/src/api-serverless/src/deploy/deploy.validation.ts
@@ -194,6 +194,9 @@ const ReleaseBusV2DeployPlanSchema = Joi.object({
 });
 
 export const ReleaseBusV2CandidateBodySchema = Joi.object({
+  candidate_id: Joi.string()
+    .guid({ version: ['uuidv4'] })
+    .optional(),
   repository: Joi.string()
     .valid(...RELEASE_BUS_V2_REPOSITORIES)
     .required(),

--- a/src/api-serverless/src/generated/models/ObjectSerializer.ts
+++ b/src/api-serverless/src/generated/models/ObjectSerializer.ts
@@ -1122,7 +1122,7 @@ import { ReleaseBusV2DeployPlan } from '../models/ReleaseBusV2DeployPlan';
 import { ReleaseBusV2Manifest  , ReleaseBusV2ManifestLaneEnum   , ReleaseBusV2ManifestStatusEnum             } from '../models/ReleaseBusV2Manifest';
 import { ReleaseBusV2ManifestListResponse } from '../models/ReleaseBusV2ManifestListResponse';
 import { ReleaseBusV2Mode } from '../models/ReleaseBusV2Mode';
-import { ReleaseBusV2RegisterRequest, ReleaseBusV2RegisterRequestRepositoryEnum        } from '../models/ReleaseBusV2RegisterRequest';
+import { ReleaseBusV2RegisterRequest , ReleaseBusV2RegisterRequestRepositoryEnum        } from '../models/ReleaseBusV2RegisterRequest';
 import { ReleaseBusV2Train , ReleaseBusV2TrainLaneEnum  , ReleaseBusV2TrainStatusEnum                    } from '../models/ReleaseBusV2Train';
 import { ReleaseBusV2TrainDetailResponse } from '../models/ReleaseBusV2TrainDetailResponse';
 import { ReleaseBusV2TrainListResponse   } from '../models/ReleaseBusV2TrainListResponse';

--- a/src/api-serverless/src/generated/models/ReleaseBusV2RegisterRequest.ts
+++ b/src/api-serverless/src/generated/models/ReleaseBusV2RegisterRequest.ts
@@ -15,6 +15,10 @@ import { ReleaseBusV2DeployPlan } from '../models/ReleaseBusV2DeployPlan';
 import { HttpFile } from '../http/http';
 
 export class ReleaseBusV2RegisterRequest {
+    /**
+    * Exact synthetic candidate id required only for the operator-only beta while global mode is OFF.
+    */
+    'candidate_id'?: string;
     'repository': ReleaseBusV2RegisterRequestRepositoryEnum;
     'pr_number': number;
     'branch_name': string;
@@ -27,6 +31,12 @@ export class ReleaseBusV2RegisterRequest {
     static readonly mapping: {[index: string]: string} | undefined = undefined;
 
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
+        {
+            "name": "candidate_id",
+            "baseName": "candidate_id",
+            "type": "string",
+            "format": "uuid"
+        },
         {
             "name": "repository",
             "baseName": "repository",

--- a/src/releaseBus/release-bus-infrastructure.test.ts
+++ b/src/releaseBus/release-bus-infrastructure.test.ts
@@ -175,7 +175,13 @@ describe('release bus infrastructure contract', () => {
       "RELEASE_BUS_MODE: ${{ vars.RELEASE_BUS_MODE || 'OFF' }}\n          RELEASE_BUS_MODE: ${{ vars.RELEASE_BUS_MODE || 'OFF' }}"
     );
     expect(deployWorkflow).toContain(
-      'del(.RELEASE_BUS_GITHUB_APP_ID, .RELEASE_BUS_GITHUB_INSTALLATION_ID, .RELEASE_BUS_WORKFLOW_AUTH_TOKEN, .RELEASE_BUS_GITHUB_WEBHOOK_SECRET)'
+      'del(.RELEASE_BUS_V2_BETA_ALLOWLIST, .RELEASE_BUS_GITHUB_APP_ID, .RELEASE_BUS_GITHUB_INSTALLATION_ID, .RELEASE_BUS_WORKFLOW_AUTH_TOKEN, .RELEASE_BUS_GITHUB_WEBHOOK_SECRET)'
+    );
+    expect(releaseBusServerless).toContain(
+      "RELEASE_BUS_V2_BETA_ALLOWLIST: ${env:RELEASE_BUS_V2_BETA_ALLOWLIST, ''}"
+    );
+    expect(deployWorkflow).toContain(
+      "RELEASE_BUS_V2_BETA_ALLOWLIST: ${{ vars.RELEASE_BUS_V2_BETA_ALLOWLIST || '' }}"
     );
   });
 

--- a/src/releaseBus/release-bus.github-app.test.ts
+++ b/src/releaseBus/release-bus.github-app.test.ts
@@ -188,6 +188,40 @@ describe('GitHub workflow operation identity', () => {
   });
 });
 
+describe('GitHub staging idle handshake', () => {
+  it('treats an active staging E2E run as shared staging ownership', async () => {
+    const app = new ReleaseBusGitHubApp();
+    (
+      app as unknown as {
+        cachedToken: { value: string; expiresAt: number };
+      }
+    ).cachedToken = { value: 'test-token', expiresAt: Date.now() + 120_000 };
+    const fetchMock = fetch as jest.MockedFunction<typeof fetch>;
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          workflow_runs: [
+            {
+              id: 12345,
+              name: 'Staging E2E',
+              display_title: 'Guarded staging E2E',
+              status: 'in_progress'
+            }
+          ]
+        })
+      )
+    );
+
+    try {
+      await expect(
+        app.hasActiveStagingMutationOrE2ERun('frontend')
+      ).resolves.toBe(true);
+    } finally {
+      fetchMock.mockReset();
+    }
+  });
+});
+
 function job(index: number): GitHubWorkflowJob {
   return {
     id: index,

--- a/src/releaseBus/release-bus.github-app.ts
+++ b/src/releaseBus/release-bus.github-app.ts
@@ -743,6 +743,75 @@ export class ReleaseBusGitHubApp {
     repository: ReleaseRepository,
     environment: 'staging' | 'prod'
   ): Promise<boolean> {
+    return this.hasActiveWorkflowRun(
+      repository,
+      `${environment} deployment`,
+      (run) => {
+        if (repository === 'backend') {
+          return (
+            run.name === 'Deploy a service' &&
+            run.display_title.includes(` to ${environment}`)
+          );
+        }
+        const names =
+          environment === 'prod'
+            ? ['Web Deploy - PROD', 'Release Bus - Deploy Frontend Production']
+            : ['Web Deploy - STAGING', 'Release Bus - Deploy Frontend Staging'];
+        return names.includes(run.name);
+      }
+    );
+  }
+
+  public async hasActiveStagingMutationOrE2ERun(
+    repository: ReleaseRepository
+  ): Promise<boolean> {
+    return this.hasActiveWorkflowRun(
+      repository,
+      'staging mutation or E2E',
+      (run) => {
+        if (repository === 'backend') {
+          return (
+            run.name === 'Deploy a service' &&
+            run.display_title.includes(' to staging')
+          );
+        }
+        return [
+          'Web Deploy - STAGING',
+          'Release Bus - Deploy Frontend Staging',
+          'Release Bus - Sync Main To Staging',
+          'Staging E2E'
+        ].includes(run.name);
+      }
+    );
+  }
+
+  public async hasActiveProductionMutationOrE2ERun(
+    repository: ReleaseRepository
+  ): Promise<boolean> {
+    return this.hasActiveWorkflowRun(
+      repository,
+      'production mutation or E2E',
+      (run) => {
+        if (repository === 'backend') {
+          return (
+            run.name === 'Deploy a service' &&
+            run.display_title.includes(' to prod')
+          );
+        }
+        return [
+          'Web Deploy - PROD',
+          'Release Bus - Deploy Frontend Production',
+          'Production E2E'
+        ].includes(run.name);
+      }
+    );
+  }
+
+  private async hasActiveWorkflowRun(
+    repository: ReleaseRepository,
+    description: string,
+    matches: (run: GitHubRun) => boolean
+  ): Promise<boolean> {
     for (const status of ['queued', 'in_progress']) {
       const response = await this.request(
         repository,
@@ -750,33 +819,12 @@ export class ReleaseBusGitHubApp {
       );
       await this.assertOk(
         response,
-        `list active ${repository} ${environment} workflow runs`
+        `list active ${repository} ${description} workflow runs`
       );
       const runs =
         ((await response.json()) as { workflow_runs?: GitHubRun[] })
           .workflow_runs ?? [];
-      if (
-        runs.some((run) => {
-          if (repository === 'backend') {
-            return (
-              run.name === 'Deploy a service' &&
-              run.display_title.includes(` to ${environment}`)
-            );
-          }
-          const names =
-            environment === 'prod'
-              ? [
-                  'Web Deploy - PROD',
-                  'Release Bus - Deploy Frontend Production'
-                ]
-              : [
-                  'Web Deploy - STAGING',
-                  'Release Bus - Deploy Frontend Staging'
-                ];
-          return names.includes(run.name);
-        })
-      )
-        return true;
+      if (runs.some(matches)) return true;
     }
     return false;
   }

--- a/src/releaseBus/serverless.yaml
+++ b/src/releaseBus/serverless.yaml
@@ -75,6 +75,7 @@ functions:
       - schedule: rate(1 minute)
     environment:
       RELEASE_BUS_V2_MODE: ${env:RELEASE_BUS_V2_MODE, 'OFF'}
+      RELEASE_BUS_V2_BETA_ALLOWLIST: ${env:RELEASE_BUS_V2_BETA_ALLOWLIST, ''}
       SENTRY_DSN: ${env:SENTRY_DSN}
 
 resources:

--- a/src/releaseBusV2/release-bus-v2.acceptance.test.ts
+++ b/src/releaseBusV2/release-bus-v2.acceptance.test.ts
@@ -3,6 +3,7 @@ const mockEnsureCommitStatus = jest.fn();
 const mockResolveRef = jest.fn();
 const mockResolveRefIfExists = jest.fn();
 const mockUpdateRef = jest.fn();
+const mockHasActiveStagingRun = jest.fn();
 
 jest.mock('@/releaseBusV2/release-bus-v2.operations', () => ({
   releaseBusV2Operations: {
@@ -15,7 +16,9 @@ jest.mock('@/releaseBus/release-bus.github-app', () => ({
     ensureCommitStatus: (...args: unknown[]) => mockEnsureCommitStatus(...args),
     resolveRef: (...args: unknown[]) => mockResolveRef(...args),
     resolveRefIfExists: (...args: unknown[]) => mockResolveRefIfExists(...args),
-    updateRef: (...args: unknown[]) => mockUpdateRef(...args)
+    updateRef: (...args: unknown[]) => mockUpdateRef(...args),
+    hasActiveStagingMutationOrE2ERun: (...args: unknown[]) =>
+      mockHasActiveStagingRun(...args)
   }
 }));
 
@@ -412,7 +415,8 @@ function harness(e2eStatus: 'RUNNING' | 'SUCCEEDED' | 'FAILED') {
   const service = {
     claimLane: jest.fn(async () => null),
     setPaused: jest.fn(async () => undefined),
-    invalidateBranch: jest.fn(async () => undefined)
+    invalidateBranch: jest.fn(async () => undefined),
+    isBetaTrainAllowed: jest.fn(async () => true)
   };
   return {
     repository,
@@ -427,10 +431,13 @@ function harness(e2eStatus: 'RUNNING' | 'SUCCEEDED' | 'FAILED') {
 
 describe('Release Bus v2 offline acceptance harness', () => {
   const previousMode = process.env.RELEASE_BUS_V2_MODE;
+  const previousBetaAllowlist = process.env.RELEASE_BUS_V2_BETA_ALLOWLIST;
 
   beforeEach(() => {
     jest.clearAllMocks();
     process.env.RELEASE_BUS_V2_MODE = 'STAGING';
+    delete process.env.RELEASE_BUS_V2_BETA_ALLOWLIST;
+    mockHasActiveStagingRun.mockResolvedValue(false);
     mockResolveRefIfExists.mockImplementation(
       async (repository: 'frontend' | 'backend') =>
         repository === 'frontend' ? FRONTEND_SHA : BACKEND_SHA
@@ -451,9 +458,119 @@ describe('Release Bus v2 offline acceptance harness', () => {
     expect(state.repository.trains.get('train-1')?.status).toBe('PREPARED');
   });
 
+  it('pauses only beta automation when the OFF allowlist is malformed', async () => {
+    const state = harness('SUCCEEDED');
+    process.env.RELEASE_BUS_V2_MODE = 'OFF';
+    process.env.RELEASE_BUS_V2_BETA_ALLOWLIST = 'not-json';
+
+    await expect(
+      state.reconciler.runOnce('acceptance-invalid-beta')
+    ).resolves.toEqual({
+      mode: 'OFF',
+      claimed: [],
+      advanced: []
+    });
+    expect(state.service.setPaused).toHaveBeenCalledWith(
+      'ALL',
+      true,
+      expect.stringContaining('allowlist is invalid'),
+      'release-bus-v2-beta'
+    );
+    expect(state.service.claimLane).not.toHaveBeenCalled();
+  });
+
+  it('enters the OFF beta lane but does not advance an unallowlisted active train', async () => {
+    const state = harness('SUCCEEDED');
+    process.env.RELEASE_BUS_V2_MODE = 'OFF';
+    process.env.RELEASE_BUS_V2_BETA_ALLOWLIST = JSON.stringify([
+      {
+        test_id: 'backend-only-1',
+        candidate_id: '11111111-1111-4111-8111-111111111111',
+        repository: 'backend',
+        branch_name: 'agent/rb2-beta-backend-one',
+        operator: 'beta-operator',
+        lanes: ['STAGING']
+      }
+    ]);
+    mockResolveRef.mockImplementation(async (repository: string) =>
+      repository === 'frontend' ? FRONTEND_SHA : BACKEND_SHA
+    );
+    state.service.isBetaTrainAllowed.mockResolvedValue(false);
+
+    await expect(state.reconciler.runOnce('acceptance-beta')).resolves.toEqual({
+      mode: 'OFF',
+      claimed: [],
+      advanced: []
+    });
+    expect(state.service.claimLane).toHaveBeenCalledTimes(1);
+    expect(state.service.claimLane).toHaveBeenCalledWith(
+      'STAGING',
+      FRONTEND_SHA,
+      BACKEND_SHA,
+      'acceptance-beta:staging'
+    );
+    expect(mockReconcileWorkflow).not.toHaveBeenCalled();
+    expect(state.repository.trains.get('train-1')?.status).toBe('PREPARED');
+  });
+
+  it('double-checks idle refs around the staging lock before a beta mutation', async () => {
+    const state = harness('SUCCEEDED');
+    process.env.RELEASE_BUS_V2_MODE = 'OFF';
+    process.env.RELEASE_BUS_V2_BETA_ALLOWLIST = JSON.stringify([
+      {
+        test_id: 'backend-only-1',
+        candidate_id: '11111111-1111-4111-8111-111111111111',
+        repository: 'backend',
+        branch_name: 'agent/rb2-beta-backend-one',
+        operator: 'beta-operator',
+        lanes: ['STAGING']
+      }
+    ]);
+    mockResolveRef.mockImplementation(async (repository: string) =>
+      repository === 'frontend' ? FRONTEND_SHA : BACKEND_SHA
+    );
+    const updateTrain = state.repository.updateTrain.bind(state.repository);
+    jest
+      .spyOn(state.repository, 'updateTrain')
+      .mockImplementation(async (id, rowVersion, fields) => {
+        const updated = await updateTrain(id, rowVersion, fields);
+        const trainAfterUpdate = state.repository.trains.get(id);
+        if (updated && trainAfterUpdate) {
+          state.repository.trains.set(id, {
+            ...trainAfterUpdate,
+            row_version: rowVersion
+          });
+        }
+        return updated;
+      });
+
+    const result = await state.reconciler.runOnce('acceptance-beta-idle');
+    expect({
+      result,
+      train: state.repository.trains.get('train-1'),
+      events: state.repository.events,
+      lock: state.repository.lock
+    }).toMatchObject({
+      result: { mode: 'OFF', claimed: [], advanced: ['train-1'] },
+      train: { status: 'DEPLOYING' },
+      lock: { owner_train_id: 'train-1' }
+    });
+    expect(mockHasActiveStagingRun).toHaveBeenCalledTimes(4);
+    expect(state.repository.events).toContainEqual(
+      expect.objectContaining({
+        eventType: 'BETA_STAGING_IDLE_HANDSHAKE',
+        trainId: 'train-1',
+        payload: expect.objectContaining({ staging_lock: 'owned' })
+      })
+    );
+  });
+
   afterAll(() => {
     if (previousMode === undefined) delete process.env.RELEASE_BUS_V2_MODE;
     else process.env.RELEASE_BUS_V2_MODE = previousMode;
+    if (previousBetaAllowlist === undefined)
+      delete process.env.RELEASE_BUS_V2_BETA_ALLOWLIST;
+    else process.env.RELEASE_BUS_V2_BETA_ALLOWLIST = previousBetaAllowlist;
   });
 
   it('serializes only dependency edges, binds E2E to the exact manifest, and is duplicate-safe', async () => {

--- a/src/releaseBusV2/release-bus-v2.acceptance.test.ts
+++ b/src/releaseBusV2/release-bus-v2.acceptance.test.ts
@@ -4,6 +4,7 @@ const mockResolveRef = jest.fn();
 const mockResolveRefIfExists = jest.fn();
 const mockUpdateRef = jest.fn();
 const mockHasActiveStagingRun = jest.fn();
+const mockHasActiveProductionRun = jest.fn();
 
 jest.mock('@/releaseBusV2/release-bus-v2.operations', () => ({
   releaseBusV2Operations: {
@@ -18,7 +19,9 @@ jest.mock('@/releaseBus/release-bus.github-app', () => ({
     resolveRefIfExists: (...args: unknown[]) => mockResolveRefIfExists(...args),
     updateRef: (...args: unknown[]) => mockUpdateRef(...args),
     hasActiveStagingMutationOrE2ERun: (...args: unknown[]) =>
-      mockHasActiveStagingRun(...args)
+      mockHasActiveStagingRun(...args),
+    hasActiveProductionMutationOrE2ERun: (...args: unknown[]) =>
+      mockHasActiveProductionRun(...args)
   }
 }));
 
@@ -438,9 +441,13 @@ describe('Release Bus v2 offline acceptance harness', () => {
     process.env.RELEASE_BUS_V2_MODE = 'STAGING';
     delete process.env.RELEASE_BUS_V2_BETA_ALLOWLIST;
     mockHasActiveStagingRun.mockResolvedValue(false);
+    mockHasActiveProductionRun.mockResolvedValue(false);
     mockResolveRefIfExists.mockImplementation(
       async (repository: 'frontend' | 'backend') =>
         repository === 'frontend' ? FRONTEND_SHA : BACKEND_SHA
+    );
+    mockResolveRef.mockImplementation(async (repository: string) =>
+      repository === 'frontend' ? FRONTEND_SHA : BACKEND_SHA
     );
   });
 
@@ -563,6 +570,41 @@ describe('Release Bus v2 offline acceptance harness', () => {
         payload: expect.objectContaining({ staging_lock: 'owned' })
       })
     );
+  });
+
+  it('releases the production beta lock when the post-lock idle snapshot fails', async () => {
+    const state = harness('SUCCEEDED');
+    process.env.RELEASE_BUS_V2_MODE = 'OFF';
+    const production = train('production-train', {
+      lane: 'PRODUCTION',
+      status: 'MERGING_PRODUCTION'
+    });
+    const context = {
+      train: production,
+      memberships: state.repository.memberships.map((item) => ({
+        ...item,
+        train_id: production.id
+      })),
+      candidates: Array.from(state.repository.candidates.values()),
+      dependencies: state.repository.dependencies
+    };
+    let resolveCalls = 0;
+    mockResolveRef.mockImplementation(async (repository: string) => {
+      resolveCalls += 1;
+      if (resolveCalls > 2) throw new Error('GitHub ref lookup failed');
+      return repository === 'frontend' ? FRONTEND_SHA : BACKEND_SHA;
+    });
+
+    await expect(
+      (
+        state.reconciler as unknown as {
+          advanceProduction(input: typeof context): Promise<void>;
+        }
+      ).advanceProduction(context)
+    ).rejects.toThrow('GitHub ref lookup failed');
+    expect(state.repository.lock.owner_train_id).toBeNull();
+    expect(state.repository.lock.lease_token).toBeNull();
+    expect(mockUpdateRef).not.toHaveBeenCalled();
   });
 
   afterAll(() => {

--- a/src/releaseBusV2/release-bus-v2.config.test.ts
+++ b/src/releaseBusV2/release-bus-v2.config.test.ts
@@ -1,0 +1,145 @@
+import {
+  getReleaseBusV2BetaAllowlist,
+  getReleaseBusV2Mode,
+  releaseBusV2BetaAllowsCandidate,
+  releaseBusV2BetaAllowsRegistration,
+  ReleaseBusV2BetaConfigurationError
+} from '@/releaseBusV2/release-bus-v2.config';
+import type {
+  ReleaseBusV2CandidateRecord,
+  ReleaseBusV2RegisterInput
+} from '@/releaseBusV2/release-bus-v2.types';
+
+const CANDIDATE_ID = '11111111-1111-4111-8111-111111111111';
+
+function configuredEntry(overrides: Record<string, unknown> = {}) {
+  return {
+    test_id: 'backend-only-1',
+    candidate_id: CANDIDATE_ID,
+    repository: 'backend',
+    branch_name: 'agent/rb2-beta-backend-one',
+    operator: 'BetaOperator',
+    lanes: ['STAGING'],
+    ...overrides
+  };
+}
+
+function registration(): ReleaseBusV2RegisterInput {
+  return {
+    candidate_id: CANDIDATE_ID,
+    repository: 'backend',
+    pr_number: 1801,
+    branch_name: 'agent/rb2-beta-backend-one',
+    expected_head_sha: 'a'.repeat(40),
+    deploy_plan: { units: ['api'], edges: [] },
+    dependencies: []
+  };
+}
+
+function candidate(): ReleaseBusV2CandidateRecord {
+  return {
+    id: CANDIDATE_ID,
+    repository: 'backend',
+    pr_number: 1801,
+    branch_name: 'agent/rb2-beta-backend-one',
+    head_sha: 'a'.repeat(40),
+    requested_by: 'betaoperator',
+    status: 'READY_FOR_STAGING',
+    deploy_plan_json: { units: ['api'], edges: [] },
+    pr_evidence_json: null,
+    current_train_id: null,
+    staging_validated_train_id: null,
+    staging_validated_manifest_id: null,
+    production_requested_at: null,
+    production_requested_by: null,
+    hold_reason: null,
+    superseded_at: null,
+    created_at: 1,
+    updated_at: 1,
+    row_version: 1
+  };
+}
+
+describe('Release Bus v2 operator-only OFF beta configuration', () => {
+  const previousMode = process.env.RELEASE_BUS_V2_MODE;
+  const previousAllowlist = process.env.RELEASE_BUS_V2_BETA_ALLOWLIST;
+
+  beforeEach(() => {
+    process.env.RELEASE_BUS_V2_MODE = 'OFF';
+    delete process.env.RELEASE_BUS_V2_BETA_ALLOWLIST;
+  });
+
+  afterAll(() => {
+    if (previousMode === undefined) delete process.env.RELEASE_BUS_V2_MODE;
+    else process.env.RELEASE_BUS_V2_MODE = previousMode;
+    if (previousAllowlist === undefined)
+      delete process.env.RELEASE_BUS_V2_BETA_ALLOWLIST;
+    else process.env.RELEASE_BUS_V2_BETA_ALLOWLIST = previousAllowlist;
+  });
+
+  it('keeps global mode OFF with no implicit beta enrollment', () => {
+    expect(getReleaseBusV2Mode()).toBe('OFF');
+    expect(getReleaseBusV2BetaAllowlist()).toEqual([]);
+  });
+
+  it('requires exact candidate, repository, branch, actor, and lane matches', () => {
+    process.env.RELEASE_BUS_V2_BETA_ALLOWLIST = JSON.stringify([
+      configuredEntry({ lanes: ['PRODUCTION', 'STAGING'] })
+    ]);
+    const allowlist = getReleaseBusV2BetaAllowlist();
+
+    expect(
+      releaseBusV2BetaAllowsRegistration(
+        allowlist,
+        registration(),
+        'BETAOPERATOR'
+      )
+    ).toBe(true);
+    expect(
+      releaseBusV2BetaAllowsRegistration(
+        allowlist,
+        { ...registration(), branch_name: 'agent/unlisted' },
+        'BETAOPERATOR'
+      )
+    ).toBe(false);
+    expect(
+      releaseBusV2BetaAllowsCandidate(allowlist, candidate(), 'STAGING')
+    ).toBe(true);
+    expect(
+      releaseBusV2BetaAllowsCandidate(
+        allowlist,
+        { ...candidate(), requested_by: 'another-operator' },
+        'STAGING'
+      )
+    ).toBe(false);
+  });
+
+  it.each([
+    'not-json',
+    '[]',
+    JSON.stringify([configuredEntry({ candidate_id: 'not-a-uuid' })]),
+    JSON.stringify([configuredEntry({ lanes: [] })]),
+    JSON.stringify([configuredEntry(), configuredEntry()]),
+    JSON.stringify([configuredEntry({ unexpected: true })]),
+    JSON.stringify([
+      configuredEntry(),
+      configuredEntry({
+        candidate_id: '22222222-2222-4222-8222-222222222222',
+        branch_name: 'agent/rb2-beta-backend-two',
+        operator: 'another-operator'
+      })
+    ]),
+    JSON.stringify([
+      configuredEntry(),
+      configuredEntry({
+        candidate_id: '22222222-2222-4222-8222-222222222222'
+      })
+    ])
+  ])('fails closed for malformed allowlist %s', (value) => {
+    process.env.RELEASE_BUS_V2_BETA_ALLOWLIST = value;
+    expect(() => getReleaseBusV2BetaAllowlist()).toThrow(
+      ReleaseBusV2BetaConfigurationError
+    );
+    expect(getReleaseBusV2Mode()).toBe('OFF');
+  });
+});

--- a/src/releaseBusV2/release-bus-v2.config.ts
+++ b/src/releaseBusV2/release-bus-v2.config.ts
@@ -1,6 +1,173 @@
-import type { ReleaseBusV2Mode } from '@/releaseBusV2/release-bus-v2.types';
+import type {
+  ReleaseBusV2CandidateRecord,
+  ReleaseBusV2Lane,
+  ReleaseBusV2Mode,
+  ReleaseBusV2RegisterInput,
+  ReleaseBusV2Repository
+} from '@/releaseBusV2/release-bus-v2.types';
 
 const MODES = new Set<ReleaseBusV2Mode>(['OFF', 'STAGING', 'PRODUCTION']);
+const BETA_LANES = new Set<ReleaseBusV2BetaLane>(['STAGING', 'PRODUCTION']);
+const BETA_UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const BETA_BRANCH_PATTERN = /^[A-Za-z0-9._/-]{1,255}$/;
+const BETA_OPERATOR_PATTERN = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/;
+const BETA_ENTRY_KEYS = [
+  'branch_name',
+  'candidate_id',
+  'lanes',
+  'operator',
+  'repository',
+  'test_id'
+] as const;
+
+function compareInvariant(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+export type ReleaseBusV2BetaLane = 'STAGING' | 'PRODUCTION';
+
+export type ReleaseBusV2BetaEntry = {
+  readonly test_id: string;
+  readonly candidate_id: string;
+  readonly repository: ReleaseBusV2Repository;
+  readonly branch_name: string;
+  readonly operator: string;
+  readonly lanes: readonly ReleaseBusV2BetaLane[];
+};
+
+export class ReleaseBusV2BetaConfigurationError extends Error {
+  public constructor() {
+    super('Release Bus v2 beta allowlist is invalid');
+    this.name = 'ReleaseBusV2BetaConfigurationError';
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+function parseBetaEntry(value: unknown): ReleaseBusV2BetaEntry {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new ReleaseBusV2BetaConfigurationError();
+  }
+  const entry = value as Record<string, unknown>;
+  const keys = Object.keys(entry).sort(compareInvariant);
+  if (
+    JSON.stringify(keys) !== JSON.stringify(BETA_ENTRY_KEYS) ||
+    typeof entry.test_id !== 'string' ||
+    !/^[A-Za-z0-9._-]{1,100}$/.test(entry.test_id) ||
+    typeof entry.candidate_id !== 'string' ||
+    !BETA_UUID_PATTERN.test(entry.candidate_id) ||
+    !['frontend', 'backend'].includes(String(entry.repository)) ||
+    typeof entry.branch_name !== 'string' ||
+    !BETA_BRANCH_PATTERN.test(entry.branch_name) ||
+    typeof entry.operator !== 'string' ||
+    !BETA_OPERATOR_PATTERN.test(entry.operator) ||
+    !Array.isArray(entry.lanes) ||
+    entry.lanes.length === 0 ||
+    entry.lanes.some(
+      (lane) =>
+        typeof lane !== 'string' ||
+        !BETA_LANES.has(lane as ReleaseBusV2BetaLane)
+    )
+  ) {
+    throw new ReleaseBusV2BetaConfigurationError();
+  }
+  const lanes = Array.from(new Set(entry.lanes as ReleaseBusV2BetaLane[])).sort(
+    compareInvariant
+  );
+  if (lanes.length !== entry.lanes.length) {
+    throw new ReleaseBusV2BetaConfigurationError();
+  }
+  return {
+    test_id: entry.test_id,
+    candidate_id: entry.candidate_id.toLowerCase(),
+    repository: entry.repository as ReleaseBusV2Repository,
+    branch_name: entry.branch_name,
+    operator: entry.operator.toLowerCase(),
+    lanes
+  };
+}
+
+/**
+ * The global mode remains OFF during beta. A non-empty, valid allowlist is the
+ * only mechanism that permits the reserved worker to touch an exact synthetic
+ * candidate. Invalid configuration fails closed.
+ */
+export function getReleaseBusV2BetaAllowlist(): readonly ReleaseBusV2BetaEntry[] {
+  const configured = process.env.RELEASE_BUS_V2_BETA_ALLOWLIST?.trim();
+  if (!configured) return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(configured);
+  } catch {
+    throw new ReleaseBusV2BetaConfigurationError();
+  }
+  if (!Array.isArray(parsed) || parsed.length === 0 || parsed.length > 20) {
+    throw new ReleaseBusV2BetaConfigurationError();
+  }
+  const entries = parsed.map(parseBetaEntry);
+  if (
+    new Set(entries.map(({ candidate_id }) => candidate_id)).size !==
+    entries.length
+  ) {
+    throw new ReleaseBusV2BetaConfigurationError();
+  }
+  if (new Set(entries.map(({ test_id }) => test_id)).size !== 1) {
+    throw new ReleaseBusV2BetaConfigurationError();
+  }
+  if (new Set(entries.map(({ operator }) => operator)).size !== 1) {
+    throw new ReleaseBusV2BetaConfigurationError();
+  }
+  if (
+    new Set(
+      entries.map(
+        ({ repository, branch_name }) => `${repository}:${branch_name}`
+      )
+    ).size !== entries.length
+  ) {
+    throw new ReleaseBusV2BetaConfigurationError();
+  }
+  return entries;
+}
+
+export function releaseBusV2BetaAllowsLane(
+  allowlist: readonly ReleaseBusV2BetaEntry[],
+  lane: ReleaseBusV2Lane | ReleaseBusV2BetaLane
+): boolean {
+  const requiredLane = lane === 'STAGING' ? 'STAGING' : 'PRODUCTION';
+  return allowlist.some((entry) => entry.lanes.includes(requiredLane));
+}
+
+export function releaseBusV2BetaAllowsRegistration(
+  allowlist: readonly ReleaseBusV2BetaEntry[],
+  input: ReleaseBusV2RegisterInput,
+  actor: string
+): boolean {
+  if (!input.candidate_id) return false;
+  return allowlist.some(
+    (entry) =>
+      entry.candidate_id === input.candidate_id?.toLowerCase() &&
+      entry.repository === input.repository &&
+      entry.branch_name === input.branch_name &&
+      entry.operator === actor.toLowerCase() &&
+      entry.lanes.includes('STAGING')
+  );
+}
+
+export function releaseBusV2BetaAllowsCandidate(
+  allowlist: readonly ReleaseBusV2BetaEntry[],
+  candidate: ReleaseBusV2CandidateRecord,
+  lane: ReleaseBusV2Lane | ReleaseBusV2BetaLane
+): boolean {
+  const requiredLane = lane === 'STAGING' ? 'STAGING' : 'PRODUCTION';
+  return allowlist.some(
+    (entry) =>
+      entry.candidate_id === candidate.id.toLowerCase() &&
+      entry.repository === candidate.repository &&
+      entry.branch_name === candidate.branch_name &&
+      entry.operator === candidate.requested_by.toLowerCase() &&
+      entry.lanes.includes(requiredLane)
+  );
+}
 
 export function getReleaseBusV2Mode(): ReleaseBusV2Mode {
   const configured = (process.env.RELEASE_BUS_V2_MODE ?? 'OFF').toUpperCase();

--- a/src/releaseBusV2/release-bus-v2.reconciler.ts
+++ b/src/releaseBusV2/release-bus-v2.reconciler.ts
@@ -4,7 +4,13 @@ import {
   releaseBusGitHubApp,
   ReleaseBusGitHubInfrastructureError
 } from '@/releaseBus/release-bus.github-app';
-import { getReleaseBusV2Mode } from '@/releaseBusV2/release-bus-v2.config';
+import {
+  getReleaseBusV2BetaAllowlist,
+  getReleaseBusV2Mode,
+  releaseBusV2BetaAllowsCandidate,
+  releaseBusV2BetaAllowsLane,
+  type ReleaseBusV2BetaEntry
+} from '@/releaseBusV2/release-bus-v2.config';
 import {
   releaseBusV2Operations,
   type ReleaseBusV2WorkflowSpec
@@ -72,6 +78,16 @@ type DeployResult = {
   readonly complete: boolean;
   readonly failedOperation: ReleaseBusV2OperationRecord | null;
   readonly operations: readonly ReleaseBusV2OperationRecord[];
+};
+
+type StagingIdleSnapshot = {
+  readonly frontend_staging_sha: string | null;
+  readonly backend_staging_sha: string | null;
+};
+
+type ProductionIdleSnapshot = {
+  readonly frontend_main_sha: string;
+  readonly backend_main_sha: string;
 };
 
 type IsolationSubsetResult =
@@ -433,18 +449,41 @@ export class ReleaseBusV2Reconciler {
   }> {
     const mode = getReleaseBusV2Mode();
     const claimed: string[] = [];
-    if (mode === 'OFF') return { mode, claimed, advanced: [] };
+    let betaAllowlist: readonly ReleaseBusV2BetaEntry[] = [];
+    if (mode === 'OFF') {
+      try {
+        betaAllowlist = getReleaseBusV2BetaAllowlist();
+      } catch {
+        const controls = await this.repository.listControls({});
+        const allControl = controls.find(({ scope }) => scope === 'ALL');
+        if (!allControl?.paused)
+          await this.service.setPaused(
+            'ALL',
+            true,
+            'Release Bus v2 OFF beta allowlist is invalid; automation remains disabled',
+            'release-bus-v2-beta'
+          );
+        return { mode, claimed, advanced: [] };
+      }
+      if (betaAllowlist.length === 0) return { mode, claimed, advanced: [] };
+    }
     const controls = await this.repository.listControls({});
     const isPaused = (scope: 'ALL' | 'STAGING' | 'PRODUCTION') =>
       controls.some(
         (control) => control.scope === scope && Boolean(control.paused)
       );
     if (isPaused('ALL')) return { mode, claimed, advanced: [] };
-    const stagingEnabled = !isPaused('STAGING');
-    const productionEnabled = mode === 'PRODUCTION' && !isPaused('PRODUCTION');
+    const stagingEnabled =
+      !isPaused('STAGING') &&
+      (mode !== 'OFF' || releaseBusV2BetaAllowsLane(betaAllowlist, 'STAGING'));
+    const productionEnabled =
+      !isPaused('PRODUCTION') &&
+      (mode === 'PRODUCTION' ||
+        (mode === 'OFF' &&
+          releaseBusV2BetaAllowsLane(betaAllowlist, 'PRODUCTION')));
     if (stagingEnabled || productionEnabled) {
       try {
-        await this.reconcileQueuedCandidateHeads();
+        await this.reconcileQueuedCandidateHeads(betaAllowlist);
         const [frontendMain, backendMain] = await Promise.all([
           releaseBusGitHubApp.resolveRef('frontend', 'main'),
           releaseBusGitHubApp.resolveRef('backend', 'main')
@@ -481,26 +520,34 @@ export class ReleaseBusV2Reconciler {
       }
     }
 
-    const active = (await this.repository.listTrains(100, {}))
+    const activeByLane = (await this.repository.listTrains(100, {}))
       .filter((train) => !TERMINAL_TRAINS.has(train.status))
       .filter((train) => {
         if (train.lane === 'STAGING') return stagingEnabled;
         if (train.lane === 'PRODUCTION') return productionEnabled;
         return stagingEnabled && productionEnabled;
-      })
-      .sort((left, right) => {
-        if (
-          left.lane === 'PRODUCTION_QUALIFICATION' &&
-          right.lane !== 'PRODUCTION_QUALIFICATION'
-        )
-          return -1;
-        if (
-          right.lane === 'PRODUCTION_QUALIFICATION' &&
-          left.lane !== 'PRODUCTION_QUALIFICATION'
-        )
-          return 1;
-        return Number(left.created_at) - Number(right.created_at);
       });
+    const active: ReleaseBusV2TrainRecord[] = [];
+    for (const train of activeByLane) {
+      if (
+        mode !== 'OFF' ||
+        (await this.service.isBetaTrainAllowed(train, betaAllowlist, {}))
+      )
+        active.push(train);
+    }
+    active.sort((left, right) => {
+      if (
+        left.lane === 'PRODUCTION_QUALIFICATION' &&
+        right.lane !== 'PRODUCTION_QUALIFICATION'
+      )
+        return -1;
+      if (
+        right.lane === 'PRODUCTION_QUALIFICATION' &&
+        left.lane !== 'PRODUCTION_QUALIFICATION'
+      )
+        return 1;
+      return Number(left.created_at) - Number(right.created_at);
+    });
     const advanced: string[] = [];
     for (const train of active) {
       try {
@@ -525,12 +572,21 @@ export class ReleaseBusV2Reconciler {
     return { mode, claimed: Array.from(new Set(claimed)), advanced };
   }
 
-  private async reconcileQueuedCandidateHeads(): Promise<void> {
-    const candidates = await this.repository.listCandidates(
-      ['READY_FOR_STAGING', 'WAITING_FOR_DEPENDENCY', 'READY_FOR_PRODUCTION'],
-      500,
-      {}
-    );
+  private async reconcileQueuedCandidateHeads(
+    betaAllowlist: readonly ReleaseBusV2BetaEntry[] = []
+  ): Promise<void> {
+    const candidates = (
+      await this.repository.listCandidates(
+        ['READY_FOR_STAGING', 'WAITING_FOR_DEPENDENCY', 'READY_FOR_PRODUCTION'],
+        500,
+        {}
+      )
+    ).filter((candidate) => {
+      if (betaAllowlist.length === 0) return true;
+      const lane =
+        candidate.status === 'READY_FOR_PRODUCTION' ? 'PRODUCTION' : 'STAGING';
+      return releaseBusV2BetaAllowsCandidate(betaAllowlist, candidate, lane);
+    });
     const branchHeads = await Promise.all(
       candidates.map(async (candidate) => ({
         candidate,
@@ -1278,6 +1334,21 @@ export class ReleaseBusV2Reconciler {
     context: TrainContext
   ): Promise<void> {
     const train = context.train;
+    const requiresBetaIdleHandshake =
+      getReleaseBusV2Mode() === 'OFF' &&
+      ['PREPARED', 'WAITING_FOR_ENVIRONMENT'].includes(train.status);
+    const beforeLock = requiresBetaIdleHandshake
+      ? await this.captureStagingIdleSnapshot()
+      : null;
+    if (requiresBetaIdleHandshake && !beforeLock) {
+      if (train.status === 'PREPARED')
+        await this.transitionTrain(train, {
+          status: 'WAITING_FOR_ENVIRONMENT',
+          recoveryMessage:
+            'Operator beta is waiting for an idle shared staging deployment, E2E, and ref handshake'
+        });
+      return;
+    }
     const lease = await this.acquireEnvironmentLease(
       'staging-environment',
       train
@@ -1290,6 +1361,37 @@ export class ReleaseBusV2Reconciler {
             'Artifacts are ready; waiting for staging deployment and E2E ownership'
         });
       return;
+    }
+    if (requiresBetaIdleHandshake && beforeLock) {
+      const afterLock = await this.captureStagingIdleSnapshot();
+      const stable =
+        afterLock !== null &&
+        afterLock.frontend_staging_sha === beforeLock.frontend_staging_sha &&
+        afterLock.backend_staging_sha === beforeLock.backend_staging_sha;
+      if (!stable) {
+        await this.releaseEnvironmentLease('staging-environment', lease);
+        if (train.status === 'PREPARED')
+          await this.transitionTrain(train, {
+            status: 'WAITING_FOR_ENVIRONMENT',
+            recoveryMessage:
+              'Shared staging changed during the beta idle handshake; lock released without mutation'
+          });
+        return;
+      }
+      await this.repository.appendEvent(
+        {
+          trainId: train.id,
+          eventType: 'BETA_STAGING_IDLE_HANDSHAKE',
+          actor: 'release-bus-v2-beta',
+          payload: {
+            ...afterLock,
+            beta_test_id: getReleaseBusV2BetaAllowlist()[0]?.test_id,
+            staging_lock: 'owned',
+            verified_at: Date.now()
+          }
+        },
+        {}
+      );
     }
     const sourceTrainId = train.parent_train_id ?? train.id;
     if (['PREPARED', 'WAITING_FOR_ENVIRONMENT'].includes(train.status)) {
@@ -1401,6 +1503,21 @@ export class ReleaseBusV2Reconciler {
     }
   }
 
+  private async captureStagingIdleSnapshot(): Promise<StagingIdleSnapshot | null> {
+    const [frontendActive, backendActive, frontendSha, backendSha] =
+      await Promise.all([
+        releaseBusGitHubApp.hasActiveStagingMutationOrE2ERun('frontend'),
+        releaseBusGitHubApp.hasActiveStagingMutationOrE2ERun('backend'),
+        releaseBusGitHubApp.resolveRefIfExists('frontend', '1a-staging'),
+        releaseBusGitHubApp.resolveRefIfExists('backend', '1a-staging')
+      ]);
+    if (frontendActive || backendActive) return null;
+    return {
+      frontend_staging_sha: frontendSha,
+      backend_staging_sha: backendSha
+    };
+  }
+
   private async advanceProduction(context: TrainContext): Promise<void> {
     const train = context.train;
     if (train.status === 'PREPARED') {
@@ -1479,11 +1596,42 @@ export class ReleaseBusV2Reconciler {
       return;
     }
 
+    const requiresBetaIdleHandshake =
+      getReleaseBusV2Mode() === 'OFF' && train.status === 'MERGING_PRODUCTION';
+    const beforeLock = requiresBetaIdleHandshake
+      ? await this.captureProductionIdleSnapshot()
+      : null;
+    if (requiresBetaIdleHandshake && !beforeLock) return;
     const lease = await this.acquireEnvironmentLease(
       'production-environment',
       train
     );
     if (!lease) return;
+    if (requiresBetaIdleHandshake && beforeLock) {
+      const afterLock = await this.captureProductionIdleSnapshot();
+      const stable =
+        afterLock !== null &&
+        afterLock.frontend_main_sha === beforeLock.frontend_main_sha &&
+        afterLock.backend_main_sha === beforeLock.backend_main_sha;
+      if (!stable) {
+        await this.releaseEnvironmentLease('production-environment', lease);
+        return;
+      }
+      await this.repository.appendEvent(
+        {
+          trainId: train.id,
+          eventType: 'BETA_PRODUCTION_IDLE_HANDSHAKE',
+          actor: 'release-bus-v2-beta',
+          payload: {
+            ...afterLock,
+            beta_test_id: getReleaseBusV2BetaAllowlist()[0]?.test_id,
+            production_lock: 'owned',
+            verified_at: Date.now()
+          }
+        },
+        {}
+      );
+    }
     if (train.status === 'MERGING_PRODUCTION') {
       await this.advanceProductionRefs(context);
       await this.updateCandidateStatuses(
@@ -1552,6 +1700,21 @@ export class ReleaseBusV2Reconciler {
         'Exact v2 production deployment completed'
       );
     }
+  }
+
+  private async captureProductionIdleSnapshot(): Promise<ProductionIdleSnapshot | null> {
+    const [frontendActive, backendActive, frontendSha, backendSha] =
+      await Promise.all([
+        releaseBusGitHubApp.hasActiveProductionMutationOrE2ERun('frontend'),
+        releaseBusGitHubApp.hasActiveProductionMutationOrE2ERun('backend'),
+        releaseBusGitHubApp.resolveRef('frontend', 'main'),
+        releaseBusGitHubApp.resolveRef('backend', 'main')
+      ]);
+    if (frontendActive || backendActive) return null;
+    return {
+      frontend_main_sha: frontendSha,
+      backend_main_sha: backendSha
+    };
   }
 
   private async advanceProductionRefs(context: TrainContext): Promise<void> {

--- a/src/releaseBusV2/release-bus-v2.reconciler.ts
+++ b/src/releaseBusV2/release-bus-v2.reconciler.ts
@@ -1363,7 +1363,13 @@ export class ReleaseBusV2Reconciler {
       return;
     }
     if (requiresBetaIdleHandshake && beforeLock) {
-      const afterLock = await this.captureStagingIdleSnapshot();
+      let afterLock: StagingIdleSnapshot | null;
+      try {
+        afterLock = await this.captureStagingIdleSnapshot();
+      } catch (error) {
+        await this.releaseEnvironmentLease('staging-environment', lease);
+        throw error;
+      }
       const stable =
         afterLock !== null &&
         afterLock.frontend_staging_sha === beforeLock.frontend_staging_sha &&
@@ -1608,7 +1614,13 @@ export class ReleaseBusV2Reconciler {
     );
     if (!lease) return;
     if (requiresBetaIdleHandshake && beforeLock) {
-      const afterLock = await this.captureProductionIdleSnapshot();
+      let afterLock: ProductionIdleSnapshot | null;
+      try {
+        afterLock = await this.captureProductionIdleSnapshot();
+      } catch (error) {
+        await this.releaseEnvironmentLease('production-environment', lease);
+        throw error;
+      }
       const stable =
         afterLock !== null &&
         afterLock.frontend_main_sha === beforeLock.frontend_main_sha &&

--- a/src/releaseBusV2/release-bus-v2.repository.ts
+++ b/src/releaseBusV2/release-bus-v2.repository.ts
@@ -143,6 +143,7 @@ export class ReleaseBusV2Repository extends LazyDbAccessCompatibleService {
 
   public async createCandidate(
     input: {
+      readonly candidateId?: string;
       readonly repository: ReleaseBusV2RepositoryName;
       readonly prNumber: number;
       readonly branchName: string;
@@ -153,7 +154,7 @@ export class ReleaseBusV2Repository extends LazyDbAccessCompatibleService {
     },
     ctx: RequestContext
   ): Promise<ReleaseBusV2CandidateRecord> {
-    const id = randomUUID();
+    const id = input.candidateId ?? randomUUID();
     const now = Date.now();
     await this.db.execute(
       `insert into ${RELEASE_BUS_V2_CANDIDATES_TABLE}

--- a/src/releaseBusV2/release-bus-v2.service.test.ts
+++ b/src/releaseBusV2/release-bus-v2.service.test.ts
@@ -1,8 +1,11 @@
 const mockResolveRef = jest.fn();
+const mockQualification = jest.fn();
 
 jest.mock('@/releaseBus/release-bus.github-app', () => ({
   releaseBusGitHubApp: {
     resolveRef: (...args: unknown[]) => mockResolveRef(...args),
+    getPullRequestQualification: (...args: unknown[]) =>
+      mockQualification(...args),
     ensureCommitStatus: jest.fn()
   }
 }));
@@ -130,5 +133,113 @@ describe('Release Bus v2 explicit production opt-in', () => {
       }),
       expect.anything()
     );
+  });
+});
+
+describe('Release Bus v2 globally-OFF operator beta registration', () => {
+  const previousMode = process.env.RELEASE_BUS_V2_MODE;
+  const previousAllowlist = process.env.RELEASE_BUS_V2_BETA_ALLOWLIST;
+  const betaId = '11111111-1111-4111-8111-111111111111';
+  const headSha = 'b'.repeat(40);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.RELEASE_BUS_V2_MODE = 'OFF';
+    process.env.RELEASE_BUS_V2_BETA_ALLOWLIST = JSON.stringify([
+      {
+        test_id: 'backend-only-1',
+        candidate_id: betaId,
+        repository: 'backend',
+        branch_name: 'agent/rb2-beta-backend-one',
+        operator: 'beta-operator',
+        lanes: ['STAGING']
+      }
+    ]);
+    mockResolveRef.mockResolvedValue(headSha);
+    mockQualification.mockResolvedValue({
+      baseSha: 'c'.repeat(40),
+      mergeSha: 'd'.repeat(40),
+      checksRunId: '100',
+      checksCompletedAt: 1,
+      artifactRunId: null,
+      artifactName: null,
+      artifactDigest: null
+    });
+  });
+
+  afterAll(() => {
+    if (previousMode === undefined) delete process.env.RELEASE_BUS_V2_MODE;
+    else process.env.RELEASE_BUS_V2_MODE = previousMode;
+    if (previousAllowlist === undefined)
+      delete process.env.RELEASE_BUS_V2_BETA_ALLOWLIST;
+    else process.env.RELEASE_BUS_V2_BETA_ALLOWLIST = previousAllowlist;
+  });
+
+  function input() {
+    return {
+      candidate_id: betaId,
+      repository: 'backend' as const,
+      pr_number: 1801,
+      branch_name: 'agent/rb2-beta-backend-one',
+      expected_head_sha: headSha,
+      deploy_plan: { units: ['api'], edges: [] },
+      dependencies: []
+    };
+  }
+
+  function betaRepository() {
+    const createCandidate = jest.fn(async (value) => ({
+      ...candidate('READY_FOR_STAGING'),
+      id: value.candidateId,
+      repository: value.repository,
+      pr_number: value.prNumber,
+      branch_name: value.branchName,
+      head_sha: value.headSha,
+      requested_by: value.requestedBy,
+      deploy_plan_json: value.deployPlan,
+      pr_evidence_json: value.prEvidence
+    }));
+    return {
+      createCandidate,
+      listControls: jest.fn(async () => []),
+      executeNativeQueriesInTransaction: jest.fn(async (callback) =>
+        callback({})
+      ),
+      supersedeOtherPrHeads: jest.fn(async () => []),
+      findCandidateByIdentity: jest.fn(async () => null),
+      listDependencies: jest.fn(async () => []),
+      addDependency: jest.fn(async () => undefined),
+      listCandidates: jest.fn(async () => []),
+      appendEvent: jest.fn(async () => undefined)
+    };
+  }
+
+  it('creates only the exact configured synthetic candidate id', async () => {
+    const repository = betaRepository();
+    const service = new ReleaseBusV2Service(repository as never);
+
+    await expect(service.register(input(), 'BETA-OPERATOR')).resolves.toEqual(
+      expect.objectContaining({
+        id: betaId,
+        branch_name: 'agent/rb2-beta-backend-one',
+        requested_by: 'BETA-OPERATOR'
+      })
+    );
+    expect(repository.createCandidate).toHaveBeenCalledWith(
+      expect.objectContaining({ candidateId: betaId }),
+      expect.anything()
+    );
+    expect(repository.supersedeOtherPrHeads).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unlisted actor without resolving or mutating the candidate', async () => {
+    const repository = betaRepository();
+    const service = new ReleaseBusV2Service(repository as never);
+
+    await expect(service.register(input(), 'ordinary-agent')).rejects.toThrow(
+      'staging readiness is disabled'
+    );
+    expect(mockResolveRef).not.toHaveBeenCalled();
+    expect(repository.createCandidate).not.toHaveBeenCalled();
   });
 });

--- a/src/releaseBusV2/release-bus-v2.service.test.ts
+++ b/src/releaseBusV2/release-bus-v2.service.test.ts
@@ -206,6 +206,7 @@ describe('Release Bus v2 globally-OFF operator beta registration', () => {
         callback({})
       ),
       supersedeOtherPrHeads: jest.fn(async () => []),
+      findCandidateById: jest.fn(async () => null),
       findCandidateByIdentity: jest.fn(async () => null),
       listDependencies: jest.fn(async () => []),
       addDependency: jest.fn(async () => undefined),
@@ -240,6 +241,45 @@ describe('Release Bus v2 globally-OFF operator beta registration', () => {
       'staging readiness is disabled'
     );
     expect(mockResolveRef).not.toHaveBeenCalled();
+    expect(repository.createCandidate).not.toHaveBeenCalled();
+  });
+
+  it('rejects reusing the one-shot beta id after the branch head moves', async () => {
+    const repository = betaRepository();
+    repository.findCandidateById.mockResolvedValue({
+      ...candidate('READY_FOR_STAGING'),
+      id: betaId,
+      repository: 'backend',
+      pr_number: 1801,
+      branch_name: 'agent/rb2-beta-backend-one',
+      head_sha: 'a'.repeat(40),
+      requested_by: 'BETA-OPERATOR'
+    } as never);
+    const service = new ReleaseBusV2Service(repository as never);
+
+    await expect(service.register(input(), 'BETA-OPERATOR')).rejects.toThrow(
+      'beta candidate id is immutable'
+    );
+    expect(repository.findCandidateByIdentity).not.toHaveBeenCalled();
+    expect(repository.createCandidate).not.toHaveBeenCalled();
+  });
+
+  it('rejects a beta id when the exact identity already belongs to another candidate', async () => {
+    const repository = betaRepository();
+    repository.findCandidateByIdentity.mockResolvedValue({
+      ...candidate('READY_FOR_STAGING'),
+      id: '22222222-2222-4222-8222-222222222222',
+      repository: 'backend',
+      pr_number: 1801,
+      branch_name: 'agent/rb2-beta-backend-one',
+      head_sha: headSha,
+      requested_by: 'ordinary-registration'
+    } as never);
+    const service = new ReleaseBusV2Service(repository as never);
+
+    await expect(service.register(input(), 'BETA-OPERATOR')).rejects.toThrow(
+      'exact beta identity already has a different candidate id'
+    );
     expect(repository.createCandidate).not.toHaveBeenCalled();
   });
 });

--- a/src/releaseBusV2/release-bus-v2.service.ts
+++ b/src/releaseBusV2/release-bus-v2.service.ts
@@ -271,19 +271,35 @@ export class ReleaseBusV2Service {
                 expectedHeadSha,
                 ctx
               );
-          let candidate = await this.repository.findCandidateByIdentity(
-            input.repository,
-            input.pr_number,
-            expectedHeadSha,
-            ctx
-          );
+          const betaCandidateId = isBetaRegistration
+            ? input.candidate_id?.toLowerCase()
+            : undefined;
+          const existingBetaCandidate = betaCandidateId
+            ? await this.repository.findCandidateById(betaCandidateId, ctx)
+            : null;
+          if (
+            existingBetaCandidate &&
+            (existingBetaCandidate.repository !== input.repository ||
+              existingBetaCandidate.pr_number !== input.pr_number ||
+              existingBetaCandidate.branch_name !== input.branch_name ||
+              existingBetaCandidate.head_sha !== expectedHeadSha)
+          )
+            throw new Error(
+              'The beta candidate id is immutable and cannot be reused for a different identity or head SHA'
+            );
+          let candidate =
+            existingBetaCandidate ??
+            (await this.repository.findCandidateByIdentity(
+              input.repository,
+              input.pr_number,
+              expectedHeadSha,
+              ctx
+            ));
           let created = false;
           if (!candidate) {
             candidate = await this.repository.createCandidate(
               {
-                candidateId: isBetaRegistration
-                  ? input.candidate_id?.toLowerCase()
-                  : undefined,
+                candidateId: betaCandidateId,
                 repository: input.repository,
                 prNumber: input.pr_number,
                 branchName: input.branch_name,

--- a/src/releaseBusV2/release-bus-v2.service.ts
+++ b/src/releaseBusV2/release-bus-v2.service.ts
@@ -4,8 +4,13 @@ import { getDeployServiceConfigs } from '@/api/deploy/deploy.config';
 import { releaseBusGitHubApp } from '@/releaseBus/release-bus.github-app';
 import {
   getReleaseBusV2Mode,
+  getReleaseBusV2BetaAllowlist,
   RELEASE_BUS_V2_LOCK_TTL_MS,
   RELEASE_BUS_V2_MAX_CANDIDATES,
+  releaseBusV2BetaAllowsCandidate,
+  releaseBusV2BetaAllowsLane,
+  releaseBusV2BetaAllowsRegistration,
+  type ReleaseBusV2BetaEntry,
   releaseBusV2AllowsLane
 } from '@/releaseBusV2/release-bus-v2.config';
 import {
@@ -205,8 +210,24 @@ export class ReleaseBusV2Service {
     actor: string
   ): Promise<ReleaseBusV2CandidateRecord> {
     const mode = getReleaseBusV2Mode();
-    if (!releaseBusV2AllowsLane(mode, 'STAGING'))
+    const betaAllowlist = mode === 'OFF' ? getReleaseBusV2BetaAllowlist() : [];
+    const isBetaRegistration =
+      mode === 'OFF' &&
+      releaseBusV2BetaAllowsRegistration(betaAllowlist, input, actor);
+    if (!releaseBusV2AllowsLane(mode, 'STAGING') && !isBetaRegistration)
       throw new Error('Release Bus v2 staging readiness is disabled');
+    if (mode !== 'OFF' && input.candidate_id)
+      throw new Error('Explicit candidate ids are reserved for the OFF beta');
+    if (
+      isBetaRegistration &&
+      input.dependencies.some(
+        ({ candidate_id }) =>
+          !betaAllowlist.some(
+            (entry) => entry.candidate_id === candidate_id.toLowerCase()
+          )
+      )
+    )
+      throw new Error('Beta dependencies must be explicitly allowlisted');
     await this.assertScopeRunning('STAGING');
     if (!/^[A-Za-z0-9._/-]{1,255}$/.test(input.branch_name))
       throw new Error('Invalid branch name');
@@ -242,12 +263,14 @@ export class ReleaseBusV2Service {
       await this.repository.executeNativeQueriesInTransaction(
         async (connection) => {
           const ctx: RequestContext = { connection };
-          const superseded = await this.repository.supersedeOtherPrHeads(
-            input.repository,
-            input.pr_number,
-            expectedHeadSha,
-            ctx
-          );
+          const superseded = isBetaRegistration
+            ? []
+            : await this.repository.supersedeOtherPrHeads(
+                input.repository,
+                input.pr_number,
+                expectedHeadSha,
+                ctx
+              );
           let candidate = await this.repository.findCandidateByIdentity(
             input.repository,
             input.pr_number,
@@ -258,6 +281,9 @@ export class ReleaseBusV2Service {
           if (!candidate) {
             candidate = await this.repository.createCandidate(
               {
+                candidateId: isBetaRegistration
+                  ? input.candidate_id?.toLowerCase()
+                  : undefined,
                 repository: input.repository,
                 prNumber: input.pr_number,
                 branchName: input.branch_name,
@@ -270,6 +296,13 @@ export class ReleaseBusV2Service {
             );
             created = true;
           } else {
+            if (
+              isBetaRegistration &&
+              candidate.id !== input.candidate_id?.toLowerCase()
+            )
+              throw new Error(
+                'The exact beta identity already has a different candidate id'
+              );
             const existingDependencies = await this.repository.listDependencies(
               [candidate.id],
               ctx
@@ -337,7 +370,11 @@ export class ReleaseBusV2Service {
                 payload: {
                   repository: candidate.repository,
                   pr_number: candidate.pr_number,
-                  head_sha: candidate.head_sha
+                  head_sha: candidate.head_sha,
+                  operator_beta: isBetaRegistration,
+                  beta_test_id: isBetaRegistration
+                    ? betaAllowlist[0]?.test_id
+                    : null
                 }
               },
               ctx
@@ -374,11 +411,16 @@ export class ReleaseBusV2Service {
     actor: string
   ): Promise<ReleaseBusV2CandidateRecord> {
     const mode = getReleaseBusV2Mode();
-    if (!releaseBusV2AllowsLane(mode, 'PRODUCTION'))
-      throw new Error('Release Bus v2 production readiness is disabled');
-    await this.assertScopeRunning('PRODUCTION');
     const snapshot = await this.repository.findCandidateById(candidateId, {});
     if (!snapshot) throw new Error('Candidate not found');
+    const betaAllowlist = mode === 'OFF' ? getReleaseBusV2BetaAllowlist() : [];
+    const isBetaPromotion =
+      mode === 'OFF' &&
+      releaseBusV2BetaAllowsCandidate(betaAllowlist, snapshot, 'PRODUCTION') &&
+      snapshot.requested_by.toLowerCase() === actor.toLowerCase();
+    if (!releaseBusV2AllowsLane(mode, 'PRODUCTION') && !isBetaPromotion)
+      throw new Error('Release Bus v2 production readiness is disabled');
+    await this.assertScopeRunning('PRODUCTION');
     if (snapshot.row_version !== expectedRowVersion)
       throw new Error(
         'Candidate changed; refresh before marking production ready'
@@ -617,7 +659,10 @@ export class ReleaseBusV2Service {
   ): Promise<ReleaseBusV2TrainRecord | null> {
     const mode = getReleaseBusV2Mode();
     const scope = laneScope(lane);
-    if (!releaseBusV2AllowsLane(mode, scope)) return null;
+    const betaAllowlist = mode === 'OFF' ? getReleaseBusV2BetaAllowlist() : [];
+    const betaLaneEnabled =
+      mode === 'OFF' && releaseBusV2BetaAllowsLane(betaAllowlist, lane);
+    if (!releaseBusV2AllowsLane(mode, scope) && !betaLaneEnabled) return null;
     await this.assertScopeRunning(scope);
     return this.repository.executeNativeQueriesInTransaction(
       async (connection) => {
@@ -631,16 +676,27 @@ export class ReleaseBusV2Service {
         );
         if (!scheduler?.lease_token) return null;
         try {
-          await this.refreshDependencyHolds(lane, ctx);
+          await this.refreshDependencyHolds(lane, ctx, betaAllowlist);
           const active = (await this.repository.listTrains(100, ctx)).find(
             (train) =>
               train.lane === lane && !TERMINAL_TRAIN_STATUSES.has(train.status)
           );
-          if (active) return active;
-          const candidates = await this.repository.listCandidates(
-            [readyStatus(lane)],
-            RELEASE_BUS_V2_MAX_CANDIDATES,
-            ctx
+          if (active) {
+            if (!betaLaneEnabled) return active;
+            return (await this.isBetaTrainAllowed(active, betaAllowlist, ctx))
+              ? active
+              : null;
+          }
+          const candidates = (
+            await this.repository.listCandidates(
+              [readyStatus(lane)],
+              RELEASE_BUS_V2_MAX_CANDIDATES,
+              ctx
+            )
+          ).filter(
+            (candidate) =>
+              !betaLaneEnabled ||
+              releaseBusV2BetaAllowsCandidate(betaAllowlist, candidate, lane)
           );
           if (candidates.length === 0) return null;
           const dependencies = await this.repository.listDependencies(
@@ -651,7 +707,8 @@ export class ReleaseBusV2Service {
             candidates,
             dependencies,
             lane,
-            ctx
+            ctx,
+            betaAllowlist
           );
           if (eligible.length === 0) return null;
           const order = topologicalOrder(
@@ -700,7 +757,12 @@ export class ReleaseBusV2Service {
             {
               trainId: train.id,
               eventType: 'TRAIN_CLAIMED',
-              payload: { lane, candidate_ids: order }
+              payload: {
+                lane,
+                candidate_ids: order,
+                operator_beta: betaLaneEnabled,
+                beta_test_id: betaLaneEnabled ? betaAllowlist[0]?.test_id : null
+              }
             },
             ctx
           );
@@ -730,6 +792,28 @@ export class ReleaseBusV2Service {
         payload: { scope, reason }
       },
       {}
+    );
+  }
+
+  public async isBetaTrainAllowed(
+    train: ReleaseBusV2TrainRecord,
+    allowlist: readonly ReleaseBusV2BetaEntry[] = getReleaseBusV2BetaAllowlist(),
+    ctx: RequestContext = {}
+  ): Promise<boolean> {
+    const memberships = await this.repository.listTrainCandidates(
+      train.id,
+      ctx
+    );
+    if (memberships.length === 0) return false;
+    const candidates = await Promise.all(
+      memberships.map(({ candidate_id }) =>
+        this.repository.findCandidateById(candidate_id, ctx)
+      )
+    );
+    return candidates.every(
+      (candidate) =>
+        candidate !== null &&
+        releaseBusV2BetaAllowsCandidate(allowlist, candidate, train.lane)
     );
   }
 
@@ -788,7 +872,8 @@ export class ReleaseBusV2Service {
     candidates: readonly ReleaseBusV2CandidateRecord[],
     dependencies: readonly ReleaseBusV2DependencyRecord[],
     lane: ReleaseBusV2Lane,
-    ctx: RequestContext
+    ctx: RequestContext,
+    betaAllowlist: readonly ReleaseBusV2BetaEntry[] = []
   ): Promise<ReleaseBusV2CandidateRecord[]> {
     const byId = new Map(
       candidates.map((candidate) => [candidate.id, candidate])
@@ -803,6 +888,18 @@ export class ReleaseBusV2Service {
           continue;
         if (lane === 'PRODUCTION' && dependency.environment === 'STAGING')
           continue;
+        if (
+          betaAllowlist.length > 0 &&
+          !betaAllowlist.some(
+            (entry) =>
+              entry.candidate_id === dependency.prerequisite_candidate_id &&
+              releaseBusV2BetaAllowsLane([entry], lane)
+          )
+        ) {
+          eligible.delete(dependency.candidate_id);
+          changed = true;
+          continue;
+        }
         const prerequisiteInBatch = eligible.has(
           dependency.prerequisite_candidate_id
         );
@@ -846,18 +943,25 @@ export class ReleaseBusV2Service {
 
   private async refreshDependencyHolds(
     lane: ReleaseBusV2Lane,
-    ctx: RequestContext
+    ctx: RequestContext,
+    betaAllowlist: readonly ReleaseBusV2BetaEntry[] = []
   ): Promise<void> {
     const waiting = await this.repository.listCandidates(
       ['WAITING_FOR_DEPENDENCY'],
       RELEASE_BUS_V2_MAX_CANDIDATES,
       ctx
     );
-    const laneWaiting = waiting.filter((candidate) =>
-      lane === 'PRODUCTION'
-        ? candidate.production_requested_at !== null
-        : candidate.production_requested_at === null
-    );
+    const laneWaiting = waiting
+      .filter(
+        (candidate) =>
+          betaAllowlist.length === 0 ||
+          releaseBusV2BetaAllowsCandidate(betaAllowlist, candidate, lane)
+      )
+      .filter((candidate) =>
+        lane === 'PRODUCTION'
+          ? candidate.production_requested_at !== null
+          : candidate.production_requested_at === null
+      );
     if (laneWaiting.length === 0) return;
     const dependencies = await this.repository.listDependencies(
       laneWaiting.map((candidate) => candidate.id),
@@ -871,6 +975,17 @@ export class ReleaseBusV2Service {
       });
       let satisfied = true;
       for (const dependency of required) {
+        if (
+          betaAllowlist.length > 0 &&
+          !betaAllowlist.some(
+            (entry) =>
+              entry.candidate_id === dependency.prerequisite_candidate_id &&
+              releaseBusV2BetaAllowsLane([entry], lane)
+          )
+        ) {
+          satisfied = false;
+          break;
+        }
         const prerequisite = await this.repository.findCandidateById(
           dependency.prerequisite_candidate_id,
           ctx

--- a/src/releaseBusV2/release-bus-v2.types.ts
+++ b/src/releaseBusV2/release-bus-v2.types.ts
@@ -190,6 +190,11 @@ export type ReleaseBusV2OperationRecord = {
 };
 
 export type ReleaseBusV2RegisterInput = {
+  /**
+   * Required only for the globally-OFF operator beta. It must exactly match
+   * the configured synthetic candidate allowlist.
+   */
+  readonly candidate_id?: string;
   readonly repository: ReleaseBusV2Repository;
   readonly pr_number: number;
   readonly branch_name: string;


### PR DESCRIPTION
## Issue
- Release Bus v2 beta validation must remain globally OFF for ordinary developers while permitting only one bounded operator-owned synthetic test.

## Fix
- Add an exact fail-closed allowlist keyed by one test id, current org operator, UUID candidate ids, repositories, branches, and lanes.
- Double-check live workflow activity and shared refs around environment-lock acquisition before any beta mutation.
- Make beta candidate ids immutable/one-shot and release environment leases if the post-lock idle snapshot fails.

## Changes
- Add OFF-mode beta registration/action/reconciler guards and explicit candidate ids.
- Add active staging/production workflow detection, double-snapshot idle handshakes, audit events, runtime env wiring, generated workflow updates, and the bounded beta runbook.
- Ordinary agents and canonical helpers continue to see OFF/manual; missing or invalid allowlists never enable automation.
- No architecture topology changed; the deployment-bus runbook is the relevant operations documentation update.

## Validation
- 100 focused tests across config, service, reconciler acceptance, routes, GitHub workflow detection, and infrastructure.
- TypeScript, lint, generated deploy config, generated API output, and API packaging pass locally.
- Exact-head PR build/API packaging run 29995996097 passed in 11m15s after rerunning one registry HTTP 504 that occurred before repository code executed.
- DCO, Sonar, Snyk, and CodeRabbit are green. Global mode, allowlist, candidates, and shared refs were not changed.

## Risk
- Level: High
- Why: deploy-control code can mutate shared staging/production refs, but only an exact configured operator beta can reach it while global mode remains OFF.
- Rollback: clear the allowlist and redeploy API then releaseBus in OFF; v1 remains disabled and the manual path remains authoritative.

## Deployment
1. api
2. releaseBus

Both deploy in production with RELEASE_BUS_V2_MODE=OFF, an empty allowlist, and explicit internal release-note opt-out.

## Review Notes
- The reconcile route already calls requireOperator, which resolves the authenticated viewer and revalidates current organization-team membership; a regression test proves an allowlisted actor removed from the team is rejected.
- Review follow-ups also moved train lookup inside the fail-closed guard, release staging/production leases on post-lock snapshot errors, and reject moved-head or cross-identity beta id reuse.