### PR TITLE
test(release-bus-v2): add production overlap candidate B

### DIFF
--- a/ops/deployment-bus/beta-fixtures/production-overlap-b-backend.md
+++ b/ops/deployment-bus/beta-fixtures/production-overlap-b-backend.md
@@ -1,0 +1,9 @@
+# Release Bus v2 production-overlap candidate B
+
+Documentation-only synthetic fixture for the exact reusable-manifest
+production beta. Candidate B deploys `attachmentsOrchestrator` independently
+from candidate A and opts out of its own release note.
+
+- Candidate ID: `5ed6578e-9b78-4101-8f16-9c70514739eb`
+- Repository: `backend`
+- Production beta lane: explicit opt-in only


### PR DESCRIPTION
Synthetic operator-only Release Bus v2 production-overlap acceptance fixture B.

- documentation-only exact backend candidate
- validates independent `attachmentsOrchestrator` preparation/deploy
- explicit no-release-note unit

No application behavior change.