### PR TITLE
Fix v2 exact production ref authority

### DIFF
--- a/ops/deployment-bus/simple-release-bus-v2.md
+++ b/ops/deployment-bus/simple-release-bus-v2.md
@@ -108,7 +108,9 @@ default-branch ruleset in both repositories. V2 uses that narrowly scoped App
 to perform a non-force fast-forward to the exact staging-validated commit; a
 pull-request-only bypass would require GitHub to manufacture a different merge
 commit and therefore fails closed. Human and team bypass actors remain
-pull-request-only.
+pull-request-only. The compensating controls are enforced in code: the App can
+write only the explicit shared/release-bus ref allowlist, and every shared-ref
+update is a non-force compare-and-swap from the recorded old SHA.
 
 V2 never authors or posts release notes itself. Production operations must feed
 the existing autonomous release-note bot complete, canonical grouping metadata

--- a/ops/deployment-bus/simple-release-bus-v2.md
+++ b/ops/deployment-bus/simple-release-bus-v2.md
@@ -180,11 +180,14 @@ read-only shadow checks. Shadow checks may resolve exact refs, PR qualification,
 current locks, and active workflow state, but must not update a shared ref,
 dispatch a deploy/E2E workflow, or create/claim a live candidate. With the
 allowlist absent, a worker invocation must claim and advance nothing.
-The only permitted OFF/empty maintenance mutation is releasing an environment
-lock already owned by a terminal train after every one of that train's
-operations is terminal. That cleanup emits
-`TERMINAL_ENVIRONMENT_LOCK_RELEASED`; it cannot claim a candidate, advance a
-train, update a shared ref, or dispatch a workflow.
+The only permitted OFF/empty maintenance mutations are reconciling a stranded
+internal `ADVANCE_MAIN_*` operation from a read-only exact `main` ref check and
+releasing an environment lock already owned by a terminal train after every one
+of that train's operations is terminal. The cleanup emits
+`TERMINAL_INTERNAL_REF_OPERATION_RECONCILED` and
+`TERMINAL_ENVIRONMENT_LOCK_RELEASED`; an unknown ref identity retains the lock.
+Cleanup cannot claim a candidate, advance a train, update a shared ref, or
+dispatch a workflow.
 
 For each single bounded staging test:
 

--- a/ops/deployment-bus/simple-release-bus-v2.md
+++ b/ops/deployment-bus/simple-release-bus-v2.md
@@ -15,11 +15,11 @@ node ops/scripts/release-bus-status.mjs
 The helper prefers `/deploy/release-bus-v2/controls` and temporarily falls back
 to the v1 endpoint only before the additive v2 API exists.
 
-| Mode         | Staging                        | Production                                                                      |
-| ------------ | ------------------------------ | ------------------------------------------------------------------------------- |
-| `OFF`        | Serialized legacy manual route | Serialized manual route with explicit owner authority; no staging evidence gate |
+| Mode         | Staging                        | Production                                                                         |
+| ------------ | ------------------------------ | ---------------------------------------------------------------------------------- |
+| `OFF`        | Serialized legacy manual route | Serialized manual route with explicit owner authority; no staging evidence gate    |
 | `STAGING`    | V2 readiness                   | Manual/disabled by default; exact operator-only production beta may be allowlisted |
-| `PRODUCTION` | V2 readiness                   | Separate explicit v2 action for an exact `STAGING_VALIDATED` candidate          |
+| `PRODUCTION` | V2 readiness                   | Separate explicit v2 action for an exact `STAGING_VALIDATED` candidate             |
 
 For an active mode, `ALL` and the target lane must be running. In `OFF`, v2
 controls are non-authoritative and the manual fallback remains available when
@@ -103,6 +103,13 @@ from current `main`:
   verify exact versions, run production-safe read-only E2E, and mark
   `PRODUCTION_DEPLOYED`.
 
+The dedicated Release Bus GitHub App must be an `always` bypass actor on the
+default-branch ruleset in both repositories. V2 uses that narrowly scoped App
+to perform a non-force fast-forward to the exact staging-validated commit; a
+pull-request-only bypass would require GitHub to manufacture a different merge
+commit and therefore fails closed. Human and team bypass actors remain
+pull-request-only.
+
 V2 never authors or posts release notes itself. Production operations must feed
 the existing autonomous release-note bot complete, canonical grouping metadata
 and an idempotent finalize signal. Internal operational candidates may opt out
@@ -110,13 +117,13 @@ explicitly.
 
 ## Failure behavior
 
