### PR TITLE
Add one-command Release Bus v2 OFF rollback

### DIFF
--- a/ops/deployment-bus/simple-release-bus-v2.md
+++ b/ops/deployment-bus/simple-release-bus-v2.md
@@ -232,7 +232,11 @@ It best-effort pauses only v2, disables the reconciler schedule, clears the
 operator beta and sets both repository variables to `OFF`, updates production
 API then reconciler with Lambda revision guards while preserving unrelated
 environment values, and verifies empty `OFF`. Manual workflows and
-`RELEASE_BUS_ENFORCEMENT` are untouched.
+`RELEASE_BUS_ENFORCEMENT` are untouched. Every mutation is idempotent; if a
+concurrent deploy or transient failure interrupts the command, run the same
+command again until its final verification succeeds. The GitHub OFF source and
+disabled schedule are intentionally retained after partial failure because
+they are the safe direction, not compensated back to enabled automation.
 
 1. clear the beta allowlist, pause v2 `ALL` if state is uncertain, and keep mode
    `OFF`;

--- a/ops/deployment-bus/simple-release-bus-v2.md
+++ b/ops/deployment-bus/simple-release-bus-v2.md
@@ -222,6 +222,18 @@ above passes and the owner explicitly authorizes cutover.
 
 Rollback:
 
+Run the account-guarded fast path from the backend repository:
+
+```bash
+node ops/scripts/release-bus-v2-fast-off.mjs --execute
+```
+
+It best-effort pauses only v2, disables the reconciler schedule, clears the
+operator beta and sets both repository variables to `OFF`, updates production
+API then reconciler with Lambda revision guards while preserving unrelated
+environment values, and verifies empty `OFF`. Manual workflows and
+`RELEASE_BUS_ENFORCEMENT` are untouched.
+
 1. clear the beta allowlist, pause v2 `ALL` if state is uncertain, and keep mode
    `OFF`;
 2. allow any already-dispatched exact operation to reach a safe terminal state;

