### PR TITLE
Add fail-closed v2 beta retry injection

### DIFF
--- a/ops/deployment-bus/simple-release-bus-v2.md
+++ b/ops/deployment-bus/simple-release-bus-v2.md
@@ -140,6 +140,20 @@ lanes. An empty variable disables all beta automation. Invalid nonempty
 configuration pauses `ALL` while mode remains `OFF`; OFF-mode manual fallback
 continues to ignore v2 controls.
 
+The infrastructure-retry case may add exactly one optional field to exactly
+one entry:
+
+```json
+"inject_infrastructure_failure_operation": "PREPARE_ARTIFACT_BACKEND"
+```
+
+The value must match the entry's repository (`PREPARE_ARTIFACT_BACKEND` or
+`PREPARE_ARTIFACT_FRONTEND`) and requires the `STAGING` lane. The reconciler
+records `BETA_INFRASTRUCTURE_FAILURE_INJECTED`, places only that exact first
+preflight attempt into `RETRY_WAIT` before dispatch, and dispatches attempt 2
+after the normal bounded delay. It never applies in production or outside the
+globally-OFF exact operator beta.
+
 Before any allowlist is installed, exhaust local integration tests and
 read-only shadow checks. Shadow checks may resolve exact refs, PR qualification,
 current locks, and active workflow state, but must not update a shared ref,

--- a/ops/deployment-bus/simple-release-bus-v2.md
+++ b/ops/deployment-bus/simple-release-bus-v2.md
@@ -159,6 +159,11 @@ read-only shadow checks. Shadow checks may resolve exact refs, PR qualification,
 current locks, and active workflow state, but must not update a shared ref,
 dispatch a deploy/E2E workflow, or create/claim a live candidate. With the
 allowlist absent, a worker invocation must claim and advance nothing.
+The only permitted OFF/empty maintenance mutation is releasing an environment
+lock already owned by a terminal train after every one of that train's
+operations is terminal. That cleanup emits
+`TERMINAL_ENVIRONMENT_LOCK_RELEASED`; it cannot claim a candidate, advance a
+train, update a shared ref, or dispatch a workflow.
 
 For each single bounded staging test:
 

--- a/src/releaseBus/release-bus.github-app.test.ts
+++ b/src/releaseBus/release-bus.github-app.test.ts
@@ -2,6 +2,7 @@ import fetch, { Response } from 'node-fetch';
 import {
   isValidGitHubWorkflowActor,
   ReleaseBusGitHubApp,
+  ReleaseBusGitHubInfrastructureError,
   releaseBusPullRequestMergeStateEligible,
   safeGitHubWorkflowLabel,
   sanitizeGitHubWorkflowJobs,
@@ -185,6 +186,35 @@ describe('GitHub workflow operation identity', () => {
         operationKey
       )
     ).toBe(false);
+  });
+});
+
+describe('GitHub workflow dispatch failure classification', () => {
+  it('treats a secondary-rate-limit 403 as retryable infrastructure', async () => {
+    const app = new ReleaseBusGitHubApp();
+    (
+      app as unknown as {
+        cachedToken: { value: string; expiresAt: number };
+      }
+    ).cachedToken = { value: 'test-token', expiresAt: Date.now() + 120_000 };
+    const fetchMock = fetch as jest.MockedFunction<typeof fetch>;
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ message: 'secondary rate limit' }), {
+        status: 403,
+        headers: { 'Retry-After': '30' }
+      })
+    );
+
+    try {
+      await expect(
+        app.dispatchWorkflow('backend', 'deploy.yml', 'main', {})
+      ).rejects.toMatchObject({
+        name: ReleaseBusGitHubInfrastructureError.name,
+        message: expect.stringContaining('secondary rate limit')
+      });
+    } finally {
+      fetchMock.mockReset();
+    }
   });
 });
 

--- a/src/releaseBus/release-bus.github-app.ts
+++ b/src/releaseBus/release-bus.github-app.ts
@@ -128,6 +128,14 @@ function isInfrastructureStatus(status: number): boolean {
   return status === 408 || status === 429 || status >= 500;
 }
 
+function isSecondaryRateLimit(response: Response): boolean {
+  return (
+    response.status === 403 &&
+    (response.headers.has('retry-after') ||
+      response.headers.get('x-ratelimit-remaining') === '0')
+  );
+}
+
 export function safeGitHubWorkflowLabel(value: unknown): string | null {
   if (typeof value !== 'string') return null;
   const sanitized = Array.from(value)
@@ -299,7 +307,10 @@ export class ReleaseBusGitHubApp {
       /* redacted status is enough */
     }
     const errorMessage = `Failed to ${operation}: ${message}`;
-    if (isInfrastructureStatus(response.status))
+    if (
+      isInfrastructureStatus(response.status) ||
+      isSecondaryRateLimit(response)
+    )
       throw new ReleaseBusGitHubInfrastructureError(errorMessage);
     throw new Error(errorMessage);
   }

--- a/src/releaseBusV2/release-bus-v2.acceptance.test.ts
+++ b/src/releaseBusV2/release-bus-v2.acceptance.test.ts
@@ -465,6 +465,35 @@ describe('Release Bus v2 offline acceptance harness', () => {
     expect(state.repository.trains.get('train-1')?.status).toBe('PREPARED');
   });
 
