### PR TITLE
test(release-bus-v2): add qualification staging fence D2

### DIFF
--- a/ops/deployment-bus/beta-fixtures/production-qualification-fence-d2-backend.md
+++ b/ops/deployment-bus/beta-fixtures/production-qualification-fence-d2-backend.md
@@ -1,0 +1,9 @@
+# Release Bus v2 qualification fence candidate D2
+
+Documentation-only backend fixture for the second bounded staging train used to
+prove that a production release set without an exact reusable manifest cannot
+acquire staging while unrelated E2E owns the staging environment.
+
+- Repository: `backend`
+- Staging test: `production-qualification-fence-d2-e2-1`
+- Production release notes: not applicable


### PR DESCRIPTION
Documentation-only operator acceptance fixture D2.

Used only to hold a bounded unrelated staging/E2E lock while a missing-manifest production qualification proves fail-closed waiting. No application behavior or production release note.