### PR TITLE
Fix beta claim isolation from unrelated trains

### DIFF
--- a/src/releaseBusV2/release-bus-v2.service.test.ts
+++ b/src/releaseBusV2/release-bus-v2.service.test.ts
@@ -354,3 +354,122 @@ describe('Release Bus v2 globally-OFF operator beta registration', () => {
     expect(repository.createCandidate).not.toHaveBeenCalled();
   });
 });
+
+describe('Release Bus v2 globally-OFF beta claim isolation', () => {
+  const previousMode = process.env.RELEASE_BUS_V2_MODE;
+  const previousAllowlist = process.env.RELEASE_BUS_V2_BETA_ALLOWLIST;
+  const betaId = '11111111-1111-4111-8111-111111111111';
+  const unrelatedId = '22222222-2222-4222-8222-222222222222';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.RELEASE_BUS_V2_MODE = 'OFF';
+    process.env.RELEASE_BUS_V2_BETA_ALLOWLIST = JSON.stringify([
+      {
+        test_id: 'isolated-active-train-1',
+        candidate_id: betaId,
+        repository: 'backend',
+        branch_name: 'agent/rb2-beta-backend-one',
+        operator: 'beta-operator',
+        lanes: ['STAGING']
+      }
+    ]);
+  });
+
+  afterAll(() => {
+    if (previousMode === undefined) delete process.env.RELEASE_BUS_V2_MODE;
+    else process.env.RELEASE_BUS_V2_MODE = previousMode;
+    if (previousAllowlist === undefined)
+      delete process.env.RELEASE_BUS_V2_BETA_ALLOWLIST;
+    else process.env.RELEASE_BUS_V2_BETA_ALLOWLIST = previousAllowlist;
+  });
+
+  function claimRepository(options: { betaTrainActive: boolean }) {
+    const betaCandidate = {
+      ...candidate(
+        options.betaTrainActive ? 'STAGING_BUILDING' : 'READY_FOR_STAGING'
+      ),
+      id: betaId,
+      repository: 'backend' as const,
+      branch_name: 'agent/rb2-beta-backend-one',
+      requested_by: 'beta-operator',
+      current_train_id: options.betaTrainActive ? 'beta-train' : null
+    };
+    const unrelatedCandidate = {
+      ...candidate('STAGING_BUILDING'),
+      id: unrelatedId,
+      repository: 'frontend' as const,
+      branch_name: 'developer/ordinary-work',
+      requested_by: 'ordinary-developer',
+      current_train_id: 'unrelated-train'
+    };
+    const unrelatedTrain = {
+      id: 'unrelated-train',
+      lane: 'STAGING',
+      status: 'PREFLIGHTING'
+    };
+    const betaTrain = {
+      id: 'beta-train',
+      lane: 'STAGING',
+      status: 'PREFLIGHTING'
+    };
+    const createdTrain = {
+      id: 'new-beta-train',
+      lane: 'STAGING',
+      status: 'COMPOSING'
+    };
+    const trains = options.betaTrainActive
+      ? [unrelatedTrain, betaTrain]
+      : [unrelatedTrain];
+    const createTrain = jest.fn(async () => createdTrain);
+    const repository = {
+      listControls: jest.fn(async () => []),
+      executeNativeQueriesInTransaction: jest.fn(async (callback) =>
+        callback({})
+      ),
+      acquireLock: jest.fn(async () => ({ lease_token: 'scheduler-token' })),
+      releaseLock: jest.fn(async () => true),
+      listTrains: jest.fn(async () => trains),
+      listCandidates: jest.fn(async (statuses: readonly string[]) =>
+        [betaCandidate].filter((item) => statuses.includes(item.status))
+      ),
+      listTrainCandidates: jest.fn(async (trainId: string) => [
+        {
+          candidate_id:
+            trainId === 'beta-train' ? betaId : unrelatedCandidate.id
+        }
+      ]),
+      findCandidateById: jest.fn(async (id: string) =>
+        id === betaId ? betaCandidate : unrelatedCandidate
+      ),
+      listDependencies: jest.fn(async () => []),
+      createTrain,
+      updateCandidate: jest.fn(async () => true),
+      appendEvent: jest.fn(async () => undefined)
+    };
+    return { repository, createTrain, createdTrain, betaTrain };
+  }
+
+  it('ignores a non-allowlisted active train when claiming an isolated beta', async () => {
+    const state = claimRepository({ betaTrainActive: false });
+    const service = new ReleaseBusV2Service(state.repository as never);
+
+    await expect(
+      service.claimLane('STAGING', 'a'.repeat(40), 'b'.repeat(40), 'beta-claim')
+    ).resolves.toEqual(state.createdTrain);
+    expect(state.createTrain).toHaveBeenCalledWith(
+      expect.objectContaining({ candidateIds: [betaId] }),
+      expect.anything()
+    );
+  });
+
+  it('reuses an existing allowlisted beta train instead of creating another', async () => {
+    const state = claimRepository({ betaTrainActive: true });
+    const service = new ReleaseBusV2Service(state.repository as never);
+
+    await expect(
+      service.claimLane('STAGING', 'a'.repeat(40), 'b'.repeat(40), 'beta-claim')
+    ).resolves.toEqual(state.betaTrain);
+    expect(state.createTrain).not.toHaveBeenCalled();
+  });
+});

--- a/src/releaseBusV2/release-bus-v2.service.ts
+++ b/src/releaseBusV2/release-bus-v2.service.ts
@@ -793,15 +793,16 @@ export class ReleaseBusV2Service {
         if (!scheduler?.lease_token) return null;
         try {
           await this.refreshDependencyHolds(lane, ctx, betaAllowlist);
-          const active = (await this.repository.listTrains(100, ctx)).find(
+          const active = (await this.repository.listTrains(100, ctx)).filter(
             (train) =>
               train.lane === lane && !TERMINAL_TRAIN_STATUSES.has(train.status)
           );
-          if (active) {
-            if (!betaLaneEnabled) return active;
-            return (await this.isBetaTrainAllowed(active, betaAllowlist, ctx))
-              ? active
-              : null;
+          if (!betaLaneEnabled && active.length > 0) return active[0] ?? null;
+          if (betaLaneEnabled) {
+            for (const train of active) {
+              if (await this.isBetaTrainAllowed(train, betaAllowlist, ctx))
+                return train;
+            }
           }
           const candidates = (
             await this.repository.listCandidates(


### PR DESCRIPTION
## What changed

- scan all nonterminal same-lane trains during an operator beta claim
- reuse an existing allowlisted beta train when present
- ignore non-allowlisted inactive trains instead of blocking the isolated beta
- add focused regression coverage for both isolation and no-duplicate behavior

## Why

A stale ordinary staging train with no lock or workflow was found before beta eligibility was applied. In global OFF mode that caused the operator-only beta claim to return without claiming, even though unrelated manual operation remained idle.

## Impact

Global mode remains OFF and ordinary developers remain on the manual route. The allowlisted beta can progress independently while environment locks continue to serialize actual shared mutations.

## Validation

- `npm test -- --runInBand src/releaseBusV2/release-bus-v2.service.test.ts` (11/11)
- Prettier check on changed files
- ESLint on changed files
- `git diff --check`