### PR TITLE
Bind Release Bus v2 manifests to exact staging identity

### DIFF
--- a/ops/deployment-bus/simple-release-bus-v2.md
+++ b/ops/deployment-bus/simple-release-bus-v2.md
@@ -60,6 +60,9 @@ register backend first and declare it as the frontend prerequisite.
    each application runs one combined sharded preflight and one immutable build.
 4. Preparation may finish while another train owns staging.
 5. The train acquires the staging lock only for deployment plus E2E.
+   Under that lock it binds every unchanged repository to the exact current
+   `1a-staging` ref, so a frontend-only or backend-only manifest describes the
+   environment E2E actually sees rather than the unrelated `main` ref.
 6. Independent backend DAG frontier units deploy concurrently; dependency edges
    serialize only required units. Dependent frontend deploys after backend.
 7. The controller persists `STAGING_DEPLOYED` with exact SHAs, artifact
@@ -83,6 +86,9 @@ from current `main`:
   validation and immutable artifacts;
 - otherwise enqueue an exact `PRODUCTION_QUALIFICATION` staging train, run
   manifest-bound E2E, then continue automatically;
+- qualification waits without retaining the staging lock when any unchanged
+  repository in staging differs from the exact production target; it must not
+  validate a subset against unrelated staged content;
 - immediately before mutation, require every `main` ref to equal its recorded
   base. A moved ref cancels and requeues the set for fresh qualification;
 - advance exact tested commits, deploy the same artifacts in dependency order,

