### PR TITLE
feat(release-bus-v2): isolate production beta in staging mode

### DIFF
--- a/ops/deployment-bus/simple-release-bus-v2.md
+++ b/ops/deployment-bus/simple-release-bus-v2.md
@@ -15,11 +15,11 @@ node ops/scripts/release-bus-status.mjs
 The helper prefers `/deploy/release-bus-v2/controls` and temporarily falls back
 to the v1 endpoint only before the additive v2 API exists.
 
-| Mode | Staging | Production |
-| --- | --- | --- |
-| `OFF` | Serialized legacy manual route | Serialized manual route with explicit owner authority; no staging evidence gate |
-| `STAGING` | V2 readiness | Production remains manual/disabled |
-| `PRODUCTION` | V2 readiness | Separate explicit v2 action for an exact `STAGING_VALIDATED` candidate |
+| Mode         | Staging                        | Production                                                                      |
+| ------------ | ------------------------------ | ------------------------------------------------------------------------------- |
+| `OFF`        | Serialized legacy manual route | Serialized manual route with explicit owner authority; no staging evidence gate |
+| `STAGING`    | V2 readiness                   | Production remains manual/disabled                                              |
+| `PRODUCTION` | V2 readiness                   | Separate explicit v2 action for an exact `STAGING_VALIDATED` candidate          |
 
 For an active mode, `ALL` and the target lane must be running. In `OFF`, v2
 controls are non-authoritative and the manual fallback remains available when
@@ -110,13 +110,13 @@ explicitly.
 
 ## Failure behavior
 
-| Class | Behavior |
-| --- | --- |
-| Candidate merge/test | Mark the direct candidate `NEEDS_REBASE` or failed; hold only transitive dependants |
-| Infrastructure | Bounded idempotent retry; no candidate isolation |
-| Retryable deployment | Retry only the failed operation; preserve successful sibling evidence |
-| Control plane | Fail the train, requeue candidates, pause automated claiming, retain manual fallback |
-| E2E | Keep the manifest unvalidated; do not globally pause unless state is unverifiable |
+| Class                | Behavior                                                                             |
+| -------------------- | ------------------------------------------------------------------------------------ |
+| Candidate merge/test | Mark the direct candidate `NEEDS_REBASE` or failed; hold only transitive dependants  |
+| Infrastructure       | Bounded idempotent retry; no candidate isolation                                     |
+| Retryable deployment | Retry only the failed operation; preserve successful sibling evidence                |
+| Control plane        | Fail the train, requeue candidates, pause automated claiming, retain manual fallback |
+| E2E                  | Keep the manifest unvalidated; do not globally pause unless state is unverifiable    |
 
 Every pending GitHub status must map to a visible candidate/train/operation state
 and recovery message. Duplicate callbacks and worker invocations reuse immutable
@@ -215,6 +215,11 @@ the allowlist empty and automation globally `OFF` until repaired.
 Production beta is a separate allowlist installation after all staging cases
 pass. Use only exact `STAGING_VALIDATED` candidate IDs, list only the explicit
 production subset, and require the operator's separate mark-ready action.
+After general staging activation, global mode remains `STAGING`: a valid
+production-only allowlist enables only those exact production candidates and
+never filters, enrolls, or blocks ordinary staging candidates. Invalid beta
+configuration pauses only `PRODUCTION`; staging automation and the manual
+fallback remain available.
 With exact validated candidates A/B/C and a reusable exact manifest, prove the
 production train is claimable and prepares while an unrelated D/E staging
 train is active, acquires only `production-environment`, and completes without

--- a/ops/deployment-bus/simple-release-bus-v2.md
+++ b/ops/deployment-bus/simple-release-bus-v2.md
@@ -18,7 +18,7 @@ to the v1 endpoint only before the additive v2 API exists.
 | Mode         | Staging                        | Production                                                                      |
 | ------------ | ------------------------------ | ------------------------------------------------------------------------------- |
 | `OFF`        | Serialized legacy manual route | Serialized manual route with explicit owner authority; no staging evidence gate |
