### PR TITLE
Fix v2 composition for already-merged candidates

### DIFF
--- a/.github/workflows/release-bus-v2-compose.yml
+++ b/.github/workflows/release-bus-v2-compose.yml
@@ -88,8 +88,13 @@ jobs:
           excluded='[]'
           while IFS= read -r sha; do
             git fetch --no-tags origin "$sha"
-            if git merge-base --is-ancestor "$sha" HEAD; then
+            ancestor_status=0
+            git merge-base --is-ancestor "$sha" HEAD || ancestor_status=$?
+            if [ "$ancestor_status" -eq 0 ]; then
               continue
+            fi
+            if [ "$ancestor_status" -ne 1 ]; then
+              exit "$ancestor_status"
             fi
             if git merge --no-ff --no-commit "$sha"; then
               git -c core.hooksPath=/dev/null commit -s \

--- a/.github/workflows/release-bus-v2-compose.yml
+++ b/.github/workflows/release-bus-v2-compose.yml
@@ -88,6 +88,9 @@ jobs:
           excluded='[]'
           while IFS= read -r sha; do
             git fetch --no-tags origin "$sha"
+            if git merge-base --is-ancestor "$sha" HEAD; then
+              continue
+            fi
             if git merge --no-ff --no-commit "$sha"; then
               git -c core.hooksPath=/dev/null commit -s \
                 -m "Release Bus v2 train $TRAIN_ID: merge backend candidate" \

--- a/src/releaseBusV2/release-bus-v2-compose-workflow.test.ts
+++ b/src/releaseBusV2/release-bus-v2-compose-workflow.test.ts
@@ -23,7 +23,7 @@ function composeScript(): string {
     'utf8'
   );
   const match = workflow.match(
-    / {6}- name: Compose deterministic candidate set[\s\S]*? {8}run: \|\n([\s\S]*?)\n {6}- name: Create scoped GitHub App token/
+    /\n {8}id: compose\n[\s\S]*?\n {8}run: \|\n([\s\S]*?)(?=\n {6}- )/
   );
   if (!match) throw new Error('Compose workflow script was not found');
   return match[1]