-| Class                | Behavior                                                                             |
-| -------------------- | ------------------------------------------------------------------------------------ |
-| Candidate merge/test | Mark the direct candidate `NEEDS_REBASE` or failed; hold only transitive dependants  |
-| Infrastructure       | Bounded idempotent retry; no candidate isolation                                     |
-| Retryable deployment | Retry only the failed operation; preserve successful sibling evidence                |
-| Control plane        | Fail the train, requeue candidates, pause automated claiming, retain manual fallback |
-| E2E                  | Keep the manifest unvalidated; do not globally pause unless state is unverifiable    |
+| Class                | Behavior                                                                                                                                           |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Candidate merge/test | Mark the direct candidate `NEEDS_REBASE` or failed; hold only transitive dependants                                                                |
+| Infrastructure       | Bounded idempotent retry; no candidate isolation                                                                                                   |
+| Retryable deployment | Retry only the failed operation; preserve successful sibling evidence                                                                              |
+| Control plane        | Fail the train, requeue candidates, pause automated claiming, release an environment lock once every operation is terminal, retain manual fallback |
+| E2E                  | Keep the manifest unvalidated; do not globally pause unless state is unverifiable                                                                  |
 
 Every pending GitHub status must map to a visible candidate/train/operation state
 and recovery message. Duplicate callbacks and worker invocations reuse immutable

