### PR TITLE
fix(release-bus-v2): reuse exact validated manifest

### DIFF
--- a/src/releaseBusV2/release-bus-v2.acceptance.test.ts
+++ b/src/releaseBusV2/release-bus-v2.acceptance.test.ts
@@ -1556,6 +1556,184 @@ describe('Release Bus v2 offline acceptance harness', () => {
     expect(source).not.toContain('BASE_CANARY');
   });
 
+  it('reuses only the exact common staging manifest before production composition', async () => {
+    const state = harness('SUCCEEDED');
+    const manifestId = 'validated-common-manifest';
+    for (const [id, current] of Array.from(
+      state.repository.candidates.entries()
+    )) {
+      state.repository.candidates.set(id, {
+        ...current,
+        staging_validated_manifest_id: manifestId,
+        staging_validated_train_id: 'train-1'
+      });
+    }
+    state.repository.manifests.set(manifestId, {
+      id: manifestId,
+      train_id: 'train-1',
+      lane: 'STAGING',
+      identity_sha256: 'f'.repeat(64),
+      status: 'STAGING_VALIDATED',
+      frontend_sha: FRONTEND_SHA,
+      backend_sha: BACKEND_SHA,
+      frontend_artifact_digest: FRONTEND_DIGEST,
+      backend_artifact_digest: BACKEND_DIGEST,
+      e2e_run_id: 'validated-e2e',
+      manifest_json: {},
+      deployed_at: 2,
+      validated_at: 3,
+      created_at: 2,
+      updated_at: 3
+    });
+    const production = train('production-train', {
+      lane: 'PRODUCTION',
+      status: 'CLAIMED',
+      frontend_composed_sha: null,
+      backend_composed_sha: null,
+      frontend_artifact_digest: null,
+      backend_artifact_digest: null
+    });
+    const context = {
+      train: production,
+      memberships: state.repository.memberships.map((item) => ({
+        ...item,
+        train_id: production.id
+      })),
+      candidates: Array.from(state.repository.candidates.values()),
+      dependencies: state.repository.dependencies
+    };
+    const findExact = (
+      state.reconciler as unknown as {
+        findExactValidatedProductionManifest(
+          input: typeof context
+        ): Promise<ReleaseBusV2ManifestRecord | null>;
+      }
+    ).findExactValidatedProductionManifest.bind(state.reconciler);
+
+    await expect(findExact(context)).resolves.toMatchObject({
+      id: manifestId,
+      frontend_sha: FRONTEND_SHA,
+      backend_sha: BACKEND_SHA
+    });
+
+    state.repository.memberships.push({
+      id: 'unselected-source-membership',
+      train_id: 'train-1',
+      candidate_id: 'not-in-production-subset',
+      sequence: 3,
+      disposition: 'INCLUDED',
+      created_at: 1
+    });
+    await expect(findExact(context)).resolves.toBeNull();
+    state.repository.memberships.pop();
+    await expect(
+      findExact({
+        ...context,
+        train: { ...production, backend_base_sha: '9'.repeat(40) }
+      })
+    ).resolves.toMatchObject({ id: manifestId });
+
+    const frontendSourceMembershipIndex =
+      state.repository.memberships.findIndex(
+        ({ candidate_id }) => candidate_id === 'frontend-candidate'
+      );
+    if (frontendSourceMembershipIndex < 0)
+      throw new Error('Missing frontend source membership');
+    state.repository.memberships[frontendSourceMembershipIndex] = {
+      ...state.repository.memberships[frontendSourceMembershipIndex],
+      disposition: 'EXCLUDED'
+    };
+    const backendOnly = {
+      ...context,
+      memberships: context.memberships.filter(
+        ({ candidate_id }) => candidate_id === 'backend-candidate'
+      ),
+      candidates: context.candidates.filter(
+        ({ repository }) => repository === 'backend'
+      ),
+      dependencies: []
+    };
+    await expect(findExact(backendOnly)).resolves.toBeNull();
+    state.repository.manifests.set(manifestId, {
+      ...(state.repository.manifests.get(
+        manifestId
+      ) as ReleaseBusV2ManifestRecord),
+      frontend_sha: production.frontend_base_sha
+    });
+    await expect(findExact(backendOnly)).resolves.toMatchObject({
+      id: manifestId
+    });
+  });
+
+  it('prepares production from the exact staging manifest without workflows', async () => {
+    const state = harness('SUCCEEDED');
+    const manifestId = 'validated-production-manifest';
+    for (const [id, current] of Array.from(
+      state.repository.candidates.entries()
+    )) {
+      state.repository.candidates.set(id, {
+        ...current,
+        staging_validated_manifest_id: manifestId,
+        staging_validated_train_id: 'train-1'
+      });
+    }
+    state.repository.manifests.set(manifestId, {
+      id: manifestId,
+      train_id: 'train-1',
+      lane: 'STAGING',
+      identity_sha256: 'e'.repeat(64),
+      status: 'STAGING_VALIDATED',
+      frontend_sha: FRONTEND_SHA,
+      backend_sha: BACKEND_SHA,
+      frontend_artifact_digest: FRONTEND_DIGEST,
+      backend_artifact_digest: BACKEND_DIGEST,
+      e2e_run_id: 'validated-e2e',
+      manifest_json: {},
+      deployed_at: 2,
+      validated_at: 3,
+      created_at: 2,
+      updated_at: 3
+    });
+    const production = train('production-train', {
+      lane: 'PRODUCTION',
+      status: 'CLAIMED',
+      frontend_composed_sha: null,
+      backend_composed_sha: null,
+      frontend_artifact_digest: null,
+      backend_artifact_digest: null
+    });
+    state.repository.trains.set(production.id, production);
+    const context = {
+      train: production,
+      memberships: state.repository.memberships.map((item) => ({
+        ...item,
+        train_id: production.id
+      })),
+      candidates: Array.from(state.repository.candidates.values()),
+      dependencies: state.repository.dependencies
+    };
+
+    await (
+      state.reconciler as unknown as {
+        advancePreparation(input: typeof context): Promise<void>;
+      }
+    ).advancePreparation(context);
+
+    expect(state.repository.trains.get(production.id)).toMatchObject({
+      status: 'PREPARED',
+      frontend_composed_sha: FRONTEND_SHA,
+      backend_composed_sha: BACKEND_SHA,
+      manifest_id: manifestId
+    });
+    expect(mockReconcileWorkflow).not.toHaveBeenCalled();
+    expect(state.repository.events).toContainEqual(
+      expect.objectContaining({
+        trainId: production.id,
+        eventType: 'EXACT_STAGING_MANIFEST_REUSED'
+      })
+    );
+  });
+
   it('proves exact four-way Jest inventory in the combined preflight', () => {
     const workflow = readFileSync(
       path.join(

--- a/src/releaseBusV2/release-bus-v2.acceptance.test.ts
+++ b/src/releaseBusV2/release-bus-v2.acceptance.test.ts
@@ -1616,6 +1616,22 @@ describe('Release Bus v2 offline acceptance harness', () => {
       backend_sha: BACKEND_SHA
     });
 
+    const validatedManifest = state.repository.manifests.get(manifestId);
+    if (!validatedManifest) throw new Error('Missing validated manifest');
+    state.repository.manifests.set(manifestId, {
+      ...validatedManifest,
+      status: 'STAGING_DEPLOYED'
+    });
+    await expect(findExact(context)).resolves.toBeNull();
+    state.repository.manifests.delete(manifestId);
+    await expect(findExact(context)).resolves.toBeNull();
+    state.repository.manifests.set(manifestId, validatedManifest);
+    const sourceTrain = state.repository.trains.get('train-1');
+    if (!sourceTrain) throw new Error('Missing source train');
+    state.repository.trains.delete('train-1');
+    await expect(findExact(context)).resolves.toBeNull();
+    state.repository.trains.set('train-1', sourceTrain);
+
     state.repository.memberships.push({
       id: 'unselected-source-membership',
       train_id: 'train-1',
@@ -1658,7 +1674,8 @@ describe('Release Bus v2 offline acceptance harness', () => {
       ...(state.repository.manifests.get(
         manifestId
       ) as ReleaseBusV2ManifestRecord),
-      frontend_sha: production.frontend_base_sha
+      frontend_sha: production.frontend_base_sha,
+      frontend_artifact_digest: null
     });
     await expect(findExact(backendOnly)).resolves.toMatchObject({
       id: manifestId
@@ -1725,11 +1742,27 @@ describe('Release Bus v2 offline acceptance harness', () => {
       backend_composed_sha: BACKEND_SHA,
       manifest_id: manifestId
     });
+    expect(
+      Array.from(state.repository.candidates.values()).map(
+        ({ status }) => status
+      )
+    ).toEqual([
+      'PRODUCTION_BUILDING_OR_QUALIFYING',
+      'PRODUCTION_BUILDING_OR_QUALIFYING'
+    ]);
     expect(mockReconcileWorkflow).not.toHaveBeenCalled();
     expect(state.repository.events).toContainEqual(
       expect.objectContaining({
         trainId: production.id,
         eventType: 'EXACT_STAGING_MANIFEST_REUSED'
+      })
+    );
+    expect(state.repository.events).toContainEqual(
+      expect.objectContaining({
+        eventType: 'EXACT_STAGING_MANIFEST_REUSED',
+        payload: expect.objectContaining({
+          manifest_identity_sha256: 'e'.repeat(64)
+        })
       })
     );
   });

--- a/src/releaseBusV2/release-bus-v2.acceptance.test.ts
+++ b/src/releaseBusV2/release-bus-v2.acceptance.test.ts
@@ -1647,7 +1647,7 @@ describe('Release Bus v2 offline acceptance harness', () => {
         ...context,
         train: { ...production, backend_base_sha: '9'.repeat(40) }
       })
-    ).resolves.toMatchObject({ id: manifestId });
+    ).resolves.toBeNull();
 
     const frontendSourceMembershipIndex =
       state.repository.memberships.findIndex(

--- a/src/releaseBusV2/release-bus-v2.reconciler.ts
+++ b/src/releaseBusV2/release-bus-v2.reconciler.ts
@@ -752,6 +752,37 @@ export class ReleaseBusV2Reconciler {
       candidateStatusForBuild(train.lane),
       train.id
     );
+    const exactProductionManifest =
+      await this.findExactValidatedProductionManifest(context);
+    if (exactProductionManifest) {
+      await this.repository.appendEvent(
+        {
+          trainId: train.id,
+          eventType: 'EXACT_STAGING_MANIFEST_REUSED',
+          actor: 'release-bus-v2',
+          payload: {
+            manifest_id: exactProductionManifest.id,
+            source_train_id: exactProductionManifest.train_id,
+            candidate_ids: relevantCandidates(context).map(({ id }) => id),
+            frontend_sha: exactProductionManifest.frontend_sha,
+            backend_sha: exactProductionManifest.backend_sha
+          }
+        },
+        {}
+      );
+      await this.transitionTrain(train, {
+        status: 'PREPARED',
+        frontendComposedSha: exactProductionManifest.frontend_sha,
+        backendComposedSha: exactProductionManifest.backend_sha,
+        frontendArtifactDigest:
+          exactProductionManifest.frontend_artifact_digest,
+        backendArtifactDigest: exactProductionManifest.backend_artifact_digest,
+        manifestId: exactProductionManifest.id,
+        recoveryMessage:
+          'The exact candidate set, staging-validated manifest, immutable artifacts, and original base SHAs were reused without composition or preflight'
+      });
+      return;
+    }
     const compositionOnly =
       train.lane === 'PRODUCTION' &&
       ['CLAIMED', 'COMPOSING'].includes(train.status);
@@ -820,6 +851,67 @@ export class ReleaseBusV2Reconciler {
         ? 'Exact artifacts prepared; waiting only for environment ownership'
         : 'Frontend and backend preparation are reconciling concurrently'
     });
+  }
+
+  private async findExactValidatedProductionManifest(
+    context: TrainContext
+  ): Promise<ReleaseBusV2ManifestRecord | null> {
+    if (context.train.lane !== 'PRODUCTION') return null;
+    const candidates = relevantCandidates(context);
+    const manifestIds = Array.from(
+      new Set(
+        candidates
+          .map(({ staging_validated_manifest_id }) =>
+            staging_validated_manifest_id?.trim()
+          )
+          .filter((id): id is string => Boolean(id))
+      )
+    );
+    if (manifestIds.length !== 1) return null;
+    if (
+      candidates.some(
+        ({ staging_validated_manifest_id }) =>
+          staging_validated_manifest_id !== manifestIds[0]
+      )
+    )
+      return null;
+    const manifest = await this.repository.findManifest(manifestIds[0], {});
+    if (!manifest || manifest.status !== 'STAGING_VALIDATED') return null;
+    const sourceTrain = await this.repository.findTrain(manifest.train_id, {});
+    if (!sourceTrain) return null;
+    const sourceMemberships = await this.repository.listTrainCandidates(
+      sourceTrain.id,
+      {}
+    );
+    const sourceCandidateIds = sourceMemberships
+      .filter(({ disposition }) => disposition === 'INCLUDED')
+      .map(({ candidate_id }) => candidate_id)
+      .sort(compareInvariant);
+    const productionCandidateIds = candidates
+      .map(({ id }) => id)
+      .sort(compareInvariant);
+    if (
+      JSON.stringify(sourceCandidateIds) !==
+      JSON.stringify(productionCandidateIds)
+    )
+      return null;
+    const hasFrontend = candidates.some(
+      ({ repository }) => repository === 'frontend'
+    );
+    const hasBackend = candidates.some(
+      ({ repository }) => repository === 'backend'
+    );
+    if (
+      !manifest.frontend_sha ||
+      !manifest.backend_sha ||
+      (hasFrontend && !manifest.frontend_artifact_digest) ||
+      (hasBackend && !manifest.backend_artifact_digest) ||
+      (!hasFrontend &&
+        manifest.frontend_sha !== context.train.frontend_base_sha) ||
+      (!hasBackend && manifest.backend_sha !== context.train.backend_base_sha)
+    )
+      return null;
+    return manifest;
   }
 
   private async prepareRepository(

--- a/src/releaseBusV2/release-bus-v2.reconciler.ts
+++ b/src/releaseBusV2/release-bus-v2.reconciler.ts
@@ -764,6 +764,7 @@ export class ReleaseBusV2Reconciler {
             manifest_id: exactProductionManifest.id,
             source_train_id: exactProductionManifest.train_id,
             candidate_ids: relevantCandidates(context).map(({ id }) => id),
+            manifest_identity_sha256: exactProductionManifest.identity_sha256,
             frontend_sha: exactProductionManifest.frontend_sha,
             backend_sha: exactProductionManifest.backend_sha
           }
@@ -890,9 +891,13 @@ export class ReleaseBusV2Reconciler {
     const productionCandidateIds = candidates
       .map(({ id }) => id)
       .sort(compareInvariant);
+    // Production readiness transitions the same durable candidate rows that
+    // staging validated; the model does not create lane-scoped candidates.
     if (
-      JSON.stringify(sourceCandidateIds) !==
-      JSON.stringify(productionCandidateIds)
+      sourceCandidateIds.length !== productionCandidateIds.length ||
+      sourceCandidateIds.some(
+        (candidateId, index) => candidateId !== productionCandidateIds[index]
+      )
     )
       return null;
     const hasFrontend = candidates.some(
@@ -901,6 +906,8 @@ export class ReleaseBusV2Reconciler {
     const hasBackend = candidates.some(
       ({ repository }) => repository === 'backend'
     );
+    // A repository absent from the subset is not deployed. It therefore needs
+    // no artifact digest, but its manifest SHA must still be the current base.
     if (
       !manifest.frontend_sha ||
       !manifest.backend_sha ||

--- a/src/releaseBusV2/release-bus-v2.reconciler.ts
+++ b/src/releaseBusV2/release-bus-v2.reconciler.ts
@@ -877,7 +877,7 @@ export class ReleaseBusV2Reconciler {
     )
       return null;
     const manifest = await this.repository.findManifest(manifestIds[0], {});
-    if (!manifest || manifest.status !== 'STAGING_VALIDATED') return null;
+    if (manifest?.status !== 'STAGING_VALIDATED') return null;
     const sourceTrain = await this.repository.findTrain(manifest.train_id, {});
     if (!sourceTrain) return null;
     const sourceMemberships = await this.repository.listTrainCandidates(
@@ -906,13 +906,19 @@ export class ReleaseBusV2Reconciler {
     const hasBackend = candidates.some(
       ({ repository }) => repository === 'backend'
     );
-    // A repository absent from the subset is not deployed. It therefore needs
-    // no artifact digest, but its manifest SHA must still be the current base.
+    // A candidate-bearing composition is base-dependent: if main advanced,
+    // the exact set must be requalified rather than rewinding the shared ref.
+    // A repository absent from the subset is not deployed; it needs no digest,
+    // but its manifest SHA must still be the current base.
     if (
       !manifest.frontend_sha ||
       !manifest.backend_sha ||
       (hasFrontend && !manifest.frontend_artifact_digest) ||
       (hasBackend && !manifest.backend_artifact_digest) ||
+      (hasFrontend &&
+        sourceTrain.frontend_base_sha !== context.train.frontend_base_sha) ||
+      (hasBackend &&
+        sourceTrain.backend_base_sha !== context.train.backend_base_sha) ||
       (!hasFrontend &&
         manifest.frontend_sha !== context.train.frontend_base_sha) ||
       (!hasBackend && manifest.backend_sha !== context.train.backend_base_sha)


### PR DESCRIPTION
## Summary
- short-circuit production preparation from a common exact STAGING_VALIDATED manifest before composition
- require exact included candidate membership and immutable artifacts, with unchanged-repository protection
- preserve auditable source manifest/train identity and emit an explicit reuse event

## Validation
- `npx jest --runInBand src/releaseBusV2/release-bus-v2.acceptance.test.ts src/releaseBusV2/release-bus-v2.reconciler.test.ts src/releaseBusV2/release-bus-v2.repository.integration.test.ts` (45 passed)
- `npm run lint`
- `git diff --check`

Release-note opt-out: internal Release Bus control-plane repair.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Production preparation can now reuse an exact, previously validated staging manifest.
  * Eligible production trains transition directly to the prepared state with existing composed SHAs and artifact details.
  * Reuse is limited to manifests with matching candidates, repositories, and source revisions.

* **Tests**
  * Added acceptance coverage for exact staging manifest matching, exclusions, source changes, and direct production preparation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->