+  it('releases a terminal train lock in OFF mode only after all operations are terminal', async () => {
+    const state = harness('SUCCEEDED');
+    process.env.RELEASE_BUS_V2_MODE = 'OFF';
+    state.repository.trains.set(
+      'train-1',
+      train('train-1', {
+        status: 'FAILED',
+        failure_class: 'CONTROL_PLANE',
+        completed_at: 4
+      })
+    );
+    await state.repository.acquireLock(
+      'staging-environment',
+      'train-1',
+      'train:train-1'
+    );
+
+    await expect(
+      state.reconciler.runOnce('acceptance-terminal-lock')
+    ).resolves.toEqual({ mode: 'OFF', claimed: [], advanced: [] });
+    expect(state.repository.lock.owner_train_id).toBeNull();
+    expect(state.repository.events).toContainEqual(
+      expect.objectContaining({
+        eventType: 'TERMINAL_ENVIRONMENT_LOCK_RELEASED',
+        trainId: 'train-1'
+      })
+    );
+  });
+
   it('pauses only beta automation when the OFF allowlist is malformed', async () => {
     const state = harness('SUCCEEDED');
     process.env.RELEASE_BUS_V2_MODE = 'OFF';

--- a/src/releaseBusV2/release-bus-v2.config.test.ts
+++ b/src/releaseBusV2/release-bus-v2.config.test.ts
@@ -3,6 +3,7 @@ import {
   getReleaseBusV2Mode,
   releaseBusV2BetaAllowsCandidate,
   releaseBusV2BetaAllowsRegistration,
+  releaseBusV2BetaInfrastructureFailureInjection,
   ReleaseBusV2BetaConfigurationError
 } from '@/releaseBusV2/release-bus-v2.config';
 import type {
@@ -114,6 +115,40 @@ describe('Release Bus v2 operator-only OFF beta configuration', () => {
     ).toBe(false);
   });
 
+  it('binds one staging-only infrastructure injection to an exact candidate', () => {
+    process.env.RELEASE_BUS_V2_BETA_ALLOWLIST = JSON.stringify([
+      configuredEntry({
+        inject_infrastructure_failure_operation: 'PREPARE_ARTIFACT_BACKEND'
+      })
+    ]);
+    const allowlist = getReleaseBusV2BetaAllowlist();
+
+    expect(
+      releaseBusV2BetaInfrastructureFailureInjection(
+        allowlist,
+        [candidate()],
+        'STAGING',
+        'PREPARE_ARTIFACT_BACKEND'
+      )
+    ).toEqual({ candidateId: CANDIDATE_ID, testId: 'backend-only-1' });
+    expect(
+      releaseBusV2BetaInfrastructureFailureInjection(
+        allowlist,
+        [candidate()],
+        'PRODUCTION',
+        'PREPARE_ARTIFACT_BACKEND'
+      )
+    ).toBeNull();
+    expect(
+      releaseBusV2BetaInfrastructureFailureInjection(
+        allowlist,
+        [{ ...candidate(), id: '22222222-2222-4222-8222-222222222222' }],
+        'STAGING',
+        'PREPARE_ARTIFACT_BACKEND'
+      )
+    ).toBeNull();
+  });
+
   it.each([
     'not-json',
     '[]',
@@ -121,6 +156,17 @@ describe('Release Bus v2 operator-only OFF beta configuration', () => {
     JSON.stringify([configuredEntry({ lanes: [] })]),
     JSON.stringify([configuredEntry(), configuredEntry()]),
     JSON.stringify([configuredEntry({ unexpected: true })]),
+    JSON.stringify([
+      configuredEntry({
+        inject_infrastructure_failure_operation: 'PREPARE_ARTIFACT_FRONTEND'
+      })
+    ]),
+    JSON.stringify([
+      configuredEntry({
+        inject_infrastructure_failure_operation: 'PREPARE_ARTIFACT_BACKEND',
+        lanes: ['PRODUCTION']
+      })
+    ]),
     JSON.stringify([
       configuredEntry(),
       configuredEntry({
@@ -133,6 +179,16 @@ describe('Release Bus v2 operator-only OFF beta configuration', () => {
       configuredEntry(),
       configuredEntry({
         candidate_id: '22222222-2222-4222-8222-222222222222'
+      })
+    ]),
+    JSON.stringify([
+      configuredEntry({
+        inject_infrastructure_failure_operation: 'PREPARE_ARTIFACT_BACKEND'
+      }),
+      configuredEntry({
+        candidate_id: '22222222-2222-4222-8222-222222222222',
+        branch_name: 'agent/rb2-beta-backend-two',
+        inject_infrastructure_failure_operation: 'PREPARE_ARTIFACT_BACKEND'
       })
     ])
   ])('fails closed for malformed allowlist %s', (value) => {

--- a/src/releaseBusV2/release-bus-v2.config.ts
+++ b/src/releaseBusV2/release-bus-v2.config.ts
@@ -20,12 +20,25 @@ const BETA_ENTRY_KEYS = [
   'repository',
   'test_id'
 ] as const;
+const BETA_ENTRY_KEYS_WITH_INFRASTRUCTURE_INJECTION = [
+  'branch_name',
+  'candidate_id',
+  'inject_infrastructure_failure_operation',
+  'lanes',
+  'operator',
+  'repository',
+  'test_id'
+] as const;
 
 function compareInvariant(left: string, right: string): number {
   return left < right ? -1 : left > right ? 1 : 0;
 }
 
 export type ReleaseBusV2BetaLane = 'STAGING' | 'PRODUCTION';
+
+export type ReleaseBusV2BetaInfrastructureFailureOperation =
+  | 'PREPARE_ARTIFACT_BACKEND'
+  | 'PREPARE_ARTIFACT_FRONTEND';
 
 export type ReleaseBusV2BetaEntry = {
   readonly test_id: string;
@@ -34,6 +47,7 @@ export type ReleaseBusV2BetaEntry = {
   readonly branch_name: string;
   readonly operator: string;
   readonly lanes: readonly ReleaseBusV2BetaLane[];
+  readonly inject_infrastructure_failure_operation?: ReleaseBusV2BetaInfrastructureFailureOperation;
 };
 
 export class ReleaseBusV2BetaConfigurationError extends Error {
@@ -50,8 +64,12 @@ function parseBetaEntry(value: unknown): ReleaseBusV2BetaEntry {
   }
   const entry = value as Record<string, unknown>;
   const keys = Object.keys(entry).sort(compareInvariant);
+  const hasInfrastructureInjection =
+    JSON.stringify(keys) ===
+    JSON.stringify(BETA_ENTRY_KEYS_WITH_INFRASTRUCTURE_INJECTION);
   if (
-    JSON.stringify(keys) !== JSON.stringify(BETA_ENTRY_KEYS) ||
+    (JSON.stringify(keys) !== JSON.stringify(BETA_ENTRY_KEYS) &&
+      !hasInfrastructureInjection) ||
     typeof entry.test_id !== 'string' ||
     !/^[A-Za-z0-9._-]{1,100}$/.test(entry.test_id) ||
     typeof entry.candidate_id !== 'string' ||
@@ -77,13 +95,31 @@ function parseBetaEntry(value: unknown): ReleaseBusV2BetaEntry {
   if (lanes.length !== entry.lanes.length) {
     throw new ReleaseBusV2BetaConfigurationError();
   }
+  const expectedInfrastructureOperation =
+    entry.repository === 'backend'
+      ? 'PREPARE_ARTIFACT_BACKEND'
+      : 'PREPARE_ARTIFACT_FRONTEND';
+  if (
+    hasInfrastructureInjection &&
+    (entry.inject_infrastructure_failure_operation !==
+      expectedInfrastructureOperation ||
+      !lanes.includes('STAGING'))
+  ) {
+    throw new ReleaseBusV2BetaConfigurationError();
+  }
   return {
     test_id: entry.test_id,
     candidate_id: entry.candidate_id.toLowerCase(),
     repository: entry.repository as ReleaseBusV2Repository,
     branch_name: entry.branch_name,
     operator: entry.operator.toLowerCase(),
-    lanes
+    lanes,
+    ...(hasInfrastructureInjection
+      ? {
+          inject_infrastructure_failure_operation:
+            entry.inject_infrastructure_failure_operation as ReleaseBusV2BetaInfrastructureFailureOperation
+        }
+      : {})
   };
 }
 
@@ -126,7 +162,39 @@ export function getReleaseBusV2BetaAllowlist(): readonly ReleaseBusV2BetaEntry[]
   ) {
     throw new ReleaseBusV2BetaConfigurationError();
   }
+  if (
+    entries.filter(
+      ({ inject_infrastructure_failure_operation }) =>
+        inject_infrastructure_failure_operation !== undefined
+    ).length > 1
+  ) {
+    throw new ReleaseBusV2BetaConfigurationError();
+  }
   return entries;
+}
+
+export function releaseBusV2BetaInfrastructureFailureInjection(
+  allowlist: readonly ReleaseBusV2BetaEntry[],
+  candidates: readonly ReleaseBusV2CandidateRecord[],
+  lane: ReleaseBusV2Lane,
+  operationType: string
+): { readonly candidateId: string; readonly testId: string } | null {
+  const entry = allowlist.find(
+    ({ inject_infrastructure_failure_operation }) =>
+      inject_infrastructure_failure_operation === operationType
+  );
+  if (
+    lane !== 'STAGING' ||
+    !entry ||
+    !candidates.some(({ id }) => id.toLowerCase() === entry.candidate_id) ||
+    candidates.some(
+      (candidate) =>
+        !releaseBusV2BetaAllowsCandidate(allowlist, candidate, lane)
+    )
+  ) {
+    return null;
+  }
+  return { candidateId: entry.candidate_id, testId: entry.test_id };
 }
 
 export function releaseBusV2BetaAllowsLane(

--- a/src/releaseBusV2/release-bus-v2.operations.test.ts
+++ b/src/releaseBusV2/release-bus-v2.operations.test.ts
@@ -286,6 +286,35 @@ describe('Release Bus v2 exact operation callbacks', () => {
     });
   });
 
+  it('exits before dispatch when another reconciler wins the reservation', async () => {
+    const state = repositoryFor(
+      operation({ external_id: null, status: 'PENDING' })
+    );
+    state.repository.updateOperation.mockImplementationOnce(async () => {
+      state.raceTo({ status: 'DISPATCHED' });
+      return false;
+    });
+    mockFindWorkflowRun.mockResolvedValue(null);
+    const service = new ReleaseBusV2Operations(state.repository as never);
+
+    await expect(
+      service.reconcileWorkflow({
+        idempotencyKey: 'rb2:train-id:prepare:frontend',
+        trainId: 'train-id',
+        operationType: 'PREPARE_ARTIFACT_FRONTEND',
+        repository: 'frontend',
+        workflow: 'release-bus-v2-preflight.yml',
+        ref: 'main',
+        environment: 'orchestration',
+        service: null,
+        expectedSha: 'a'.repeat(40),
+        artifactDigest: null,
+        inputs: {}
+      })
+    ).resolves.toMatchObject({ status: 'DISPATCHED' });
+    expect(mockDispatchWorkflow).not.toHaveBeenCalled();
+  });
+
   it('preserves a hard dispatch rejection as a control-plane failure', async () => {
     const state = repositoryFor(
       operation({ external_id: null, status: 'PENDING' })
@@ -326,6 +355,41 @@ describe('Release Bus v2 exact operation callbacks', () => {
     mockFindWorkflowRun.mockResolvedValue(null);
     mockDispatchWorkflow.mockRejectedValueOnce(
       Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' })
+    );
+    const service = new ReleaseBusV2Operations(state.repository as never);
+
+    await service.reconcileWorkflow({
+      idempotencyKey: 'rb2:train-id:prepare:frontend',
+      trainId: 'train-id',
+      operationType: 'PREPARE_ARTIFACT_FRONTEND',
+      repository: 'frontend',
+      workflow: 'release-bus-v2-preflight.yml',
+      ref: 'main',
+      environment: 'orchestration',
+      service: null,
+      expectedSha: 'a'.repeat(40),
+      artifactDigest: null,
+      inputs: {}
+    });
+
+    expect(state.current()).toMatchObject({
+      status: 'RETRY_WAIT',
+      attempt: 1,
+      failure_class: 'INFRASTRUCTURE',
+      result_json: { retry_same_attempt: true, transport_failures: 1 }
+    });
+  });
+
+  it('retries a raw secondary-rate-limit 403 with the same attempt key', async () => {
+    const state = repositoryFor(
+      operation({ external_id: null, status: 'PENDING' })
+    );
+    mockFindWorkflowRun.mockResolvedValue(null);
+    mockDispatchWorkflow.mockRejectedValueOnce(
+      Object.assign(new Error('secondary rate limit'), {
+        status: 403,
+        retryAfter: '30'
+      })
     );
     const service = new ReleaseBusV2Operations(state.repository as never);
 

--- a/src/releaseBusV2/release-bus-v2.operations.test.ts
+++ b/src/releaseBusV2/release-bus-v2.operations.test.ts
@@ -232,6 +232,76 @@ describe('Release Bus v2 exact operation callbacks', () => {
     expect(mockDispatchWorkflow).not.toHaveBeenCalled();
   });
 
+  it('allows only one dispatch while an exact attempt is not yet discoverable', async () => {
+    const state = repositoryFor(
+      operation({ external_id: null, status: 'PENDING' })
+    );
+    mockFindWorkflowRun.mockResolvedValue(null);
+    const service = new ReleaseBusV2Operations(state.repository as never);
+    const spec = {
+      idempotencyKey: 'rb2:train-id:prepare:frontend',
+      trainId: 'train-id',
+      operationType: 'PREPARE_ARTIFACT_FRONTEND',
+      repository: 'frontend' as const,
+      workflow: 'release-bus-v2-preflight.yml',
+      ref: 'main',
+      environment: 'orchestration',
+      service: null,
+      expectedSha: 'a'.repeat(40),
+      artifactDigest: null,
+      inputs: {}
+    };
+
+    await expect(
+      Promise.all([
+        service.reconcileWorkflow(spec),
+        service.reconcileWorkflow(spec)
+      ])
+    ).resolves.toEqual([
+      expect.objectContaining({ status: 'DISPATCHED' }),
+      expect.objectContaining({ status: 'DISPATCHED' })
+    ]);
+    expect(mockDispatchWorkflow).toHaveBeenCalledTimes(1);
+    expect(state.current()).toMatchObject({
+      external_id: null,
+      status: 'DISPATCHED',
+      attempt: 1
+    });
+  });
+
+  it('recovers a stale dispatch reservation without changing its attempt key', async () => {
+    const state = repositoryFor(
+      operation({
+        external_id: null,
+        status: 'DISPATCHED',
+        updated_at: Date.now() - 31_000
+      })
+    );
+    mockFindWorkflowRun.mockResolvedValue(null);
+    const service = new ReleaseBusV2Operations(state.repository as never);
+
+    await service.reconcileWorkflow({
+      idempotencyKey: 'rb2:train-id:prepare:frontend',
+      trainId: 'train-id',
+      operationType: 'PREPARE_ARTIFACT_FRONTEND',
+      repository: 'frontend',
+      workflow: 'release-bus-v2-preflight.yml',
+      ref: 'main',
+      environment: 'orchestration',
+      service: null,
+      expectedSha: 'a'.repeat(40),
+      artifactDigest: null,
+      inputs: {}
+    });
+
+    expect(mockDispatchWorkflow).not.toHaveBeenCalled();
+    expect(state.current()).toMatchObject({
+      status: 'RETRY_WAIT',
+      attempt: 1,
+      result_json: { retry_same_attempt: true, transport_failures: 1 }
+    });
+  });
+
   it('binds the immutable artifact digest from the structured terminal report', async () => {
     const state = repositoryFor(operation());
     const service = new ReleaseBusV2Operations(state.repository as never);

--- a/src/releaseBusV2/release-bus-v2.operations.test.ts
+++ b/src/releaseBusV2/release-bus-v2.operations.test.ts
@@ -319,6 +319,38 @@ describe('Release Bus v2 exact operation callbacks', () => {
     });
   });
 
+  it('retries an unwrapped transient dispatch error with the same attempt key', async () => {
+    const state = repositoryFor(
+      operation({ external_id: null, status: 'PENDING' })
+    );
+    mockFindWorkflowRun.mockResolvedValue(null);
+    mockDispatchWorkflow.mockRejectedValueOnce(
+      Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' })
+    );
+    const service = new ReleaseBusV2Operations(state.repository as never);
+
+    await service.reconcileWorkflow({
+      idempotencyKey: 'rb2:train-id:prepare:frontend',
+      trainId: 'train-id',
+      operationType: 'PREPARE_ARTIFACT_FRONTEND',
+      repository: 'frontend',
+      workflow: 'release-bus-v2-preflight.yml',
+      ref: 'main',
+      environment: 'orchestration',
+      service: null,
+      expectedSha: 'a'.repeat(40),
+      artifactDigest: null,
+      inputs: {}
+    });
+
+    expect(state.current()).toMatchObject({
+      status: 'RETRY_WAIT',
+      attempt: 1,
+      failure_class: 'INFRASTRUCTURE',
+      result_json: { retry_same_attempt: true, transport_failures: 1 }
+    });
+  });
+
   it('recovers a stale dispatch reservation without changing its attempt key', async () => {
     const state = repositoryFor(
       operation({

--- a/src/releaseBusV2/release-bus-v2.operations.test.ts
+++ b/src/releaseBusV2/release-bus-v2.operations.test.ts
@@ -114,6 +114,13 @@ function repositoryFor(initial: ReleaseBusV2OperationRecord) {
     current: () => current,
     expireRetry: () => {
       current = { ...current, next_retry_at: 0 };
+    },
+    raceTo: (fields: Partial<ReleaseBusV2OperationRecord>) => {
+      current = {
+        ...current,
+        ...fields,
+        row_version: current.row_version + 1
+      };
     }
   };
 }
@@ -187,6 +194,42 @@ describe('Release Bus v2 exact operation callbacks', () => {
       failure_class: null
     });
     expect(state.repository.appendEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('observes the winning workflow callback when reconciles overlap', async () => {
+    const state = repositoryFor(
+      operation({ external_id: null, status: 'PENDING' })
+    );
+    state.repository.updateOperation.mockImplementationOnce(async () => {
+      state.raceTo({ external_id: '12345', status: 'RUNNING' });
+      return false;
+    });
+    mockFindWorkflowRun.mockResolvedValue({
+      id: 12345,
+      status: 'in_progress',
+      conclusion: null
+    });
+    const service = new ReleaseBusV2Operations(state.repository as never);
+
+    await expect(
+      service.reconcileWorkflow({
+        idempotencyKey: 'rb2:train-id:prepare:frontend',
+        trainId: 'train-id',
+        operationType: 'PREPARE_ARTIFACT_FRONTEND',
+        repository: 'frontend',
+        workflow: 'release-bus-v2-preflight.yml',
+        ref: 'main',
+        environment: 'orchestration',
+        service: null,
+        expectedSha: 'a'.repeat(40),
+        artifactDigest: null,
+        inputs: {}
+      })
+    ).resolves.toMatchObject({
+      external_id: '12345',
+      status: 'RUNNING'
+    });
+    expect(mockDispatchWorkflow).not.toHaveBeenCalled();
   });
 
   it('binds the immutable artifact digest from the structured terminal report', async () => {

--- a/src/releaseBusV2/release-bus-v2.operations.test.ts
+++ b/src/releaseBusV2/release-bus-v2.operations.test.ts
@@ -99,6 +99,7 @@ function repositoryFor(initial: ReleaseBusV2OperationRecord) {
           fields.completedAt === undefined
             ? current.completed_at
             : (fields.completedAt as number | null),
+        updated_at: Date.now(),
         row_version: current.row_version + 1
       };
       return true;
@@ -121,12 +122,20 @@ function repositoryFor(initial: ReleaseBusV2OperationRecord) {
         ...fields,
         row_version: current.row_version + 1
       };
+    },
+    ageUpdatedAt: (milliseconds: number) => {
+      current = { ...current, updated_at: current.updated_at - milliseconds };
     }
   };
 }
 
 describe('Release Bus v2 exact operation callbacks', () => {
-  beforeEach(() => jest.clearAllMocks());
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetWorkflowRunIdentity.mockReset();
+    mockFindWorkflowRun.mockReset();
+    mockDispatchWorkflow.mockReset();
+  });
 
   it('injects one transparent beta infrastructure retry before dispatch', async () => {
     const state = repositoryFor(
@@ -266,6 +275,47 @@ describe('Release Bus v2 exact operation callbacks', () => {
       external_id: null,
       status: 'DISPATCHED',
       attempt: 1
+    });
+
+    state.ageUpdatedAt(31_000);
+    await service.reconcileWorkflow(spec);
+    expect(state.current()).toMatchObject({
+      status: 'RETRY_WAIT',
+      attempt: 1,
+      result_json: { retry_same_attempt: true, transport_failures: 1 }
+    });
+  });
+
+  it('preserves a hard dispatch rejection as a control-plane failure', async () => {
+    const state = repositoryFor(
+      operation({ external_id: null, status: 'PENDING' })
+    );
+    mockFindWorkflowRun.mockResolvedValue(null);
+    mockDispatchWorkflow.mockRejectedValueOnce(
+      new Error('HTTP 422 workflow input rejected')
+    );
+    const service = new ReleaseBusV2Operations(state.repository as never);
+
+    await expect(
+      service.reconcileWorkflow({
+        idempotencyKey: 'rb2:train-id:prepare:frontend',
+        trainId: 'train-id',
+        operationType: 'PREPARE_ARTIFACT_FRONTEND',
+        repository: 'frontend',
+        workflow: 'release-bus-v2-preflight.yml',
+        ref: 'main',
+        environment: 'orchestration',
+        service: null,
+        expectedSha: 'a'.repeat(40),
+        artifactDigest: null,
+        inputs: {}
+      })
+    ).rejects.toThrow('HTTP 422 workflow input rejected');
+    expect(state.current()).toMatchObject({
+      status: 'FAILED',
+      failure_class: 'CONTROL_PLANE',
+      failure_message:
+        'GitHub workflow dispatch was rejected before creation: HTTP 422 workflow input rejected'
     });
   });
 

--- a/src/releaseBusV2/release-bus-v2.operations.test.ts
+++ b/src/releaseBusV2/release-bus-v2.operations.test.ts
@@ -106,6 +106,7 @@ function repositoryFor(initial: ReleaseBusV2OperationRecord) {
   );
   return {
     repository: {
+      appendEvent: jest.fn(async () => undefined),
       findOperation: jest.fn(async () => current),
       getOrCreateOperation: jest.fn(async () => current),
       updateOperation
@@ -119,6 +120,74 @@ function repositoryFor(initial: ReleaseBusV2OperationRecord) {
 
 describe('Release Bus v2 exact operation callbacks', () => {
   beforeEach(() => jest.clearAllMocks());
+
+  it('injects one transparent beta infrastructure retry before dispatch', async () => {
+    const state = repositoryFor(
+      operation({
+        external_id: null,
+        status: 'PENDING',
+        idempotency_key: 'rb2:train-id:prepare:backend',
+        operation_type: 'PREPARE_ARTIFACT_BACKEND',
+        repository: 'backend'
+      })
+    );
+    const service = new ReleaseBusV2Operations(state.repository as never);
+    const spec = {
+      idempotencyKey: 'rb2:train-id:prepare:backend',
+      trainId: 'train-id',
+      operationType: 'PREPARE_ARTIFACT_BACKEND',
+      repository: 'backend' as const,
+      workflow: 'release-bus-v2-preflight.yml',
+      ref: 'main',
+      environment: 'orchestration',
+      service: null,
+      expectedSha: 'a'.repeat(40),
+      artifactDigest: null,
+      inputs: {},
+      betaInfrastructureFailureInjection: {
+        candidateId: '11111111-1111-4111-8111-111111111111',
+        testId: 'infrastructure-retry-1'
+      }
+    };
+
+    await service.reconcileWorkflow(spec);
+    expect(state.current()).toMatchObject({
+      status: 'RETRY_WAIT',
+      attempt: 1,
+      external_id: null,
+      failure_class: 'INFRASTRUCTURE',
+      failure_message:
+        'Injected operator beta infrastructure failure before dispatch'
+    });
+    expect(state.repository.appendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        candidateId: '11111111-1111-4111-8111-111111111111',
+        eventType: 'BETA_INFRASTRUCTURE_FAILURE_INJECTED',
+        trainId: 'train-id'
+      }),
+      {}
+    );
+    expect(mockDispatchWorkflow).not.toHaveBeenCalled();
+
+    state.expireRetry();
+    mockFindWorkflowRun.mockResolvedValue(null);
+    await service.reconcileWorkflow(spec);
+    expect(mockDispatchWorkflow).toHaveBeenCalledWith(
+      'backend',
+      'release-bus-v2-preflight.yml',
+      'main',
+      expect.objectContaining({
+        operation_key: 'rb2:train-id:prepare:backend:a2'
+      })
+    );
+    expect(state.current()).toMatchObject({
+      status: 'DISPATCHED',
+      attempt: 2,
+      external_id: null,
+      failure_class: null
+    });
+    expect(state.repository.appendEvent).toHaveBeenCalledTimes(1);
+  });
 
   it('binds the immutable artifact digest from the structured terminal report', async () => {
     const state = repositoryFor(operation());

--- a/src/releaseBusV2/release-bus-v2.operations.ts
+++ b/src/releaseBusV2/release-bus-v2.operations.ts
@@ -86,12 +86,34 @@ const DISPATCH_DISCOVERY_GRACE_MS = 30_000;
 
 function isGitHubInfrastructureError(error: unknown): error is Error {
   const infrastructureType: unknown = ReleaseBusGitHubInfrastructureError;
+  const candidate = error as {
+    readonly code?: unknown;
+    readonly name?: unknown;
+    readonly status?: unknown;
+    readonly statusCode?: unknown;
+  };
+  const code = typeof candidate?.code === 'string' ? candidate.code : '';
+  const status = Number(candidate?.status ?? candidate?.statusCode ?? 0);
   return (
     error instanceof Error &&
     ((typeof infrastructureType === 'function' &&
       error instanceof infrastructureType) ||
       error.name === 'ReleaseBusGitHubInfrastructureError' ||
-      error.constructor.name === 'ReleaseBusGitHubInfrastructureError')
+      error.constructor.name === 'ReleaseBusGitHubInfrastructureError' ||
+      ['AbortError', 'FetchError', 'TimeoutError'].includes(error.name) ||
+      [
+        'ECONNABORTED',
+        'ECONNREFUSED',
+        'ECONNRESET',
+        'EAI_AGAIN',
+        'ENETDOWN',
+        'ENETUNREACH',
+        'ENOTFOUND',
+        'ETIMEDOUT'
+      ].includes(code) ||
+      status === 408 ||
+      status === 429 ||
+      status >= 500)
   );
 }
 

--- a/src/releaseBusV2/release-bus-v2.operations.ts
+++ b/src/releaseBusV2/release-bus-v2.operations.ts
@@ -26,6 +26,10 @@ export type ReleaseBusV2WorkflowSpec = {
   readonly artifactDigest: string | null;
   readonly inputs: Readonly<Record<string, string>>;
   readonly maxAttempts?: number;
+  readonly betaInfrastructureFailureInjection?: {
+    readonly candidateId: string;
+    readonly testId: string;
+  };
 };
 
 export type ReleaseBusV2Authorization = {
@@ -171,7 +175,9 @@ export class ReleaseBusV2Operations {
         request: {
           workflow: spec.workflow,
           ref: spec.ref,
-          inputs: spec.inputs
+          inputs: spec.inputs,
+          beta_infrastructure_failure_injection:
+            spec.betaInfrastructureFailureInjection ?? null
         },
         maxAttempts: spec.maxAttempts
       },
@@ -212,6 +218,42 @@ export class ReleaseBusV2Operations {
       operation =
         (await this.repository.findOperation(spec.idempotencyKey, {})) ??
         operation;
+    }
+
+    if (
+      operation.status === 'PENDING' &&
+      operation.attempt === 1 &&
+      operation.external_id === null &&
+      spec.betaInfrastructureFailureInjection
+    ) {
+      const nextRetryAt = Date.now() + retryDelayMs(operation.attempt);
+      await this.update(operation, {
+        status: 'RETRY_WAIT',
+        nextRetryAt,
+        failureClass: 'INFRASTRUCTURE',
+        failureMessage:
+          'Injected operator beta infrastructure failure before dispatch'
+      });
+      await this.repository.appendEvent(
+        {
+          trainId: operation.train_id,
+          candidateId: spec.betaInfrastructureFailureInjection.candidateId,
+          eventType: 'BETA_INFRASTRUCTURE_FAILURE_INJECTED',
+          actor: 'release-bus-v2-beta',
+          payload: {
+            attempt: operation.attempt,
+            next_retry_at: nextRetryAt,
+            operation_id: operation.id,
+            operation_type: operation.operation_type,
+            test_id: spec.betaInfrastructureFailureInjection.testId
+          }
+        },
+        {}
+      );
+      return (
+        (await this.repository.findOperation(spec.idempotencyKey, {})) ??
+        operation
+      );
     }
 
     const attemptKey = attemptOperationKey(

--- a/src/releaseBusV2/release-bus-v2.operations.ts
+++ b/src/releaseBusV2/release-bus-v2.operations.ts
@@ -324,6 +324,15 @@ export class ReleaseBusV2Operations {
     } catch (error) {
       if (isGitHubInfrastructureError(error))
         return this.deferTransportRetry(operation, error.message);
+      if (operation.status === 'DISPATCHED' && operation.external_id === null)
+        await this.update(operation, {
+          status: 'FAILED',
+          failureClass: 'CONTROL_PLANE',
+          failureMessage: `GitHub workflow dispatch was rejected before creation: ${
+            error instanceof Error ? error.message : 'unknown dispatch error'
+          }`,
+          completedAt: Date.now()
+        });
       throw error;
     }
     if (!run && operation.status === 'DISPATCHED') {

--- a/src/releaseBusV2/release-bus-v2.operations.ts
+++ b/src/releaseBusV2/release-bus-v2.operations.ts
@@ -88,12 +88,33 @@ function isGitHubInfrastructureError(error: unknown): error is Error {
   const infrastructureType: unknown = ReleaseBusGitHubInfrastructureError;
   const candidate = error as {
     readonly code?: unknown;
+    readonly headers?: unknown;
     readonly name?: unknown;
+    readonly retryAfter?: unknown;
     readonly status?: unknown;
     readonly statusCode?: unknown;
   };
   const code = typeof candidate?.code === 'string' ? candidate.code : '';
   const status = Number(candidate?.status ?? candidate?.statusCode ?? 0);
+  const headers = candidate?.headers as
+    | { readonly get?: (name: string) => string | null }
+    | Readonly<Record<string, unknown>>
+    | undefined;
+  const headerValue = (name: string): unknown => {
+    if (typeof headers?.get === 'function') return headers.get(name);
+    if (!headers || typeof headers !== 'object') return undefined;
+    const record = headers as Readonly<Record<string, unknown>>;
+    return (
+      record[name] ??
+      Object.entries(record).find(
+        ([key]) => key.toLowerCase() === name.toLowerCase()
+      )?.[1]
+    );
+  };
+  const retrySignaled =
+    candidate?.retryAfter !== undefined ||
+    headerValue('retry-after') !== undefined ||
+    headerValue('x-ratelimit-remaining') === '0';
   return (
     error instanceof Error &&
     ((typeof infrastructureType === 'function' &&
@@ -113,6 +134,7 @@ function isGitHubInfrastructureError(error: unknown): error is Error {
       ].includes(code) ||
       status === 408 ||
       status === 429 ||
+      (status === 403 && retrySignaled) ||
       status >= 500)
   );
 }

--- a/src/releaseBusV2/release-bus-v2.operations.ts
+++ b/src/releaseBusV2/release-bus-v2.operations.ts
@@ -82,6 +82,8 @@ function retryDelayMs(attempt: number): number {
   return Math.min(30_000 * 2 ** Math.max(0, attempt - 1), 5 * 60_000);
 }
 
+const DISPATCH_DISCOVERY_GRACE_MS = 30_000;
+
 function isGitHubInfrastructureError(error: unknown): error is Error {
   const infrastructureType: unknown = ReleaseBusGitHubInfrastructureError;
   return (
@@ -304,24 +306,36 @@ export class ReleaseBusV2Operations {
         );
       }
       if (!run && operation.status === 'PENDING') {
+        // Reserve the exact attempt before calling GitHub. Concurrent
+        // reconcilers race on this optimistic update, so only one winner can
+        // dispatch while the workflow is not yet discoverable.
+        await this.update(operation, { status: 'DISPATCHED', result: null });
+        operation =
+          (await this.repository.findOperation(spec.idempotencyKey, {})) ??
+          operation;
         await releaseBusGitHubApp.dispatchWorkflow(
           spec.repository,
           spec.workflow,
           spec.ref,
           dispatchInputs
         );
+        return operation;
       }
     } catch (error) {
       if (isGitHubInfrastructureError(error))
         return this.deferTransportRetry(operation, error.message);
       throw error;
     }
-    if (!run && operation.status === 'PENDING') {
-      await this.update(operation, { status: 'DISPATCHED', result: null });
-      return (
-        (await this.repository.findOperation(spec.idempotencyKey, {})) ??
-        operation
-      );
+    if (!run && operation.status === 'DISPATCHED') {
+      if (
+        Date.now() - Number(operation.updated_at) >=
+        DISPATCH_DISCOVERY_GRACE_MS
+      )
+        return this.deferTransportRetry(
+          operation,
+          'Reserved dispatch was not discoverable after the indexing grace period'
+        );
+      return operation;
     }
     if (!run) return operation;
     if (

--- a/src/releaseBusV2/release-bus-v2.operations.ts
+++ b/src/releaseBusV2/release-bus-v2.operations.ts
@@ -162,6 +162,26 @@ export class ReleaseBusV2Operations {
   public async reconcileWorkflow(
     spec: ReleaseBusV2WorkflowSpec
   ): Promise<ReleaseBusV2OperationRecord> {
+    try {
+      return await this.reconcileWorkflowOnce(spec);
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        error.message === 'Release Bus v2 operation changed concurrently'
+      ) {
+        const current = await this.repository.findOperation(
+          spec.idempotencyKey,
+          {}
+        );
+        if (current) return current;
+      }
+      throw error;
+    }
+  }
+
+  private async reconcileWorkflowOnce(
+    spec: ReleaseBusV2WorkflowSpec
+  ): Promise<ReleaseBusV2OperationRecord> {
     let operation = await this.repository.getOrCreateOperation(
       {
         idempotencyKey: spec.idempotencyKey,

--- a/src/releaseBusV2/release-bus-v2.reconciler.ts
+++ b/src/releaseBusV2/release-bus-v2.reconciler.ts
@@ -48,6 +48,11 @@ const TERMINAL_TRAINS = new Set<ReleaseBusV2TrainStatus>([
   'FAILED',
   'CANCELLED'
 ]);
+const TERMINAL_OPERATIONS = new Set<ReleaseBusV2OperationRecord['status']>([
+  'SUCCEEDED',
+  'FAILED',
+  'CANCELLED'
+]);
 // The lock is renewed every minute, but its expiry must also outlive the
 // longest deployment/E2E workflow during a temporary control-plane outage.
 // Workflow timeouts are at most 90 minutes, so two hours prevents overlapping
@@ -120,6 +125,21 @@ function isGitHubInfrastructureError(error: unknown): error is Error {
       error instanceof infrastructureType) ||
       error.name === 'ReleaseBusGitHubInfrastructureError' ||
       error.constructor.name === 'ReleaseBusGitHubInfrastructureError')
+  );
+}
+
+function isOptimisticConcurrencyConflict(error: unknown): error is Error {
+  return (
+    error instanceof Error &&
+    (error.message === 'Release Bus v2 operation changed concurrently' ||
+      error.message === 'Release Bus v2 train changed concurrently' ||
+      error.message === 'Candidate changed concurrently' ||
+      /^(frontend|backend) main operation changed concurrently$/.test(
+        error.message
+      ) ||
+      /^Candidate .* changed during deterministic isolation$/.test(
+        error.message
+      ))
   );
 }
 
@@ -450,6 +470,7 @@ export class ReleaseBusV2Reconciler {
   }> {
     const mode = getReleaseBusV2Mode();
     const claimed: string[] = [];
+    await this.releaseTerminalEnvironmentLocks();
     let betaAllowlist: readonly ReleaseBusV2BetaEntry[] = [];
     if (mode === 'OFF') {
       try {
@@ -555,6 +576,11 @@ export class ReleaseBusV2Reconciler {
         await this.advanceUntilExternalWait(train);
         advanced.push(train.id);
       } catch (error) {
+        // Lambda invocations and workflow callbacks may overlap. Optimistic
+        // locking identifies the winner; the loser must observe on the next
+        // pass instead of turning a valid idempotent advance into a bus-wide
+        // control-plane failure.
+        if (isOptimisticConcurrencyConflict(error)) continue;
         if (error instanceof MainMovedError) {
           await this.cancelForMovedMain(train, error.message);
           continue;
@@ -2295,6 +2321,41 @@ export class ReleaseBusV2Reconciler {
       ENVIRONMENT_LOCK_TTL_MS,
       {}
     );
+  }
+
+  private async releaseTerminalEnvironmentLocks(): Promise<void> {
+    const locks = await this.repository.listLocks({});
+    for (const lock of locks) {
+      if (
+        !lock.owner_train_id ||
+        !lock.lease_token ||
+        !['staging-environment', 'production-environment'].includes(lock.name)
+      )
+        continue;
+      const train = await this.repository.findTrain(lock.owner_train_id, {});
+      if (!train || !TERMINAL_TRAINS.has(train.status)) continue;
+      const operations = await this.repository.listOperations(train.id, {});
+      if (
+        operations.some(
+          (operation) => !TERMINAL_OPERATIONS.has(operation.status)
+        )
+      )
+        continue;
+      if (await this.repository.releaseLock(lock.name, lock.lease_token, {}))
+        await this.repository.appendEvent(
+          {
+            trainId: train.id,
+            eventType: 'TERMINAL_ENVIRONMENT_LOCK_RELEASED',
+            actor: 'release-bus-v2',
+            payload: {
+              lock: lock.name,
+              train_status: train.status,
+              operation_count: operations.length
+            }
+          },
+          {}
+        );
+    }
   }
 
   private async releaseEnvironmentLease(

--- a/src/releaseBusV2/release-bus-v2.reconciler.ts
+++ b/src/releaseBusV2/release-bus-v2.reconciler.ts
@@ -8,6 +8,7 @@ import {
   getReleaseBusV2BetaAllowlist,
   getReleaseBusV2Mode,
   releaseBusV2BetaAllowsCandidate,
+  releaseBusV2BetaInfrastructureFailureInjection,
   releaseBusV2BetaAllowsLane,
   type ReleaseBusV2BetaEntry
 } from '@/releaseBusV2/release-bus-v2.config';
@@ -866,10 +867,20 @@ export class ReleaseBusV2Reconciler {
     const evidence = fastCandidate
       ? reusablePrArtifact(fastCandidate, repository, graph?.units ?? [])
       : null;
+    const operationType = `PREPARE_ARTIFACT_${repository.toUpperCase()}`;
+    const betaInfrastructureFailureInjection =
+      getReleaseBusV2Mode() === 'OFF' && train.lane === 'STAGING'
+        ? releaseBusV2BetaInfrastructureFailureInjection(
+            getReleaseBusV2BetaAllowlist(),
+            candidates,
+            train.lane,
+            operationType
+          )
+        : null;
     const artifact = await releaseBusV2Operations.reconcileWorkflow({
       idempotencyKey: operationKey(train.id, `prepare:${repository}`),
       trainId: train.id,
-      operationType: `PREPARE_ARTIFACT_${repository.toUpperCase()}`,
+      operationType,
       repository,
       workflow: 'release-bus-v2-preflight.yml',
       ref: 'main',
@@ -896,7 +907,10 @@ export class ReleaseBusV2Reconciler {
             }
           : {})
       },
-      maxAttempts: 3
+      maxAttempts: 3,
+      ...(betaInfrastructureFailureInjection
+        ? { betaInfrastructureFailureInjection }
+        : {})
     });
     return {
       repository,


### PR DESCRIPTION
## Summary

- extend the strict OFF-beta allowlist with one optional, repository-bound staging preflight failure injection
- place only the exact first preflight attempt into transparent INFRASTRUCTURE RETRY_WAIT before dispatch
- emit BETA_INFRASTRUCTURE_FAILURE_INJECTED and dispatch attempt 2 after the normal bounded delay
- reject multiple, mismatched, production-only, or unknown injection configuration
- document the exact operator procedure

## Safety

- global Release Bus v2 mode remains OFF
- injection is possible only for one exact allowlisted synthetic candidate in STAGING
- no workflow is dispatched for injected attempt 1; attempt 2 uses the normal immutable idempotency key
- production and ordinary developer/manual paths cannot activate this behavior
- no architecture topology change

## Validation

- 49 focused v2 tests passed across config, operations, reconciler, and acceptance suites
- root TypeScript compile passed
- targeted ESLint passed with zero warnings
- targeted Prettier check passed
- generate:deploy-config passed with no generated diff
- git diff --check passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added staging-only beta infrastructure failure injection during artifact preparation that triggers automatic retry with event tracking.
  - Terminal environment locks are now released for trains in terminal states when running in offline mode.

- **Bug Fixes**
  - Improved detection of GitHub infrastructure errors, including secondary rate limiting and retry-signaling responses.
  - Failure injection configuration is strictly validated to prevent invalid or duplicate configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->