--- a/src/releaseBus/release-bus.github-app.ts
+++ b/src/releaseBus/release-bus.github-app.ts
@@ -169,7 +169,10 @@ export function releaseBusPullRequestMergeStateEligible(
   if (mergeable === false) return false;
   if (['clean', 'unstable', 'behind'].includes(mergeableState ?? ''))
     return true;
-  // The Release Bus GitHub App is a pull-request-mode ruleset bypass actor.
+  // The Release Bus GitHub App is a ruleset bypass actor. Production v2 also
+  // needs `always` bypass mode so it can non-force fast-forward the exact
+  // staging-validated commit instead of manufacturing a different PR merge
+  // commit. Human/team bypass actors remain pull-request-only.
   // GitHub still reports `blocked` for maintainer-review requirements, so only
   // accept that state when the merge tree itself is explicitly mergeable. The
   // exact merge-tree checks are independently required below.

--- a/src/releaseBusV2/release-bus-v2.acceptance.test.ts
+++ b/src/releaseBusV2/release-bus-v2.acceptance.test.ts
@@ -394,6 +394,101 @@ class InMemoryAcceptanceRepository {
     return this.operations.filter((item) => item.train_id === trainId);
   }
 
+  public async findOperation(
+    idempotencyKey: string
+  ): Promise<ReleaseBusV2OperationRecord | null> {
+    return (
+      this.operations.find((item) => item.idempotency_key === idempotencyKey) ??
+      null
+    );
+  }
+
+  public async getOrCreateOperation(input: {
+    readonly idempotencyKey: string;
+    readonly trainId: string;
+    readonly operationType: string;
+    readonly repository: 'frontend' | 'backend';
+    readonly service: string | null;
+    readonly environment: string;
+    readonly expectedSha: string | null;
+    readonly artifactDigest: string | null;
+    readonly request: unknown;
+    readonly maxAttempts: number;
+  }): Promise<ReleaseBusV2OperationRecord> {
+    const existing = await this.findOperation(input.idempotencyKey);
+    if (existing) return existing;
+    const now = Date.now();
+    const created: ReleaseBusV2OperationRecord = {
+      id: `operation-${this.operations.length + 1}`,
+      idempotency_key: input.idempotencyKey,
+      train_id: input.trainId,
+      operation_type: input.operationType,
+      repository: input.repository,
+      service: input.service,
+      environment: input.environment,
+      expected_sha: input.expectedSha,
+      artifact_digest: input.artifactDigest,
+      external_id: null,
+      status: 'PENDING',
+      attempt: 1,
+      max_attempts: input.maxAttempts,
+      next_retry_at: null,
+      failure_class: null,
+      failure_message: null,
+      request_json: input.request,
+      result_json: null,
+      started_at: null,
+      completed_at: null,
+      created_at: now,
+      updated_at: now,
+      row_version: 1
+    };
+    this.operations.push(created);
+    return created;
+  }
+
+  public async updateOperation(
+    id: string,
+    rowVersion: number,
+    fields: Partial<{
+      readonly status: ReleaseBusV2OperationRecord['status'];
+      readonly externalId: string | null;
+      readonly result: unknown;
+      readonly failureClass: ReleaseBusV2OperationRecord['failure_class'];
+      readonly failureMessage: string | null;
+      readonly completedAt: number | null;
+    }>
+  ): Promise<boolean> {
+    const index = this.operations.findIndex((item) => item.id === id);
+    const current = this.operations[index];
+    if (!current || current.row_version !== rowVersion) return false;
+    this.operations[index] = {
+      ...current,
+      status: fields.status ?? current.status,
+      external_id:
+        fields.externalId === undefined
+          ? current.external_id
+          : fields.externalId,
+      result_json:
+        fields.result === undefined ? current.result_json : fields.result,
+      failure_class:
+        fields.failureClass === undefined
+          ? current.failure_class
+          : fields.failureClass,
+      failure_message:
+        fields.failureMessage === undefined
+          ? current.failure_message
+          : fields.failureMessage,
+      completed_at:
+        fields.completedAt === undefined
+          ? current.completed_at
+          : fields.completedAt,
+      updated_at: Date.now(),
+      row_version: current.row_version + 1
+    };
+    return true;
+  }
+
   public async createManifest(
     input: Omit<ReleaseBusV2ManifestRecord, 'id' | 'created_at' | 'updated_at'>
   ): Promise<ReleaseBusV2ManifestRecord> {
@@ -1399,6 +1494,79 @@ describe('Release Bus v2 offline acceptance harness', () => {
       ).advanceProductionRefs(context)
     ).rejects.toThrow('main moved');
     expect(mockUpdateRef).not.toHaveBeenCalled();
+  });
+
+  it('terminalizes a rejected exact main update and safely releases its production lock', async () => {
+    const state = harness('SUCCEEDED');
+    const production = train('production-train', {
+      lane: 'PRODUCTION',
+      status: 'MERGING_PRODUCTION'
+    });
+    state.repository.trains.set(production.id, production);
+    state.repository.memberships.forEach((membership, index) => {
+      state.repository.memberships[index] = {
+        ...membership,
+        train_id: production.id
+      };
+    });
+    state.repository.lock = {
+      ...state.repository.lock,
+      name: 'production-environment'
+    };
+    await state.repository.acquireLock(
+      'production-environment',
+      production.id,
+      `train:${production.id}`
+    );
+    mockResolveRef.mockResolvedValue(production.backend_base_sha);
+    mockUpdateRef.mockRejectedValue(
+      new Error('Repository rule violations found')
+    );
+
+    await expect(
+      (
+        state.reconciler as unknown as {
+          advanceMainRef(
+            input: ReleaseBusV2TrainRecord,
+            repository: 'backend',
+            observedSha: string
+          ): Promise<void>;
+        }
+      ).advanceMainRef(production, 'backend', production.backend_base_sha ?? '')
+    ).rejects.toThrow('Repository rule violations found');
+
+    const mainOperation = state.repository.operations.find(
+      (item) => item.operation_type === 'ADVANCE_MAIN_BACKEND'
+    );
+    expect(mainOperation).toEqual(
+      expect.objectContaining({
+        status: 'FAILED',
+        failure_class: 'CONTROL_PLANE',
+        completed_at: expect.any(Number)
+      })
+    );
+
+    await (
+      state.reconciler as unknown as {
+        failTrain(
+          input: ReleaseBusV2TrainRecord,
+          failureClass: 'CONTROL_PLANE',
+          message: string
+        ): Promise<void>;
+      }
+    ).failTrain(production, 'CONTROL_PLANE', 'ruleset rejected update');
+
+    expect(state.repository.lock.owner_train_id).toBeNull();
+    expect(state.repository.events).toContainEqual(
+      expect.objectContaining({
+        eventType: 'TERMINAL_ENVIRONMENT_LOCK_RELEASED',
+        trainId: production.id,
+        payload: expect.objectContaining({
+          lock: 'production-environment',
+          train_status: 'FAILED'
+        })
+      })
+    );
   });
 
   it('pauses only automation and requeues candidates on a control-plane defect', async () => {

--- a/src/releaseBusV2/release-bus-v2.acceptance.test.ts
+++ b/src/releaseBusV2/release-bus-v2.acceptance.test.ts
@@ -456,6 +456,7 @@ class InMemoryAcceptanceRepository {
       readonly result: unknown;
       readonly failureClass: ReleaseBusV2OperationRecord['failure_class'];
       readonly failureMessage: string | null;
+      readonly attempt: number;
       readonly completedAt: number | null;
     }>
   ): Promise<boolean> {
@@ -479,6 +480,7 @@ class InMemoryAcceptanceRepository {
         fields.failureMessage === undefined
           ? current.failure_message
           : fields.failureMessage,
+      attempt: fields.attempt ?? current.attempt,
       completed_at:
         fields.completedAt === undefined
           ? current.completed_at
@@ -1678,6 +1680,171 @@ describe('Release Bus v2 offline acceptance harness', () => {
         })
       })
     );
