### PR TITLE
fix(release-bus-v2): retain retried fence runs

### DIFF
--- a/src/releaseBusV2/release-bus-v2.acceptance.test.ts
+++ b/src/releaseBusV2/release-bus-v2.acceptance.test.ts
@@ -6,6 +6,7 @@ const mockUpdateRef = jest.fn();
 const mockHasActiveStagingRun = jest.fn();
 const mockHasStagingRunSince = jest.fn();
 const mockHasActiveProductionRun = jest.fn();
+const mockFindWorkflowRun = jest.fn();
 
 jest.mock('@/releaseBusV2/release-bus-v2.operations', () => ({
   releaseBusV2Operations: {
@@ -24,7 +25,8 @@ jest.mock('@/releaseBus/release-bus.github-app', () => ({
     hasStagingMutationOrE2ERunSince: (...args: unknown[]) =>
       mockHasStagingRunSince(...args),
     hasActiveProductionMutationOrE2ERun: (...args: unknown[]) =>
-      mockHasActiveProductionRun(...args)
+      mockHasActiveProductionRun(...args),
+    findWorkflowRun: (...args: unknown[]) => mockFindWorkflowRun(...args)
   }
 }));
 
@@ -616,6 +618,7 @@ describe('Release Bus v2 offline acceptance harness', () => {
     mockHasActiveStagingRun.mockResolvedValue(false);
     mockHasStagingRunSince.mockResolvedValue(false);
     mockHasActiveProductionRun.mockResolvedValue(false);
+    mockFindWorkflowRun.mockResolvedValue(null);
     mockResolveRefIfExists.mockImplementation(
       async (repository: 'frontend' | 'backend') =>
         repository === 'frontend' ? FRONTEND_SHA : BACKEND_SHA
@@ -1423,6 +1426,58 @@ describe('Release Bus v2 offline acceptance harness', () => {
     expect(mockReconcileWorkflow).toHaveBeenCalledTimes(externalCalls);
   });
 
+  it('ignores every exact retried workflow attempt in the final staging fence', async () => {
+    const state = harness('SUCCEEDED');
+    mockFindWorkflowRun.mockResolvedValue({ id: 101 });
+    mockReconcileWorkflow.mockImplementation(async (spec) => {
+      const typed = spec as {
+        operationType: string;
+        service: string | null;
+      };
+      const repository =
+        typed.operationType.includes('FRONTEND') ||
+        typed.operationType === 'E2E_STAGING'
+          ? 'frontend'
+          : 'backend';
+      const completed = operation(
+        'train-1',
+        typed.operationType,
+        repository,
+        typed.operationType === 'E2E_STAGING'
+          ? '202'
+          : `run-${typed.service ?? typed.operationType}`,
+        typed.service
+      );
+      const retried =
+        typed.operationType === 'E2E_STAGING'
+          ? {
+              ...completed,
+              idempotency_key: 'rb2:train-1:e2e:staging',
+              attempt: 2,
+              max_attempts: 2,
+              request_json: { workflow: 'staging-e2e.yml' }
+            }
+          : completed;
+      state.repository.operations.push(retried);
+      return retried;
+    });
+
+    await state.reconciler.runOnce('acceptance-retried-final-fence');
+
+    expect(state.repository.trains.get('train-1')?.status).toBe(
+      'STAGING_VALIDATED'
+    );
+    expect(mockFindWorkflowRun).toHaveBeenCalledWith(
+      'frontend',
+      'staging-e2e.yml',
+      'rb2:train-1:e2e:staging:a1'
+    );
+    expect(mockHasStagingRunSince).toHaveBeenCalledTimes(2);
+    for (const [, , ignoredRunIds] of mockHasStagingRunSince.mock.calls) {
+      expect(ignoredRunIds).toEqual(expect.arrayContaining(['101', '202']));
+    }
+  });
+
   it('fails closed when an unrelated staging workflow ran after the beta handshake', async () => {
     const state = harness('SUCCEEDED');
     process.env.RELEASE_BUS_V2_MODE = 'OFF';
@@ -1483,15 +1538,15 @@ describe('Release Bus v2 offline acceptance harness', () => {
         trainId: 'train-1'
       })
     );
-    const expectedRunIds = state.repository.operations
-      .map(({ external_id }) => external_id)
-      .filter((runId): runId is string => runId !== null);
+    const expectedRunIds = new Set(
+      state.repository.operations
+        .map(({ external_id }) => external_id)
+        .filter((runId): runId is string => runId !== null)
+    );
     expect(mockHasStagingRunSince).toHaveBeenCalledTimes(2);
     for (const [, , ignoredRunIds] of mockHasStagingRunSince.mock.calls) {
-      expect(ignoredRunIds).toHaveLength(expectedRunIds.length);
-      expect(new Set(ignoredRunIds as string[])).toEqual(
-        new Set(expectedRunIds)
-      );
+      expect(ignoredRunIds).toHaveLength(expectedRunIds.size);
+      expect(new Set(ignoredRunIds as string[])).toEqual(expectedRunIds);
     }
   });
 

--- a/src/releaseBusV2/release-bus-v2.reconciler.ts
+++ b/src/releaseBusV2/release-bus-v2.reconciler.ts
@@ -1891,9 +1891,7 @@ export class ReleaseBusV2Reconciler {
       );
       return false;
     }
-    const operationRunIds = (await this.repository.listOperations(train.id, {}))
-      .map(({ external_id }) => external_id)
-      .filter((runId): runId is string => runId !== null);
+    const operationRunIds = await this.stagingFenceRunIds(train.id);
     const currentSnapshot = await this.captureStagingIdleSnapshot({
       since: handshake.workflow_fence_started_at,
       ignoredRunIds: operationRunIds
@@ -1948,6 +1946,53 @@ export class ReleaseBusV2Reconciler {
       {}
     );
     return true;
+  }
+
+  /**
+   * Operation rows retain the current attempt so reconciliation stays exactly
+   * idempotent, but an infrastructure retry replaces external_id with the new
+   * run. Recover every earlier exact attempt from its immutable operation key
+   * before evaluating the final shared-state fence. If GitHub can no longer
+   * prove an earlier attempt, the ordinary workflow scan still sees it and the
+   * fence fails closed.
+   */
+  private async stagingFenceRunIds(trainId: string): Promise<string[]> {
+    const operations = await this.repository.listOperations(trainId, {});
+    const runIds = new Set(
+      operations
+        .map(({ external_id }) => external_id)
+        .filter((runId): runId is string => runId !== null)
+    );
+    const previousAttempts = operations.flatMap((operation) => {
+      if (operation.attempt <= 1 || operation.repository === null) return [];
+      const request = parseStoredJson<{ workflow?: unknown }>(
+        operation.request_json
+      );
+      if (typeof request?.workflow !== 'string' || !request.workflow)
+        throw new Error(
+          `Retried operation ${operation.id} has no immutable workflow identity`
+        );
+      return Array.from({ length: operation.attempt - 1 }, (_, index) => ({
+        operation,
+        attempt: index + 1,
+        workflow: request.workflow as string
+      }));
+    });
+    const discovered = await Promise.all(
+      previousAttempts.map(({ operation, attempt, workflow }) =>
+        releaseBusGitHubApp.findWorkflowRun(
+          operation.repository!,
+          workflow,
+          `${operation.idempotency_key}:a${attempt}`
+        )
+      )
+    );
+    for (const run of discovered) {
+      if (run) runIds.add(String(run.id));
+    }
+    return Array.from(runIds).sort((left, right) =>
+      left.localeCompare(right, 'en')
+    );
   }
 
   private async findStagingIdleHandshake(


### PR DESCRIPTION
Fix the final staging fence so infrastructure retries preserve every exact workflow attempt run ID.

The fence reconstructs prior attempts from immutable operation keys and still fails closed if GitHub cannot prove one.

Focused validation: 45/45 v2 acceptance/reconciler tests, Prettier, targeted ESLint, diff check.

Release-note impact: none; internal Release Bus operational change.

Supersedes #1820 solely to add the required DCO trailer without force-pushing.