### PR TITLE
test(release-bus-v2): add unrelated staging candidate D

### DIFF
--- a/ops/deployment-bus/beta-fixtures/production-overlap-d-backend.md
+++ b/ops/deployment-bus/beta-fixtures/production-overlap-d-backend.md
@@ -1,0 +1,8 @@
+# Release Bus v2 unrelated staging candidate D
+
+Documentation-only backend fixture for the staging train that must overlap the
+independent production A/B/C train without sharing an environment lock.
+
+- Candidate ID: `1baa1530-7126-4627-b3f7-818ce6b40f67`
+- Repository: `backend`
+- Staging test: `production-overlap-d-e-1`


### PR DESCRIPTION
Synthetic operator-only Release Bus v2 overlap fixture D.

- documentation-only unrelated backend staging candidate
- holds the staging environment during the production overlap proof
- no application behavior change

Release notes: none.