### PR TITLE
Fix v2 beta post-E2E shared-state fence

### DIFF
--- a/ops/deployment-bus/simple-release-bus-v2.md
+++ b/ops/deployment-bus/simple-release-bus-v2.md
@@ -180,7 +180,13 @@ For each single bounded staging test:
    releases the lock without mutation.
 4. Run exactly one case to a terminal state. Record ready-to-deployed timing;
    report E2E separately. Verify transparent checks, exact artifacts/manifests,
-   one build per artifact, and no duplicate workflow dispatch.
+   one build per artifact, and no duplicate workflow dispatch. Before a green
+   E2E result may become `STAGING_VALIDATED`, re-check both staging refs and
+   every staging deploy/E2E workflow created since the recorded idle
+   handshake, ignoring only the train's exact workflow run IDs. Any unrelated
+   active or completed mutation fails closed as a control-plane error, marks
+   the mixed manifest failed, requeues rather than isolates candidates, pauses
+   v2 automation, and releases staging ownership.
 5. Clear the allowlist, deploy API then `releaseBus` with the empty value, and
    prove helpers still report `OFF`, the train is terminal, all related
    workflows are terminal, and the staging lock is free before the next case.

--- a/ops/deployment-bus/simple-release-bus-v2.md
+++ b/ops/deployment-bus/simple-release-bus-v2.md
@@ -182,8 +182,9 @@ For each single bounded staging test:
    report E2E separately. Verify transparent checks, exact artifacts/manifests,
    one build per artifact, and no duplicate workflow dispatch. Before a green
    E2E result may become `STAGING_VALIDATED`, re-check both staging refs and
-   every staging deploy/E2E workflow created since the recorded idle
-   handshake, ignoring only the train's exact workflow run IDs. Any unrelated
+   every staging deploy/E2E workflow created since the first pre-lock idle
+   snapshot, ignoring only the train's exact workflow run IDs. Paginate the
+   history and fail closed if its bounded scan cap is exhausted. Any unrelated
    active or completed mutation fails closed as a control-plane error, marks
    the mixed manifest failed, requeues rather than isolates candidates, pauses
    v2 automation, and releases staging ownership.

--- a/ops/deployment-bus/simple-release-bus-v2.md
+++ b/ops/deployment-bus/simple-release-bus-v2.md
@@ -200,13 +200,22 @@ the allowlist empty and automation globally `OFF` until repaired.
 
 Production beta is a separate allowlist installation after all staging cases
 pass. Use only exact `STAGING_VALIDATED` candidate IDs, list only the explicit
-production subset, and require the operator's separate mark-ready action. The
-first production beta must reuse exact qualification; if a qualification train
-appears, stop with mode `OFF` and do not mutate staging. Before production
-mutation the reconciler performs the analogous double active-workflow/main-ref
-snapshot under `production-environment` and records
+production subset, and require the operator's separate mark-ready action.
+With exact validated candidates A/B/C and a reusable exact manifest, prove the
+production train is claimable and prepares while an unrelated D/E staging
+train is active, acquires only `production-environment`, and completes without
+waiting for, cancelling, or interfering with D/E. Record overlapping train and
+operation run IDs, distinct environment-lock ownership, and timings; the
+scheduler lock must be claim-only and brief rather than serializing either
+lane's workflows. Separately prove that an exact A/B/C set without a reusable
+validated manifest enters `PRODUCTION_QUALIFICATION` and waits for
+`staging-environment` behind D/E instead of contaminating D/E E2E, then may
+proceed after qualification. Any dependency on D/E must hold A/B/C throughout.
+Before production mutation the reconciler performs the analogous double
+active-workflow/main-ref snapshot under `production-environment` and records
 `BETA_PRODUCTION_IDLE_HANDSHAKE`. Prove 3–5 minute backend or 10–15 minute
-frontend promotion, then clear/deploy the empty allowlist and return to idle.
+frontend promotion, exactly-once deployment and release-note finalization,
+then clear/deploy the empty allowlist and return to idle.
 
 General `STAGING` or `PRODUCTION` mode enablement is forbidden until every case
 above passes and the owner explicitly authorizes cutover.

--- a/src/releaseBus/release-bus.github-app.test.ts
+++ b/src/releaseBus/release-bus.github-app.test.ts
@@ -250,6 +250,84 @@ describe('GitHub staging idle handshake', () => {
       fetchMock.mockReset();
     }
   });