+  });
+
+  it('accepts an exact main update that succeeded before its transport error', async () => {
+    const state = harness('SUCCEEDED');
+    const production = train('accepted-production', {
+      lane: 'PRODUCTION',
+      status: 'MERGING_PRODUCTION'
+    });
+    state.repository.trains.set(production.id, production);
+    mockUpdateRef.mockRejectedValue(new Error('response connection reset'));
+    mockResolveRef.mockResolvedValue(production.backend_composed_sha);
+
+    await expect(
+      (
+        state.reconciler as unknown as {
+          advanceMainRef(
+            input: ReleaseBusV2TrainRecord,
+            repository: 'backend',
+            observedSha: string
+          ): Promise<void>;
+        }
+      ).advanceMainRef(production, 'backend', production.backend_base_sha ?? '')
+    ).resolves.toBeUndefined();
+
+    expect(
+      state.repository.operations.find(
+        (item) => item.operation_type === 'ADVANCE_MAIN_BACKEND'
+      )
+    ).toEqual(
+      expect.objectContaining({
+        status: 'SUCCEEDED',
+        external_id: production.backend_composed_sha,
+        completed_at: expect.any(Number)
+      })
+    );
+  });
+
+  it('bounds exact main infrastructure retries in the durable operation', async () => {
+    const state = harness('SUCCEEDED');
+    const production = train('retry-production', {
+      lane: 'PRODUCTION',
+      status: 'MERGING_PRODUCTION'
+    });
+    state.repository.trains.set(production.id, production);
+    const infrastructureError = new Error('GitHub returned 503');
+    infrastructureError.name = 'ReleaseBusGitHubInfrastructureError';
+    mockUpdateRef.mockRejectedValue(infrastructureError);
+    mockResolveRef.mockResolvedValue(production.backend_base_sha);
+    const advance = () =>
+      (
+        state.reconciler as unknown as {
+          advanceMainRef(
+            input: ReleaseBusV2TrainRecord,
+            repository: 'backend',
+            observedSha: string
+          ): Promise<void>;
+        }
+      ).advanceMainRef(
+        production,
+        'backend',
+        production.backend_base_sha ?? ''
+      );
+
+    await expect(advance()).rejects.toThrow('GitHub returned 503');
+    await expect(advance()).rejects.toThrow('GitHub returned 503');
+    await expect(advance()).rejects.toThrow('GitHub returned 503');
+
+    expect(mockUpdateRef).toHaveBeenCalledTimes(3);
+    expect(
+      state.repository.operations.find(
+        (item) => item.operation_type === 'ADVANCE_MAIN_BACKEND'
+      )
+    ).toEqual(
+      expect.objectContaining({
+        status: 'FAILED',
+        attempt: 3,
+        max_attempts: 3,
+        failure_class: 'INFRASTRUCTURE',
+        completed_at: expect.any(Number)
+      })
+    );
+  });
+
+  it('cancels a main operation when its post-failure ref is an unexpected third SHA', async () => {
+    const state = harness('SUCCEEDED');
+    const production = train('moved-production', {
+      lane: 'PRODUCTION',
+      status: 'MERGING_PRODUCTION'
+    });
+    state.repository.trains.set(production.id, production);
+    mockUpdateRef.mockRejectedValue(new Error('update rejected'));
+    mockResolveRef.mockResolvedValue('9'.repeat(40));
+
+    await expect(
+      (
+        state.reconciler as unknown as {
+          advanceMainRef(
+            input: ReleaseBusV2TrainRecord,
+            repository: 'backend',
+            observedSha: string
+          ): Promise<void>;
+        }
+      ).advanceMainRef(production, 'backend', production.backend_base_sha ?? '')
+    ).rejects.toThrow('main moved');
+    expect(
+      state.repository.operations.find(
+        (item) => item.operation_type === 'ADVANCE_MAIN_BACKEND'
+      )
+    ).toEqual(
+      expect.objectContaining({
+        status: 'CANCELLED',
+        failure_class: 'INTERACTION',
+        completed_at: expect.any(Number)
+      })
+    );
+  });
+
+  it('pauses for exact reconciliation after a partial multi-repository main advance', async () => {
+    const state = harness('SUCCEEDED');
+    const production = train('partial-production', {
+      lane: 'PRODUCTION',
+      status: 'MERGING_PRODUCTION'
+    });
+    const context = {
+      train: production,
+      memberships: state.repository.memberships.map((item) => ({
+        ...item,
+        train_id: production.id
+      })),
+      candidates: Array.from(state.repository.candidates.values()),
+      dependencies: state.repository.dependencies
+    };
+    mockResolveRef.mockImplementation(async (repository: string) =>
+      repository === 'backend'
+        ? production.backend_base_sha
+        : production.frontend_base_sha
+    );
+    mockUpdateRef.mockImplementation(async (repository: string) => {
+      if (repository === 'frontend')
+        throw new Error('frontend update rejected');
+    });
+    let frontendReads = 0;
+    mockResolveRef.mockImplementation(async (repository: string) => {
+      if (repository === 'backend') return production.backend_base_sha;
+      frontendReads += 1;
+      return frontendReads > 1 ? '9'.repeat(40) : production.frontend_base_sha;
+    });
+
+    await expect(
+      (
+        state.reconciler as unknown as {
+          advanceProductionRefs(input: typeof context): Promise<void>;
+        }
+      ).advanceProductionRefs(context)
+    ).rejects.toThrow('Partial production main advance: backend');
+    expect(
+      state.repository.operations.find(
+        (item) => item.operation_type === 'ADVANCE_MAIN_BACKEND'
+      )?.status
+    ).toBe('SUCCEEDED');
+    expect(
+      state.repository.operations.find(
+        (item) => item.operation_type === 'ADVANCE_MAIN_FRONTEND'
+      )?.status
+    ).toBe('CANCELLED');
   });
 
   it('pauses only automation and requeues candidates on a control-plane defect', async () => {

--- a/src/releaseBusV2/release-bus-v2.acceptance.test.ts
+++ b/src/releaseBusV2/release-bus-v2.acceptance.test.ts
@@ -666,6 +666,117 @@ describe('Release Bus v2 offline acceptance harness', () => {
     );
   });
 
+  it('reconciles a stranded terminal main operation before releasing its lock', async () => {
+    const state = harness('SUCCEEDED');
+    process.env.RELEASE_BUS_V2_MODE = 'OFF';
+    const failed = train('terminal-production', {
+      lane: 'PRODUCTION',
+      status: 'FAILED',
+      failure_class: 'CONTROL_PLANE',
+      completed_at: 4
+    });
+    state.repository.trains.set(failed.id, failed);
+    state.repository.operations.push({
+      ...operation(failed.id, 'ADVANCE_MAIN_BACKEND', 'backend', 'unused'),
+      id: 'stranded-main-operation',
+      idempotency_key: `rb2:${failed.id}:advance-main:backend`,
+      expected_sha: failed.backend_composed_sha,
+      external_id: null,
+      status: 'PENDING',
+      failure_class: null,
+      failure_message: null,
+      completed_at: null
+    });
+    state.repository.lock = {
+      ...state.repository.lock,
+      name: 'production-environment'
+    };
+    await state.repository.acquireLock(
+      'production-environment',
+      failed.id,
+      `train:${failed.id}`
+    );
+    mockResolveRef.mockResolvedValue(failed.backend_base_sha);
+
+    await state.reconciler.runOnce('acceptance-terminal-ref-reconciliation');
+
+    expect(
+      state.repository.operations.find(
+        (item) => item.id === 'stranded-main-operation'
+      )
+    ).toEqual(
+      expect.objectContaining({
+        status: 'FAILED',
+        failure_class: 'CONTROL_PLANE',
+        completed_at: expect.any(Number)
+      })
+    );
+    expect(state.repository.lock.owner_train_id).toBeNull();
+    expect(state.repository.events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          eventType: 'TERMINAL_INTERNAL_REF_OPERATION_RECONCILED',
+          trainId: failed.id,
+          payload: expect.objectContaining({
+            repository: 'backend',
+            operation_status: 'FAILED',
+            observed_sha: failed.backend_base_sha
+          })
+        }),
+        expect.objectContaining({
+          eventType: 'TERMINAL_ENVIRONMENT_LOCK_RELEASED',
+          trainId: failed.id
+        })
+      ])
+    );
+  });
+
+  it('retains a terminal lock when a stranded main operation is still ambiguous', async () => {
+    const state = harness('SUCCEEDED');
+    process.env.RELEASE_BUS_V2_MODE = 'OFF';
+    const failed = train('ambiguous-production', {
+      lane: 'PRODUCTION',
+      status: 'FAILED',
+      failure_class: 'CONTROL_PLANE',
+      completed_at: 4
+    });
+    state.repository.trains.set(failed.id, failed);
+    state.repository.operations.push({
+      ...operation(failed.id, 'ADVANCE_MAIN_BACKEND', 'backend', 'unused'),
+      id: 'ambiguous-main-operation',
+      idempotency_key: `rb2:${failed.id}:advance-main:backend`,
+      expected_sha: failed.backend_composed_sha,
+      external_id: null,
+      status: 'PENDING',
+      completed_at: null
+    });
+    state.repository.lock = {
+      ...state.repository.lock,
+      name: 'production-environment'
+    };
+    await state.repository.acquireLock(
+      'production-environment',
+      failed.id,
+      `train:${failed.id}`
+    );
+    mockResolveRef.mockResolvedValue('9'.repeat(40));
+
+    await state.reconciler.runOnce('acceptance-ambiguous-terminal-ref');
+
+    expect(
+      state.repository.operations.find(
+        (item) => item.id === 'ambiguous-main-operation'
+      )?.status
+    ).toBe('PENDING');
+    expect(state.repository.lock.owner_train_id).toBe(failed.id);
+    expect(state.repository.events).not.toContainEqual(
+      expect.objectContaining({
+        eventType: 'TERMINAL_ENVIRONMENT_LOCK_RELEASED',
+        trainId: failed.id
+      })
+    );
+  });
+
   it('pauses only beta automation when the OFF allowlist is malformed', async () => {
     const state = harness('SUCCEEDED');
     process.env.RELEASE_BUS_V2_MODE = 'OFF';

--- a/src/releaseBusV2/release-bus-v2.reconciler.ts
+++ b/src/releaseBusV2/release-bus-v2.reconciler.ts
@@ -2250,8 +2250,21 @@ export class ReleaseBusV2Reconciler {
         );
       throw new MainMovedError(message);
     }
-    for (const item of current)
-      await this.advanceMainRef(train, item.repository, item.sha);
+    const advanced: ReleaseBusV2Repository[] = [];
+    for (const item of current) {
+      try {
+        await this.advanceMainRef(train, item.repository, item.sha);
+        advanced.push(item.repository);
+      } catch (error) {
+        if (advanced.length > 0)
+          throw new Error(
+            `Partial production main advance: ${advanced.join(', ')} reached the exact composed SHA before ${item.repository} failed; automation must remain paused for exact reconciliation. ${
+              error instanceof Error ? error.message : 'Unknown ref failure'
+            }`
+          );
+        throw error;
+      }
+    }
   }
 
   private async advanceMainRef(
@@ -2279,7 +2292,7 @@ export class ReleaseBusV2Reconciler {
               ? train.frontend_base_sha
               : train.backend_base_sha
         },
-        maxAttempts: 1
+        maxAttempts: 3
       },
       {}
     );