--- a/ops/scripts/release-bus-v2-fast-off.mjs
+++ b/ops/scripts/release-bus-v2-fast-off.mjs
@@ -1,0 +1,270 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+
+const EXPECTED_ACCOUNT = '987989283142';
+const REPOSITORIES = [
+  '6529-Collections/6529seize-backend',
+  '6529-Collections/6529seize-frontend'
+];
+const FUNCTIONS = ['seizeAPI', 'releaseBusV2Reconciler'];
+const RULE_PREFIX = 'releaseBus-prod-V2ReconcilerEventsRuleSchedule1';
+const API_URL =
+  process.env.RELEASE_BUS_API_URL?.trim() || 'https://api.6529.io';
+
+class RollbackError extends Error {}
+
+function run(executable, args, { allowFailure = false } = {}) {
+  const result = spawnSync(
+    executable, // NOSONAR -- fixed executable names; no bus input controls PATH.
+    args,
+    {
+      encoding: 'utf8',
+      maxBuffer: 5 * 1024 * 1024,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 60_000
+    }
+  );
+  if (result.error?.code === 'ENOENT')
+    throw new RollbackError(`${executable} is required for fast v2 rollback.`);
+  if (result.status !== 0 && !allowFailure)
+    throw new RollbackError(
+      `${executable} failed during fast v2 rollback (${result.status ?? 'unknown'}).`
+    );
+  return { ok: result.status === 0, stdout: result.stdout?.trim() ?? '' };
+}
+
+function parseJson(value, description) {
+  try {
+    return JSON.parse(value);
+  } catch {
+    throw new RollbackError(`${description} returned malformed JSON.`);
+  }
+}
+
+function requireExecuteFlag() {
+  if (process.argv.length !== 3 || process.argv[2] !== '--execute')
+    throw new RollbackError(
+      'Usage: node ops/scripts/release-bus-v2-fast-off.mjs --execute'
+    );
+}
+
+function verifyIdentity() {
+  const identity = parseJson(
+    run('aws', ['sts', 'get-caller-identity', '--output', 'json']).stdout,
+    'AWS identity lookup'
+  );
+  if (identity.Account !== EXPECTED_ACCOUNT)
+    throw new RollbackError(
+      `Expected AWS account ${EXPECTED_ACCOUNT}; refusing account ${String(identity.Account)}.`
+    );
+  const auth = run('gh', ['auth', 'status']);
+  if (!auth.ok) throw new RollbackError('GitHub CLI is not authenticated.');
+}
+
+function getGitHubToken() {
+  const token = run('gh', ['auth', 'token']).stdout;
+  if (!token) throw new RollbackError('Unable to obtain GitHub token.');
+  return token;
+}
+
+async function pauseAutomationBestEffort(token) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 10_000);
+  timeout.unref();
+  try {
+    const response = await fetch(
+      new URL('/deploy/release-bus-v2/pause', API_URL),
+      {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json',
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({
+          scope: 'ALL',
+          reason: 'Fast rollback to OFF; manual fallback remains authoritative'
+        }),
+        redirect: 'error',
+        signal: controller.signal
+      }
+    );
+    return response.ok;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function findScheduleRule() {
+  const rules = parseJson(
+    run('aws', [
+      'events',
+      'list-rules',
+      '--name-prefix',
+      RULE_PREFIX,
+      '--query',
+      'Rules[].Name',
+      '--output',
+      'json'
+    ]).stdout,
+    'EventBridge rule lookup'
+  );
+  if (!Array.isArray(rules) || rules.length !== 1 || !rules[0])
+    throw new RollbackError(
+      `Expected exactly one v2 reconciler schedule; found ${Array.isArray(rules) ? rules.length : 'invalid data'}.`
+    );
+  return rules[0];
+}
+
+function disableSchedule(ruleName) {
+  run('aws', ['events', 'disable-rule', '--name', ruleName]);
+}
+
+function setGitHubModesOff() {
+  for (const repository of REPOSITORIES) {
+    run('gh', [
+      'variable',
+      'set',
+      'RELEASE_BUS_V2_MODE',
+      '--body',
+      'OFF',
+      '--repo',
+      repository
+    ]);
+    run(
+      'gh',
+      [
+        'variable',
+        'delete',
+        'RELEASE_BUS_V2_BETA_ALLOWLIST',
+        '--repo',
+        repository
+      ],
+      { allowFailure: true }
+    );
+  }
+}
+
+function updateFunctionOff(functionName) {
+  const configuration = parseJson(
+    run('aws', [
+      'lambda',
+      'get-function-configuration',
+      '--function-name',
+      functionName,
+      '--output',
+      'json'
+    ]).stdout,
+    `${functionName} configuration lookup`
+  );
+  const variables = configuration.Environment?.Variables;
+  if (
+    typeof configuration.RevisionId !== 'string' ||
+    variables === null ||
+    typeof variables !== 'object' ||
+    Array.isArray(variables)
+  )
+    throw new RollbackError(`${functionName} configuration is incomplete.`);
+  const nextVariables = {
+    ...variables,
+    RELEASE_BUS_V2_MODE: 'OFF',
+    RELEASE_BUS_V2_BETA_ALLOWLIST: ''
+  };
+  run('aws', [
+    'lambda',
+    'update-function-configuration',
+    '--function-name',
+    functionName,
+    '--revision-id',
+    configuration.RevisionId,
+    '--environment',
+    JSON.stringify({ Variables: nextVariables }),
+    '--no-cli-pager'
+  ]);
+  run('aws', [
+    'lambda',
+    'wait',
+    'function-updated-v2',
+    '--function-name',
+    functionName
+  ]);
+}
+
+function verifyFunctionOff(functionName) {
+  const configuration = parseJson(
+    run('aws', [
+      'lambda',
+      'get-function-configuration',
+      '--function-name',
+      functionName,
+      '--output',
+      'json'
+    ]).stdout,
+    `${functionName} verification`
+  );
+  if (
+    configuration.LastUpdateStatus !== 'Successful' ||
+    configuration.Environment?.Variables?.RELEASE_BUS_V2_MODE !== 'OFF' ||
+    (configuration.Environment?.Variables?.RELEASE_BUS_V2_BETA_ALLOWLIST ??
+      '') !== ''
+  )
+    throw new RollbackError(`${functionName} did not verify empty OFF.`);
+}
+
+async function verifyApiOff(token) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 15_000);
+  timeout.unref();
+  try {
+    const response = await fetch(
+      new URL('/deploy/release-bus-v2/controls', API_URL),
+      {
+        headers: {
+          Accept: 'application/json',
+          Authorization: `Bearer ${token}`
+        },
+        redirect: 'error',
+        signal: controller.signal
+      }
+    );
+    if (!response.ok) throw new Error('status failed');
+    const payload = await response.json();
+    if (payload?.mode !== 'OFF') throw new Error('mode is not OFF');
+  } catch {
+    throw new RollbackError('Release Bus v2 API did not verify OFF.');
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+try {
+  requireExecuteFlag();
+  verifyIdentity();
+  const token = getGitHubToken();
+  const pauseAccepted = await pauseAutomationBestEffort(token);
+  const scheduleRule = findScheduleRule();
+  disableSchedule(scheduleRule);
+  setGitHubModesOff();
+  for (const functionName of FUNCTIONS) updateFunctionOff(functionName);
+  for (const functionName of FUNCTIONS) verifyFunctionOff(functionName);
+  await verifyApiOff(token);
+  process.stdout.write(
+    `${JSON.stringify({
+      mode: 'OFF',
+      beta_allowlist: 'empty',
+      schedule: 'DISABLED',
+      controls_pause_requested: pauseAccepted,
+      functions: FUNCTIONS
+    })}\n`
+  );
+} catch (error) {
+  const message =
+    error instanceof RollbackError
+      ? error.message
+      : 'Fast v2 rollback failed unexpectedly.';
+  process.stderr.write(`${message}\n`);
+  process.exitCode = 1;
+}

--- a/ops/scripts/release-bus-v2-fast-off.mjs
+++ b/ops/scripts/release-bus-v2-fast-off.mjs
@@ -3,6 +3,7 @@
 import { spawnSync } from 'node:child_process';
 
 const EXPECTED_ACCOUNT = '987989283142';
+const EXPECTED_REGION = 'us-east-1';
 const REPOSITORIES = [
   '6529-Collections/6529seize-backend',
   '6529-Collections/6529seize-frontend'
@@ -14,7 +15,11 @@ const API_URL =
 
 class RollbackError extends Error {}
 
-function run(executable, args, { allowFailure = false } = {}) {
+function run(
+  executable,
+  args,
+  { allowFailure = false, timeoutMs = 60_000 } = {}
+) {
   const result = spawnSync(
     executable, // NOSONAR -- fixed executable names; no bus input controls PATH.
     args,
@@ -22,7 +27,7 @@ function run(executable, args, { allowFailure = false } = {}) {
       encoding: 'utf8',
       maxBuffer: 5 * 1024 * 1024,
       stdio: ['ignore', 'pipe', 'pipe'],
-      timeout: 60_000
+      timeout: timeoutMs
     }
   );
   if (result.error?.code === 'ENOENT')
@@ -31,7 +36,15 @@ function run(executable, args, { allowFailure = false } = {}) {
     throw new RollbackError(
       `${executable} failed during fast v2 rollback (${result.status ?? 'unknown'}).`
     );
-  return { ok: result.status === 0, stdout: result.stdout?.trim() ?? '' };
+  return {
+    ok: result.status === 0,
+    stdout: result.stdout?.trim() ?? '',
+    stderr: result.stderr?.trim() ?? ''
+  };
+}
+
+function runAws(args, options) {
+  return run('aws', [...args, '--region', EXPECTED_REGION], options);
 }
 
 function parseJson(value, description) {
@@ -51,7 +64,7 @@ function requireExecuteFlag() {
 
 function verifyIdentity() {
   const identity = parseJson(
-    run('aws', ['sts', 'get-caller-identity', '--output', 'json']).stdout,
+    runAws(['sts', 'get-caller-identity', '--output', 'json']).stdout,
     'AWS identity lookup'
   );
   if (identity.Account !== EXPECTED_ACCOUNT)
@@ -60,6 +73,7 @@ function verifyIdentity() {
     );
   const auth = run('gh', ['auth', 'status']);
   if (!auth.ok) throw new RollbackError('GitHub CLI is not authenticated.');
+  return identity;
 }
 
 function getGitHubToken() {
@@ -100,7 +114,7 @@ async function pauseAutomationBestEffort(token) {
 
 function findScheduleRule() {
   const rules = parseJson(
-    run('aws', [
+    runAws([
       'events',
       'list-rules',
       '--name-prefix',
@@ -120,7 +134,19 @@ function findScheduleRule() {
 }
 
 function disableSchedule(ruleName) {
-  run('aws', ['events', 'disable-rule', '--name', ruleName]);
+  runAws(['events', 'disable-rule', '--name', ruleName]);
+  const state = runAws([
+    'events',
+    'describe-rule',
+    '--name',
+    ruleName,
+    '--query',
+    'State',
+    '--output',
+    'text'
+  ]).stdout;
+  if (state !== 'DISABLED')
+    throw new RollbackError('V2 reconciler schedule did not verify disabled.');
 }
 
 function setGitHubModesOff() {
@@ -149,53 +175,80 @@ function setGitHubModesOff() {
 }
 
 function updateFunctionOff(functionName) {
-  const configuration = parseJson(
-    run('aws', [
-      'lambda',
-      'get-function-configuration',
-      '--function-name',
-      functionName,
-      '--output',
-      'json'
-    ]).stdout,
-    `${functionName} configuration lookup`
-  );
-  const variables = configuration.Environment?.Variables;
-  if (
-    typeof configuration.RevisionId !== 'string' ||
-    variables === null ||
-    typeof variables !== 'object' ||
-    Array.isArray(variables)
-  )
-    throw new RollbackError(`${functionName} configuration is incomplete.`);
-  const nextVariables = {
-    ...variables,
-    RELEASE_BUS_V2_MODE: 'OFF',
-    RELEASE_BUS_V2_BETA_ALLOWLIST: ''
-  };
-  run('aws', [
-    'lambda',
-    'update-function-configuration',
-    '--function-name',
-    functionName,
-    '--revision-id',
-    configuration.RevisionId,
-    '--environment',
-    JSON.stringify({ Variables: nextVariables }),
-    '--no-cli-pager'
-  ]);
-  run('aws', [
-    'lambda',
-    'wait',
-    'function-updated-v2',
-    '--function-name',
-    functionName
-  ]);
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    const configuration = parseJson(
+      runAws([
+        'lambda',
+        'get-function-configuration',
+        '--function-name',
+        functionName,
+        '--output',
+        'json'
+      ]).stdout,
+      `${functionName} configuration lookup`
+    );
+    const variables = configuration.Environment?.Variables;
+    if (
+      typeof configuration.RevisionId !== 'string' ||
+      variables === null ||
+      typeof variables !== 'object' ||
+      Array.isArray(variables)
+    )
+      throw new RollbackError(`${functionName} configuration is incomplete.`);
+    const nextVariables = {
+      ...variables,
+      RELEASE_BUS_V2_MODE: 'OFF',
+      RELEASE_BUS_V2_BETA_ALLOWLIST: ''
+    };
+    const update = runAws(
+      [
+        'lambda',
+        'update-function-configuration',
+        '--function-name',
+        functionName,
+        '--revision-id',
+        configuration.RevisionId,
+        '--environment',
+        JSON.stringify({ Variables: nextVariables }),
+        '--no-cli-pager'
+      ],
+      { allowFailure: true }
+    );
+    if (!update.ok) {
+      if (attempt < 3) continue;
+      throw new RollbackError(
+        `${functionName} OFF update failed after 3 revision-safe attempts.`
+      );
+    }
+    const wait = runAws(
+      [
+        'lambda',
+        'wait',
+        'function-updated-v2',
+        '--function-name',
+        functionName
+      ],
+      { allowFailure: true, timeoutMs: 180_000 }
+    );
+    if (!wait.ok) {
+      if (attempt < 3) continue;
+      throw new RollbackError(
+        `${functionName} OFF update did not settle after 3 attempts.`
+      );
+    }
+    try {
+      verifyFunctionOff(functionName);
+      process.stderr.write(`Verified ${functionName} empty OFF.\n`);
+      return;
+    } catch (error) {
+      if (attempt === 3) throw error;
+    }
+  }
 }
 
 function verifyFunctionOff(functionName) {
   const configuration = parseJson(
-    run('aws', [
+    runAws([
       'lambda',
       'get-function-configuration',
       '--function-name',
@@ -241,15 +294,21 @@ async function verifyApiOff(token) {
 }
 
 try {
+  const startedAt = new Date().toISOString();
   requireExecuteFlag();
-  verifyIdentity();
+  const identity = verifyIdentity();
   const token = getGitHubToken();
   const pauseAccepted = await pauseAutomationBestEffort(token);
+  process.stderr.write(
+    pauseAccepted
+      ? 'V2 ALL pause accepted before rollback.\n'
+      : 'Warning: V2 ALL pause was not accepted; continuing with the OFF fail-safe.\n'
+  );
   const scheduleRule = findScheduleRule();
   disableSchedule(scheduleRule);
+  process.stderr.write(`Disabled reconciler schedule ${scheduleRule}.\n`);
   setGitHubModesOff();
   for (const functionName of FUNCTIONS) updateFunctionOff(functionName);
-  for (const functionName of FUNCTIONS) verifyFunctionOff(functionName);
   await verifyApiOff(token);
   process.stdout.write(
     `${JSON.stringify({
@@ -257,7 +316,12 @@ try {
       beta_allowlist: 'empty',
       schedule: 'DISABLED',
       controls_pause_requested: pauseAccepted,
-      functions: FUNCTIONS
+      functions: FUNCTIONS,
+      aws_account: EXPECTED_ACCOUNT,
+      aws_region: EXPECTED_REGION,
+      actor_arn: identity.Arn ?? null,
+      started_at: startedAt,
+      completed_at: new Date().toISOString()
     })}\n`
   );
 } catch (error) {

--- a/ops/scripts/release-bus-v2-fast-off.test.ts
+++ b/ops/scripts/release-bus-v2-fast-off.test.ts
@@ -44,26 +44,37 @@ beforeAll(async () => {
     [
       '#!/bin/sh',
       'if [ "$1" = "sts" ]; then',
-      '  printf \'{"Account":"%s"}\\n\' "$MOCK_AWS_ACCOUNT"',
+      '  printf \'{"Account":"%s","Arn":"arn:aws:iam::%s:user/test-operator"}\\n\' "$MOCK_AWS_ACCOUNT" "$MOCK_AWS_ACCOUNT"',
       '  exit 0',
       'fi',
       'if [ "$1" = "events" ] && [ "$2" = "list-rules" ]; then',
+      '  if [ "${MOCK_RULE_COUNT:-1}" = "0" ]; then printf \'[]\\n\'; exit 0; fi',
       '  printf \'["releaseBus-prod-V2ReconcilerEventsRuleSchedule1-test"]\\n\'',
       '  exit 0',
       'fi',
       'if [ "$1" = "events" ] && [ "$2" = "disable-rule" ]; then exit 0; fi',
+      'if [ "$1" = "events" ] && [ "$2" = "describe-rule" ]; then printf \'DISABLED\\n\'; exit 0; fi',
       'if [ "$1" = "lambda" ] && [ "$2" = "get-function-configuration" ]; then',
       '  printf \'{"RevisionId":"revision-1","LastUpdateStatus":"Successful","Environment":{"Variables":{"KEEP":"value","RELEASE_BUS_V2_MODE":"OFF","RELEASE_BUS_V2_BETA_ALLOWLIST":""}}}\\n\'',
       '  exit 0',
       'fi',
       'if [ "$1" = "lambda" ] && [ "$2" = "update-function-configuration" ]; then',
-      '  found=0',
+      '  keep=0',
+      '  mode=0',
+      '  worker=0',
       '  for argument in "$@"; do',
       '    case "$argument" in',
-      '      *\'"KEEP":"value"\'*\'"RELEASE_BUS_V2_MODE":"OFF"\'*) found=1 ;;',
+      '      *\'"KEEP":"value"\'*) keep=1 ;;',
+      '    esac',
+      '    case "$argument" in',
+      '      *\'"RELEASE_BUS_V2_MODE":"OFF"\'*) mode=1 ;;',
+      '    esac',
+      '    case "$argument" in',
+      '      releaseBusV2Reconciler) worker=1 ;;',
       '    esac',
       '  done',
-      '  if [ "$found" = "1" ]; then exit 0; fi',
+      '  if [ "$worker" = "1" ] && [ "${MOCK_FAIL_WORKER_UPDATE:-0}" = "1" ]; then exit 4; fi',
+      '  if [ "$keep" = "1" ] && [ "$mode" = "1" ]; then exit 0; fi',
       '  exit 3',
       'fi',
       'if [ "$1" = "lambda" ] && [ "$2" = "wait" ]; then exit 0; fi',
@@ -82,7 +93,8 @@ afterAll(async () => {
 function runScript(
   apiUrl: string,
   args = ['--execute'],
-  account = '987989283142'
+  account = '987989283142',
+  overrides: NodeJS.ProcessEnv = {}
 ): Promise<Result> {
   return new Promise((resolve, reject) => {
     execFile(
@@ -94,7 +106,8 @@ function runScript(
           PATH: mockBin,
           MOCK_GH_TOKEN: TOKEN,
           MOCK_AWS_ACCOUNT: account,
-          RELEASE_BUS_API_URL: apiUrl
+          RELEASE_BUS_API_URL: apiUrl,
+          ...overrides
         },
         maxBuffer: 1024 * 1024,
         timeout: 10_000
@@ -158,14 +171,24 @@ describe('release-bus-v2 fast OFF rollback', () => {
     const url = await listen(server);
     try {
       const result = await runScript(url);
-      expect(result).toMatchObject({ code: 0, stderr: '' });
-      expect(JSON.parse(result.stdout)).toEqual({
+      expect(result.code).toBe(0);
+      expect(result.stderr).toContain('V2 ALL pause accepted');
+      expect(result.stderr).toContain('Verified seizeAPI empty OFF');
+      expect(result.stderr).toContain(
+        'Verified releaseBusV2Reconciler empty OFF'
+      );
+      expect(JSON.parse(result.stdout)).toMatchObject({
         mode: 'OFF',
         beta_allowlist: 'empty',
         schedule: 'DISABLED',
         controls_pause_requested: true,
-        functions: ['seizeAPI', 'releaseBusV2Reconciler']
+        functions: ['seizeAPI', 'releaseBusV2Reconciler'],
+        aws_account: '987989283142',
+        aws_region: 'us-east-1',
+        actor_arn: 'arn:aws:iam::987989283142:user/test-operator'
       });
+      expect(JSON.parse(result.stdout).started_at).toMatch(/Z$/);
+      expect(JSON.parse(result.stdout).completed_at).toMatch(/Z$/);
       expect(requests).toEqual([
         { method: 'POST', url: '/deploy/release-bus-v2/pause' },
         { method: 'GET', url: '/deploy/release-bus-v2/controls' }
@@ -189,5 +212,32 @@ describe('release-bus-v2 fast OFF rollback', () => {
     const result = await runScript('http://127.0.0.1:1', []);
     expect(result.code).not.toBe(0);
     expect(result.stderr).toContain('Usage:');
+  });
+
+  it('fails closed when the reconciler schedule cannot be identified', async () => {
+    const result = await runScript(
+      'http://127.0.0.1:1',
+      ['--execute'],
+      '987989283142',
+      { MOCK_RULE_COUNT: '0' }
+    );
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toContain(
+      'Expected exactly one v2 reconciler schedule; found 0'
+    );
+  });
+
+  it('reports a bounded partial failure for safe command rerun', async () => {
+    const result = await runScript(
+      'http://127.0.0.1:1',
+      ['--execute'],
+      '987989283142',
+      { MOCK_FAIL_WORKER_UPDATE: '1' }
+    );
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toContain('Verified seizeAPI empty OFF');
+    expect(result.stderr).toContain(
+      'releaseBusV2Reconciler OFF update failed after 3 revision-safe attempts'
+    );
   });
 });

--- a/ops/scripts/release-bus-v2-fast-off.test.ts
+++ b/ops/scripts/release-bus-v2-fast-off.test.ts
@@ -1,0 +1,193 @@
+import { execFile } from 'node:child_process';
+import { chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { createServer, type Server } from 'node:http';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+const SCRIPT_PATH = path.resolve(__dirname, 'release-bus-v2-fast-off.mjs');
+const TOKEN = 'rollback-test-token-that-must-never-be-printed';
+
+type Result = {
+  readonly code: number;
+  readonly stdout: string;
+  readonly stderr: string;
+};
+
+let tempRoot: string;
+let mockBin: string;
+
+beforeAll(async () => {
+  tempRoot = await mkdtemp(path.join(tmpdir(), 'release-bus-v2-fast-off-'));
+  mockBin = path.join(tempRoot, 'bin');
+  await mkdir(mockBin);
+  const ghPath = path.join(mockBin, 'gh');
+  await writeFile(
+    ghPath,
+    [
+      '#!/bin/sh',
+      'if [ "$1" = "auth" ] && [ "$2" = "status" ]; then exit 0; fi',
+      'if [ "$1" = "auth" ] && [ "$2" = "token" ]; then',
+      '  printf "%s\\n" "$MOCK_GH_TOKEN"',
+      '  exit 0',
+      'fi',
+      'if [ "$1" = "variable" ]; then exit 0; fi',
+      'exit 2',
+      ''
+    ].join('\n'),
+    'utf8'
+  );
+  await chmod(ghPath, 0o700);
+
+  const awsPath = path.join(mockBin, 'aws');
+  await writeFile(
+    awsPath,
+    [
+      '#!/bin/sh',
+      'if [ "$1" = "sts" ]; then',
+      '  printf \'{"Account":"%s"}\\n\' "$MOCK_AWS_ACCOUNT"',
+      '  exit 0',
+      'fi',
+      'if [ "$1" = "events" ] && [ "$2" = "list-rules" ]; then',
+      '  printf \'["releaseBus-prod-V2ReconcilerEventsRuleSchedule1-test"]\\n\'',
+      '  exit 0',
+      'fi',
+      'if [ "$1" = "events" ] && [ "$2" = "disable-rule" ]; then exit 0; fi',
+      'if [ "$1" = "lambda" ] && [ "$2" = "get-function-configuration" ]; then',
+      '  printf \'{"RevisionId":"revision-1","LastUpdateStatus":"Successful","Environment":{"Variables":{"KEEP":"value","RELEASE_BUS_V2_MODE":"OFF","RELEASE_BUS_V2_BETA_ALLOWLIST":""}}}\\n\'',
+      '  exit 0',
+      'fi',
+      'if [ "$1" = "lambda" ] && [ "$2" = "update-function-configuration" ]; then',
+      '  found=0',
+      '  for argument in "$@"; do',
+      '    case "$argument" in',
+      '      *\'"KEEP":"value"\'*\'"RELEASE_BUS_V2_MODE":"OFF"\'*) found=1 ;;',
+      '    esac',
+      '  done',
+      '  if [ "$found" = "1" ]; then exit 0; fi',
+      '  exit 3',
+      'fi',
+      'if [ "$1" = "lambda" ] && [ "$2" = "wait" ]; then exit 0; fi',
+      'exit 2',
+      ''
+    ].join('\n'),
+    'utf8'
+  );
+  await chmod(awsPath, 0o700);
+});
+
+afterAll(async () => {
+  await rm(tempRoot, { recursive: true, force: true });
+});
+
+function runScript(
+  apiUrl: string,
+  args = ['--execute'],
+  account = '987989283142'
+): Promise<Result> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      process.execPath,
+      [SCRIPT_PATH, ...args],
+      {
+        env: {
+          ...process.env,
+          PATH: mockBin,
+          MOCK_GH_TOKEN: TOKEN,
+          MOCK_AWS_ACCOUNT: account,
+          RELEASE_BUS_API_URL: apiUrl
+        },
+        maxBuffer: 1024 * 1024,
+        timeout: 10_000
+      },
+      (error, stdout, stderr) => {
+        try {
+          expect(`${stdout}${stderr}`).not.toContain(TOKEN);
+          resolve({
+            code:
+              error === null
+                ? 0
+                : typeof error.code === 'number'
+                  ? error.code
+                  : 1,
+            stdout,
+            stderr
+          });
+        } catch (assertionError) {
+          reject(assertionError);
+        }
+      }
+    );
+  });
+}
+
+async function listen(server: Server): Promise<string> {
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  const address = server.address();
+  if (address === null || typeof address === 'string')
+    throw new Error('test server did not bind');
+  return `http://127.0.0.1:${address.port}`;
+}
+
+async function close(server: Server): Promise<void> {
+  server.closeAllConnections?.();
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+describe('release-bus-v2 fast OFF rollback', () => {
+  it('preserves environment values and verifies empty OFF', async () => {
+    const requests: Array<{ method: string; url: string }> = [];
+    const server = createServer((request, response) => {
+      requests.push({
+        method: request.method ?? '',
+        url: request.url ?? ''
+      });
+      response.writeHead(200, { 'Content-Type': 'application/json' });
+      response.end(
+        JSON.stringify(
+          request.method === 'GET'
+            ? { mode: 'OFF', controls: [] }
+            : { mode: 'STAGING' }
+        )
+      );
+    });
+    const url = await listen(server);
+    try {
+      const result = await runScript(url);
+      expect(result).toMatchObject({ code: 0, stderr: '' });
+      expect(JSON.parse(result.stdout)).toEqual({
+        mode: 'OFF',
+        beta_allowlist: 'empty',
+        schedule: 'DISABLED',
+        controls_pause_requested: true,
+        functions: ['seizeAPI', 'releaseBusV2Reconciler']
+      });
+      expect(requests).toEqual([
+        { method: 'POST', url: '/deploy/release-bus-v2/pause' },
+        { method: 'GET', url: '/deploy/release-bus-v2/controls' }
+      ]);
+    } finally {
+      await close(server);
+    }
+  });
+
+  it('refuses to mutate a different AWS account', async () => {
+    const result = await runScript(
+      'http://127.0.0.1:1',
+      ['--execute'],
+      '111111111111'
+    );
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toContain('Expected AWS account 987989283142');
+  });
+
+  it('requires the explicit execute flag', async () => {
+    const result = await runScript('http://127.0.0.1:1', []);
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toContain('Usage:');
+  });
+});


### PR DESCRIPTION
## Summary
- add an explicit-flag, account-guarded one-command v2 rollback to empty OFF
- best-effort pause v2, disable its schedule, set both repository variables OFF, and update API then reconciler with Lambda revision guards
- preserve every unrelated Lambda environment variable and verify both functions plus the API report OFF
- leave manual deploy enforcement untouched

## Validation
- rollback helper Jest: 3/3 pass
- focused TypeScript ESLint: pass
- Prettier and `node --check`: pass
- tests prove environment preservation, account refusal, explicit execution, and token redaction

Release notes: omitted (internal Release Bus operational control).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a fast rollback tool to disable Release Bus v2, pause related automation, disable scheduling, and set connected services to OFF mode.
  * Added safety checks for execution authorization, AWS account validation, and GitHub authentication.
  * Added final status verification and structured success or failure output.

* **Tests**
  * Added coverage for successful rollback execution, account validation, required command-line confirmation, and protection of sensitive tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->