### PR TITLE
Label Release Bus deploy alerts as Release Train

### DIFF
--- a/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.test.ts
+++ b/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.test.ts
@@ -340,6 +340,44 @@ describe('CiPipelineAlertService', () => {
     expect(dropCreationApiService.toggleHideLinkPreview).not.toHaveBeenCalled();
   });
 
+  it.each([
+    { environment: 'staging', waveId: 'staging-wave' },
+    { environment: 'prod', waveId: 'prod-wave' }
+  ] as const)(
+    'attributes $environment deployments to the Release Train',
+    async ({ environment, waveId }) => {
+      const service = new CiPipelineAlertService(
+        dropCreationApiService as any,
+        identitiesRepository as any
+      );
+
+      await service.postAlert(
+        {
+          ...baseRequest,
+          status: 'success',
+          environment,
+          triggered_by_github_login: '6529-release-bus[bot]'
+        },
+        {}
+      );
+
+      expect(identitiesRepository.getIdsByHandles).not.toHaveBeenCalled();
+      expect(
+        dropCreationApiService.createDrop.mock.calls[0][0].createDropRequest
+      ).toEqual(
+        expect.objectContaining({
+          wave_id: waveId,
+          mentioned_users: [],
+          parts: [
+            expect.objectContaining({
+              content: expect.stringContaining('Initiated by: Release Train')
+            })
+          ]
+        })
+      );
+    }
+  );
+
   it('posts with an unknown initiator when the 6529 mapping is missing', async () => {
     const service = new CiPipelineAlertService(
       dropCreationApiService as any,

--- a/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.ts
+++ b/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.ts
@@ -9,6 +9,7 @@ import { env } from '@/env';
 import { identitiesDb, IdentitiesDb } from '@/identities/identities.db';
 import { Logger } from '@/logging';
 import { RequestContext } from '@/request.context';
+import { isReleaseBusGitHubAppActor } from '@/releaseBus/release-bus.constants';
 import {
   releaseNoteGenerationQueue,
   ReleaseNoteGenerationQueue
@@ -243,6 +244,18 @@ function formatServiceLabel(request: CiPipelineAlertRequest): string {
   return service ? `${repoLabel} - ${service}` : repoLabel;
 }
 
+function formatInitiator(
+  request: CiPipelineAlertRequest,
+  mentions: AlertMentions
+): string {
+  if (isReleaseBusGitHubAppActor(request.triggered_by_github_login)) {
+    return 'Release Train';
+  }
+  return mentions.triggeredBy
+    ? '@[' + mentions.triggeredBy.handle + ']'
+    : 'unknown';
+}
+
 function getGithubRepoUrl(request: CiPipelineAlertRequest): string | null {
   try {
     const runUrl = new URL(request.run_url);
@@ -407,14 +420,16 @@ export class CiPipelineAlertService {
     const triggeredByGithubLogin = normalizeOptionalValue(
       request.triggered_by_github_login
     );
-    const triggeredByHandle = triggeredByGithubLogin
-      ? GITHUB_TO_6529_HANDLES[triggeredByGithubLogin.toLowerCase()]
-      : null;
+    const isReleaseTrain = isReleaseBusGitHubAppActor(triggeredByGithubLogin);
+    const triggeredByHandle =
+      triggeredByGithubLogin && !isReleaseTrain
+        ? GITHUB_TO_6529_HANDLES[triggeredByGithubLogin.toLowerCase()]
+        : null;
     if (!triggeredByGithubLogin) {
       this.logger.warn(
         'Unable to resolve CI workflow initiator: GitHub login is missing'
       );
-    } else if (!triggeredByHandle) {
+    } else if (!isReleaseTrain && !triggeredByHandle) {
       this.logger.warn(
         `Unable to resolve CI workflow initiator ${triggeredByGithubLogin}: 6529 profile mapping is missing`
       );
@@ -545,9 +560,7 @@ export class CiPipelineAlertService {
     const formattedDescription = description
       ? truncate(sanitizeAlertText(description), MAX_ALERT_DESCRIPTION_LENGTH)
       : null;
-    const triggeredBy = mentions.triggeredBy
-      ? '@[' + mentions.triggeredBy.handle + ']'
-      : 'unknown';
+    const triggeredBy = formatInitiator(request, mentions);
     const lines = [
       formatAlertHeading(request),
       '',

--- a/src/releaseBus/release-bus.constants.ts
+++ b/src/releaseBus/release-bus.constants.ts
@@ -1,0 +1,7 @@
+export const RELEASE_BUS_GITHUB_APP_ACTOR = '6529-release-bus[bot]';
+
+export function isReleaseBusGitHubAppActor(
+  actor: string | null | undefined
+): boolean {
+  return actor?.toLowerCase() === RELEASE_BUS_GITHUB_APP_ACTOR;
+}

--- a/src/releaseBus/release-bus.github-app.ts
+++ b/src/releaseBus/release-bus.github-app.ts
@@ -1,5 +1,6 @@
 import { createSign } from 'node:crypto';
 import fetch, { type RequestInit, type Response } from 'node-fetch';
+import { isReleaseBusGitHubAppActor } from '@/releaseBus/release-bus.constants';
 import type { ReleaseRepository } from '@/releaseBus/release-bus.types';
 
 type InstallationToken = {
@@ -31,7 +32,7 @@ export function isValidGitHubWorkflowActor(actor: string): boolean {
   // `[bot]` suffix. Only the Release Bus App may drive automated operations;
   // human logins retain GitHub's 39-character limit for manual attribution.
   return (
-    /^[A-Za-z0-9-]{1,39}$/.test(actor) || actor === '6529-release-bus[bot]'
+    /^[A-Za-z0-9-]{1,39}$/.test(actor) || isReleaseBusGitHubAppActor(actor)
   );
 }
 export type GitHubWorkflowJob = {


### PR DESCRIPTION
## Issue
- Deploy notifications show `Initiated by: unknown` when the Release Bus GitHub App dispatches staging or production work.

## Fix
- Recognize the authoritative `6529-release-bus[bot]` workflow actor and render it as `Release Train` instead of attempting to resolve it as a human 6529 profile.

## Changes
- Centralize the Release Bus GitHub App actor contract.
- Preserve existing human profile mention behavior.
- Suppress the missing-profile warning for the known automation actor.
- Cover both `staging` and `prod` wave targets.
- No API schema, architecture, database, or frontend changes are required.

## Validation
- `npm run lint`
- `npm run build` — 283 suites and 2,616 tests passed, followed by TypeScript compilation.
- Focused CI alert and Release Bus GitHub App tests — 42 tests passed.

## Risk
- Level: Low
- Why: Formatting-only behavior behind an existing authenticated CI notification path; manual human attribution is unchanged.
- Rollback: Revert this commit and redeploy the API.

## Deployment
- Deploy backend service `api` only.
- In active Release Bus v2 mode, qualify the exact PR head in staging before the separate production-ready action.

## Review Notes
- Please verify that the known Release Bus actor remains distinct from human GitHub-to-6529 mappings and is not mentioned as the posting `ci6529` profile.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release Train success alerts now identify the initiator as “Release Train.”
  * Release Train alerts use the appropriate wave for staging and production environments.
  * Release-bus automation actors are recognized more reliably when validating workflow activity.

* **Bug Fixes**
  * Prevented unnecessary user-mention lookups for Release Train alerts.
  * Improved fallback handling when an alert initiator cannot be identified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->