+
+  it('detects a completed staging deploy after the handshake and ignores exact train runs', async () => {
+    const app = new ReleaseBusGitHubApp();
+    (
+      app as unknown as {
+        cachedToken: { value: string; expiresAt: number };
+      }
+    ).cachedToken = { value: 'test-token', expiresAt: Date.now() + 120_000 };
+    const fetchMock = fetch as jest.MockedFunction<typeof fetch>;
+    const since = Date.parse('2026-07-23T13:22:00Z');
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          workflow_runs: [
+            {
+              id: 100,
+              name: 'Deploy api to staging train exact [rb2:exact]',
+              path: '.github/workflows/deploy.yml',
+              display_title: 'Deploy api to staging train exact [rb2:exact]',
+              created_at: '2026-07-23T13:22:10Z'
+            },
+            {
+              id: 101,
+              name: 'Deploy api to staging [manual]',
+              path: '.github/workflows/deploy.yml',
+              display_title: 'Deploy api to staging [manual]',
+              created_at: '2026-07-23T13:23:22Z'
+            }
+          ]
+        })
+      )
+    );
+
+    try {
+      await expect(
+        app.hasStagingMutationOrE2ERunSince('backend', since, ['100'])
+      ).resolves.toBe(true);
+      expect(String(fetchMock.mock.calls[0]?.[0])).toContain(
+        'created=%3E%3D2026-07-23T13%3A22%3A00.000Z'
+      );
+    } finally {
+      fetchMock.mockReset();
+    }
+  });
+
+  it('does not treat ignored exact train workflows as external mutation', async () => {
+    const app = new ReleaseBusGitHubApp();
+    (
+      app as unknown as {
+        cachedToken: { value: string; expiresAt: number };
+      }
+    ).cachedToken = { value: 'test-token', expiresAt: Date.now() + 120_000 };
+    const fetchMock = fetch as jest.MockedFunction<typeof fetch>;
+    const since = Date.parse('2026-07-23T13:22:00Z');
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          workflow_runs: [
+            {
+              id: 100,
+              name: 'Release Bus - Staging E2E exact train',
+              path: '.github/workflows/staging-e2e.yml',
+              display_title: 'Exact train E2E',
+              created_at: '2026-07-23T13:22:20Z'
+            }
+          ]
+        })
+      )
+    );
+
+    try {
+      await expect(
+        app.hasStagingMutationOrE2ERunSince('frontend', since, ['100'])
+      ).resolves.toBe(false);
+    } finally {
+      fetchMock.mockReset();
+    }
+  });
 });
 
 function job(index: number): GitHubWorkflowJob {

--- a/src/releaseBus/release-bus.github-app.test.ts
+++ b/src/releaseBus/release-bus.github-app.test.ts
@@ -328,6 +328,123 @@ describe('GitHub staging idle handshake', () => {
       fetchMock.mockReset();
     }
   });
+
+  it('excludes a date-filter result created before the fence window', async () => {
+    const app = new ReleaseBusGitHubApp();
+    (
+      app as unknown as {
+        cachedToken: { value: string; expiresAt: number };
+      }
+    ).cachedToken = { value: 'test-token', expiresAt: Date.now() + 120_000 };
+    const fetchMock = fetch as jest.MockedFunction<typeof fetch>;
+    const since = Date.parse('2026-07-23T13:22:00Z');
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          workflow_runs: [
+            {
+              id: 99,
+              name: 'Deploy api to staging [manual]',
+              path: '.github/workflows/deploy.yml',
+              display_title: 'Deploy api to staging [manual]',
+              created_at: '2026-07-23T13:21:59Z'
+            }
+          ]
+        })
+      )
+    );
+
+    try {
+      await expect(
+        app.hasStagingMutationOrE2ERunSince('backend', since)
+      ).resolves.toBe(false);
+    } finally {
+      fetchMock.mockReset();
+    }
+  });
+
+  it('paginates the beta fence history before accepting an idle result', async () => {
+    const app = new ReleaseBusGitHubApp();
+    (
+      app as unknown as {
+        cachedToken: { value: string; expiresAt: number };
+      }
+    ).cachedToken = { value: 'test-token', expiresAt: Date.now() + 120_000 };
+    const fetchMock = fetch as jest.MockedFunction<typeof fetch>;
+    const since = Date.parse('2026-07-23T13:22:00Z');
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            workflow_runs: Array.from({ length: 100 }, (_, index) => ({
+              id: index + 1,
+              name: 'Unrelated CI',
+              path: '.github/workflows/ci.yml',
+              display_title: 'Unrelated CI',
+              created_at: '2026-07-23T13:23:00Z'
+            }))
+          })
+        )
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            workflow_runs: [
+              {
+                id: 101,
+                name: 'Web Deploy - STAGING',
+                path: '.github/workflows/deploy-staging.yml',
+                display_title: 'Web Deploy - STAGING',
+                created_at: '2026-07-23T13:22:30Z'
+              }
+            ]
+          })
+        )
+      );
+
+    try {
+      await expect(
+        app.hasStagingMutationOrE2ERunSince('frontend', since)
+      ).resolves.toBe(true);
+      expect(String(fetchMock.mock.calls[1]?.[0])).toContain('page=2');
+    } finally {
+      fetchMock.mockReset();
+    }
+  });
+
+  it('does not confuse a staging-canary title with shared staging', async () => {
+    const app = new ReleaseBusGitHubApp();
+    (
+      app as unknown as {
+        cachedToken: { value: string; expiresAt: number };
+      }
+    ).cachedToken = { value: 'test-token', expiresAt: Date.now() + 120_000 };
+    const fetchMock = fetch as jest.MockedFunction<typeof fetch>;
+    const since = Date.parse('2026-07-23T13:22:00Z');
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          workflow_runs: [
+            {
+              id: 101,
+              name: 'Deploy api to staging-canary [manual]',
+              path: '.github/workflows/deploy.yml',
+              display_title: 'Deploy api to staging-canary [manual]',
+              created_at: '2026-07-23T13:22:30Z'
+            }
+          ]
+        })
+      )
+    );
+
+    try {
+      await expect(
+        app.hasStagingMutationOrE2ERunSince('backend', since)
+      ).resolves.toBe(false);
+    } finally {
+      fetchMock.mockReset();
+    }
+  });
 });
 
 function job(index: number): GitHubWorkflowJob {

--- a/src/releaseBus/release-bus.github-app.test.ts
+++ b/src/releaseBus/release-bus.github-app.test.ts
@@ -445,6 +445,18 @@ describe('GitHub staging idle handshake', () => {
       fetchMock.mockReset();
     }
   });