--- a/src/releaseBusV2/release-bus-v2.acceptance.test.ts
+++ b/src/releaseBusV2/release-bus-v2.acceptance.test.ts
@@ -271,6 +271,14 @@ class InMemoryAcceptanceRepository {
       ...current,
       status:
         (fields.status as ReleaseBusV2TrainRecord['status']) ?? current.status,
+      frontend_composed_sha:
+        fields.frontendComposedSha === undefined
+          ? current.frontend_composed_sha
+          : (fields.frontendComposedSha as string | null),
+      backend_composed_sha:
+        fields.backendComposedSha === undefined
+          ? current.backend_composed_sha
+          : (fields.backendComposedSha as string | null),
       manifest_id:
         fields.manifestId === undefined
           ? current.manifest_id
@@ -640,6 +648,158 @@ describe('Release Bus v2 offline acceptance harness', () => {
           staging_lock: 'owned',
           workflow_fence_started_at: expect.any(Number),
           verified_at: expect.any(Number)
+        })
+      })
+    );
+  });
+
+  it('binds an unchanged repository to the exact shared staging ref before deployment', async () => {
+    const state = harness('SUCCEEDED');
+    const backendStagingSha = 'e'.repeat(40);
+    state.repository.memberships.splice(
+      0,
+      state.repository.memberships.length,
+      state.repository.memberships.find(
+        ({ candidate_id }) => candidate_id === 'frontend-candidate'
+      )!
+    );
+    mockResolveRefIfExists.mockImplementation(
+      async (repository: 'frontend' | 'backend') =>
+        repository === 'frontend' ? 'f'.repeat(40) : backendStagingSha
+    );
+
+    const context = {
+      train: state.repository.trains.get('train-1')!,
+      memberships: [...state.repository.memberships],
+      candidates: Array.from(state.repository.candidates.values()),
+      dependencies: state.repository.dependencies
+    };
+    await (
+      state.reconciler as unknown as {
+        advanceStagingOrQualification(input: typeof context): Promise<void>;
+      }
+    ).advanceStagingOrQualification(context);
+
+    expect(state.repository.trains.get('train-1')).toEqual(
+      expect.objectContaining({
+        status: 'DEPLOYING',
+        frontend_composed_sha: FRONTEND_SHA,
+        backend_composed_sha: backendStagingSha
+      })
+    );
+    expect(state.repository.events).toContainEqual(
+      expect.objectContaining({
+        eventType: 'STAGING_ENVIRONMENT_IDENTITY_BOUND',
+        trainId: 'train-1',
+        payload: expect.objectContaining({
+          frontend_sha: FRONTEND_SHA,
+          backend_sha: backendStagingSha,
+          frontend_from_existing_staging: false,
+          backend_from_existing_staging: true
+        })
+      })
+    );
+  });
+
+  it('holds exact production qualification when an unchanged repository differs in staging', async () => {
+    const state = harness('SUCCEEDED');
+    state.repository.trains.set(
+      'train-1',
+      train('train-1', { lane: 'PRODUCTION_QUALIFICATION' })
+    );
+    state.repository.memberships.splice(
+      0,
+      state.repository.memberships.length,
+      state.repository.memberships.find(
+        ({ candidate_id }) => candidate_id === 'frontend-candidate'
+      )!
+    );
+    mockResolveRefIfExists.mockImplementation(
+      async (repository: 'frontend' | 'backend') =>
+        repository === 'frontend' ? FRONTEND_SHA : 'e'.repeat(40)
+    );
+
+    const context = {
+      train: state.repository.trains.get('train-1')!,
+      memberships: [...state.repository.memberships],
+      candidates: Array.from(state.repository.candidates.values()),
+      dependencies: state.repository.dependencies
+    };
+    await (
+      state.reconciler as unknown as {
+        advanceStagingOrQualification(input: typeof context): Promise<void>;
+      }
+    ).advanceStagingOrQualification(context);
+
+    expect(state.repository.trains.get('train-1')).toEqual(
+      expect.objectContaining({
+        status: 'WAITING_FOR_ENVIRONMENT',
+        backend_composed_sha: BACKEND_SHA,
+        recovery_message: expect.stringContaining(
+          'unchanged repositories in staging'
+        )
+      })
+    );
+    expect(state.repository.lock.owner_train_id).toBeNull();
+    expect(mockReconcileWorkflow).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        operationType: expect.stringMatching(/^DEPLOY_/)
+      })
+    );
+    expect(state.repository.events).toContainEqual(
+      expect.objectContaining({
+        eventType: 'PRODUCTION_QUALIFICATION_ENVIRONMENT_HOLD',
+        trainId: 'train-1'
+      })
+    );
+  });
+
+  it('starts exact production qualification after unchanged staging matches the target', async () => {
+    const state = harness('SUCCEEDED');
+    state.repository.trains.set(
+      'train-1',
+      train('train-1', { lane: 'PRODUCTION_QUALIFICATION' })
+    );
+    state.repository.memberships.splice(
+      0,
+      state.repository.memberships.length,
+      state.repository.memberships.find(
+        ({ candidate_id }) => candidate_id === 'frontend-candidate'
+      )!
+    );
+    mockResolveRefIfExists.mockImplementation(
+      async (repository: 'frontend' | 'backend') =>
+        repository === 'frontend' ? 'e'.repeat(40) : BACKEND_SHA
+    );
+    const context = {
+      train: state.repository.trains.get('train-1')!,
+      memberships: [...state.repository.memberships],
+      candidates: Array.from(state.repository.candidates.values()),
+      dependencies: state.repository.dependencies
+    };
+
+    await (
+      state.reconciler as unknown as {
+        advanceStagingOrQualification(input: typeof context): Promise<void>;
+      }
+    ).advanceStagingOrQualification(context);
+
+    expect(state.repository.trains.get('train-1')).toEqual(
+      expect.objectContaining({
+        status: 'DEPLOYING',
+        frontend_composed_sha: FRONTEND_SHA,
+        backend_composed_sha: BACKEND_SHA
+      })
+    );
+    expect(state.repository.lock.owner_train_id).toBe('train-1');
+    expect(state.repository.events).toContainEqual(
+      expect.objectContaining({
+        eventType: 'STAGING_ENVIRONMENT_IDENTITY_BOUND',
+        trainId: 'train-1',
+        payload: expect.objectContaining({
+          frontend_sha: FRONTEND_SHA,
+          backend_sha: BACKEND_SHA,
+          backend_from_existing_staging: false
         })
       })
     );

--- a/src/releaseBusV2/release-bus-v2.acceptance.test.ts
+++ b/src/releaseBusV2/release-bus-v2.acceptance.test.ts
@@ -683,6 +683,8 @@ describe('Release Bus v2 offline acceptance harness', () => {
     expect(state.repository.trains.get('train-1')).toEqual(
       expect.objectContaining({
         status: 'DEPLOYING',
+        frontend_base_sha: '1'.repeat(40),
+        backend_base_sha: '2'.repeat(40),
         frontend_composed_sha: FRONTEND_SHA,
         backend_composed_sha: backendStagingSha
       })
@@ -752,6 +754,89 @@ describe('Release Bus v2 offline acceptance harness', () => {
         trainId: 'train-1'
       })
     );
+  });
+
+  it('keeps a waiting qualification held when the unchanged staging repository still differs', async () => {
+    const state = harness('SUCCEEDED');
+    state.repository.trains.set(
+      'train-1',
+      train('train-1', {
+        lane: 'PRODUCTION_QUALIFICATION',
+        status: 'WAITING_FOR_ENVIRONMENT'
+      })
+    );
+    state.repository.memberships.splice(
+      0,
+      state.repository.memberships.length,
+      state.repository.memberships.find(
+        ({ candidate_id }) => candidate_id === 'frontend-candidate'
+      )!
+    );
+    mockResolveRefIfExists.mockImplementation(
+      async (repository: 'frontend' | 'backend') =>
+        repository === 'frontend' ? FRONTEND_SHA : 'e'.repeat(40)
+    );
+    const context = {
+      train: state.repository.trains.get('train-1')!,
+      memberships: [...state.repository.memberships],
+      candidates: Array.from(state.repository.candidates.values()),
+      dependencies: state.repository.dependencies
+    };
+
+    await (
+      state.reconciler as unknown as {
+        advanceStagingOrQualification(input: typeof context): Promise<void>;
+      }
+    ).advanceStagingOrQualification(context);
+
+    expect(state.repository.trains.get('train-1')).toEqual(
+      expect.objectContaining({
+        status: 'WAITING_FOR_ENVIRONMENT',
+        frontend_composed_sha: FRONTEND_SHA,
+        backend_composed_sha: BACKEND_SHA
+      })
+    );
+    expect(state.repository.lock.owner_train_id).toBeNull();
+    expect(mockReconcileWorkflow).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        operationType: expect.stringMatching(/^DEPLOY_/)
+      })
+    );
+  });
+
+  it('allows a coupled qualification to replace both unrelated staging repositories', async () => {
+    const state = harness('SUCCEEDED');
+    state.repository.trains.set(
+      'train-1',
+      train('train-1', { lane: 'PRODUCTION_QUALIFICATION' })
+    );
+    mockResolveRefIfExists.mockImplementation(
+      async (repository: 'frontend' | 'backend') =>
+        repository === 'frontend' ? 'e'.repeat(40) : 'f'.repeat(40)
+    );
+    const context = {
+      train: state.repository.trains.get('train-1')!,
+      memberships: [...state.repository.memberships],
+      candidates: Array.from(state.repository.candidates.values()),
+      dependencies: state.repository.dependencies
+    };
+
+    await (
+      state.reconciler as unknown as {
+        advanceStagingOrQualification(input: typeof context): Promise<void>;
+      }
+    ).advanceStagingOrQualification(context);
+
+    expect(state.repository.trains.get('train-1')).toEqual(
+      expect.objectContaining({
+        status: 'DEPLOYING',
+        frontend_base_sha: '1'.repeat(40),
+        backend_base_sha: '2'.repeat(40),
+        frontend_composed_sha: FRONTEND_SHA,
+        backend_composed_sha: BACKEND_SHA
+      })
+    );
+    expect(state.repository.lock.owner_train_id).toBe('train-1');
   });
 
   it('starts exact production qualification after unchanged staging matches the target', async () => {

--- a/src/releaseBusV2/release-bus-v2.acceptance.test.ts
+++ b/src/releaseBusV2/release-bus-v2.acceptance.test.ts
@@ -666,9 +666,7 @@ describe('Release Bus v2 offline acceptance harness', () => {
     mockResolveRefIfExists.mockImplementation(
       async (repository: 'frontend' | 'backend', ref: string) => {
         expect(ref).toBe('1a-staging');
-        return repository === 'frontend'
-          ? 'f'.repeat(40)
-          : backendStagingSha;
+        return repository === 'frontend' ? 'f'.repeat(40) : backendStagingSha;
       }
     );
 

--- a/src/releaseBusV2/release-bus-v2.acceptance.test.ts
+++ b/src/releaseBusV2/release-bus-v2.acceptance.test.ts
@@ -664,8 +664,12 @@ describe('Release Bus v2 offline acceptance harness', () => {
       )!
     );
     mockResolveRefIfExists.mockImplementation(
-      async (repository: 'frontend' | 'backend') =>
-        repository === 'frontend' ? 'f'.repeat(40) : backendStagingSha
+      async (repository: 'frontend' | 'backend', ref: string) => {
+        expect(ref).toBe('1a-staging');
+        return repository === 'frontend'
+          ? 'f'.repeat(40)
+          : backendStagingSha;
+      }
     );
 
     const context = {
@@ -689,6 +693,7 @@ describe('Release Bus v2 offline acceptance harness', () => {
         backend_composed_sha: backendStagingSha
       })
     );
+    expect(state.repository.lock.owner_train_id).toBe('train-1');
     expect(state.repository.events).toContainEqual(
       expect.objectContaining({
         eventType: 'STAGING_ENVIRONMENT_IDENTITY_BOUND',

--- a/src/releaseBusV2/release-bus-v2.reconciler.ts
+++ b/src/releaseBusV2/release-bus-v2.reconciler.ts
@@ -96,6 +96,13 @@ type StagingIdleHandshakeSnapshot = StagingIdleSnapshot & {
   readonly verified_at: number;
 };
 
+type StagingEnvironmentBinding = {
+  readonly frontendSha: string;
+  readonly backendSha: string;
+  readonly frontendFromExistingStaging: boolean;
+  readonly backendFromExistingStaging: boolean;
+};
+
 type ProductionIdleSnapshot = {
   readonly frontend_main_sha: string;
   readonly backend_main_sha: string;
@@ -1379,21 +1386,25 @@ export class ReleaseBusV2Reconciler {
     context: TrainContext
   ): Promise<void> {
     const train = context.train;
+    const requiresIdleHandshake = [
+      'PREPARED',
+      'WAITING_FOR_ENVIRONMENT'
+    ].includes(train.status);
     const requiresBetaIdleHandshake =
-      getReleaseBusV2Mode() === 'OFF' &&
-      ['PREPARED', 'WAITING_FOR_ENVIRONMENT'].includes(train.status);
+      getReleaseBusV2Mode() === 'OFF' && requiresIdleHandshake;
     const workflowFenceStartedAt = requiresBetaIdleHandshake
       ? Date.now()
       : null;
-    const beforeLock = requiresBetaIdleHandshake
+    const beforeLock = requiresIdleHandshake
       ? await this.captureStagingIdleSnapshot()
       : null;
-    if (requiresBetaIdleHandshake && !beforeLock) {
+    if (requiresIdleHandshake && !beforeLock) {
       if (train.status === 'PREPARED')
         await this.transitionTrain(train, {
           status: 'WAITING_FOR_ENVIRONMENT',
-          recoveryMessage:
-            'Operator beta is waiting for an idle shared staging deployment, E2E, and ref handshake'
+          recoveryMessage: requiresBetaIdleHandshake
+            ? 'Operator beta is waiting for an idle shared staging deployment, E2E, and ref handshake'
+            : 'Waiting for an idle shared staging deployment, E2E, and ref handshake'
         });
       return;
     }
@@ -1410,7 +1421,8 @@ export class ReleaseBusV2Reconciler {
         });
       return;
     }
-    if (requiresBetaIdleHandshake && beforeLock) {
+    let environmentBinding: StagingEnvironmentBinding | null = null;
+    if (requiresIdleHandshake && beforeLock) {
       let afterLock: StagingIdleSnapshot | null;
       try {
         afterLock = await this.captureStagingIdleSnapshot();
@@ -1418,11 +1430,11 @@ export class ReleaseBusV2Reconciler {
         await this.releaseEnvironmentLease('staging-environment', lease);
         throw error;
       }
-      const stable =
-        afterLock !== null &&
-        afterLock.frontend_staging_sha === beforeLock.frontend_staging_sha &&
-        afterLock.backend_staging_sha === beforeLock.backend_staging_sha;
-      if (!stable) {
+      if (
+        !afterLock ||
+        afterLock.frontend_staging_sha !== beforeLock.frontend_staging_sha ||
+        afterLock.backend_staging_sha !== beforeLock.backend_staging_sha
+      ) {
         await this.releaseEnvironmentLease('staging-environment', lease);
         if (train.status === 'PREPARED')
           await this.transitionTrain(train, {
@@ -1432,21 +1444,78 @@ export class ReleaseBusV2Reconciler {
           });
         return;
       }
+      if (!afterLock.frontend_staging_sha || !afterLock.backend_staging_sha) {
+        await this.releaseEnvironmentLease('staging-environment', lease);
+        await this.failTrain(
+          train,
+          'CONTROL_PLANE',
+          'Shared staging has no exact frontend or backend ref identity'
+        );
+        return;
+      }
+      environmentBinding = this.bindStagingEnvironmentIdentity(
+        context,
+        afterLock
+      );
+      if (!environmentBinding) {
+        await this.releaseEnvironmentLease('staging-environment', lease);
+        if (train.status === 'PREPARED') {
+          await this.repository.appendEvent(
+            {
+              trainId: train.id,
+              eventType: 'PRODUCTION_QUALIFICATION_ENVIRONMENT_HOLD',
+              actor: 'release-bus-v2',
+              payload: {
+                target_frontend_sha: train.frontend_composed_sha,
+                target_backend_sha: train.backend_composed_sha,
+                staging_frontend_sha: afterLock.frontend_staging_sha,
+                staging_backend_sha: afterLock.backend_staging_sha
+              }
+            },
+            {}
+          );
+          await this.transitionTrain(train, {
+            status: 'WAITING_FOR_ENVIRONMENT',
+            recoveryMessage:
+              'Exact production qualification is waiting for unchanged repositories in staging to match the production target manifest'
+          });
+        }
+        return;
+      }
       await this.repository.appendEvent(
         {
           trainId: train.id,
-          eventType: 'BETA_STAGING_IDLE_HANDSHAKE',
-          actor: 'release-bus-v2-beta',
+          eventType: 'STAGING_ENVIRONMENT_IDENTITY_BOUND',
+          actor: 'release-bus-v2',
           payload: {
-            ...afterLock,
-            beta_test_id: getReleaseBusV2BetaAllowlist()[0]?.test_id,
-            staging_lock: 'owned',
-            workflow_fence_started_at: workflowFenceStartedAt,
-            verified_at: Date.now()
+            lane: train.lane,
+            frontend_sha: environmentBinding.frontendSha,
+            backend_sha: environmentBinding.backendSha,
+            frontend_from_existing_staging:
+              environmentBinding.frontendFromExistingStaging,
+            backend_from_existing_staging:
+              environmentBinding.backendFromExistingStaging
           }
         },
         {}
       );
+      if (requiresBetaIdleHandshake) {
+        await this.repository.appendEvent(
+          {
+            trainId: train.id,
+            eventType: 'BETA_STAGING_IDLE_HANDSHAKE',
+            actor: 'release-bus-v2-beta',
+            payload: {
+              ...afterLock,
+              beta_test_id: getReleaseBusV2BetaAllowlist()[0]?.test_id,
+              staging_lock: 'owned',
+              workflow_fence_started_at: workflowFenceStartedAt,
+              verified_at: Date.now()
+            }
+          },
+          {}
+        );
+      }
     }
     const sourceTrainId = train.parent_train_id ?? train.id;
     if (['PREPARED', 'WAITING_FOR_ENVIRONMENT'].includes(train.status)) {
@@ -1458,6 +1527,8 @@ export class ReleaseBusV2Reconciler {
         );
       await this.transitionTrain(train, {
         status: 'DEPLOYING',
+        frontendComposedSha: environmentBinding?.frontendSha,
+        backendComposedSha: environmentBinding?.backendSha,
         recoveryMessage:
           'Staging ownership acquired; exact immutable artifacts are deploying'
       });
@@ -1640,6 +1711,42 @@ export class ReleaseBusV2Reconciler {
       });
       await this.releaseEnvironmentLease('staging-environment', lease);
     }
+  }
+
+  private bindStagingEnvironmentIdentity(
+    context: TrainContext,
+    snapshot: StagingIdleSnapshot
+  ): StagingEnvironmentBinding | null {
+    const train = context.train;
+    const frontendTarget = train.frontend_composed_sha;
+    const backendTarget = train.backend_composed_sha;
+    const frontendStaging = snapshot.frontend_staging_sha;
+    const backendStaging = snapshot.backend_staging_sha;
+    if (
+      !frontendTarget ||
+      !backendTarget ||
+      !frontendStaging ||
+      !backendStaging
+    )
+      throw new Error('Staging environment identity is incomplete');
+    const hasFrontend = relevantCandidates(context, 'frontend').length > 0;
+    const hasBackend = relevantCandidates(context, 'backend').length > 0;
+    if (train.lane === 'PRODUCTION_QUALIFICATION') {
+      if (!hasFrontend && frontendStaging !== frontendTarget) return null;
+      if (!hasBackend && backendStaging !== backendTarget) return null;
+    }
+    return {
+      frontendSha:
+        train.lane === 'STAGING' && !hasFrontend
+          ? frontendStaging
+          : frontendTarget,
+      backendSha:
+        train.lane === 'STAGING' && !hasBackend
+          ? backendStaging
+          : backendTarget,
+      frontendFromExistingStaging: train.lane === 'STAGING' && !hasFrontend,
+      backendFromExistingStaging: train.lane === 'STAGING' && !hasBackend
+    };
   }
 
   private async captureStagingIdleSnapshot(fence?: {

--- a/src/releaseBusV2/release-bus-v2.reconciler.ts
+++ b/src/releaseBusV2/release-bus-v2.reconciler.ts
@@ -1436,12 +1436,15 @@ export class ReleaseBusV2Reconciler {
         afterLock.backend_staging_sha !== beforeLock.backend_staging_sha
       ) {
         await this.releaseEnvironmentLease('staging-environment', lease);
-        if (train.status === 'PREPARED')
+        if (train.status === 'PREPARED') {
           await this.transitionTrain(train, {
             status: 'WAITING_FOR_ENVIRONMENT',
             recoveryMessage:
               'Shared staging changed during the beta idle handshake; lock released without mutation'
           });
+        }
+        // WAITING_FOR_ENVIRONMENT re-entry must never fall through without a
+        // stable snapshot and an owned lease.
         return;
       }
       if (!afterLock.frontend_staging_sha || !afterLock.backend_staging_sha) {
@@ -1480,6 +1483,8 @@ export class ReleaseBusV2Reconciler {
               'Exact production qualification is waiting for unchanged repositories in staging to match the production target manifest'
           });
         }
+        // A held qualification remains waiting and retries from a fresh
+        // snapshot; it must never advance without an environment binding.
         return;
       }
       await this.repository.appendEvent(
@@ -1489,6 +1494,10 @@ export class ReleaseBusV2Reconciler {
           actor: 'release-bus-v2',
           payload: {
             lane: train.lane,
+            target_frontend_sha: train.frontend_composed_sha,
+            target_backend_sha: train.backend_composed_sha,
+            staging_frontend_sha: afterLock.frontend_staging_sha,
+            staging_backend_sha: afterLock.backend_staging_sha,
             frontend_sha: environmentBinding.frontendSha,
             backend_sha: environmentBinding.backendSha,
             frontend_from_existing_staging:
@@ -1732,6 +1741,9 @@ export class ReleaseBusV2Reconciler {
     const hasFrontend = relevantCandidates(context, 'frontend').length > 0;
     const hasBackend = relevantCandidates(context, 'backend').length > 0;
     if (train.lane === 'PRODUCTION_QUALIFICATION') {
+      // Candidate-bearing repositories are about to be deployed to their
+      // composed targets. Only unchanged counterparts must already match the
+      // exact production target before qualification can own staging.
       if (!hasFrontend && frontendStaging !== frontendTarget) return null;
       if (!hasBackend && backendStaging !== backendTarget) return null;
     }


### PR DESCRIPTION
## Issue
- A frontend-only beta train prepared against backend `main`, while a manual release moved backend staging. The train would have recorded the unrelated `main` SHA in its E2E manifest.

## Fix
- Double-check shared staging for every staging/qualification ownership acquisition.
- Bind unrepresented repositories in ordinary staging trains to the exact locked `1a-staging` refs.
- Hold production qualification without retaining the lock when an unrepresented staging repository differs from the exact production target.

## Changes
- Persist transparent environment-binding and qualification-hold events.
- Fail closed when either staging ref identity is missing.
- Document unchanged-repository staging and production-qualification behavior.

## Validation
- `npm test -- src/releaseBusV2/release-bus-v2.acceptance.test.ts --runInBand` (19/19)
- focused ESLint with zero warnings
- Prettier check and `git diff --check`

## Risk
- Level: Medium
- Why: changes only the pre-deploy staging ownership boundary and exact manifest identity; no schema or workflow changes.
- Rollback: keep v2 OFF/empty and revert this commit. Manual workflows remain authoritative.

## Deployment
- `api`, then `releaseBus`, both with v1/v2 OFF and an empty beta allowlist before any retry.
- Release-note opt-out: this is an internal Release Bus operational change.

## Review Notes
- Focus on frontend-only/backend-only manifest identity and fail-closed production qualification when the untouched repository is not the exact target.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Staging deployments now consistently use the exact repository versions currently staged.
  * Production qualification no longer validates against mismatched or unrelated staging content.
  * Qualification waits safely until all unchanged repositories match the production target, then resumes automatically.
  * Improved handling of staging environment identity and composed version information during deployment.
* **Documentation**
  * Updated operational guidance for staging locks and production qualification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->