### PR TITLE
test(release-bus-v2): add production overlap candidate A

### DIFF
--- a/ops/deployment-bus/beta-fixtures/production-overlap-a-backend.md
+++ b/ops/deployment-bus/beta-fixtures/production-overlap-a-backend.md
@@ -1,0 +1,10 @@
+# Release Bus v2 production-overlap candidate A
+
+Documentation-only synthetic fixture for the exact reusable-manifest
+production beta. Candidate A deploys `api`, participates in staging test
+`production-overlap-1`, and intentionally exercises autonomous release-note
+finalization in production.
+
+- Candidate ID: `0cbaba35-48c5-4339-a428-f39749846054`
+- Repository: `backend`
+- Production beta lane: explicit opt-in only


### PR DESCRIPTION
Synthetic operator-only Release Bus v2 production-overlap acceptance fixture A.

- documentation-only exact backend candidate
- validates `api` release metadata/finalization
- no application behavior change

Release notes: explicit beta publication acceptance.