@@ -85,9 +85,100 @@ describe('Release Bus v2 backend composition workflow', () => {
       ).toEqual({
         composed_sha: baseSha,
         excluded_shas: [],
+        // A newly-created release branch is not the immutable-branch reuse
+        // path, even when every candidate is already present in its base.
         reused: false
       });
       expect(runGit(repository, 'rev-parse', 'HEAD')).toBe(baseSha);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('skips an ancestor while still merging a new candidate', () => {
+    const root = mkdtempSync(
+      path.join(tmpdir(), 'release-bus-v2-compose-mixed-')
+    );
+    const origin = path.join(root, 'origin.git');
+    const repository = path.join(root, 'repository');
+    const runnerTemp = path.join(root, 'runner-temp');
+    try {
+      execFileSync('git', ['init', '--bare', origin]);
+      execFileSync('git', ['init', '--initial-branch=main', repository]);
+      mkdirSync(runnerTemp);
+      runGit(repository, 'config', 'user.name', 'Release Bus Test');
+      runGit(
+        repository,
+        'config',
+        'user.email',
+        'release-bus-test@example.com'
+      );
+      runGit(repository, 'remote', 'add', 'origin', origin);
+      writeFileSync(path.join(repository, 'ancestor.txt'), 'ancestor\n');
+      runGit(repository, 'add', 'ancestor.txt');
+      runGit(repository, 'commit', '-m', 'ancestor candidate');
+      const ancestorSha = runGit(repository, 'rev-parse', 'HEAD');
+      writeFileSync(path.join(repository, 'main.txt'), 'main\n');
+      runGit(repository, 'add', 'main.txt');
+      runGit(repository, 'commit', '-m', 'main after ancestor');
+      const baseSha = runGit(repository, 'rev-parse', 'HEAD');
+      runGit(repository, 'push', 'origin', 'main');
+
+      runGit(repository, 'switch', '-c', 'new-candidate', baseSha);
+      writeFileSync(path.join(repository, 'new.txt'), 'new candidate\n');
+      runGit(repository, 'add', 'new.txt');
+      runGit(repository, 'commit', '-m', 'new candidate');
+      const newCandidateSha = runGit(repository, 'rev-parse', 'HEAD');
+      runGit(repository, 'push', 'origin', 'new-candidate');
+      runGit(repository, 'switch', 'main');
+
+      execFileSync('bash', ['-c', composeScript()], {
+        cwd: repository,
+        env: {
+          ...process.env,
+          BASE_SHA: baseSha,
+          CANDIDATE_SHAS: JSON.stringify([ancestorSha, newCandidateSha]),
+          RELEASE_BRANCH: 'release-bus-v2/production-train-mixed-backend',
+          RELEASE_BUS_GIT_EMAIL: 'release-bus-test@example.com',
+          RELEASE_BUS_GIT_NAME: 'Release Bus Test',
+          RUNNER_TEMP: runnerTemp,
+          TRAIN_ID: 'mixed'
+        },
+        stdio: ['ignore', 'pipe', 'pipe']
+      });
+
+      const composedSha = runGit(repository, 'rev-parse', 'HEAD');
+      expect(composedSha).not.toBe(baseSha);
+      expect(
+        JSON.parse(
+          readFileSync(path.join(runnerTemp, 'composition.json'), 'utf8')
+        )
+      ).toEqual({
+        composed_sha: composedSha,
+        excluded_shas: [],
+        reused: false
+      });
+      expect(
+        runGit(
+          repository,
+          'merge-base',
+          '--is-ancestor',
+          ancestorSha,
+          composedSha
+        )
+      ).toBe('');
+      expect(
+        runGit(
+          repository,
+          'merge-base',
+          '--is-ancestor',
+          newCandidateSha,
+          composedSha
+        )
+      ).toBe('');
+      expect(
+        runGit(repository, 'rev-list', '--parents', '-n', '1', 'HEAD')
+      ).toBe(`${composedSha} ${baseSha} ${newCandidateSha}`);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/src/releaseBusV2/release-bus-v2-compose-workflow.test.ts
+++ b/src/releaseBusV2/release-bus-v2-compose-workflow.test.ts
@@ -1,0 +1,95 @@
+import { execFileSync } from 'node:child_process';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+function runGit(cwd: string, ...args: string[]): string {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe']
+  }).trim();
+}
+
+function composeScript(): string {
+  const workflow = readFileSync(
+    path.join(process.cwd(), '.github/workflows/release-bus-v2-compose.yml'),
+    'utf8'
+  );
+  const match = workflow.match(
+    / {6}- name: Compose deterministic candidate set[\s\S]*? {8}run: \|\n([\s\S]*?)\n {6}- name: Create scoped GitHub App token/
+  );
+  if (!match) throw new Error('Compose workflow script was not found');
+  return match[1]
+    .split('\n')
+    .map((line) => line.replace(/^ {10}/, ''))
+    .join('\n');
+}
+
+describe('Release Bus v2 backend composition workflow', () => {
+  it('successfully reuses current main when every candidate is already an ancestor', () => {
+    const root = mkdtempSync(
+      path.join(tmpdir(), 'release-bus-v2-compose-ancestor-')
+    );
+    const origin = path.join(root, 'origin.git');
+    const repository = path.join(root, 'repository');
+    const runnerTemp = path.join(root, 'runner-temp');
+    try {
+      execFileSync('git', ['init', '--bare', origin]);
+      execFileSync('git', ['init', '--initial-branch=main', repository]);
+      mkdirSync(runnerTemp);
+      runGit(repository, 'config', 'user.name', 'Release Bus Test');
+      runGit(
+        repository,
+        'config',
+        'user.email',
+        'release-bus-test@example.com'
+      );
+      runGit(repository, 'remote', 'add', 'origin', origin);
+      writeFileSync(path.join(repository, 'candidate.txt'), 'candidate\n');
+      runGit(repository, 'add', 'candidate.txt');
+      runGit(repository, 'commit', '-m', 'candidate');
+      const candidateSha = runGit(repository, 'rev-parse', 'HEAD');
+      writeFileSync(path.join(repository, 'main.txt'), 'newer main\n');
+      runGit(repository, 'add', 'main.txt');
+      runGit(repository, 'commit', '-m', 'newer main');
+      const baseSha = runGit(repository, 'rev-parse', 'HEAD');
+      runGit(repository, 'push', 'origin', 'main');
+
+      execFileSync('bash', ['-c', composeScript()], {
+        cwd: repository,
+        env: {
+          ...process.env,
+          BASE_SHA: baseSha,
+          CANDIDATE_SHAS: JSON.stringify([candidateSha]),
+          RELEASE_BRANCH:
+            'release-bus-v2/production-train-already-merged-backend',
+          RELEASE_BUS_GIT_EMAIL: 'release-bus-test@example.com',
+          RELEASE_BUS_GIT_NAME: 'Release Bus Test',
+          RUNNER_TEMP: runnerTemp,
+          TRAIN_ID: 'already-merged'
+        },
+        stdio: ['ignore', 'pipe', 'pipe']
+      });
+
+      expect(
+        JSON.parse(
+          readFileSync(path.join(runnerTemp, 'composition.json'), 'utf8')
+        )
+      ).toEqual({
+        composed_sha: baseSha,
+        excluded_shas: [],
+        reused: false
+      });
+      expect(runGit(repository, 'rev-parse', 'HEAD')).toBe(baseSha);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- skip candidate merges when the exact candidate SHA is already an ancestor of the immutable composition base
- preserve exact composition metadata and unchanged HEAD for this fast path
- add a regression that executes the workflow's real inline composition script against an already-merged candidate

## Incident
Production train `6cd85ad3-e6ed-407b-8f77-1a56efeab283` reached backend composition with candidate SHAs already present in backend main. `git merge` correctly reported “Already up to date”, but the workflow then unconditionally ran `git commit`, causing deterministic retryable infrastructure failures. Production automation is paused before environment mutation; staging remains available.

## Validation
- `npx jest src/releaseBusV2/release-bus-v2-compose-workflow.test.ts src/releaseBusV2/release-bus-v2.acceptance.test.ts --runInBand` (40 tests)
- `npx tsc --noEmit`
- `npm run lint`
- `npx prettier --check .github/workflows/release-bus-v2-compose.yml src/releaseBusV2/release-bus-v2-compose-workflow.test.ts`
- release-bus v2 generator/diff checks

## Rollout
Workflow-only change. Once merged, retried composition dispatches use the fixed workflow definition while checking out and composing the train's immutable base SHA. No Lambda runtime mutation is required for this patch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release workflow composition by skipping candidate commits already included in the current branch history.
  * Prevented unnecessary merge attempts while preserving the expected composed result.

* **Tests**
  * Added automated coverage for deterministic candidate selection and repository state preservation in the release workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->