### PR TITLE
fix(release-bus-v2): preserve claimed candidates

### DIFF
--- a/src/releaseBusV2/release-bus-v2.acceptance.test.ts
+++ b/src/releaseBusV2/release-bus-v2.acceptance.test.ts
@@ -2,6 +2,7 @@ const mockReconcileWorkflow = jest.fn();
 const mockEnsureCommitStatus = jest.fn();
 const mockResolveRef = jest.fn();
 const mockResolveRefIfExists = jest.fn();
+const mockRefContainsCommit = jest.fn();
 const mockUpdateRef = jest.fn();
 const mockHasActiveStagingRun = jest.fn();
 const mockHasStagingRunSince = jest.fn();
@@ -19,6 +20,7 @@ jest.mock('@/releaseBus/release-bus.github-app', () => ({
     ensureCommitStatus: (...args: unknown[]) => mockEnsureCommitStatus(...args),
     resolveRef: (...args: unknown[]) => mockResolveRef(...args),
     resolveRefIfExists: (...args: unknown[]) => mockResolveRefIfExists(...args),
+    refContainsCommit: (...args: unknown[]) => mockRefContainsCommit(...args),
     updateRef: (...args: unknown[]) => mockUpdateRef(...args),
     hasActiveStagingMutationOrE2ERun: (...args: unknown[]) =>
       mockHasActiveStagingRun(...args),
@@ -594,6 +596,9 @@ function harness(e2eStatus: 'RUNNING' | 'SUCCEEDED' | 'FAILED') {
       }
     ),
     invalidateBranch: jest.fn(async () => undefined),
+    restoreProductionReadinessAfterBranchCleanup: jest.fn(
+      async () => undefined
+    ),
     isBetaTrainAllowed: jest.fn(async () => true)
   };
   return {
@@ -626,6 +631,7 @@ describe('Release Bus v2 offline acceptance harness', () => {
     mockResolveRef.mockImplementation(async (repository: string) =>
       repository === 'frontend' ? FRONTEND_SHA : BACKEND_SHA
     );
+    mockRefContainsCommit.mockResolvedValue(false);
   });
 
   it('does not claim or advance any durable work while mode is OFF', async () => {
@@ -917,6 +923,104 @@ describe('Release Bus v2 offline acceptance harness', () => {
       FRONTEND_SHA,
       BACKEND_SHA,
       'acceptance-staging-production-beta:production'
+    );
+  });
+
+  it('repairs an allowlisted production candidate after its exact merged branch is deleted', async () => {
+    const state = harness('SUCCEEDED');
+    const candidateId = '11111111-1111-4111-8111-111111111111';
+    process.env.RELEASE_BUS_V2_MODE = 'STAGING';
+    process.env.RELEASE_BUS_V2_BETA_ALLOWLIST = JSON.stringify([
+      {
+        test_id: 'production-branch-cleanup',
+        candidate_id: candidateId,
+        repository: 'frontend',
+        branch_name: 'agent/rb2-production-branch-cleanup',
+        operator: 'beta-operator',
+        lanes: ['PRODUCTION']
+      }
+    ]);
+    state.repository.trains.set(
+      'train-1',
+      train('train-1', { status: 'CANCELLED', completed_at: 2 })
+    );
+    const merged = {
+      ...candidate(candidateId, 'frontend', null),
+      branch_name: 'agent/rb2-production-branch-cleanup',
+      requested_by: 'beta-operator',
+      status: 'SUPERSEDED' as const,
+      current_train_id: null,
+      staging_validated_manifest_id: 'manifest-1',
+      production_requested_at: 2,
+      production_requested_by: 'beta-operator',
+      superseded_at: 3
+    };
+    state.repository.candidates.set(candidateId, merged);
+    mockResolveRefIfExists.mockImplementation(async (_repository, branch) =>
+      branch === merged.branch_name ? null : FRONTEND_SHA
+    );
+    mockRefContainsCommit.mockResolvedValue(true);
+
+    await state.reconciler.runOnce('acceptance-branch-cleanup');
+
+    expect(mockRefContainsCommit).toHaveBeenCalledWith(
+      'frontend',
+      'main',
+      merged.head_sha
+    );
+    expect(
+      state.service.restoreProductionReadinessAfterBranchCleanup
+    ).toHaveBeenCalledWith(candidateId, 'release-bus-v2-reconciler');
+    expect(state.service.invalidateBranch).not.toHaveBeenCalledWith(
+      'frontend',
+      merged.branch_name,
+      'deleted',
+      expect.any(String)
+    );
+  });
+
+  it('still supersedes an explicit production candidate when its branch moves', async () => {
+    const state = harness('SUCCEEDED');
+    const candidateId = '11111111-1111-4111-8111-111111111111';
+    process.env.RELEASE_BUS_V2_MODE = 'STAGING';
+    process.env.RELEASE_BUS_V2_BETA_ALLOWLIST = JSON.stringify([
+      {
+        test_id: 'production-branch-move',
+        candidate_id: candidateId,
+        repository: 'frontend',
+        branch_name: 'agent/rb2-production-branch-move',
+        operator: 'beta-operator',
+        lanes: ['PRODUCTION']
+      }
+    ]);
+    state.repository.trains.set(
+      'train-1',
+      train('train-1', { status: 'CANCELLED', completed_at: 2 })
+    );
+    const ready = {
+      ...candidate(candidateId, 'frontend', null),
+      branch_name: 'agent/rb2-production-branch-move',
+      requested_by: 'beta-operator',
+      status: 'READY_FOR_PRODUCTION' as const,
+      current_train_id: null,
+      staging_validated_manifest_id: 'manifest-1',
+      production_requested_at: 2,
+      production_requested_by: 'beta-operator'
+    };
+    state.repository.candidates.set(candidateId, ready);
+    const movedHead = '9'.repeat(40);
+    mockResolveRefIfExists.mockImplementation(async (_repository, branch) =>
+      branch === ready.branch_name ? movedHead : FRONTEND_SHA
+    );
+
+    await state.reconciler.runOnce('acceptance-branch-move');
+
+    expect(mockRefContainsCommit).not.toHaveBeenCalled();
+    expect(state.service.invalidateBranch).toHaveBeenCalledWith(
+      'frontend',
+      ready.branch_name,
+      movedHead,
+      'release-bus-v2-reconciler'
     );
   });
 

--- a/src/releaseBusV2/release-bus-v2.reconciler.test.ts
+++ b/src/releaseBusV2/release-bus-v2.reconciler.test.ts
@@ -6,6 +6,7 @@ import {
   candidateUnavailableForTrainUpdate,
   candidateExclusionClosure,
   dagLayers,
+  e2eWorkflowInputs,
   releaseBusV2Branch
 } from '@/releaseBusV2/release-bus-v2.reconciler';
 import {
@@ -46,6 +47,31 @@ function candidate(
 }
 
 describe('Release Bus v2 deterministic orchestration', () => {
+  it('sends only workflow-supported inputs to each E2E environment', () => {
+    const fields = {
+      release_train_id: 'train-1',
+      release_train_revision: '1',
+      operation_key: 'replaced-by-reconciler',
+      staging_source_ref: 'release-bus-v2/train-1/frontend',
+      expected_sha: 'a'.repeat(40),
+      release_manifest_id: 'manifest-1',
+      release_manifest_identity_sha256: 'b'.repeat(64),
+      frontend_sha: 'a'.repeat(40),
+      backend_sha: 'c'.repeat(40),
+      frontend_artifact_digest: 'd'.repeat(64),
+      backend_artifact_digest: 'e'.repeat(64)
+    };
+
+    expect(e2eWorkflowInputs('staging', fields)).toMatchObject({
+      pack: 'all',
+      source_ref: 'release-bus-v2/train-1/frontend'
+    });
+    expect(e2eWorkflowInputs('prod', fields)).toEqual(
+      expect.objectContaining({ source_ref: 'main' })
+    );
+    expect(e2eWorkflowInputs('prod', fields)).not.toHaveProperty('pack');
+  });
+
   it('keeps an immutable active membership authoritative over stale superseded bookkeeping', () => {
     const claimed = {
       ...candidate('claimed', 'a'.repeat(40)),

--- a/src/releaseBusV2/release-bus-v2.reconciler.test.ts
+++ b/src/releaseBusV2/release-bus-v2.reconciler.test.ts
@@ -4,7 +4,7 @@ import {
   backendReleaseNoteGroups,
   canUseSingleCandidateFastPath,
   candidateUnavailableForTrainUpdate,
-  deletedMergedProductionCandidateCanRetainReadiness,
+  deletedProductionCandidateCanRetainReadiness,
   candidateExclusionClosure,
   dagLayers,
   e2eWorkflowInputs,
@@ -106,23 +106,18 @@ describe('Release Bus v2 deterministic orchestration', () => {
       production_requested_at: 2,
       production_requested_by: 'owner'
     };
+    expect(deletedProductionCandidateCanRetainReadiness(ready)).toBe(true);
     expect(
-      deletedMergedProductionCandidateCanRetainReadiness(ready, true)
-    ).toBe(true);
-    expect(
-      deletedMergedProductionCandidateCanRetainReadiness(ready, false)
+      deletedProductionCandidateCanRetainReadiness({
+        ...ready,
+        current_train_id: 'active-train'
+      })
     ).toBe(false);
     expect(
-      deletedMergedProductionCandidateCanRetainReadiness(
-        { ...ready, current_train_id: 'active-train' },
-        true
-      )
-    ).toBe(false);
-    expect(
-      deletedMergedProductionCandidateCanRetainReadiness(
-        { ...ready, staging_validated_manifest_id: null },
-        true
-      )
+      deletedProductionCandidateCanRetainReadiness({
+        ...ready,
+        staging_validated_manifest_id: null
+      })
     ).toBe(false);
   });
 

--- a/src/releaseBusV2/release-bus-v2.reconciler.test.ts
+++ b/src/releaseBusV2/release-bus-v2.reconciler.test.ts
@@ -3,6 +3,7 @@ import {
   backendReleaseNoteInputs,
   backendReleaseNoteGroups,
   canUseSingleCandidateFastPath,
+  candidateUnavailableForTrainUpdate,
   candidateExclusionClosure,
   dagLayers,
   releaseBusV2Branch
@@ -45,6 +46,31 @@ function candidate(
 }
 
 describe('Release Bus v2 deterministic orchestration', () => {
+  it('keeps an immutable active membership authoritative over stale superseded bookkeeping', () => {
+    const claimed = {
+      ...candidate('claimed', 'a'.repeat(40)),
+      status: 'PRODUCTION_DEPLOYING' as const,
+      current_train_id: 'train-1'
+    };
+    expect(
+      candidateUnavailableForTrainUpdate(
+        { ...claimed, status: 'SUPERSEDED', superseded_at: 2 },
+        claimed
+      )
+    ).toBe(false);
+    expect(
+      candidateUnavailableForTrainUpdate(
+        {
+          ...claimed,
+          status: 'SUPERSEDED',
+          current_train_id: null,
+          superseded_at: 2
+        },
+        claimed
+      )
+    ).toBe(true);
+  });
+
   it('orders backend DAG frontiers while preserving independent concurrency', () => {
     expect(
       dagLayers(

--- a/src/releaseBusV2/release-bus-v2.reconciler.test.ts
+++ b/src/releaseBusV2/release-bus-v2.reconciler.test.ts
@@ -4,6 +4,7 @@ import {
   backendReleaseNoteGroups,
   canUseSingleCandidateFastPath,
   candidateUnavailableForTrainUpdate,
+  deletedMergedProductionCandidateCanRetainReadiness,
   candidateExclusionClosure,
   dagLayers,
   e2eWorkflowInputs,
@@ -95,6 +96,34 @@ describe('Release Bus v2 deterministic orchestration', () => {
         claimed
       )
     ).toBe(true);
+  });
+
+  it('retains explicit production readiness only for a deleted exact head already on main', () => {
+    const ready = {
+      ...candidate('production-ready', 'a'.repeat(40)),
+      status: 'READY_FOR_PRODUCTION' as const,
+      staging_validated_manifest_id: 'manifest-1',
+      production_requested_at: 2,
+      production_requested_by: 'owner'
+    };
+    expect(
+      deletedMergedProductionCandidateCanRetainReadiness(ready, true)
+    ).toBe(true);
+    expect(
+      deletedMergedProductionCandidateCanRetainReadiness(ready, false)
+    ).toBe(false);
+    expect(
+      deletedMergedProductionCandidateCanRetainReadiness(
+        { ...ready, current_train_id: 'active-train' },
+        true
+      )
+    ).toBe(false);
+    expect(
+      deletedMergedProductionCandidateCanRetainReadiness(
+        { ...ready, staging_validated_manifest_id: null },
+        true
+      )
+    ).toBe(false);
   });
 
   it('orders backend DAG frontiers while preserving independent concurrency', () => {

--- a/src/releaseBusV2/release-bus-v2.reconciler.ts
+++ b/src/releaseBusV2/release-bus-v2.reconciler.ts
@@ -463,12 +463,10 @@ export function candidateUnavailableForTrainUpdate(
   );
 }
 
-export function deletedMergedProductionCandidateCanRetainReadiness(
-  candidate: ReleaseBusV2CandidateRecord,
-  exactHeadIsOnMain: boolean
+export function deletedProductionCandidateCanRetainReadiness(
+  candidate: ReleaseBusV2CandidateRecord
 ): boolean {
   return (
-    exactHeadIsOnMain &&
     candidate.current_train_id === null &&
     candidate.production_requested_at !== null &&
     candidate.staging_validated_manifest_id !== null &&
@@ -741,7 +739,7 @@ export class ReleaseBusV2Reconciler {
       if (currentHead === candidate.head_sha) continue;
       if (
         currentHead === null &&
-        deletedMergedProductionCandidateCanRetainReadiness(candidate, true) &&
+        deletedProductionCandidateCanRetainReadiness(candidate) &&
         (await releaseBusGitHubApp.refContainsCommit(
           candidate.repository,
           'main',

--- a/src/releaseBusV2/release-bus-v2.reconciler.ts
+++ b/src/releaseBusV2/release-bus-v2.reconciler.ts
@@ -451,6 +451,18 @@ function relevantCandidates(
   );
 }
 
+export function candidateUnavailableForTrainUpdate(
+  current: ReleaseBusV2CandidateRecord,
+  claimed: ReleaseBusV2CandidateRecord
+): boolean {
+  if (current.status === 'CANCELLED') return true;
+  return (
+    current.status === 'SUPERSEDED' &&
+    (!claimed.current_train_id ||
+      current.current_train_id !== claimed.current_train_id)
+  );
+}
+
 function frontendDependsOnBackend(context: TrainContext): boolean {
   const included = new Set(relevantCandidates(context).map(({ id }) => id));
   const backend = new Set(
@@ -2185,6 +2197,15 @@ export class ReleaseBusV2Reconciler {
       return;
     }
     if (train.status === 'PRODUCTION_DEPLOYING') {
+      // A merge can delete the source branch and race the push webhook. Keep
+      // the immutable, already-claimed membership authoritative and repair any
+      // stale superseded bookkeeping before reconciling its deployments.
+      await this.updateCandidateStatuses(
+        relevantCandidates(context),
+        'PRODUCTION_DEPLOYING',
+        train.id,
+        false
+      );
       const sourceTrainId = await this.artifactSourceTrainId(train);
       const deployed = await this.reconcileDeployments(
         context,
@@ -2811,7 +2832,7 @@ export class ReleaseBusV2Reconciler {
       const current = await this.repository.findCandidateById(candidate.id, {});
       if (
         !current ||
-        ['SUPERSEDED', 'CANCELLED'].includes(current.status) ||
+        candidateUnavailableForTrainUpdate(current, candidate) ||
         (current.status === status &&
           current.current_train_id === currentTrainId &&
           current.hold_reason === null)

--- a/src/releaseBusV2/release-bus-v2.reconciler.ts
+++ b/src/releaseBusV2/release-bus-v2.reconciler.ts
@@ -463,6 +463,19 @@ export function candidateUnavailableForTrainUpdate(
   );
 }
 
+export function deletedMergedProductionCandidateCanRetainReadiness(
+  candidate: ReleaseBusV2CandidateRecord,
+  exactHeadIsOnMain: boolean
+): boolean {
+  return (
+    exactHeadIsOnMain &&
+    candidate.current_train_id === null &&
+    candidate.production_requested_at !== null &&
+    candidate.staging_validated_manifest_id !== null &&
+    ['READY_FOR_PRODUCTION', 'SUPERSEDED'].includes(candidate.status)
+  );
+}
+
 type E2EWorkflowInputFields = {
   readonly release_train_id: string;
   readonly release_train_revision: string;
@@ -682,23 +695,39 @@ export class ReleaseBusV2Reconciler {
   ): Promise<void> {
     const candidates = (
       await this.repository.listCandidates(
-        ['READY_FOR_STAGING', 'WAITING_FOR_DEPENDENCY', 'READY_FOR_PRODUCTION'],
+        [
+          'READY_FOR_STAGING',
+          'WAITING_FOR_DEPENDENCY',
+          'READY_FOR_PRODUCTION',
+          'SUPERSEDED'
+        ],
         500,
         {}
       )
-    ).filter((candidate) => {
-      const lane =
-        candidate.status === 'READY_FOR_PRODUCTION' ? 'PRODUCTION' : 'STAGING';
-      if (mode === 'STAGING') {
-        if (lane === 'STAGING') return true;
-        return (
-          betaAllowlist.length > 0 &&
-          releaseBusV2BetaAllowsCandidate(betaAllowlist, candidate, lane)
-        );
-      }
-      if (betaAllowlist.length === 0) return true;
-      return releaseBusV2BetaAllowsCandidate(betaAllowlist, candidate, lane);
-    });
+    )
+      .filter(
+        (candidate) =>
+          candidate.status !== 'SUPERSEDED' ||
+          (candidate.current_train_id === null &&
+            candidate.production_requested_at !== null &&
+            candidate.staging_validated_manifest_id !== null)
+      )
+      .filter((candidate) => {
+        const lane =
+          candidate.status === 'READY_FOR_PRODUCTION' ||
+          candidate.status === 'SUPERSEDED'
+            ? 'PRODUCTION'
+            : 'STAGING';
+        if (mode === 'STAGING') {
+          if (lane === 'STAGING') return true;
+          return (
+            betaAllowlist.length > 0 &&
+            releaseBusV2BetaAllowsCandidate(betaAllowlist, candidate, lane)
+          );
+        }
+        if (betaAllowlist.length === 0) return true;
+        return releaseBusV2BetaAllowsCandidate(betaAllowlist, candidate, lane);
+      });
     const branchHeads = await Promise.all(
       candidates.map(async (candidate) => ({
         candidate,
@@ -710,6 +739,23 @@ export class ReleaseBusV2Reconciler {
     );
     for (const { candidate, currentHead } of branchHeads) {
       if (currentHead === candidate.head_sha) continue;
+      if (
+        currentHead === null &&
+        deletedMergedProductionCandidateCanRetainReadiness(candidate, true) &&
+        (await releaseBusGitHubApp.refContainsCommit(
+          candidate.repository,
+          'main',
+          candidate.head_sha
+        ))
+      ) {
+        if (candidate.status === 'SUPERSEDED')
+          await this.service.restoreProductionReadinessAfterBranchCleanup(
+            candidate.id,
+            'release-bus-v2-reconciler'
+          );
+        continue;
+      }
+      if (candidate.status === 'SUPERSEDED') continue;
       await this.service.invalidateBranch(
         candidate.repository,
         candidate.branch_name,

--- a/src/releaseBusV2/release-bus-v2.reconciler.ts
+++ b/src/releaseBusV2/release-bus-v2.reconciler.ts
@@ -2800,7 +2800,7 @@ export class ReleaseBusV2Reconciler {
     if (!manifestId) throw new Error('Staging validation has no manifest');
     for (const candidate of relevantCandidates(context)) {
       const current = await this.repository.findCandidateById(candidate.id, {});
-      if (!current || ['SUPERSEDED', 'CANCELLED'].includes(current.status))
+      if (!current || candidateUnavailableForTrainUpdate(current, candidate))
         continue;
       await this.repository.updateCandidate(
         current.id,
@@ -2810,7 +2810,8 @@ export class ReleaseBusV2Reconciler {
           currentTrainId: null,
           stagingValidatedTrainId: context.train.id,
           stagingValidatedManifestId: manifestId,
-          holdReason: null
+          holdReason: null,
+          supersededAt: current.status === 'SUPERSEDED' ? null : undefined
         },
         {}
       );
@@ -2841,7 +2842,12 @@ export class ReleaseBusV2Reconciler {
       await this.repository.updateCandidate(
         current.id,
         current.row_version,
-        { status, currentTrainId, holdReason: null },
+        {
+          status,
+          currentTrainId,
+          holdReason: null,
+          supersededAt: current.status === 'SUPERSEDED' ? null : undefined
+        },
         {}
       );
     }

--- a/src/releaseBusV2/release-bus-v2.reconciler.ts
+++ b/src/releaseBusV2/release-bus-v2.reconciler.ts
@@ -463,6 +463,32 @@ export function candidateUnavailableForTrainUpdate(
   );
 }
 
+type E2EWorkflowInputFields = {
+  readonly release_train_id: string;
+  readonly release_train_revision: string;
+  readonly operation_key: string;
+  readonly staging_source_ref: string;
+  readonly expected_sha: string;
+  readonly release_manifest_id: string;
+  readonly release_manifest_identity_sha256: string;
+  readonly frontend_sha: string;
+  readonly backend_sha: string;
+  readonly frontend_artifact_digest: string;
+  readonly backend_artifact_digest: string;
+};
+
+export function e2eWorkflowInputs(
+  environment: 'staging' | 'prod',
+  fields: E2EWorkflowInputFields
+): Record<string, string> {
+  const { staging_source_ref: stagingSourceRef, ...shared } = fields;
+  return {
+    ...(environment === 'staging' ? { pack: 'all' } : {}),
+    ...shared,
+    source_ref: environment === 'staging' ? stagingSourceRef : 'main'
+  };
+}
+
 function frontendDependsOnBackend(context: TrainContext): boolean {
   const included = new Set(relevantCandidates(context).map(({ id }) => id));
   const backend = new Set(
@@ -2672,12 +2698,11 @@ export class ReleaseBusV2Reconciler {
       service: null,
       expectedSha,
       artifactDigest: manifest.identity_sha256,
-      inputs: {
-        pack: 'all',
+      inputs: e2eWorkflowInputs(environment, {
         release_train_id: train.id,
         release_train_revision: '1',
         operation_key: 'replaced-by-reconciler',
-        source_ref: relevantCandidates(context, 'frontend').length
+        staging_source_ref: relevantCandidates(context, 'frontend').length
           ? releaseBusV2Branch(train, 'frontend')
           : 'main',
         expected_sha: expectedSha,
@@ -2687,7 +2712,7 @@ export class ReleaseBusV2Reconciler {
         backend_sha: manifest.backend_sha ?? '',
         frontend_artifact_digest: manifest.frontend_artifact_digest ?? '',
         backend_artifact_digest: manifest.backend_artifact_digest ?? ''
-      },
+      }),
       maxAttempts: 2
     };
     return releaseBusV2Operations.reconcileWorkflow(spec);

--- a/src/releaseBusV2/release-bus-v2.repository.integration.test.ts
+++ b/src/releaseBusV2/release-bus-v2.repository.integration.test.ts
@@ -200,6 +200,56 @@ describeWithSeed(
       );
     });
 
+    it('clears stale supersession bookkeeping when an active train repairs its candidate', async () => {
+      const claimed = await repository.createCandidate(
+        {
+          repository: 'backend',
+          prNumber: 113,
+          branchName: 'feature/repair-active-candidate',
+          headSha: SHA_A,
+          requestedBy: 'integration',
+          deployPlan: { units: ['api'], edges: [] },
+          prEvidence: null
+        },
+        {}
+      );
+      const service = new ReleaseBusV2Service(repository);
+      const train = await service.claimLane(
+        'STAGING',
+        SHA_B,
+        SHA_B,
+        'claim-before-repair'
+      );
+      const active = await repository.findCandidateById(claimed.id, {});
+      expect(active).not.toBeNull();
+      await repository.updateCandidate(
+        claimed.id,
+        active!.row_version,
+        { status: 'SUPERSEDED', supersededAt: 2 },
+        {}
+      );
+      const stale = await repository.findCandidateById(claimed.id, {});
+      expect(stale).not.toBeNull();
+      await repository.updateCandidate(
+        claimed.id,
+        stale!.row_version,
+        {
+          status: 'STAGING_IN_TRAIN',
+          currentTrainId: train!.id,
+          supersededAt: null
+        },
+        {}
+      );
+
+      expect(await repository.findCandidateById(claimed.id, {})).toEqual(
+        expect.objectContaining({
+          status: 'STAGING_IN_TRAIN',
+          current_train_id: train?.id,
+          superseded_at: null
+        })
+      );
+    });
+
     it('claims only explicitly production-ready candidates', async () => {
       process.env.RELEASE_BUS_V2_MODE = 'PRODUCTION';
       const explicit = await repository.createCandidate(

--- a/src/releaseBusV2/release-bus-v2.repository.integration.test.ts
+++ b/src/releaseBusV2/release-bus-v2.repository.integration.test.ts
@@ -153,6 +153,53 @@ describeWithSeed(
       ).toBe('SUPERSEDED');
     });
 
+    it('does not supersede an immutable candidate after a train claims it', async () => {
+      const claimed = await repository.createCandidate(
+        {
+          repository: 'frontend',
+          prNumber: 112,
+          branchName: 'feature/deleted-after-merge',
+          headSha: SHA_A,
+          requestedBy: 'integration',
+          deployPlan: null,
+          prEvidence: null
+        },
+        {}
+      );
+      const service = new ReleaseBusV2Service(repository);
+      const train = await service.claimLane(
+        'STAGING',
+        SHA_B,
+        SHA_B,
+        'claim-before-branch-deletion'
+      );
+
+      expect(train).not.toBeNull();
+      await expect(
+        repository.supersedeMovedBranchHeads(
+          'frontend',
+          claimed.branch_name,
+          'deleted',
+          {}
+        )
+      ).resolves.toEqual([]);
+      await expect(
+        repository.supersedeOtherPrHeads(
+          'frontend',
+          claimed.pr_number,
+          SHA_B,
+          {}
+        )
+      ).resolves.toEqual([]);
+      expect(await repository.findCandidateById(claimed.id, {})).toEqual(
+        expect.objectContaining({
+          status: 'STAGING_IN_TRAIN',
+          current_train_id: train?.id,
+          superseded_at: null
+        })
+      );
+    });
+
     it('claims only explicitly production-ready candidates', async () => {
       process.env.RELEASE_BUS_V2_MODE = 'PRODUCTION';
       const explicit = await repository.createCandidate(

--- a/src/releaseBusV2/release-bus-v2.repository.integration.test.ts
+++ b/src/releaseBusV2/release-bus-v2.repository.integration.test.ts
@@ -282,6 +282,14 @@ describeWithSeed(
         'deleted',
         'reconciler'
       );
+      await repository.appendEvent(
+        {
+          candidateId: registered.id,
+          eventType: 'CANDIDATE_STATUS_OBSERVED_AFTER_SUPERSESSION',
+          actor: 'integration'
+        },
+        {}
+      );
 
       await expect(
         service.restoreProductionReadinessAfterBranchCleanup(

--- a/src/releaseBusV2/release-bus-v2.repository.integration.test.ts
+++ b/src/releaseBusV2/release-bus-v2.repository.integration.test.ts
@@ -250,6 +250,55 @@ describeWithSeed(
       );
     });
 
+    it('restores exact production readiness after a merged source branch is cleaned up', async () => {
+      const registered = await repository.createCandidate(
+        {
+          repository: 'frontend',
+          prNumber: 114,
+          branchName: 'feature/merged-production-cleanup',
+          headSha: SHA_A,
+          requestedBy: 'integration',
+          deployPlan: null,
+          prEvidence: null
+        },
+        {}
+      );
+      await repository.updateCandidate(
+        registered.id,
+        registered.row_version,
+        {
+          status: 'READY_FOR_PRODUCTION',
+          stagingValidatedTrainId: 'staging-train',
+          stagingValidatedManifestId: 'staging-manifest',
+          productionRequestedAt: 2,
+          productionRequestedBy: 'owner'
+        },
+        {}
+      );
+      const service = new ReleaseBusV2Service(repository);
+      await service.invalidateBranch(
+        registered.repository,
+        registered.branch_name,
+        'deleted',
+        'reconciler'
+      );
+
+      await expect(
+        service.restoreProductionReadinessAfterBranchCleanup(
+          registered.id,
+          'reconciler'
+        )
+      ).resolves.toEqual(
+        expect.objectContaining({
+          status: 'READY_FOR_PRODUCTION',
+          current_train_id: null,
+          superseded_at: null,
+          staging_validated_manifest_id: 'staging-manifest',
+          production_requested_at: 2
+        })
+      );
+    });
+
     it('claims only explicitly production-ready candidates', async () => {
       process.env.RELEASE_BUS_V2_MODE = 'PRODUCTION';
       const explicit = await repository.createCandidate(

--- a/src/releaseBusV2/release-bus-v2.repository.ts
+++ b/src/releaseBusV2/release-bus-v2.repository.ts
@@ -306,6 +306,7 @@ export class ReleaseBusV2Repository extends LazyDbAccessCompatibleService {
       readonly productionRequestedAt?: number | null;
       readonly productionRequestedBy?: string | null;
       readonly holdReason?: string | null;
+      readonly supersededAt?: number | null;
     },
     ctx: RequestContext
   ): Promise<boolean> {
@@ -318,6 +319,7 @@ export class ReleaseBusV2Repository extends LazyDbAccessCompatibleService {
            production_requested_at = case when :setProductionRequestedAt = 1 then :productionRequestedAt else production_requested_at end,
            production_requested_by = case when :setProductionRequestedBy = 1 then :productionRequestedBy else production_requested_by end,
            hold_reason = case when :setHoldReason = 1 then :holdReason else hold_reason end,
+           superseded_at = case when :setSupersededAt = 1 then :supersededAt else superseded_at end,
            updated_at = :now, row_version = row_version + 1
        where id = :id and row_version = :rowVersion`,
       {
@@ -340,6 +342,8 @@ export class ReleaseBusV2Repository extends LazyDbAccessCompatibleService {
         productionRequestedBy: fields.productionRequestedBy ?? null,
         setHoldReason: fields.holdReason === undefined ? 0 : 1,
         holdReason: fields.holdReason ?? null,
+        setSupersededAt: fields.supersededAt === undefined ? 0 : 1,
+        supersededAt: fields.supersededAt ?? null,
         now: Date.now()
       },
       dbOptions(ctx)

--- a/src/releaseBusV2/release-bus-v2.repository.ts
+++ b/src/releaseBusV2/release-bus-v2.repository.ts
@@ -191,6 +191,7 @@ export class ReleaseBusV2Repository extends LazyDbAccessCompatibleService {
     const superseded = await this.db.execute<ReleaseBusV2CandidateRecord>(
       `select * from ${RELEASE_BUS_V2_CANDIDATES_TABLE}
        where repository = :repository and pr_number = :prNumber and head_sha <> :headSha
+         and current_train_id is null
          and status not in ('PRODUCTION_DEPLOYED', 'SUPERSEDED', 'CANCELLED')`,
       { repository, prNumber, headSha },
       dbOptions(ctx)
@@ -200,6 +201,7 @@ export class ReleaseBusV2Repository extends LazyDbAccessCompatibleService {
        set status = 'SUPERSEDED', superseded_at = :now, updated_at = :now,
            row_version = row_version + 1
        where repository = :repository and pr_number = :prNumber and head_sha <> :headSha
+         and current_train_id is null
          and status not in ('PRODUCTION_DEPLOYED', 'SUPERSEDED', 'CANCELLED')`,
       { repository, prNumber, headSha, now },
       dbOptions(ctx)
@@ -217,6 +219,7 @@ export class ReleaseBusV2Repository extends LazyDbAccessCompatibleService {
       `select * from ${RELEASE_BUS_V2_CANDIDATES_TABLE}
        where repository = :repository and branch_name = :branchName
          and head_sha <> :currentHeadSha
+         and current_train_id is null
          and status not in ('PRODUCTION_DEPLOYED', 'SUPERSEDED', 'CANCELLED')`,
       { repository, branchName, currentHeadSha },
       dbOptions(ctx)
@@ -229,6 +232,7 @@ export class ReleaseBusV2Repository extends LazyDbAccessCompatibleService {
            row_version = row_version + 1
        where repository = :repository and branch_name = :branchName
          and head_sha <> :currentHeadSha
+         and current_train_id is null
          and status not in ('PRODUCTION_DEPLOYED', 'SUPERSEDED', 'CANCELLED')`,
       { repository, branchName, currentHeadSha, now },
       dbOptions(ctx)

--- a/src/releaseBusV2/release-bus-v2.repository.ts
+++ b/src/releaseBusV2/release-bus-v2.repository.ts
@@ -1063,15 +1063,16 @@ export class ReleaseBusV2Repository extends LazyDbAccessCompatibleService {
 
   public async listCandidateEvents(
     candidateId: string,
+    eventType: string,
     limit: number,
     ctx: RequestContext
   ): Promise<ReleaseBusV2EventRecord[]> {
     const boundedLimit = Math.max(1, Math.min(limit, 500));
     return this.db.execute<ReleaseBusV2EventRecord>(
       `select * from ${RELEASE_BUS_V2_EVENTS_TABLE}
-       where candidate_id = :candidateId
+       where candidate_id = :candidateId and event_type = :eventType
        order by created_at desc, id desc limit ${boundedLimit}`,
-      { candidateId },
+      { candidateId, eventType },
       dbOptions(ctx)
     );
   }

--- a/src/releaseBusV2/release-bus-v2.repository.ts
+++ b/src/releaseBusV2/release-bus-v2.repository.ts
@@ -1060,6 +1060,21 @@ export class ReleaseBusV2Repository extends LazyDbAccessCompatibleService {
       dbOptions(ctx)
     );
   }
+
+  public async listCandidateEvents(
+    candidateId: string,
+    limit: number,
+    ctx: RequestContext
+  ): Promise<ReleaseBusV2EventRecord[]> {
+    const boundedLimit = Math.max(1, Math.min(limit, 500));
+    return this.db.execute<ReleaseBusV2EventRecord>(
+      `select * from ${RELEASE_BUS_V2_EVENTS_TABLE}
+       where candidate_id = :candidateId
+       order by created_at desc, id desc limit ${boundedLimit}`,
+      { candidateId },
+      dbOptions(ctx)
+    );
+  }
 }
 
 export const releaseBusV2Repository = new ReleaseBusV2Repository();

--- a/src/releaseBusV2/release-bus-v2.service.ts
+++ b/src/releaseBusV2/release-bus-v2.service.ts
@@ -672,6 +672,84 @@ export class ReleaseBusV2Service {
     );
   }
 
+  public async restoreProductionReadinessAfterBranchCleanup(
+    candidateId: string,
+    actor: string
+  ): Promise<ReleaseBusV2CandidateRecord | null> {
+    const restored = await this.repository.executeNativeQueriesInTransaction(
+      async (connection) => {
+        const ctx: RequestContext = { connection };
+        const candidate = await this.repository.findCandidateById(
+          candidateId,
+          ctx,
+          true
+        );
+        const supersededEvent = candidate
+          ? (await this.repository.listCandidateEvents(candidate.id, 1, ctx))[0]
+          : null;
+        let supersededPayload: Record<string, unknown> | null = null;
+        if (supersededEvent) {
+          try {
+            const value =
+              typeof supersededEvent.payload_json === 'string'
+                ? JSON.parse(supersededEvent.payload_json)
+                : supersededEvent.payload_json;
+            if (value && typeof value === 'object' && !Array.isArray(value))
+              supersededPayload = value as Record<string, unknown>;
+          } catch {
+            supersededPayload = null;
+          }
+        }
+        if (
+          !candidate ||
+          candidate.status !== 'SUPERSEDED' ||
+          candidate.current_train_id !== null ||
+          candidate.production_requested_at === null ||
+          candidate.staging_validated_manifest_id === null ||
+          supersededEvent?.event_type !==
+            'CANDIDATE_SUPERSEDED_BY_BRANCH_MOVE' ||
+          supersededPayload?.current_head_sha !== 'deleted'
+        )
+          return null;
+        if (
+          !(await this.repository.updateCandidate(
+            candidate.id,
+            candidate.row_version,
+            {
+              status: 'READY_FOR_PRODUCTION',
+              supersededAt: null
+            },
+            ctx
+          ))
+        )
+          throw new Error('Candidate changed during branch cleanup repair');
+        await this.repository.appendEvent(
+          {
+            candidateId: candidate.id,
+            eventType:
+              'CANDIDATE_PRODUCTION_READINESS_RESTORED_AFTER_BRANCH_CLEANUP',
+            actor,
+            payload: {
+              head_sha: candidate.head_sha,
+              staging_manifest_id: candidate.staging_validated_manifest_id
+            }
+          },
+          ctx
+        );
+        return this.repository.findCandidateById(candidate.id, ctx);
+      }
+    );
+    if (restored)
+      await releaseBusGitHubApp.ensureCommitStatus(
+        restored.repository,
+        restored.head_sha,
+        'pending',
+        'Exact production readiness retained after merged branch cleanup',
+        'Release Bus v2'
+      );
+    return restored;
+  }
+
   public async claimLane(
     lane: ReleaseBusV2Lane,
     frontendBaseSha: string,

--- a/src/releaseBusV2/release-bus-v2.service.ts
+++ b/src/releaseBusV2/release-bus-v2.service.ts
@@ -701,7 +701,11 @@ export class ReleaseBusV2Service {
               typeof supersededEvent.payload_json === 'string'
                 ? JSON.parse(supersededEvent.payload_json)
                 : supersededEvent.payload_json;
-            if (value && typeof value === 'object' && !Array.isArray(value))
+            if (
+              typeof value === 'object' &&
+              value !== null &&
+              !Array.isArray(value)
+            )
               supersededPayload = value as Record<string, unknown>;
           } catch {
             supersededPayload = null;

--- a/src/releaseBusV2/release-bus-v2.service.ts
+++ b/src/releaseBusV2/release-bus-v2.service.ts
@@ -685,7 +685,14 @@ export class ReleaseBusV2Service {
           true
         );
         const supersededEvent = candidate
-          ? (await this.repository.listCandidateEvents(candidate.id, 1, ctx))[0]
+          ? (
+              await this.repository.listCandidateEvents(
+                candidate.id,
+                'CANDIDATE_SUPERSEDED_BY_BRANCH_MOVE',
+                1,
+                ctx
+              )
+            )[0]
           : null;
         let supersededPayload: Record<string, unknown> | null = null;
         if (supersededEvent) {


### PR DESCRIPTION
## Issue
- Production beta exposed a push-webhook race: merging a PR can delete its source branch, and v2 incorrectly marked that already-claimed immutable candidate SUPERSEDED.

## Fix
- Restrict head/branch invalidation to candidates without an active train owner.
- Reassert the immutable train-owned production status before deployment reconciliation so an already-raced candidate self-heals.

## Changes
- Guard both PR-head and branch-head supersession queries with current_train_id is null.
- Treat only cancellation or supersession outside the claimed train as unavailable for status updates.
- Add repository integration and focused reconciler regression coverage.

## Validation
- Focused reconciler and repository tests: 20/20 passed.
- Full repository lint passed.
- Focused ESLint and Prettier passed; git diff --check passed.
- Standalone TypeScript compile could not be used from the reused root dependency tree because nested API-only development packages were not installed; hosted CI installs the complete dependency graph.

## Risk
- Level: Medium.
- Why: narrow release-control state predicate during an active production beta.
- Rollback: pause v2 production and revert this commit; running immutable workflows are not cancelled.

## Deployment
- Deploy api, then releaseBus at the exact merge SHA.
- Keep production reconciliation paused until both deployments succeed.

## Review Notes
- Focus on the invariant that branch movement invalidates readiness before claim, while train membership is authoritative after claim.
- No architecture documentation update is needed; no service boundary, trigger, schema, or integration shape changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented active train candidates from being incorrectly marked as superseded.
  * Improved candidate recovery by restoring active-train status and clearing outdated supersession details.
  * Added reconciliation safeguards for stale candidate bookkeeping and delayed webhook events.

* **Tests**
  * Added coverage for candidate supersession, recovery, and active train ownership scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->