### PR TITLE
test(release-bus-v2): add qualification staging fence D3

### DIFF
--- a/ops/deployment-bus/beta-fixtures/production-qualification-fence-d3-backend.md
+++ b/ops/deployment-bus/beta-fixtures/production-qualification-fence-d3-backend.md
@@ -1,0 +1,9 @@
+# Release Bus v2 qualification fence candidate D3
+
+Documentation-only backend fixture for the bounded staging train that proves a
+production release set without a reusable exact manifest waits for the staging
+environment instead of contaminating an unrelated active E2E validation.
+
+- Repository: `backend`
+- Staging test: `production-qualification-fence-d3-e3-1`
+- Production release notes: not applicable

--- a/ops/deployment-bus/beta-fixtures/production-qualification-fence-d3-backend.md
+++ b/ops/deployment-bus/beta-fixtures/production-qualification-fence-d3-backend.md
@@ -5,5 +5,6 @@ production release set without a reusable exact manifest waits for the staging
 environment instead of contaminating an unrelated active E2E validation.
 
 - Repository: `backend`
+- Candidate ID: `c47943f7-14a7-4a02-b1ab-93609ce26a66`
 - Staging test: `production-qualification-fence-d3-e3-1`
 - Production release notes: not applicable


### PR DESCRIPTION
Docs-only operator beta fixture for the bounded missing-manifest qualification wait proof. No production release note.