+
+  it('fails closed on a malformed exact train workflow id', async () => {
+    const app = new ReleaseBusGitHubApp();
+
+    await expect(
+      app.hasStagingMutationOrE2ERunSince(
+        'backend',
+        Date.parse('2026-07-23T13:22:00Z'),
+        ['reserved:operation']
+      )
+    ).rejects.toThrow('Invalid staging workflow fence run id');
+  });
 });
 
 function job(index: number): GitHubWorkflowJob {

--- a/src/releaseBus/release-bus.github-app.ts
+++ b/src/releaseBus/release-bus.github-app.ts
@@ -116,6 +116,7 @@ const REPOSITORIES: Readonly<Record<ReleaseRepository, string>> = {
 const MAX_WORKFLOW_JOBS = 100;
 const MAX_WORKFLOW_STEPS = 100;
 const MAX_WORKFLOW_LABEL_LENGTH = 500;
+const MAX_STAGING_FENCE_PAGES = 10;
 
 export class ReleaseBusGitHubInfrastructureError extends Error {
   public constructor(message: string) {
@@ -801,24 +802,34 @@ export class ReleaseBusGitHubApp {
       ignoredRunIds.filter((runId) => /^\d+$/.test(runId)).map(Number)
     );
     const created = encodeURIComponent(`>=${new Date(since).toISOString()}`);
-    const response = await this.request(
-      repository,
-      `/actions/runs?created=${created}&per_page=100`
-    );
-    await this.assertOk(
-      response,
-      `list ${repository} staging workflow runs since the beta handshake`
-    );
-    const runs =
-      ((await response.json()) as { workflow_runs?: GitHubRun[] })
-        .workflow_runs ?? [];
-    return runs.some(
-      (run) =>
-        !ignored.has(run.id) &&
-        typeof run.created_at === 'string' &&
-        Date.parse(run.created_at) >= since &&
-        this.isStagingMutationOrE2ERun(repository, run)
-    );
+    for (let page = 1; page <= MAX_STAGING_FENCE_PAGES; page += 1) {
+      const response = await this.request(
+        repository,
+        `/actions/runs?created=${created}&per_page=100&page=${page}`
+      );
+      await this.assertOk(
+        response,
+        `list ${repository} staging workflow runs since the beta handshake`
+      );
+      const runs =
+        ((await response.json()) as { workflow_runs?: GitHubRun[] })
+          .workflow_runs ?? [];
+      if (
+        runs.some(
+          (run) =>
+            !ignored.has(run.id) &&
+            typeof run.created_at === 'string' &&
+            Date.parse(run.created_at) >= since &&
+            this.isStagingMutationOrE2ERun(repository, run)
+        )
+      )
+        return true;
+      if (runs.length < 100) return false;
+    }
+    // A bounded beta cannot safely prove the environment idle when more than
+    // 1,000 workflow runs fit inside its fence window. Fail closed rather than
+    // silently ignoring an older mutation.
+    return true;
   }
 
   private isStagingMutationOrE2ERun(
@@ -875,7 +886,7 @@ export class ReleaseBusGitHubApp {
     return (
       (run.path === '.github/workflows/deploy.yml' ||
         run.name === 'Deploy a service') &&
-      run.display_title.includes(` to ${environment}`)
+      new RegExp(` to ${environment}(?:\\s|$)`).test(run.display_title)
     );
   }
 

--- a/src/releaseBus/release-bus.github-app.ts
+++ b/src/releaseBus/release-bus.github-app.ts
@@ -759,16 +759,23 @@ export class ReleaseBusGitHubApp {
       `${environment} deployment`,
       (run) => {
         if (repository === 'backend') {
-          return (
-            run.name === 'Deploy a service' &&
-            run.display_title.includes(` to ${environment}`)
-          );
+          return this.isBackendDeploymentRun(run, environment);
         }
-        const names =
+        const paths =
+          environment === 'prod'
+            ? [
+                '.github/workflows/build-upload-deploy-prod.yml',
+                '.github/workflows/release-bus-deploy-production.yml'
+              ]
+            : [
+                '.github/workflows/deploy-staging.yml',
+                '.github/workflows/release-bus-deploy-staging.yml'
+              ];
+        const legacyNames =
           environment === 'prod'
             ? ['Web Deploy - PROD', 'Release Bus - Deploy Frontend Production']
             : ['Web Deploy - STAGING', 'Release Bus - Deploy Frontend Staging'];
-        return names.includes(run.name);
+        return paths.includes(run.path ?? '') || legacyNames.includes(run.name);
       }
     );
   }
@@ -779,21 +786,61 @@ export class ReleaseBusGitHubApp {
     return this.hasActiveWorkflowRun(
       repository,
       'staging mutation or E2E',
-      (run) => {
-        if (repository === 'backend') {
-          return (
-            run.name === 'Deploy a service' &&
-            run.display_title.includes(' to staging')
-          );
-        }
-        return [
-          'Web Deploy - STAGING',
-          'Release Bus - Deploy Frontend Staging',
-          'Release Bus - Sync Main To Staging',
-          'Staging E2E'
-        ].includes(run.name);
-      }
+      (run) => this.isStagingMutationOrE2ERun(repository, run)
     );
+  }
+
+  public async hasStagingMutationOrE2ERunSince(
+    repository: ReleaseRepository,
+    since: number,
+    ignoredRunIds: readonly string[] = []
+  ): Promise<boolean> {
+    if (!Number.isInteger(since) || since < 1)
+      throw new Error('Invalid staging workflow fence timestamp');
+    const ignored = new Set(
+      ignoredRunIds.filter((runId) => /^\d+$/.test(runId)).map(Number)
+    );
+    const created = encodeURIComponent(`>=${new Date(since).toISOString()}`);
+    const response = await this.request(
+      repository,
+      `/actions/runs?created=${created}&per_page=100`
+    );
+    await this.assertOk(
+      response,
+      `list ${repository} staging workflow runs since the beta handshake`
+    );
+    const runs =
+      ((await response.json()) as { workflow_runs?: GitHubRun[] })
+        .workflow_runs ?? [];
+    return runs.some(
+      (run) =>
+        !ignored.has(run.id) &&
+        typeof run.created_at === 'string' &&
+        Date.parse(run.created_at) >= since &&
+        this.isStagingMutationOrE2ERun(repository, run)
+    );
+  }
+
+  private isStagingMutationOrE2ERun(
+    repository: ReleaseRepository,
+    run: GitHubRun
+  ): boolean {
+    if (repository === 'backend') {
+      return this.isBackendDeploymentRun(run, 'staging');
+    }
+    const paths = [
+      '.github/workflows/deploy-staging.yml',
+      '.github/workflows/release-bus-deploy-staging.yml',
+      '.github/workflows/release-bus-sync-staging.yml',
+      '.github/workflows/staging-e2e.yml'
+    ];
+    const legacyNames = [
+      'Web Deploy - STAGING',
+      'Release Bus - Deploy Frontend Staging',
+      'Release Bus - Sync Main To Staging',
+      'Staging E2E'
+    ];
+    return paths.includes(run.path ?? '') || legacyNames.includes(run.name);
   }
 
   public async hasActiveProductionMutationOrE2ERun(
@@ -804,17 +851,31 @@ export class ReleaseBusGitHubApp {
       'production mutation or E2E',
       (run) => {
         if (repository === 'backend') {
-          return (
-            run.name === 'Deploy a service' &&
-            run.display_title.includes(' to prod')
-          );
+          return this.isBackendDeploymentRun(run, 'prod');
         }
-        return [
+        const paths = [
+          '.github/workflows/build-upload-deploy-prod.yml',
+          '.github/workflows/release-bus-deploy-production.yml',
+          '.github/workflows/production-e2e.yml'
+        ];
+        const legacyNames = [
           'Web Deploy - PROD',
           'Release Bus - Deploy Frontend Production',
           'Production E2E'
-        ].includes(run.name);
+        ];
+        return paths.includes(run.path ?? '') || legacyNames.includes(run.name);
       }
+    );
+  }
+
+  private isBackendDeploymentRun(
+    run: GitHubRun,
+    environment: 'staging' | 'prod'
+  ): boolean {
+    return (
+      (run.path === '.github/workflows/deploy.yml' ||
+        run.name === 'Deploy a service') &&
+      run.display_title.includes(` to ${environment}`)
     );
   }
 

--- a/src/releaseBus/release-bus.github-app.ts
+++ b/src/releaseBus/release-bus.github-app.ts
@@ -798,9 +798,9 @@ export class ReleaseBusGitHubApp {
   ): Promise<boolean> {
     if (!Number.isInteger(since) || since < 1)
       throw new Error('Invalid staging workflow fence timestamp');
-    const ignored = new Set(
-      ignoredRunIds.filter((runId) => /^\d+$/.test(runId)).map(Number)
-    );
+    if (ignoredRunIds.some((runId) => !/^\d+$/.test(runId)))
+      throw new Error('Invalid staging workflow fence run id');
+    const ignored = new Set(ignoredRunIds.map(Number));
     const created = encodeURIComponent(`>=${new Date(since).toISOString()}`);
     for (let page = 1; page <= MAX_STAGING_FENCE_PAGES; page += 1) {
       const response = await this.request(

--- a/src/releaseBusV2/release-bus-v2.acceptance.test.ts
+++ b/src/releaseBusV2/release-bus-v2.acceptance.test.ts
@@ -4,6 +4,7 @@ const mockResolveRef = jest.fn();
 const mockResolveRefIfExists = jest.fn();
 const mockUpdateRef = jest.fn();
 const mockHasActiveStagingRun = jest.fn();
+const mockHasStagingRunSince = jest.fn();
 const mockHasActiveProductionRun = jest.fn();
 
 jest.mock('@/releaseBusV2/release-bus-v2.operations', () => ({
@@ -20,6 +21,8 @@ jest.mock('@/releaseBus/release-bus.github-app', () => ({
     updateRef: (...args: unknown[]) => mockUpdateRef(...args),
     hasActiveStagingMutationOrE2ERun: (...args: unknown[]) =>
       mockHasActiveStagingRun(...args),
+    hasStagingMutationOrE2ERunSince: (...args: unknown[]) =>
+      mockHasStagingRunSince(...args),
     hasActiveProductionMutationOrE2ERun: (...args: unknown[]) =>
       mockHasActiveProductionRun(...args)
   }
@@ -145,7 +148,14 @@ class InMemoryAcceptanceRepository {
   public readonly dependencies: ReleaseBusV2DependencyRecord[] = [];
   public readonly operations: ReleaseBusV2OperationRecord[] = [];
   public readonly manifests = new Map<string, ReleaseBusV2ManifestRecord>();
-  public readonly events: unknown[] = [];
+  public readonly events: Array<{
+    readonly trainId?: string | null;
+    readonly candidateId?: string | null;
+    readonly eventType: string;
+    readonly actor?: string | null;
+    readonly payload?: unknown;
+    readonly createdAt: number;
+  }> = [];
   public lock: ReleaseBusV2LockRecord = {
     name: 'staging-environment',
     owner_train_id: null,
@@ -287,8 +297,35 @@ class InMemoryAcceptanceRepository {
     return true;
   }
 
-  public async appendEvent(input: unknown): Promise<void> {
-    this.events.push(input);
+  public async appendEvent(
+    input: Omit<(typeof this.events)[number], 'createdAt'>
+  ): Promise<void> {
+    this.events.push({ ...input, createdAt: Date.now() });
+  }
+
+  public async listEvents(trainId: string): Promise<
+    Array<{
+      readonly id: string;
+      readonly train_id: string | null;
+      readonly candidate_id: string | null;
+      readonly event_type: string;
+      readonly github_actor: string | null;
+      readonly payload_json: unknown;
+      readonly created_at: number;
+    }>
+  > {
+    return this.events
+      .filter((event) => event.trainId === trainId)
+      .map((event, index) => ({
+        id: `event-${index}`,
+        train_id: event.trainId ?? null,
+        candidate_id: event.candidateId ?? null,
+        event_type: event.eventType,
+        github_actor: event.actor ?? null,
+        payload_json: event.payload ?? null,
+        created_at: event.createdAt
+      }))
+      .reverse();
   }
 
   public async acquireLock(
@@ -441,6 +478,7 @@ describe('Release Bus v2 offline acceptance harness', () => {
     process.env.RELEASE_BUS_V2_MODE = 'STAGING';
     delete process.env.RELEASE_BUS_V2_BETA_ALLOWLIST;
     mockHasActiveStagingRun.mockResolvedValue(false);
+    mockHasStagingRunSince.mockResolvedValue(false);
     mockHasActiveProductionRun.mockResolvedValue(false);
     mockResolveRefIfExists.mockImplementation(
       async (repository: 'frontend' | 'backend') =>
@@ -732,6 +770,76 @@ describe('Release Bus v2 offline acceptance harness', () => {
     const externalCalls = mockReconcileWorkflow.mock.calls.length;
     await state.reconciler.runOnce('acceptance-duplicate');
     expect(mockReconcileWorkflow).toHaveBeenCalledTimes(externalCalls);
+  });
+
+  it('fails closed when an unrelated staging workflow ran after the beta handshake', async () => {
+    const state = harness('SUCCEEDED');
+    process.env.RELEASE_BUS_V2_MODE = 'OFF';
+    process.env.RELEASE_BUS_V2_BETA_ALLOWLIST = JSON.stringify([
+      {
+        test_id: 'frontend-only-fence',
+        candidate_id: '11111111-1111-4111-8111-111111111111',
+        repository: 'frontend',
+        branch_name: 'agent/rb2-beta-frontend-fence',
+        operator: 'beta-operator',
+        lanes: ['STAGING']
+      }
+    ]);
+    mockHasStagingRunSince.mockResolvedValue(true);
+    mockReconcileWorkflow.mockImplementation(async (spec) => {
+      const typed = spec as { operationType: string; service: string | null };
+      const completed = operation(
+        'train-1',
+        typed.operationType,
+        typed.operationType.includes('FRONTEND') ||
+          typed.operationType === 'E2E_STAGING'
+          ? 'frontend'
+          : 'backend',
+        `run-${typed.service ?? typed.operationType}`,
+        typed.service
+      );
+      state.repository.operations.push(completed);
+      return completed;
+    });
+
+    await state.reconciler.runOnce('acceptance-beta-final-fence');
+
+    expect(state.repository.trains.get('train-1')).toEqual(
+      expect.objectContaining({
+        status: 'FAILED',
+        failure_class: 'CONTROL_PLANE',
+        failure_message: expect.stringContaining('Shared staging')
+      })
+    );
+    expect(
+      Array.from(state.repository.candidates.values()).every(
+        (item) => item.status === 'READY_FOR_STAGING'
+      )
+    ).toBe(true);
+    expect(Array.from(state.repository.manifests.values())[0]?.status).toBe(
+      'FAILED'
+    );
+    expect(state.repository.lock.owner_train_id).toBeNull();
+    expect(state.service.setPaused).toHaveBeenCalledWith(
+      'ALL',
+      true,
+      expect.stringContaining('control-plane failure'),
+      'release-bus-v2'
+    );
+    expect(state.repository.events).toContainEqual(
+      expect.objectContaining({
+        eventType: 'BETA_STAGING_FINAL_FENCE_VIOLATED',
+        trainId: 'train-1'
+      })
+    );
+    expect(mockHasStagingRunSince).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(Number),
+      expect.arrayContaining([
+        expect.stringContaining('run-DEPLOY'),
+        expect.stringContaining('run-E2E')
+      ])
+    );
   });
 
   it('keeps staging locked and prevents a second mutation while exact E2E is running', async () => {

--- a/src/releaseBusV2/release-bus-v2.acceptance.test.ts
+++ b/src/releaseBusV2/release-bus-v2.acceptance.test.ts
@@ -156,6 +156,7 @@ class InMemoryAcceptanceRepository {
     readonly payload?: unknown;
     readonly createdAt: number;
   }> = [];
+  private eventClock = Date.now();
   public lock: ReleaseBusV2LockRecord = {
     name: 'staging-environment',
     owner_train_id: null,
@@ -300,7 +301,8 @@ class InMemoryAcceptanceRepository {
   public async appendEvent(
     input: Omit<(typeof this.events)[number], 'createdAt'>
   ): Promise<void> {
-    this.events.push({ ...input, createdAt: Date.now() });
+    this.eventClock += 1;
+    this.events.push({ ...input, createdAt: this.eventClock });
   }
 
   public async listEvents(trainId: string): Promise<
@@ -634,7 +636,11 @@ describe('Release Bus v2 offline acceptance harness', () => {
       expect.objectContaining({
         eventType: 'BETA_STAGING_IDLE_HANDSHAKE',
         trainId: 'train-1',
-        payload: expect.objectContaining({ staging_lock: 'owned' })
+        payload: expect.objectContaining({
+          staging_lock: 'owned',
+          workflow_fence_started_at: expect.any(Number),
+          verified_at: expect.any(Number)
+        })
       })
     );
   });
@@ -832,14 +838,16 @@ describe('Release Bus v2 offline acceptance harness', () => {
         trainId: 'train-1'
       })
     );
-    expect(mockHasStagingRunSince).toHaveBeenCalledWith(
-      expect.any(String),
-      expect.any(Number),
-      expect.arrayContaining([
-        expect.stringContaining('run-DEPLOY'),
-        expect.stringContaining('run-E2E')
-      ])
-    );
+    const expectedRunIds = state.repository.operations
+      .map(({ external_id }) => external_id)
+      .filter((runId): runId is string => runId !== null);
+    expect(mockHasStagingRunSince).toHaveBeenCalledTimes(2);
+    for (const [, , ignoredRunIds] of mockHasStagingRunSince.mock.calls) {
+      expect(ignoredRunIds).toHaveLength(expectedRunIds.length);
+      expect(new Set(ignoredRunIds as string[])).toEqual(
+        new Set(expectedRunIds)
+      );
+    }
   });
 
   it('keeps staging locked and prevents a second mutation while exact E2E is running', async () => {

--- a/src/releaseBusV2/release-bus-v2.reconciler.ts
+++ b/src/releaseBusV2/release-bus-v2.reconciler.ts
@@ -92,6 +92,7 @@ type StagingIdleSnapshot = {
 };
 
 type StagingIdleHandshakeSnapshot = StagingIdleSnapshot & {
+  readonly workflow_fence_started_at: number;
   readonly verified_at: number;
 };
 
@@ -1381,6 +1382,9 @@ export class ReleaseBusV2Reconciler {
     const requiresBetaIdleHandshake =
       getReleaseBusV2Mode() === 'OFF' &&
       ['PREPARED', 'WAITING_FOR_ENVIRONMENT'].includes(train.status);
+    const workflowFenceStartedAt = requiresBetaIdleHandshake
+      ? Date.now()
+      : null;
     const beforeLock = requiresBetaIdleHandshake
       ? await this.captureStagingIdleSnapshot()
       : null;
@@ -1437,6 +1441,7 @@ export class ReleaseBusV2Reconciler {
             ...afterLock,
             beta_test_id: getReleaseBusV2BetaAllowlist()[0]?.test_id,
             staging_lock: 'owned',
+            workflow_fence_started_at: workflowFenceStartedAt,
             verified_at: Date.now()
           }
         },
@@ -1533,19 +1538,41 @@ export class ReleaseBusV2Reconciler {
       if (e2e.status !== 'SUCCEEDED') return;
       if (getReleaseBusV2Mode() === 'OFF') {
         const handshake = await this.findStagingIdleHandshake(train.id);
+        if (!handshake) {
+          if (train.manifest_id)
+            await this.repository.updateManifestStatus(
+              train.manifest_id,
+              'FAILED',
+              e2e.external_id,
+              {}
+            );
+          await this.repository.appendEvent(
+            {
+              trainId: train.id,
+              eventType: 'BETA_STAGING_FINAL_FENCE_MISSING',
+              actor: 'release-bus-v2-beta',
+              payload: { e2e_run_id: e2e.external_id }
+            },
+            {}
+          );
+          await this.failTrain(
+            train,
+            'CONTROL_PLANE',
+            'Beta staging idle-handshake evidence is missing or malformed; successful E2E cannot be accepted without an end-to-end fence',
+            lease
+          );
+          return;
+        }
         const operationRunIds = (
           await this.repository.listOperations(train.id, {})
         )
           .map(({ external_id }) => external_id)
           .filter((runId): runId is string => runId !== null);
-        const currentSnapshot = handshake
-          ? await this.captureStagingIdleSnapshot({
-              since: handshake.verified_at,
-              ignoredRunIds: operationRunIds
-            })
-          : null;
+        const currentSnapshot = await this.captureStagingIdleSnapshot({
+          since: handshake.workflow_fence_started_at,
+          ignoredRunIds: operationRunIds
+        });
         const stable =
-          handshake !== null &&
           currentSnapshot !== null &&
           currentSnapshot.frontend_staging_sha ===
             handshake.frontend_staging_sha &&
@@ -1662,13 +1689,17 @@ export class ReleaseBusV2Reconciler {
     }
     if (
       !payload ||
+      !Number.isInteger(payload.workflow_fence_started_at) ||
+      Number(payload.workflow_fence_started_at) < 1 ||
       !Number.isInteger(payload.verified_at) ||
       Number(payload.verified_at) < 1 ||
+      Number(payload.workflow_fence_started_at) > Number(payload.verified_at) ||
       !this.isOptionalSha(payload.frontend_staging_sha) ||
       !this.isOptionalSha(payload.backend_staging_sha)
     )
       return null;
     return {
+      workflow_fence_started_at: Number(payload.workflow_fence_started_at),
       verified_at: Number(payload.verified_at),
       frontend_staging_sha: payload.frontend_staging_sha ?? null,
       backend_staging_sha: payload.backend_staging_sha ?? null

--- a/src/releaseBusV2/release-bus-v2.reconciler.ts
+++ b/src/releaseBusV2/release-bus-v2.reconciler.ts
@@ -91,6 +91,10 @@ type StagingIdleSnapshot = {
   readonly backend_staging_sha: string | null;
 };
 
+type StagingIdleHandshakeSnapshot = StagingIdleSnapshot & {
+  readonly verified_at: number;
+};
+
 type ProductionIdleSnapshot = {
   readonly frontend_main_sha: string;
   readonly backend_main_sha: string;
@@ -1527,6 +1531,68 @@ export class ReleaseBusV2Reconciler {
         return;
       }
       if (e2e.status !== 'SUCCEEDED') return;
+      if (getReleaseBusV2Mode() === 'OFF') {
+        const handshake = await this.findStagingIdleHandshake(train.id);
+        const operationRunIds = (
+          await this.repository.listOperations(train.id, {})
+        )
+          .map(({ external_id }) => external_id)
+          .filter((runId): runId is string => runId !== null);
+        const currentSnapshot = handshake
+          ? await this.captureStagingIdleSnapshot({
+              since: handshake.verified_at,
+              ignoredRunIds: operationRunIds
+            })
+          : null;
+        const stable =
+          handshake !== null &&
+          currentSnapshot !== null &&
+          currentSnapshot.frontend_staging_sha ===
+            handshake.frontend_staging_sha &&
+          currentSnapshot.backend_staging_sha === handshake.backend_staging_sha;
+        if (!stable) {
+          if (train.manifest_id)
+            await this.repository.updateManifestStatus(
+              train.manifest_id,
+              'FAILED',
+              e2e.external_id,
+              {}
+            );
+          await this.repository.appendEvent(
+            {
+              trainId: train.id,
+              eventType: 'BETA_STAGING_FINAL_FENCE_VIOLATED',
+              actor: 'release-bus-v2-beta',
+              payload: {
+                handshake,
+                current_snapshot: currentSnapshot,
+                ignored_train_run_ids: operationRunIds
+              }
+            },
+            {}
+          );
+          await this.failTrain(
+            train,
+            'CONTROL_PLANE',
+            'Shared staging refs or deploy/E2E workflows changed after the beta idle handshake; successful E2E cannot validate a mixed environment',
+            lease
+          );
+          return;
+        }
+        await this.repository.appendEvent(
+          {
+            trainId: train.id,
+            eventType: 'BETA_STAGING_FINAL_FENCE_VERIFIED',
+            actor: 'release-bus-v2-beta',
+            payload: {
+              ...currentSnapshot,
+              handshake_verified_at: handshake.verified_at,
+              verified_at: Date.now()
+            }
+          },
+          {}
+        );
+      }
       if (train.manifest_id)
         await this.repository.updateManifestStatus(
           train.manifest_id,
@@ -1549,11 +1615,26 @@ export class ReleaseBusV2Reconciler {
     }
   }
 
-  private async captureStagingIdleSnapshot(): Promise<StagingIdleSnapshot | null> {
+  private async captureStagingIdleSnapshot(fence?: {
+    readonly since: number;
+    readonly ignoredRunIds: readonly string[];
+  }): Promise<StagingIdleSnapshot | null> {
     const [frontendActive, backendActive, frontendSha, backendSha] =
       await Promise.all([
-        releaseBusGitHubApp.hasActiveStagingMutationOrE2ERun('frontend'),
-        releaseBusGitHubApp.hasActiveStagingMutationOrE2ERun('backend'),
+        fence
+          ? releaseBusGitHubApp.hasStagingMutationOrE2ERunSince(
+              'frontend',
+              fence.since,
+              fence.ignoredRunIds
+            )
+          : releaseBusGitHubApp.hasActiveStagingMutationOrE2ERun('frontend'),
+        fence
+          ? releaseBusGitHubApp.hasStagingMutationOrE2ERunSince(
+              'backend',
+              fence.since,
+              fence.ignoredRunIds
+            )
+          : releaseBusGitHubApp.hasActiveStagingMutationOrE2ERun('backend'),
         releaseBusGitHubApp.resolveRefIfExists('frontend', '1a-staging'),
         releaseBusGitHubApp.resolveRefIfExists('backend', '1a-staging')
       ]);
@@ -1562,6 +1643,44 @@ export class ReleaseBusV2Reconciler {
       frontend_staging_sha: frontendSha,
       backend_staging_sha: backendSha
     };
+  }
+
+  private async findStagingIdleHandshake(
+    trainId: string
+  ): Promise<StagingIdleHandshakeSnapshot | null> {
+    const event = (await this.repository.listEvents(trainId, 200, {})).find(
+      ({ event_type }) => event_type === 'BETA_STAGING_IDLE_HANDSHAKE'
+    );
+    if (!event) return null;
+    let payload: Partial<StagingIdleHandshakeSnapshot> | null;
+    try {
+      payload = parseStoredJson<Partial<StagingIdleHandshakeSnapshot>>(
+        event.payload_json
+      );
+    } catch {
+      return null;
+    }
+    if (
+      !payload ||
+      !Number.isInteger(payload.verified_at) ||
+      Number(payload.verified_at) < 1 ||
+      !this.isOptionalSha(payload.frontend_staging_sha) ||
+      !this.isOptionalSha(payload.backend_staging_sha)
+    )
+      return null;
+    return {
+      verified_at: Number(payload.verified_at),
+      frontend_staging_sha: payload.frontend_staging_sha ?? null,
+      backend_staging_sha: payload.backend_staging_sha ?? null
+    };
+  }
+
+  private isOptionalSha(value: unknown): value is string | null | undefined {
+    return (
+      value === null ||
+      value === undefined ||
+      (typeof value === 'string' && /^[a-f0-9]{40}$/.test(value))
+    );
   }
 
   private async advanceProduction(context: TrainContext): Promise<void> {


### PR DESCRIPTION
## Summary
- fail closed before STAGING_VALIDATED if either staging ref changes after the beta idle handshake
- scan staging deploy/E2E workflow history since the handshake, ignoring only this train's exact workflow run IDs
- match live workflows by workflow path so dynamic run names cannot evade the fence
- requeue candidates, fail the mixed manifest, pause automation, and release staging ownership on violation

## Incident proof
The read-only fence query identifies unrelated successful backend staging deploys 30010983181 and 30011184804 after the frontend-only beta handshake, while the exact train E2E 30010909589 remains explicitly ignorable.

## Validation
- Prettier check: pass
- focused ESLint: pass
- GitHub/reconciler/acceptance Jest suites: 42/42 pass
- git diff --check: pass

Release notes: omitted (internal Release Bus operational change).