### PR TITLE
Release Bus v2 beta: backend-only fixture 1

### DIFF
--- a/ops/deployment-bus/beta-fixtures/backend-only-1.md
+++ b/ops/deployment-bus/beta-fixtures/backend-only-1.md
@@ -1,0 +1,9 @@
+# Release Bus v2 backend-only beta fixture 1
+
+This file intentionally changes no runtime behavior. It gives the bounded
+operator-only staging acceptance test one exact green merge-tree while its
+deploy plan selects only the backend `api` unit.
+
+- Test ID: `backend-only-1`
+- Candidate ID: `6549ea1d-5914-488b-b6f4-3e88cc7a222b`
+- Global Release Bus v2 mode: `OFF`


### PR DESCRIPTION
## Purpose
- Provide one bounded operator-only backend staging acceptance candidate while global Release Bus v2 mode remains OFF.

## Scope
- Adds a documentation-only fixture; no runtime behavior changes.
- Exact candidate id: `6549ea1d-5914-488b-b6f4-3e88cc7a222b`.
- Exact branch: `agent/rb2-v2-accept-backend-only-1`.
- Planned staging deploy unit: `api` only.

## Safety
- This PR is synthetic and must not be merged to main.
- It may be composed into `1a-staging` only by the exact operator beta after a fresh double-snapshot idle handshake and staging-lock acquisition.
- Global mode stays OFF, the allowlist is cleared after this one test, and no release note is requested.

## Validation
- `git diff --check`.
- Full PR checks provide the exact green merge-tree evidence used by the acceptance test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a beta fixture configuration for validating a backend-only release scenario.
  * Documented the test and candidate identifiers, with the global release mode set to off.
  * Clarified that the fixture does not change runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->