-| `STAGING`    | V2 readiness                   | Production remains manual/disabled                                              |
+| `STAGING`    | V2 readiness                   | Manual/disabled by default; exact operator-only production beta may be allowlisted |
 | `PRODUCTION` | V2 readiness                   | Separate explicit v2 action for an exact `STAGING_VALIDATED` candidate          |
 
 For an active mode, `ALL` and the target lane must be running. In `OFF`, v2

--- a/src/releaseBusV2/release-bus-v2.acceptance.test.ts
+++ b/src/releaseBusV2/release-bus-v2.acceptance.test.ts
@@ -32,6 +32,7 @@ import { ReleaseBusV2Reconciler } from '@/releaseBusV2/release-bus-v2.reconciler
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import type {
+  ReleaseBusV2ControlRecord,
   ReleaseBusV2DependencyRecord,
   ReleaseBusV2LockRecord,
   ReleaseBusV2ManifestRecord,
@@ -156,6 +157,22 @@ class InMemoryAcceptanceRepository {
     readonly payload?: unknown;
     readonly createdAt: number;
   }> = [];
+  public readonly controls = new Map<
+    ReleaseBusV2ControlRecord['scope'],
+    ReleaseBusV2ControlRecord
+  >(
+    (['ALL', 'STAGING', 'PRODUCTION'] as const).map((scope) => [
+      scope,
+      {
+        scope,
+        paused: false,
+        reason: null,
+        github_actor: null,
+        updated_at: 1,
+        row_version: 1
+      }
+    ])
+  );
   private eventClock = Date.now();
   public lock: ReleaseBusV2LockRecord = {
     name: 'staging-environment',
@@ -168,14 +185,8 @@ class InMemoryAcceptanceRepository {
     row_version: 1
   };
 
-  public async listControls(): Promise<
-    Array<{ readonly scope: string; readonly paused: boolean }>
-  > {
-    return [
-      { scope: 'ALL', paused: false },
-      { scope: 'STAGING', paused: false },
-      { scope: 'PRODUCTION', paused: false }
-    ];
+  public async listControls(): Promise<ReleaseBusV2ControlRecord[]> {
+    return Array.from(this.controls.values());
   }
 
   public async listTrains(): Promise<ReleaseBusV2TrainRecord[]> {
@@ -464,7 +475,25 @@ function harness(e2eStatus: 'RUNNING' | 'SUCCEEDED' | 'FAILED') {
   );
   const service = {
     claimLane: jest.fn(async () => null),
-    setPaused: jest.fn(async () => undefined),
+    setPaused: jest.fn(
+      async (
+        scope: ReleaseBusV2ControlRecord['scope'],
+        paused: boolean,
+        reason: string,
+        actor: string
+      ) => {
+        const prior = repository.controls.get(scope);
+        if (!prior) throw new Error(`Missing ${scope} control`);
+        repository.controls.set(scope, {
+          ...prior,
+          paused,
+          reason,
+          github_actor: actor,
+          updated_at: prior.updated_at + 1,
+          row_version: prior.row_version + 1
+        });
+      }
+    ),
     invalidateBranch: jest.fn(async () => undefined),
     isBetaTrainAllowed: jest.fn(async () => true)
   };
@@ -591,6 +620,51 @@ describe('Release Bus v2 offline acceptance harness', () => {
       FRONTEND_SHA,
       BACKEND_SHA,
       'acceptance-invalid-production-beta:staging'
+    );
+  });
+
+  it('resumes only a beta-owned production pause after allowlist repair', async () => {
+    const state = harness('SUCCEEDED');
+    process.env.RELEASE_BUS_V2_MODE = 'STAGING';
+    process.env.RELEASE_BUS_V2_BETA_ALLOWLIST = JSON.stringify([
+      {
+        test_id: 'production-subset-repaired',
+        candidate_id: '11111111-1111-4111-8111-111111111111',
+        repository: 'backend',
+        branch_name: 'agent/rb2-production-subset-repaired',
+        operator: 'beta-operator',
+        lanes: ['PRODUCTION']
+      }
+    ]);
+    state.repository.controls.set('PRODUCTION', {
+      scope: 'PRODUCTION',
+      paused: true,
+      reason: 'invalid beta config',
+      github_actor: 'release-bus-v2-beta',
+      updated_at: 2,
+      row_version: 2
+    });
+    state.repository.trains.set(
+      'train-1',
+      train('train-1', { status: 'CANCELLED', completed_at: 2 })
+    );
+
+    await expect(
+      state.reconciler.runOnce('acceptance-repaired-production-beta')
+    ).resolves.toEqual({ mode: 'STAGING', claimed: [], advanced: [] });
+    expect(state.service.setPaused).toHaveBeenCalledWith(
+      'PRODUCTION',
+      false,
+      expect.stringContaining('recovered'),
+      'release-bus-v2-beta'
+    );
+    expect(state.service.claimLane).toHaveBeenCalledTimes(2);
+    expect(state.service.claimLane).toHaveBeenNthCalledWith(
+      2,
+      'PRODUCTION',
+      FRONTEND_SHA,
+      BACKEND_SHA,
+      'acceptance-repaired-production-beta:production'
     );
   });
 

--- a/src/releaseBusV2/release-bus-v2.acceptance.test.ts
+++ b/src/releaseBusV2/release-bus-v2.acceptance.test.ts
@@ -563,6 +563,108 @@ describe('Release Bus v2 offline acceptance harness', () => {
     expect(state.service.claimLane).not.toHaveBeenCalled();
   });
 
+  it('pauses only production for an invalid STAGING-mode beta allowlist', async () => {
+    const state = harness('SUCCEEDED');
+    process.env.RELEASE_BUS_V2_MODE = 'STAGING';
+    process.env.RELEASE_BUS_V2_BETA_ALLOWLIST = 'not-json';
+    state.repository.trains.set(
+      'train-1',
+      train('train-1', { status: 'CANCELLED', completed_at: 2 })
+    );
+
+    await expect(
+      state.reconciler.runOnce('acceptance-invalid-production-beta')
+    ).resolves.toEqual({
+      mode: 'STAGING',
+      claimed: [],
+      advanced: []
+    });
+    expect(state.service.setPaused).toHaveBeenCalledWith(
+      'PRODUCTION',
+      true,
+      expect.stringContaining('staging remains enabled'),
+      'release-bus-v2-beta'
+    );
+    expect(state.service.claimLane).toHaveBeenCalledTimes(1);
+    expect(state.service.claimLane).toHaveBeenCalledWith(
+      'STAGING',
+      FRONTEND_SHA,
+      BACKEND_SHA,
+      'acceptance-invalid-production-beta:staging'
+    );
+  });
+
+  it('claims ordinary staging and allowlisted production independently in STAGING mode', async () => {
+    const state = harness('SUCCEEDED');
+    process.env.RELEASE_BUS_V2_MODE = 'STAGING';
+    process.env.RELEASE_BUS_V2_BETA_ALLOWLIST = JSON.stringify([
+      {
+        test_id: 'production-subset-1',
+        candidate_id: '11111111-1111-4111-8111-111111111111',
+        repository: 'backend',
+        branch_name: 'agent/rb2-production-subset-one',
+        operator: 'beta-operator',
+        lanes: ['PRODUCTION']
+      }
+    ]);
+    state.repository.trains.set(
+      'train-1',
+      train('train-1', { status: 'CANCELLED', completed_at: 2 })
+    );
+
+    await expect(
+      state.reconciler.runOnce('acceptance-staging-production-beta')
+    ).resolves.toEqual({
+      mode: 'STAGING',
+      claimed: [],
+      advanced: []
+    });
+    expect(state.service.claimLane).toHaveBeenNthCalledWith(
+      1,
+      'STAGING',
+      FRONTEND_SHA,
+      BACKEND_SHA,
+      'acceptance-staging-production-beta:staging'
+    );
+    expect(state.service.claimLane).toHaveBeenNthCalledWith(
+      2,
+      'PRODUCTION',
+      FRONTEND_SHA,
+      BACKEND_SHA,
+      'acceptance-staging-production-beta:production'
+    );
+  });
+
+  it('does not advance an unallowlisted production train in STAGING mode', async () => {
+    const state = harness('SUCCEEDED');
+    process.env.RELEASE_BUS_V2_MODE = 'STAGING';
+    process.env.RELEASE_BUS_V2_BETA_ALLOWLIST = JSON.stringify([
+      {
+        test_id: 'production-subset-1',
+        candidate_id: '11111111-1111-4111-8111-111111111111',
+        repository: 'backend',
+        branch_name: 'agent/rb2-production-subset-one',
+        operator: 'beta-operator',
+        lanes: ['PRODUCTION']
+      }
+    ]);
+    state.repository.trains.set(
+      'train-1',
+      train('train-1', { lane: 'PRODUCTION', status: 'PREPARED' })
+    );
+    state.service.isBetaTrainAllowed.mockResolvedValue(false);
+
+    await expect(
+      state.reconciler.runOnce('acceptance-unlisted-production-train')
+    ).resolves.toEqual({
+      mode: 'STAGING',
+      claimed: [],
+      advanced: []
+    });
+    expect(state.repository.trains.get('train-1')?.status).toBe('PREPARED');
+    expect(mockReconcileWorkflow).not.toHaveBeenCalled();
+  });
+
   it('enters the OFF beta lane but does not advance an unallowlisted active train', async () => {
     const state = harness('SUCCEEDED');
     process.env.RELEASE_BUS_V2_MODE = 'OFF';

--- a/src/releaseBusV2/release-bus-v2.config.test.ts
+++ b/src/releaseBusV2/release-bus-v2.config.test.ts
@@ -2,6 +2,7 @@ import {
   getReleaseBusV2BetaAllowlist,
   getReleaseBusV2Mode,
   releaseBusV2BetaAllowsCandidate,
+  releaseBusV2BetaAllowsLaneInMode,
   releaseBusV2BetaAllowsRegistration,
   releaseBusV2BetaInfrastructureFailureInjection,
   ReleaseBusV2BetaConfigurationError
@@ -112,6 +113,23 @@ describe('Release Bus v2 operator-only OFF beta configuration', () => {
         { ...candidate(), requested_by: 'another-operator' },
         'STAGING'
       )
+    ).toBe(false);
+  });
+
+  it('keeps a STAGING-mode beta confined to the production lane', () => {
+    process.env.RELEASE_BUS_V2_BETA_ALLOWLIST = JSON.stringify([
+      configuredEntry({ lanes: ['PRODUCTION'] })
+    ]);
+    const allowlist = getReleaseBusV2BetaAllowlist();
+
+    expect(
+      releaseBusV2BetaAllowsLaneInMode('STAGING', allowlist, 'PRODUCTION')
+    ).toBe(true);
+    expect(
+      releaseBusV2BetaAllowsLaneInMode('STAGING', allowlist, 'STAGING')
+    ).toBe(false);
+    expect(
+      releaseBusV2BetaAllowsLaneInMode('PRODUCTION', allowlist, 'PRODUCTION')
     ).toBe(false);
   });
 

--- a/src/releaseBusV2/release-bus-v2.config.ts
+++ b/src/releaseBusV2/release-bus-v2.config.ts
@@ -205,6 +205,24 @@ export function releaseBusV2BetaAllowsLane(
   return allowlist.some((entry) => entry.lanes.includes(requiredLane));
 }
 
+/**
+ * OFF permits exact operator beta entries in either lane. Once staging is
+ * generally enabled, only the production lane may remain operator-only beta;
+ * the allowlist must never narrow or enroll ordinary staging candidates.
+ */
+export function releaseBusV2BetaAllowsLaneInMode(
+  mode: ReleaseBusV2Mode,
+  allowlist: readonly ReleaseBusV2BetaEntry[],
+  lane: ReleaseBusV2Lane | ReleaseBusV2BetaLane
+): boolean {
+  if (mode === 'OFF') return releaseBusV2BetaAllowsLane(allowlist, lane);
+  return (
+    mode === 'STAGING' &&
+    lane === 'PRODUCTION' &&
+    releaseBusV2BetaAllowsLane(allowlist, lane)
+  );
+}
+
 export function releaseBusV2BetaAllowsRegistration(
   allowlist: readonly ReleaseBusV2BetaEntry[],
   input: ReleaseBusV2RegisterInput,

--- a/src/releaseBusV2/release-bus-v2.reconciler.ts
+++ b/src/releaseBusV2/release-bus-v2.reconciler.ts
@@ -10,6 +10,7 @@ import {
   releaseBusV2BetaAllowsCandidate,
   releaseBusV2BetaInfrastructureFailureInjection,
   releaseBusV2BetaAllowsLane,
+  releaseBusV2BetaAllowsLaneInMode,
   type ReleaseBusV2BetaEntry
 } from '@/releaseBusV2/release-bus-v2.config';
 import {
@@ -484,22 +485,27 @@ export class ReleaseBusV2Reconciler {
     const claimed: string[] = [];
     await this.releaseTerminalEnvironmentLocks();
     let betaAllowlist: readonly ReleaseBusV2BetaEntry[] = [];
-    if (mode === 'OFF') {
+    if (mode === 'OFF' || mode === 'STAGING') {
       try {
         betaAllowlist = getReleaseBusV2BetaAllowlist();
       } catch {
+        const scope = mode === 'OFF' ? 'ALL' : 'PRODUCTION';
         const controls = await this.repository.listControls({});
-        const allControl = controls.find(({ scope }) => scope === 'ALL');
-        if (!allControl?.paused)
+        const control = controls.find((item) => item.scope === scope);
+        if (!control?.paused)
           await this.service.setPaused(
-            'ALL',
+            scope,
             true,
-            'Release Bus v2 OFF beta allowlist is invalid; automation remains disabled',
+            mode === 'OFF'
+              ? 'Release Bus v2 OFF beta allowlist is invalid; automation remains disabled'
+              : 'Release Bus v2 production beta allowlist is invalid; staging remains enabled',
             'release-bus-v2-beta'
           );
-        return { mode, claimed, advanced: [] };
+        if (mode === 'OFF') return { mode, claimed, advanced: [] };
+        betaAllowlist = [];
       }
-      if (betaAllowlist.length === 0) return { mode, claimed, advanced: [] };
+      if (mode === 'OFF' && betaAllowlist.length === 0)
+        return { mode, claimed, advanced: [] };
     }
     const controls = await this.repository.listControls({});
     const isPaused = (scope: 'ALL' | 'STAGING' | 'PRODUCTION') =>
@@ -513,11 +519,10 @@ export class ReleaseBusV2Reconciler {
     const productionEnabled =
       !isPaused('PRODUCTION') &&
       (mode === 'PRODUCTION' ||
-        (mode === 'OFF' &&
-          releaseBusV2BetaAllowsLane(betaAllowlist, 'PRODUCTION')));
+        releaseBusV2BetaAllowsLaneInMode(mode, betaAllowlist, 'PRODUCTION'));
     if (stagingEnabled || productionEnabled) {
       try {
-        await this.reconcileQueuedCandidateHeads(betaAllowlist);
+        await this.reconcileQueuedCandidateHeads(betaAllowlist, mode);
         const [frontendMain, backendMain] = await Promise.all([
           releaseBusGitHubApp.resolveRef('frontend', 'main'),
           releaseBusGitHubApp.resolveRef('backend', 'main')
@@ -563,8 +568,10 @@ export class ReleaseBusV2Reconciler {
       });
     const active: ReleaseBusV2TrainRecord[] = [];
     for (const train of activeByLane) {
+      const requiresBetaEligibility =
+        mode === 'OFF' || (mode === 'STAGING' && train.lane !== 'STAGING');
       if (
-        mode !== 'OFF' ||
+        !requiresBetaEligibility ||
         (await this.service.isBetaTrainAllowed(train, betaAllowlist, {}))
       )
         active.push(train);
@@ -612,7 +619,8 @@ export class ReleaseBusV2Reconciler {
   }
 
   private async reconcileQueuedCandidateHeads(
-    betaAllowlist: readonly ReleaseBusV2BetaEntry[] = []
+    betaAllowlist: readonly ReleaseBusV2BetaEntry[] = [],
+    mode = getReleaseBusV2Mode()
   ): Promise<void> {
     const candidates = (
       await this.repository.listCandidates(
@@ -621,9 +629,16 @@ export class ReleaseBusV2Reconciler {
         {}
       )
     ).filter((candidate) => {
-      if (betaAllowlist.length === 0) return true;
       const lane =
         candidate.status === 'READY_FOR_PRODUCTION' ? 'PRODUCTION' : 'STAGING';
+      if (mode === 'STAGING') {
+        if (lane === 'STAGING') return true;
+        return (
+          betaAllowlist.length > 0 &&
+          releaseBusV2BetaAllowsCandidate(betaAllowlist, candidate, lane)
+        );
+      }
+      if (betaAllowlist.length === 0) return true;
       return releaseBusV2BetaAllowsCandidate(betaAllowlist, candidate, lane);
     });
     const branchHeads = await Promise.all(
@@ -1937,8 +1952,18 @@ export class ReleaseBusV2Reconciler {
       return;
     }
 
+    const mode = getReleaseBusV2Mode();
+    const betaAllowlist =
+      mode === 'OFF' || mode === 'STAGING'
+        ? getReleaseBusV2BetaAllowlist()
+        : [];
+    const stagingModeProductionBeta =
+      mode === 'STAGING' &&
+      releaseBusV2BetaAllowsLaneInMode(mode, betaAllowlist, 'PRODUCTION') &&
+      (await this.service.isBetaTrainAllowed(train, betaAllowlist, {}));
     const requiresBetaIdleHandshake =
-      getReleaseBusV2Mode() === 'OFF' && train.status === 'MERGING_PRODUCTION';
+      train.status === 'MERGING_PRODUCTION' &&
+      (mode === 'OFF' || stagingModeProductionBeta);
     const beforeLock = requiresBetaIdleHandshake
       ? await this.captureProductionIdleSnapshot()
       : null;
@@ -1971,7 +1996,7 @@ export class ReleaseBusV2Reconciler {
           actor: 'release-bus-v2-beta',
           payload: {
             ...afterLock,
-            beta_test_id: getReleaseBusV2BetaAllowlist()[0]?.test_id,
+            beta_test_id: betaAllowlist[0]?.test_id,
             production_lock: 'owned',
             verified_at: Date.now()
           }

--- a/src/releaseBusV2/release-bus-v2.reconciler.ts
+++ b/src/releaseBusV2/release-bus-v2.reconciler.ts
@@ -486,8 +486,10 @@ export class ReleaseBusV2Reconciler {
     await this.releaseTerminalEnvironmentLocks();
     let betaAllowlist: readonly ReleaseBusV2BetaEntry[] = [];
     if (mode === 'OFF' || mode === 'STAGING') {
+      let betaAllowlistValid = false;
       try {
         betaAllowlist = getReleaseBusV2BetaAllowlist();
+        betaAllowlistValid = true;
       } catch {
         const scope = mode === 'OFF' ? 'ALL' : 'PRODUCTION';
         const controls = await this.repository.listControls({});
@@ -503,6 +505,24 @@ export class ReleaseBusV2Reconciler {
           );
         if (mode === 'OFF') return { mode, claimed, advanced: [] };
         betaAllowlist = [];
+      }
+      if (betaAllowlistValid) {
+        const betaScope = mode === 'OFF' ? 'ALL' : 'PRODUCTION';
+        const betaControl = (await this.repository.listControls({})).find(
+          (item) => item.scope === betaScope
+        );
+        if (
+          betaControl?.paused &&
+          betaControl.github_actor === 'release-bus-v2-beta'
+        )
+          await this.service.setPaused(
+            betaScope,
+            false,
+            mode === 'OFF'
+              ? 'Release Bus v2 beta allowlist configuration recovered; OFF manual fallback remains authoritative'
+              : 'Release Bus v2 production beta allowlist configuration recovered',
+            'release-bus-v2-beta'
+          );
       }
       if (mode === 'OFF' && betaAllowlist.length === 0)
         return { mode, claimed, advanced: [] };
@@ -1996,6 +2016,7 @@ export class ReleaseBusV2Reconciler {
           actor: 'release-bus-v2-beta',
           payload: {
             ...afterLock,
+            // Config validation requires one shared test_id across all entries.
             beta_test_id: betaAllowlist[0]?.test_id,
             production_lock: 'owned',
             verified_at: Date.now()

--- a/src/releaseBusV2/release-bus-v2.service.test.ts
+++ b/src/releaseBusV2/release-bus-v2.service.test.ts
@@ -136,6 +136,77 @@ describe('Release Bus v2 explicit production opt-in', () => {
   });
 });
 
+describe('Release Bus v2 STAGING-mode production beta opt-in', () => {
+  const previousMode = process.env.RELEASE_BUS_V2_MODE;
+  const previousAllowlist = process.env.RELEASE_BUS_V2_BETA_ALLOWLIST;
+  const betaId = '11111111-1111-4111-8111-111111111111';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.RELEASE_BUS_V2_MODE = 'STAGING';
+    process.env.RELEASE_BUS_V2_BETA_ALLOWLIST = JSON.stringify([
+      {
+        test_id: 'production-subset-1',
+        candidate_id: betaId,
+        repository: 'frontend',
+        branch_name: 'feature/exact',
+        operator: 'beta-operator',
+        lanes: ['PRODUCTION']
+      }
+    ]);
+  });
+
+  afterAll(() => {
+    if (previousMode === undefined) delete process.env.RELEASE_BUS_V2_MODE;
+    else process.env.RELEASE_BUS_V2_MODE = previousMode;
+    if (previousAllowlist === undefined)
+      delete process.env.RELEASE_BUS_V2_BETA_ALLOWLIST;
+    else process.env.RELEASE_BUS_V2_BETA_ALLOWLIST = previousAllowlist;
+  });
+
+  it('allows only the exact validated allowlisted operator candidate', async () => {
+    const exact = {
+      ...candidate('STAGING_VALIDATED'),
+      id: betaId,
+      requested_by: 'beta-operator'
+    };
+    const state = repositoryFor(exact);
+    mockResolveRef.mockResolvedValue(exact.head_sha);
+    const service = new ReleaseBusV2Service(state.repository as never);
+
+    await expect(
+      service.markReadyForProduction(
+        betaId,
+        exact.head_sha,
+        exact.row_version,
+        'beta-operator'
+      )
+    ).resolves.toEqual(
+      expect.objectContaining({ status: 'READY_FOR_PRODUCTION' })
+    );
+  });
+
+  it('does not broaden production readiness to another actor', async () => {
+    const exact = {
+      ...candidate('STAGING_VALIDATED'),
+      id: betaId,
+      requested_by: 'beta-operator'
+    };
+    const state = repositoryFor(exact);
+    const service = new ReleaseBusV2Service(state.repository as never);
+
+    await expect(
+      service.markReadyForProduction(
+        betaId,
+        exact.head_sha,
+        exact.row_version,
+        'another-actor'
+      )
+    ).rejects.toThrow('production readiness is disabled');
+    expect(mockResolveRef).not.toHaveBeenCalled();
+  });
+});
+
 describe('Release Bus v2 globally-OFF operator beta registration', () => {
   const previousMode = process.env.RELEASE_BUS_V2_MODE;
   const previousAllowlist = process.env.RELEASE_BUS_V2_BETA_ALLOWLIST;

--- a/src/releaseBusV2/release-bus-v2.service.ts
+++ b/src/releaseBusV2/release-bus-v2.service.ts
@@ -390,7 +390,8 @@ export class ReleaseBusV2Service {
                   head_sha: candidate.head_sha,
                   operator_beta: isBetaRegistration,
                   beta_test_id: isBetaRegistration
-                    ? betaAllowlist[0]?.test_id
+                    ? // Config validation requires one shared test_id.
+                      betaAllowlist[0]?.test_id
                     : null
                 }
               },
@@ -787,6 +788,7 @@ export class ReleaseBusV2Service {
                 lane,
                 candidate_ids: order,
                 operator_beta: betaLaneEnabled,
+                // Config validation requires one shared test_id.
                 beta_test_id: betaLaneEnabled ? betaAllowlist[0]?.test_id : null
               }
             },

--- a/src/releaseBusV2/release-bus-v2.service.ts
+++ b/src/releaseBusV2/release-bus-v2.service.ts
@@ -9,6 +9,7 @@ import {
   RELEASE_BUS_V2_MAX_CANDIDATES,
   releaseBusV2BetaAllowsCandidate,
   releaseBusV2BetaAllowsLane,
+  releaseBusV2BetaAllowsLaneInMode,
   releaseBusV2BetaAllowsRegistration,
   type ReleaseBusV2BetaEntry,
   releaseBusV2AllowsLane
@@ -429,9 +430,12 @@ export class ReleaseBusV2Service {
     const mode = getReleaseBusV2Mode();
     const snapshot = await this.repository.findCandidateById(candidateId, {});
     if (!snapshot) throw new Error('Candidate not found');
-    const betaAllowlist = mode === 'OFF' ? getReleaseBusV2BetaAllowlist() : [];
+    const betaAllowlist =
+      mode === 'OFF' || mode === 'STAGING'
+        ? getReleaseBusV2BetaAllowlist()
+        : [];
     const isBetaPromotion =
-      mode === 'OFF' &&
+      releaseBusV2BetaAllowsLaneInMode(mode, betaAllowlist, 'PRODUCTION') &&
       releaseBusV2BetaAllowsCandidate(betaAllowlist, snapshot, 'PRODUCTION') &&
       snapshot.requested_by.toLowerCase() === actor.toLowerCase();
     if (!releaseBusV2AllowsLane(mode, 'PRODUCTION') && !isBetaPromotion)
@@ -675,9 +679,15 @@ export class ReleaseBusV2Service {
   ): Promise<ReleaseBusV2TrainRecord | null> {
     const mode = getReleaseBusV2Mode();
     const scope = laneScope(lane);
-    const betaAllowlist = mode === 'OFF' ? getReleaseBusV2BetaAllowlist() : [];
-    const betaLaneEnabled =
-      mode === 'OFF' && releaseBusV2BetaAllowsLane(betaAllowlist, lane);
+    const betaAllowlist =
+      mode === 'OFF' || (mode === 'STAGING' && lane === 'PRODUCTION')
+        ? getReleaseBusV2BetaAllowlist()
+        : [];
+    const betaLaneEnabled = releaseBusV2BetaAllowsLaneInMode(
+      mode,
+      betaAllowlist,
+      lane
+    );
     if (!releaseBusV2AllowsLane(mode, scope) && !betaLaneEnabled) return null;
     await this.assertScopeRunning(scope);
     return this.repository.executeNativeQueriesInTransaction(


### PR DESCRIPTION
Enables the separately allowlisted production beta after general staging cutover without narrowing or enrolling ordinary staging candidates.

- production-only beta allowlist is honored in global STAGING mode
- invalid beta config pauses only PRODUCTION
- unallowlisted production/qualification trains cannot advance
- production beta retains the double idle handshake

Validation: focused Release Bus v2 config/service/acceptance tests (48/48); npm run lint; signed DCO commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added production beta opt-in support while Release Bus v2 operates in **STAGING** mode.
  * Staging candidates continue to operate normally, while production candidates are limited to exact allowlisted entries.
  * Allowlisted production lanes can be claimed and marked ready independently.
  * Invalid beta configuration pauses only production automation, preserving staging workflows and manual fallback.

* **Documentation**
  * Clarified staging-mode routing and failure-handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->