### PR TITLE
test(release-bus-v2): add infrastructure retry beta fixture

### DIFF
--- a/ops/deployment-bus/beta-fixtures/infrastructure-retry-backend-1.md
+++ b/ops/deployment-bus/beta-fixtures/infrastructure-retry-backend-1.md
@@ -1,0 +1,12 @@
+# Release Bus v2 infrastructure-retry backend beta fixture 1
+
+This file intentionally changes no runtime behavior. It gives the bounded
+operator-only infrastructure-retry acceptance test one exact green backend
+merge-tree. The deploy plan selects only `api`; the matching one-shot beta
+configuration injects an infrastructure failure into
+`PREPARE_ARTIFACT_BACKEND` before dispatch, then requires the same operation to
+retry idempotently and deploy without candidate isolation or duplicate work.
+
+- Test ID: `infrastructure-retry-1`
+- Candidate ID: `91a20f74-230b-4e66-9e1b-308930523c13`
+- Global Release Bus v2 mode: `OFF`


### PR DESCRIPTION
Adds a documentation-only synthetic fixture for the bounded operator-only infrastructure-retry acceptance case.

The fixture gives the exact green backend merge-tree a stable test ID and candidate ID. Runtime behavior and shared deployment refs are unchanged. The later one-shot allowlist will inject a pre-dispatch PREPARE_ARTIFACT_BACKEND infrastructure failure and verify an idempotent retry without isolation or duplicate work.

Validation: git diff --cached --check; exact-head GitHub checks and artifact generation are expected on this PR.