@@ -2308,24 +2321,45 @@ export class ReleaseBusV2Reconciler {
           'main'
         );
         if (afterFailure !== composed) {
-          if (afterFailure !== base)
-            throw new MainMovedError(
-              `${repository} main moved from ${base} to ${afterFailure}`
-            );
-          if (!isGitHubInfrastructureError(error)) {
-            const message =
-              error instanceof Error
-                ? error.message
-                : `Failed to advance ${repository} main`;
+          const message =
+            error instanceof Error
+              ? error.message
+              : `Failed to advance ${repository} main`;
+          if (afterFailure !== base) {
             if (
               !(await this.repository.updateOperation(
                 operation.id,
                 operation.row_version,
                 {
-                  status: 'FAILED',
-                  failureClass: 'CONTROL_PLANE',
-                  failureMessage: message,
+                  status: 'CANCELLED',
+                  failureClass: 'INTERACTION',
+                  failureMessage: `${repository} main moved to ${afterFailure} during exact advancement`,
                   completedAt: Date.now()
+                },
+                {}
+              ))
+            )
+              throw new Error(
+                `${repository} main operation changed concurrently`
+              );
+            throw new MainMovedError(
+              `${repository} main moved from ${base} to ${afterFailure}`
+            );
+          }
+          if (isGitHubInfrastructureError(error)) {
+            const exhausted = operation.attempt >= operation.max_attempts;
+            if (
+              !(await this.repository.updateOperation(
+                operation.id,
+                operation.row_version,
+                {
+                  status: exhausted ? 'FAILED' : 'PENDING',
+                  failureClass: 'INFRASTRUCTURE',
+                  failureMessage: `Exact ${repository} main advancement transport failure ${operation.attempt}/${operation.max_attempts}: ${message}`,
+                  attempt: exhausted
+                    ? operation.attempt
+                    : operation.attempt + 1,
+                  completedAt: exhausted ? Date.now() : null
                 },
                 {}
               ))
@@ -2335,6 +2369,22 @@ export class ReleaseBusV2Reconciler {
               );
             throw error;
           }
+          if (
+            !(await this.repository.updateOperation(
+              operation.id,
+              operation.row_version,
+              {
+                status: 'FAILED',
+                failureClass: 'CONTROL_PLANE',
+                failureMessage: message,
+                completedAt: Date.now()
+              },
+              {}
+            ))
+          )
+            throw new Error(
+              `${repository} main operation changed concurrently`
+            );
           throw error;
         }
       }

--- a/src/releaseBusV2/release-bus-v2.reconciler.ts
+++ b/src/releaseBusV2/release-bus-v2.reconciler.ts
@@ -2815,7 +2815,86 @@ export class ReleaseBusV2Reconciler {
         continue;
       const train = await this.repository.findTrain(lock.owner_train_id, {});
       if (!train || !TERMINAL_TRAINS.has(train.status)) continue;
-      const operations = await this.repository.listOperations(train.id, {});
+      let operations = await this.repository.listOperations(train.id, {});
+      for (const operation of operations) {
+        if (
+          operation.status !== 'PENDING' ||
+          !['ADVANCE_MAIN_BACKEND', 'ADVANCE_MAIN_FRONTEND'].includes(
+            operation.operation_type
+          ) ||
+          !operation.repository ||
+          !operation.expected_sha
+        )
+          continue;
+        const base =
+          operation.repository === 'frontend'
+            ? train.frontend_base_sha
+            : train.backend_base_sha;
+        if (!base) continue;
+        let observedSha: string;
+        try {
+          observedSha = await releaseBusGitHubApp.resolveRef(
+            operation.repository,
+            'main'
+          );
+        } catch {
+          // A terminal cleanup may never guess at an ambiguous ref outcome.
+          // Retain the lock and retry the read on a later invocation.
+          continue;
+        }
+        const status =
+          observedSha === operation.expected_sha
+            ? ('SUCCEEDED' as const)
+            : observedSha === base
+              ? ('FAILED' as const)
+              : null;
+        if (!status) continue;
+        if (
+          await this.repository.updateOperation(
+            operation.id,
+            operation.row_version,
+            {
+              status,
+              externalId:
+                status === 'SUCCEEDED' ? operation.expected_sha : undefined,
+              result: {
+                base_sha: base,
+                deployed_sha:
+                  status === 'SUCCEEDED' ? operation.expected_sha : null,
+                observed_sha: observedSha,
+                reconciled_after_terminal_train: true
+              },
+              failureClass:
+                status === 'FAILED'
+                  ? (train.failure_class ?? 'CONTROL_PLANE')
+                  : null,
+              failureMessage:
+                status === 'FAILED'
+                  ? 'Terminal train retained main at its exact recorded base'
+                  : null,
+              completedAt: Date.now()
+            },
+            {}
+          )
+        )
+          await this.repository.appendEvent(
+            {
+              trainId: train.id,
+              eventType: 'TERMINAL_INTERNAL_REF_OPERATION_RECONCILED',
+              actor: 'release-bus-v2',
+              payload: {
+                operation_id: operation.id,
+                repository: operation.repository,
+                operation_status: status,
+                observed_sha: observedSha,
+                expected_base_sha: base,
+                expected_target_sha: operation.expected_sha
+              }
+            },
+            {}
+          );
+      }
+      operations = await this.repository.listOperations(train.id, {});
       if (
         operations.some(
           (operation) => !TERMINAL_OPERATIONS.has(operation.status)

--- a/src/releaseBusV2/release-bus-v2.reconciler.ts
+++ b/src/releaseBusV2/release-bus-v2.reconciler.ts
@@ -1706,8 +1706,7 @@ export class ReleaseBusV2Reconciler {
           train,
           deployed.failedOperation.failure_class ?? 'DEPLOYMENT',
           deployed.failedOperation.failure_message ??
-            'Staging deployment failed',
-          lease
+            'Staging deployment failed'
         );
         return;
       }
@@ -1738,8 +1737,7 @@ export class ReleaseBusV2Reconciler {
         await this.failTrain(
           train,
           e2e.failure_class ?? 'E2E',
-          e2e.failure_message ?? 'Staging E2E failed',
-          lease
+          e2e.failure_message ?? 'Staging E2E failed'
         );
         return;
       }
@@ -1762,8 +1760,7 @@ export class ReleaseBusV2Reconciler {
         await this.failTrain(
           train,
           e2e.failure_class ?? 'E2E',
-          e2e.failure_message ?? 'Staging E2E failed',
-          lease
+          e2e.failure_message ?? 'Staging E2E failed'
         );
         return;
       }
@@ -1890,8 +1887,7 @@ export class ReleaseBusV2Reconciler {
       await this.failTrain(
         train,
         'CONTROL_PLANE',
-        'Staging idle-handshake evidence is missing or malformed; successful E2E cannot be accepted without an end-to-end fence',
-        lease
+        'Staging idle-handshake evidence is missing or malformed; successful E2E cannot be accepted without an end-to-end fence'
       );
       return false;
     }
@@ -1932,8 +1928,7 @@ export class ReleaseBusV2Reconciler {
       await this.failTrain(
         train,
         'CONTROL_PLANE',
-        'Shared staging refs or deploy/E2E workflows changed after the idle handshake; successful E2E cannot validate a mixed environment',
-        lease
+        'Shared staging refs or deploy/E2E workflows changed after the idle handshake; successful E2E cannot validate a mixed environment'
       );
       return false;
     }
@@ -2156,8 +2151,7 @@ export class ReleaseBusV2Reconciler {
           train,
           deployed.failedOperation.failure_class ?? 'DEPLOYMENT',
           deployed.failedOperation.failure_message ??
-            'Production deployment failed',
-          lease
+            'Production deployment failed'
         );
         return;
       }
@@ -2167,8 +2161,7 @@ export class ReleaseBusV2Reconciler {
         await this.failTrain(
           train,
           e2e.failure_class ?? 'E2E',
-          e2e.failure_message ?? 'Production E2E failed',
-          lease
+          e2e.failure_message ?? 'Production E2E failed'
         );
         return;
       }
@@ -2301,9 +2294,51 @@ export class ReleaseBusV2Reconciler {
         : train.backend_composed_sha;
     if (!base || !composed)
       throw new Error(`Missing ${repository} release SHA`);
-    if (observedSha === base)
-      await releaseBusGitHubApp.updateRef(repository, 'main', base, composed);
-    else if (observedSha !== composed)
+    if (observedSha === base) {
+      try {
+        await releaseBusGitHubApp.updateRef(repository, 'main', base, composed);
+      } catch (error) {
+        // A ref update can fail after GitHub accepted it. Re-read the ref before
+        // deciding whether the durable operation is complete, retryable, or a
+        // terminal control-plane failure. This keeps exact main advancement
+        // idempotent and prevents a known-rejected update from leaving a
+        // permanently PENDING operation behind a terminal train lock.
+        const afterFailure = await releaseBusGitHubApp.resolveRef(
+          repository,
+          'main'
+        );
+        if (afterFailure !== composed) {
+          if (afterFailure !== base)
+            throw new MainMovedError(
+              `${repository} main moved from ${base} to ${afterFailure}`
+            );
+          if (!isGitHubInfrastructureError(error)) {
+            const message =
+              error instanceof Error
+                ? error.message
+                : `Failed to advance ${repository} main`;
+            if (
+              !(await this.repository.updateOperation(
+                operation.id,
+                operation.row_version,
+                {
+                  status: 'FAILED',
+                  failureClass: 'CONTROL_PLANE',
+                  failureMessage: message,
+                  completedAt: Date.now()
+                },
+                {}
+              ))
+            )
+              throw new Error(
+                `${repository} main operation changed concurrently`
+              );
+            throw error;
+          }
+          throw error;
+        }
+      }
+    } else if (observedSha !== composed)
       throw new MainMovedError(
         `${repository} main moved from ${base} to ${observedSha}`
       );
@@ -2815,8 +2850,7 @@ export class ReleaseBusV2Reconciler {
   private async failTrain(
     train: ReleaseBusV2TrainRecord,
     failureClass: ReleaseBusV2FailureClass,
-    message: string,
-    lease?: ReleaseBusV2LockRecord
+    message: string
   ): Promise<void> {
     const current = await this.repository.findTrain(train.id, {});
     if (!current || TERMINAL_TRAINS.has(current.status)) return;
@@ -2863,14 +2897,10 @@ export class ReleaseBusV2Reconciler {
           : 'Exact state is retained for idempotent diagnosis or retry',
       completedAt: Date.now()
     });
-    if (lease) {
-      await this.releaseEnvironmentLease(
-        current.lane === 'PRODUCTION'
-          ? 'production-environment'
-          : 'staging-environment',
-        lease
-      );
-    }
+    // Release ownership only after the train and every operation are terminal.
+    // If a mutation outcome is still ambiguous, the nonterminal operation
+    // deliberately retains the lease until reconciliation can prove its state.
+    await this.releaseTerminalEnvironmentLocks();
   }
 
   private async deferTrainForInfrastructure(


### PR DESCRIPTION
## What changed

- disambiguate exact `main` ref update failures before terminalizing the durable operation
- reconcile a pre-existing stranded internal ref operation from a read-only exact `main` check
- release environment ownership only after the failed train and every operation are terminal
- retain ownership when the ref outcome is ambiguous
- document the dedicated Release Bus App `always` ruleset-bypass invariant while keeping human/team bypass PR-only
- add offline acceptance coverage for rejected, recoverable, and ambiguous production ref outcomes

## Root cause

The production v2 fast path correctly reused the exact staging-validated manifest, but the dedicated GitHub App was configured for pull-request-only bypass. A direct non-force fast-forward was rejected, and the synchronous ref operation remained `PENDING`, retaining the terminal train lock.

## Validation

- 40/40 focused Release Bus v2 tests passed
- targeted ESLint passed
- Prettier passed
- `git diff --check` passed

No application release notes should be generated for this internal operational change.