### PR TITLE
Harden v2 stale production replans and exact staging execution

### DIFF
--- a/src/releaseBusV2/release-bus-v2.acceptance.test.ts
+++ b/src/releaseBusV2/release-bus-v2.acceptance.test.ts
@@ -538,8 +538,8 @@ class InMemoryAcceptanceRepository {
 function harness(e2eStatus: 'RUNNING' | 'SUCCEEDED' | 'FAILED') {
   const repository = new InMemoryAcceptanceRepository();
   const backend = candidate('backend-candidate', 'backend', {
-    units: ['migration', 'worker', 'api'],
-    edges: [['migration', 'api']]
+    units: ['dbMigrationsLoop', 'ethPriceLoop', 'api'],
+    edges: [['dbMigrationsLoop', 'api']]
   });
   const frontend = candidate('frontend-candidate', 'frontend', null);
   repository.candidates.set(backend.id, backend);
@@ -1783,7 +1783,7 @@ describe('Release Bus v2 offline acceptance harness', () => {
     );
     expect(maximumBackend).toBe(2);
     expect(sequence.indexOf('start:api')).toBeGreaterThan(
-      sequence.indexOf('finish:migration')
+      sequence.indexOf('finish:dbMigrationsLoop')
     );
     expect(sequence.indexOf('start:frontend')).toBeGreaterThan(
       sequence.indexOf('finish:api')
@@ -2015,6 +2015,145 @@ describe('Release Bus v2 offline acceptance harness', () => {
         (item) => item.status !== 'STAGING_VALIDATED'
       )
     ).toBe(true);
+  });
+
+  it('requeues a production plan when candidate-bearing main moves before qualification', async () => {
+    const state = harness('SUCCEEDED');
+    process.env.RELEASE_BUS_V2_MODE = 'PRODUCTION';
+    const production = train('train-1', {
+      lane: 'PRODUCTION',
+      status: 'CLAIMED',
+      frontend_composed_sha: null,
+      backend_composed_sha: null,
+      frontend_artifact_digest: null,
+      backend_artifact_digest: null
+    });
+    state.repository.trains.set(production.id, production);
+    for (const [id, current] of Array.from(
+      state.repository.candidates.entries()
+    )) {
+      state.repository.candidates.set(id, {
+        ...current,
+        status: 'PRODUCTION_BUILDING_OR_QUALIFYING',
+        current_train_id: production.id
+      });
+    }
+    mockResolveRef.mockImplementation(async (repository: string) =>
+      repository === 'frontend' ? '9'.repeat(40) : production.backend_base_sha
+    );
+
+    await state.reconciler.runOnce('acceptance-production-main-moved');
+
+    expect(state.repository.trains.get(production.id)).toEqual(
+      expect.objectContaining({
+        status: 'CANCELLED',
+        failure_class: 'INTERACTION',
+        failure_message: expect.stringContaining('frontend main moved')
+      })
+    );
+    expect(
+      Array.from(state.repository.candidates.values()).map(
+        ({ status, current_train_id }) => ({ status, current_train_id })
+      )
+    ).toEqual([
+      { status: 'READY_FOR_PRODUCTION', current_train_id: null },
+      { status: 'READY_FOR_PRODUCTION', current_train_id: null }
+    ]);
+    expect(mockReconcileWorkflow).not.toHaveBeenCalled();
+    expect(state.repository.lock.owner_train_id).toBeNull();
+  });
+
+  it('waits for dispatched composition before requeueing a moved production plan', async () => {
+    const state = harness('SUCCEEDED');
+    process.env.RELEASE_BUS_V2_MODE = 'PRODUCTION';
+    const production = train('train-1', {
+      lane: 'PRODUCTION',
+      status: 'COMPOSING',
+      frontend_composed_sha: null,
+      backend_composed_sha: null,
+      frontend_artifact_digest: null,
+      backend_artifact_digest: null
+    });
+    state.repository.trains.set(production.id, production);
+    for (const [id, current] of Array.from(
+      state.repository.candidates.entries()
+    )) {
+      state.repository.candidates.set(id, {
+        ...current,
+        status: 'PRODUCTION_BUILDING_OR_QUALIFYING',
+        current_train_id: production.id
+      });
+    }
+    const running = {
+      ...operation(
+        production.id,
+        'COMPOSE_FRONTEND',
+        'frontend',
+        'running-compose'
+      ),
+      status: 'RUNNING' as const,
+      request_json: {
+        workflow: 'release-bus-v2-preflight.yml',
+        ref: 'release-bus-v2/production-train-train-1-frontend',
+        inputs: {
+          release_train_id: production.id,
+          expected_sha: FRONTEND_SHA
+        }
+      },
+      completed_at: null
+    };
+    state.repository.operations.push(running);
+    mockResolveRef.mockImplementation(async (repository: string) =>
+      repository === 'frontend' ? '9'.repeat(40) : production.backend_base_sha
+    );
+
+    await state.reconciler.runOnce('acceptance-production-main-moved-running');
+    await state.reconciler.runOnce(
+      'acceptance-production-main-moved-running-again'
+    );
+
+    expect(state.repository.trains.get(production.id)).toEqual(
+      expect.objectContaining({
+        status: 'COMPOSING',
+        recovery_message: expect.stringContaining(
+          'waiting for already-dispatched orchestration'
+        )
+      })
+    );
+    expect(
+      state.repository.operations.find(({ id }) => id === running.id)?.status
+    ).toBe('RUNNING');
+    expect(mockReconcileWorkflow).toHaveBeenCalledTimes(3);
+    expect(mockReconcileWorkflow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        idempotencyKey: running.idempotency_key,
+        operationType: running.operation_type
+      })
+    );
+    expect(state.repository.operations).toHaveLength(3);
+
+    const runningIndex = state.repository.operations.findIndex(
+      ({ id }) => id === running.id
+    );
+    state.repository.operations[runningIndex] = {
+      ...state.repository.operations[runningIndex],
+      status: 'SUCCEEDED',
+      completed_at: Date.now(),
+      row_version: state.repository.operations[runningIndex].row_version + 1
+    };
+    await state.reconciler.runOnce('acceptance-production-main-moved-terminal');
+
+    expect(state.repository.trains.get(production.id)?.status).toBe(
+      'CANCELLED'
+    );
+    expect(
+      Array.from(state.repository.candidates.values()).every(
+        ({ status, current_train_id }) =>
+          status === 'READY_FOR_PRODUCTION' && current_train_id === null
+      )
+    ).toBe(true);
+    expect(mockReconcileWorkflow).toHaveBeenCalledTimes(3);
+    expect(state.repository.operations).toHaveLength(3);
   });
 
   it('never mutates production when either exact main base moved', async () => {
@@ -2602,6 +2741,11 @@ describe('Release Bus v2 offline acceptance harness', () => {
       frontend_artifact_digest: null,
       backend_artifact_digest: null
     });
+    mockResolveRef.mockImplementation(async (repository: string) =>
+      repository === 'frontend'
+        ? production.frontend_base_sha
+        : production.backend_base_sha
+    );
     state.repository.trains.set(production.id, production);
     const context = {
       train: production,
@@ -2645,6 +2789,137 @@ describe('Release Bus v2 offline acceptance harness', () => {
         eventType: 'EXACT_STAGING_MANIFEST_REUSED',
         payload: expect.objectContaining({
           manifest_identity_sha256: 'e'.repeat(64)
+        })
+      })
+    );
+  });
+
+  it('runs staging E2E from the immutable exact-composition release ref', async () => {
+    const state = harness('SUCCEEDED');
+    const manifestId = 'exact-workflow-manifest';
+    const exactTrain = train('train-1', { manifest_id: manifestId });
+    state.repository.trains.set(exactTrain.id, exactTrain);
+    state.repository.manifests.set(manifestId, {
+      id: manifestId,
+      train_id: exactTrain.id,
+      lane: 'STAGING',
+      identity_sha256: 'e'.repeat(64),
+      status: 'STAGING_DEPLOYED',
+      frontend_sha: FRONTEND_SHA,
+      backend_sha: BACKEND_SHA,
+      frontend_artifact_digest: FRONTEND_DIGEST,
+      backend_artifact_digest: BACKEND_DIGEST,
+      e2e_run_id: null,
+      manifest_json: {},
+      deployed_at: 2,
+      validated_at: null,
+      created_at: 2,
+      updated_at: 2
+    });
+    const releaseRef = `release-bus-v2/staging-train-${exactTrain.id}-frontend`;
+    mockResolveRefIfExists.mockImplementation(
+      async (repository: string, ref: string) =>
+        repository === 'frontend' && ref === releaseRef ? FRONTEND_SHA : null
+    );
+    mockReconcileWorkflow.mockResolvedValue(
+      operation(exactTrain.id, 'E2E_STAGING', 'frontend', 'exact-e2e')
+    );
+    const context = {
+      train: exactTrain,
+      memberships: [...state.repository.memberships],
+      candidates: Array.from(state.repository.candidates.values()),
+      dependencies: state.repository.dependencies
+    };
+
+    await (
+      state.reconciler as unknown as {
+        reconcileE2E(
+          input: typeof context,
+          environment: 'staging'
+        ): Promise<ReleaseBusV2OperationRecord>;
+      }
+    ).reconcileE2E(context, 'staging');
+
+    expect(mockReconcileWorkflow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        operationType: 'E2E_STAGING',
+        ref: releaseRef,
+        expectedSha: FRONTEND_SHA,
+        inputs: expect.objectContaining({
+          source_ref: releaseRef,
+          expected_sha: FRONTEND_SHA
+        })
+      })
+    );
+  });
+
+  it('runs backend-only staging E2E from the exact shared staging ref when main moved', async () => {
+    const state = harness('SUCCEEDED');
+    const manifestId = 'backend-only-workflow-manifest';
+    const exactTrain = train('train-1', {
+      manifest_id: manifestId,
+      frontend_artifact_digest: null
+    });
+    state.repository.trains.set(exactTrain.id, exactTrain);
+    state.repository.memberships.splice(
+      0,
+      state.repository.memberships.length,
+      state.repository.memberships.find(
+        ({ candidate_id }) => candidate_id === 'backend-candidate'
+      )!
+    );
+    state.repository.manifests.set(manifestId, {
+      id: manifestId,
+      train_id: exactTrain.id,
+      lane: 'STAGING',
+      identity_sha256: 'e'.repeat(64),
+      status: 'STAGING_DEPLOYED',
+      frontend_sha: FRONTEND_SHA,
+      backend_sha: BACKEND_SHA,
+      frontend_artifact_digest: null,
+      backend_artifact_digest: BACKEND_DIGEST,
+      e2e_run_id: null,
+      manifest_json: {},
+      deployed_at: 2,
+      validated_at: null,
+      created_at: 2,
+      updated_at: 2
+    });
+    mockResolveRefIfExists.mockImplementation(
+      async (repository: string, ref: string) => {
+        if (repository !== 'frontend') return null;
+        if (ref === '1a-staging') return FRONTEND_SHA;
+        if (ref === 'main') return '9'.repeat(40);
+        return null;
+      }
+    );
+    mockReconcileWorkflow.mockResolvedValue(
+      operation(exactTrain.id, 'E2E_STAGING', 'frontend', 'exact-e2e')
+    );
+    const context = {
+      train: exactTrain,
+      memberships: [...state.repository.memberships],
+      candidates: Array.from(state.repository.candidates.values()),
+      dependencies: state.repository.dependencies
+    };
+
+    await (
+      state.reconciler as unknown as {
+        reconcileE2E(
+          input: typeof context,
+          environment: 'staging'
+        ): Promise<ReleaseBusV2OperationRecord>;
+      }
+    ).reconcileE2E(context, 'staging');
+
+    expect(mockReconcileWorkflow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        operationType: 'E2E_STAGING',
+        ref: '1a-staging',
+        expectedSha: FRONTEND_SHA,
+        inputs: expect.objectContaining({
+          source_ref: '1a-staging',
+          expected_sha: FRONTEND_SHA
         })
       })
     );

--- a/src/releaseBusV2/release-bus-v2.acceptance.test.ts
+++ b/src/releaseBusV2/release-bus-v2.acceptance.test.ts
@@ -2063,6 +2063,41 @@ describe('Release Bus v2 offline acceptance harness', () => {
     expect(state.repository.lock.owner_train_id).toBeNull();
   });
 
+  it('fails closed when a production main ref does not resolve to a valid SHA', async () => {
+    const state = harness('SUCCEEDED');
+    const production = train('production-invalid-main', {
+      lane: 'PRODUCTION',
+      status: 'CLAIMED',
+      frontend_composed_sha: null,
+      backend_composed_sha: null,
+      frontend_artifact_digest: null,
+      backend_artifact_digest: null
+    });
+    const context = {
+      train: production,
+      memberships: state.repository.memberships.map((membership) => ({
+        ...membership,
+        train_id: production.id
+      })),
+      candidates: Array.from(state.repository.candidates.values()),
+      dependencies: state.repository.dependencies
+    };
+    mockResolveRef.mockImplementation(async (repository: string) =>
+      repository === 'frontend' ? null : production.backend_base_sha
+    );
+
+    await expect(
+      (
+        state.reconciler as unknown as {
+          advancePreparation(input: typeof context): Promise<void>;
+        }
+      ).advancePreparation(context)
+    ).rejects.toThrow(
+      'Invalid SHA returned for frontend:main while fencing a production replan'
+    );
+    expect(mockReconcileWorkflow).not.toHaveBeenCalled();
+  });
+
   it('waits for dispatched composition before requeueing a moved production plan', async () => {
     const state = harness('SUCCEEDED');
     process.env.RELEASE_BUS_V2_MODE = 'PRODUCTION';
@@ -2103,6 +2138,21 @@ describe('Release Bus v2 offline acceptance harness', () => {
       completed_at: null
     };
     state.repository.operations.push(running);
+    let completeDuringReconcile = false;
+    mockReconcileWorkflow.mockImplementation(async () => {
+      const runningIndex = state.repository.operations.findIndex(
+        ({ id }) => id === running.id
+      );
+      if (completeDuringReconcile) {
+        state.repository.operations[runningIndex] = {
+          ...state.repository.operations[runningIndex],
+          status: 'SUCCEEDED',
+          completed_at: Date.now(),
+          row_version: state.repository.operations[runningIndex].row_version + 1
+        };
+      }
+      return state.repository.operations[runningIndex];
+    });
     mockResolveRef.mockImplementation(async (repository: string) =>
       repository === 'frontend' ? '9'.repeat(40) : production.backend_base_sha
     );
@@ -2132,15 +2182,21 @@ describe('Release Bus v2 offline acceptance harness', () => {
     );
     expect(state.repository.operations).toHaveLength(3);
 
-    const runningIndex = state.repository.operations.findIndex(
-      ({ id }) => id === running.id
+    completeDuringReconcile = true;
+    mockFindWorkflowRun.mockResolvedValue({ status: 'in_progress' });
+    await state.reconciler.runOnce(
+      'acceptance-production-main-moved-terminal-callback'
     );
-    state.repository.operations[runningIndex] = {
-      ...state.repository.operations[runningIndex],
-      status: 'SUCCEEDED',
-      completed_at: Date.now(),
-      row_version: state.repository.operations[runningIndex].row_version + 1
-    };
+
+    expect(state.repository.trains.get(production.id)?.status).toBe(
+      'COMPOSING'
+    );
+    expect(
+      state.repository.operations.find(({ id }) => id === running.id)?.status
+    ).toBe('SUCCEEDED');
+    expect(mockReconcileWorkflow).toHaveBeenCalledTimes(4);
+
+    mockFindWorkflowRun.mockResolvedValue({ status: 'completed' });
     await state.reconciler.runOnce('acceptance-production-main-moved-terminal');
 
     expect(state.repository.trains.get(production.id)?.status).toBe(
@@ -2152,7 +2208,7 @@ describe('Release Bus v2 offline acceptance harness', () => {
           status === 'READY_FOR_PRODUCTION' && current_train_id === null
       )
     ).toBe(true);
-    expect(mockReconcileWorkflow).toHaveBeenCalledTimes(3);
+    expect(mockReconcileWorkflow).toHaveBeenCalledTimes(4);
     expect(state.repository.operations).toHaveLength(3);
   });
 

--- a/src/releaseBusV2/release-bus-v2.acceptance.test.ts
+++ b/src/releaseBusV2/release-bus-v2.acceptance.test.ts
@@ -2063,6 +2063,54 @@ describe('Release Bus v2 offline acceptance harness', () => {
     expect(state.repository.lock.owner_train_id).toBeNull();
   });
 
+  it('replans a backend-only production train when its immutable frontend identity moved', async () => {
+    const state = harness('SUCCEEDED');
+    process.env.RELEASE_BUS_V2_MODE = 'PRODUCTION';
+    const production = train('train-1', {
+      lane: 'PRODUCTION',
+      status: 'CLAIMED',
+      frontend_composed_sha: null,
+      backend_composed_sha: null,
+      frontend_artifact_digest: null,
+      backend_artifact_digest: null
+    });
+    state.repository.trains.set(production.id, production);
+    state.repository.memberships.splice(
+      0,
+      state.repository.memberships.length,
+      state.repository.memberships.find(
+        ({ candidate_id }) => candidate_id === 'backend-candidate'
+      )!
+    );
+    state.repository.candidates.set('backend-candidate', {
+      ...state.repository.candidates.get('backend-candidate')!,
+      status: 'PRODUCTION_BUILDING_OR_QUALIFYING',
+      current_train_id: production.id
+    });
+    mockResolveRef.mockImplementation(async (repository: string) =>
+      repository === 'frontend' ? '9'.repeat(40) : production.backend_base_sha
+    );
+
+    await state.reconciler.runOnce(
+      'acceptance-backend-only-unchanged-main-moved'
+    );
+
+    expect(state.repository.trains.get(production.id)).toEqual(
+      expect.objectContaining({
+        status: 'CANCELLED',
+        failure_class: 'INTERACTION',
+        failure_message: expect.stringContaining('frontend main moved')
+      })
+    );
+    expect(state.repository.candidates.get('backend-candidate')).toEqual(
+      expect.objectContaining({
+        status: 'READY_FOR_PRODUCTION',
+        current_train_id: null
+      })
+    );
+    expect(mockReconcileWorkflow).not.toHaveBeenCalled();
+  });
+
   it('fails closed when a production main ref does not resolve to a valid SHA', async () => {
     const state = harness('SUCCEEDED');
     const production = train('production-invalid-main', {

--- a/src/releaseBusV2/release-bus-v2.reconciler.test.ts
+++ b/src/releaseBusV2/release-bus-v2.reconciler.test.ts
@@ -301,6 +301,25 @@ describe('Release Bus v2 deterministic orchestration', () => {
     });
   });
 
+  it('preserves ordering across a backend unit filtered from the environment', () => {
+    const planned = {
+      ...candidate('projected-ordering', 'd'.repeat(40)),
+      deploy_plan_json: {
+        units: ['dbMigrationsLoop', 'mediaResizerLoop', 'ethPriceLoop'],
+        edges: [
+          ['dbMigrationsLoop', 'mediaResizerLoop'],
+          ['mediaResizerLoop', 'ethPriceLoop']
+        ] as Array<readonly [string, string]>
+      }
+    };
+
+    expect(backendGraph([planned], 'staging')).toEqual({
+      units: ['dbMigrationsLoop', 'ethPriceLoop'],
+      edges: [['dbMigrationsLoop', 'ethPriceLoop']],
+      layers: [['dbMigrationsLoop'], ['ethPriceLoop']]
+    });
+  });
+
   it('fails closed on dependency cycles', () => {
     expect(() =>
       dagLayers(

--- a/src/releaseBusV2/release-bus-v2.reconciler.test.ts
+++ b/src/releaseBusV2/release-bus-v2.reconciler.test.ts
@@ -280,6 +280,27 @@ describe('Release Bus v2 deterministic orchestration', () => {
     ).toEqual([['dbMigrationsLoop'], ['api']]);
   });
 
+  it('filters production-only backend units from staging without changing production', () => {
+    const planned = {
+      ...candidate('environment-scoped', 'd'.repeat(40)),
+      deploy_plan_json: {
+        units: ['api', 'releaseBus'],
+        edges: [['api', 'releaseBus']] as Array<readonly [string, string]>
+      }
+    };
+
+    expect(backendGraph([planned], 'staging')).toEqual({
+      units: ['api'],
+      edges: [],
+      layers: [['api']]
+    });
+    expect(backendGraph([planned], 'prod')).toEqual({
+      units: ['api', 'releaseBus'],
+      edges: [['api', 'releaseBus']],
+      layers: [['api'], ['releaseBus']]
+    });
+  });
+
   it('fails closed on dependency cycles', () => {
     expect(() =>
       dagLayers(

--- a/src/releaseBusV2/release-bus-v2.reconciler.ts
+++ b/src/releaseBusV2/release-bus-v2.reconciler.ts
@@ -1,5 +1,8 @@
 import { createHash, randomUUID } from 'node:crypto';
-import { getDeployServiceConfigs } from '@/api/deploy/deploy.config';
+import {
+  getDeployServiceConfigs,
+  type DeployEnvironment
+} from '@/api/deploy/deploy.config';
 import {
   releaseBusGitHubApp,
   ReleaseBusGitHubInfrastructureError
@@ -134,7 +137,13 @@ type IsolationDiagnosis = {
   } | null;
 };
 
-class MainMovedError extends Error {}
+class MainMovedError extends Error {
+  public constructor(message: string) {
+    super(message);
+    this.name = 'MainMovedError';
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
 
 function isGitHubInfrastructureError(error: unknown): error is Error {
   const infrastructureType: unknown = ReleaseBusGitHubInfrastructureError;
@@ -302,27 +311,45 @@ function candidateStatusForDeploy(
 }
 
 export function backendGraph(
-  candidates: readonly ReleaseBusV2CandidateRecord[]
+  candidates: readonly ReleaseBusV2CandidateRecord[],
+  environment?: DeployEnvironment
 ): {
   readonly units: readonly string[];
   readonly edges: ReadonlyArray<readonly [string, string]>;
   readonly layers: readonly string[][];
 } {
+  const serviceConfigs = getDeployServiceConfigs();
+  const allowedUnits = environment
+    ? new Set(
+        serviceConfigs
+          .filter(({ allowed_environments }) =>
+            allowed_environments.includes(environment)
+          )
+          .map(({ name }) => name)
+      )
+    : null;
   const units = new Set<string>();
   const edgeKeys = new Set<string>();
   const edges: Array<readonly [string, string]> = [];
   for (const candidate of candidates) {
     if (candidate.repository !== 'backend') continue;
     const plan = storedDeployPlan(candidate);
-    for (const unit of plan?.units ?? []) units.add(unit);
+    for (const unit of plan?.units ?? []) {
+      if (!allowedUnits || allowedUnits.has(unit)) units.add(unit);
+    }
+  }
+  for (const candidate of candidates) {
+    if (candidate.repository !== 'backend') continue;
+    const plan = storedDeployPlan(candidate);
     for (const [from, to] of plan?.edges ?? []) {
+      if (!units.has(from) || !units.has(to)) continue;
       const key = `${from}\u0000${to}`;
       if (edgeKeys.has(key)) continue;
       edgeKeys.add(key);
       edges.push([from, to]);
     }
   }
-  for (const service of getDeployServiceConfigs()) {
+  for (const service of serviceConfigs) {
     if (!units.has(service.name)) continue;
     for (const dependency of service.default_dependencies) {
       if (!units.has(dependency)) continue;
@@ -835,8 +862,98 @@ export class ReleaseBusV2Reconciler {
     };
   }
 
+  private async deferMovedProductionPlan(
+    context: TrainContext
+  ): Promise<boolean> {
+    const train = context.train;
+    if (train.lane !== 'PRODUCTION') return false;
+    const repositories = ['backend', 'frontend'] as const;
+    const current = await Promise.all(
+      repositories.map(async (repository) => ({
+        repository,
+        sha: await releaseBusGitHubApp.resolveRef(repository, 'main')
+      }))
+    );
+    const moved = current.find(({ repository, sha }) => {
+      const base =
+        repository === 'frontend'
+          ? train.frontend_base_sha
+          : train.backend_base_sha;
+      const composed =
+        repository === 'frontend'
+          ? train.frontend_composed_sha
+          : train.backend_composed_sha;
+      return sha !== base && sha !== composed;
+    });
+    if (!moved) return false;
+    const base =
+      moved.repository === 'frontend'
+        ? train.frontend_base_sha
+        : train.backend_base_sha;
+    const message = `${moved.repository} main moved from ${base} to ${moved.sha}; production composition must be rebuilt and requalified`;
+    const operations = await this.repository.listOperations(train.id, {});
+    const active = operations.filter(
+      ({ external_id, status }) =>
+        ['DISPATCHED', 'RUNNING'].includes(status) ||
+        (status === 'PENDING' && external_id !== null)
+    );
+    if (active.length === 0) throw new MainMovedError(message);
+    await Promise.all(
+      active.map(async (operation) => {
+        const request = parseStoredJson<{
+          readonly workflow?: unknown;
+          readonly ref?: unknown;
+          readonly inputs?: unknown;
+        }>(operation.request_json);
+        if (
+          !operation.repository ||
+          !operation.environment ||
+          !operation.expected_sha ||
+          typeof request?.workflow !== 'string' ||
+          typeof request.ref !== 'string' ||
+          !request.inputs ||
+          typeof request.inputs !== 'object'
+        )
+          throw new Error(
+            `Dispatched operation ${operation.id} has no immutable workflow identity`
+          );
+        await releaseBusV2Operations.reconcileWorkflow({
+          idempotencyKey: operation.idempotency_key,
+          trainId: operation.train_id,
+          operationType: operation.operation_type,
+          repository: operation.repository,
+          workflow: request.workflow,
+          ref: request.ref,
+          environment: operation.environment,
+          service: operation.service,
+          expectedSha: operation.expected_sha,
+          artifactDigest: operation.artifact_digest,
+          inputs: request.inputs as Readonly<Record<string, string>>,
+          maxAttempts: operation.max_attempts
+        });
+      })
+    );
+    const refreshed = await this.repository.listOperations(train.id, {});
+    if (
+      !refreshed.some(
+        ({ external_id, status }) =>
+          ['DISPATCHED', 'RUNNING'].includes(status) ||
+          (status === 'PENDING' && external_id !== null)
+      )
+    )
+      throw new MainMovedError(message);
+    const recoveryMessage = `${message}; waiting for already-dispatched orchestration to report terminal before the safe replan`;
+    if (train.recovery_message !== recoveryMessage)
+      await this.transitionTrain(train, {
+        status: train.status,
+        recoveryMessage
+      });
+    return true;
+  }
+
   private async advancePreparation(context: TrainContext): Promise<void> {
     const train = context.train;
+    if (await this.deferMovedProductionPlan(context)) return;
     if (relevantCandidates(context).length === 0) {
       await this.transitionTrain(train, {
         status: 'CANCELLED',
@@ -2282,6 +2399,7 @@ export class ReleaseBusV2Reconciler {
   private async advanceProduction(context: TrainContext): Promise<void> {
     const train = context.train;
     if (train.status === 'PREPARED') {
+      if (await this.deferMovedProductionPlan(context)) return;
       const exact = await this.repository.findValidatedManifestByRelease(
         train.frontend_composed_sha,
         train.backend_composed_sha,
@@ -2711,7 +2829,7 @@ export class ReleaseBusV2Reconciler {
     const train = context.train;
     const source = await this.artifactSource(artifactSourceTrainId);
     const backendCandidates = relevantCandidates(context, 'backend');
-    const graph = backendGraph(backendCandidates);
+    const graph = backendGraph(backendCandidates, environment);
     const operations: ReleaseBusV2OperationRecord[] = [];
     let backendComplete = graph.units.length === 0;
     for (const layer of graph.layers) {
@@ -2888,6 +3006,22 @@ export class ReleaseBusV2Reconciler {
           : null)
     )
       throw new Error('E2E manifest does not match the exact train release');
+    const releaseBranch = releaseBusV2Branch(train, 'frontend');
+    let exactSourceRef = 'main';
+    if (environment === 'staging') {
+      const sourceRefs = [releaseBranch, '1a-staging', 'main'];
+      const sourceShas = await Promise.all(
+        sourceRefs.map((ref) =>
+          releaseBusGitHubApp.resolveRefIfExists('frontend', ref)
+        )
+      );
+      const exactIndex = sourceShas.findIndex((sha) => sha === expectedSha);
+      if (exactIndex < 0)
+        throw new Error(
+          `No immutable frontend workflow ref resolves to exact staging SHA ${expectedSha}`
+        );
+      exactSourceRef = sourceRefs[exactIndex];
+    }
     const spec: ReleaseBusV2WorkflowSpec = {
       idempotencyKey: operationKey(train.id, `e2e:${environment}`),
       trainId: train.id,
@@ -2895,7 +3029,7 @@ export class ReleaseBusV2Reconciler {
       repository: 'frontend',
       workflow:
         environment === 'staging' ? 'staging-e2e.yml' : 'production-e2e.yml',
-      ref: 'main',
+      ref: exactSourceRef,
       environment,
       service: null,
       expectedSha,
@@ -2904,9 +3038,7 @@ export class ReleaseBusV2Reconciler {
         release_train_id: train.id,
         release_train_revision: '1',
         operation_key: 'replaced-by-reconciler',
-        staging_source_ref: relevantCandidates(context, 'frontend').length
-          ? releaseBusV2Branch(train, 'frontend')
-          : 'main',
+        staging_source_ref: exactSourceRef,
         expected_sha: expectedSha,
         release_manifest_id: manifest.id,
         release_manifest_identity_sha256: manifest.identity_sha256,
@@ -2986,7 +3118,10 @@ export class ReleaseBusV2Reconciler {
       artifact_source_train_id: artifactSourceTrainId,
       train_id: train.id,
       lane: train.lane,
-      backend_graph: backendGraph(relevantCandidates(context, 'backend')),
+      backend_graph: backendGraph(
+        relevantCandidates(context, 'backend'),
+        status === 'PRODUCTION_DEPLOYED' ? 'prod' : 'staging'
+      ),
       operations: operations.map((operation) => ({
         type: operation.operation_type,
         service: operation.service,
@@ -3369,6 +3504,32 @@ export class ReleaseBusV2Reconciler {
   ): Promise<void> {
     const current = await this.repository.findTrain(train.id, {});
     if (!current || TERMINAL_TRAINS.has(current.status)) return;
+    const operations = await this.repository.listOperations(current.id, {});
+    if (
+      operations.some(
+        ({ external_id, status }) =>
+          ['DISPATCHED', 'RUNNING'].includes(status) ||
+          (status === 'PENDING' && external_id !== null)
+      )
+    )
+      return;
+    for (const operation of operations) {
+      if (TERMINAL_OPERATIONS.has(operation.status)) continue;
+      if (
+        !(await this.repository.updateOperation(
+          operation.id,
+          operation.row_version,
+          {
+            status: 'CANCELLED',
+            failureClass: 'INTERACTION',
+            failureMessage: message,
+            completedAt: Date.now()
+          },
+          {}
+        ))
+      )
+        throw new Error('Release Bus v2 operation changed concurrently');
+    }
     const context = await this.loadContext(current);
     await this.updateCandidateStatuses(
       relevantCandidates(context),

--- a/src/releaseBusV2/release-bus-v2.reconciler.ts
+++ b/src/releaseBusV2/release-bus-v2.reconciler.ts
@@ -171,6 +171,26 @@ function isOptimisticConcurrencyConflict(error: unknown): error is Error {
   );
 }
 
+function operationMayStillBeRunning(
+  operation: ReleaseBusV2OperationRecord
+): boolean {
+  return (
+    ['DISPATCHED', 'RUNNING'].includes(operation.status) ||
+    (operation.status === 'PENDING' && operation.external_id !== null)
+  );
+}
+
+function stringRecord(value: unknown): Readonly<Record<string, string>> | null {
+  if (
+    !value ||
+    typeof value !== 'object' ||
+    Array.isArray(value) ||
+    !Object.values(value).every((item) => typeof item === 'string')
+  )
+    return null;
+  return value as Readonly<Record<string, string>>;
+}
+
 function parseStoredJson<T>(value: unknown): T | null {
   if (value === null) return null;
   return typeof value === 'string' ? (JSON.parse(value) as T) : (value as T);
@@ -319,7 +339,7 @@ export function backendGraph(
   readonly layers: readonly string[][];
 } {
   const serviceConfigs = getDeployServiceConfigs();
-  const allowedUnits = environment
+  const allowedServiceNames = environment
     ? new Set(
         serviceConfigs
           .filter(({ allowed_environments }) =>
@@ -328,36 +348,68 @@ export function backendGraph(
           .map(({ name }) => name)
       )
     : null;
-  const units = new Set<string>();
-  const edgeKeys = new Set<string>();
-  const edges: Array<readonly [string, string]> = [];
+  const requestedUnits = new Set<string>();
   for (const candidate of candidates) {
     if (candidate.repository !== 'backend') continue;
     const plan = storedDeployPlan(candidate);
-    for (const unit of plan?.units ?? []) {
-      if (!allowedUnits || allowedUnits.has(unit)) units.add(unit);
-    }
+    for (const unit of plan?.units ?? []) requestedUnits.add(unit);
   }
+  const allEdgeKeys = new Set<string>();
+  const allEdges: Array<readonly [string, string]> = [];
+  const addEdge = (
+    target: Array<readonly [string, string]>,
+    keys: Set<string>,
+    from: string,
+    to: string
+  ) => {
+    const key = `${from}\u0000${to}`;
+    if (keys.has(key)) return;
+    keys.add(key);
+    target.push([from, to]);
+  };
   for (const candidate of candidates) {
     if (candidate.repository !== 'backend') continue;
     const plan = storedDeployPlan(candidate);
     for (const [from, to] of plan?.edges ?? []) {
-      if (!units.has(from) || !units.has(to)) continue;
-      const key = `${from}\u0000${to}`;
-      if (edgeKeys.has(key)) continue;
-      edgeKeys.add(key);
-      edges.push([from, to]);
+      if (!requestedUnits.has(from) || !requestedUnits.has(to)) continue;
+      addEdge(allEdges, allEdgeKeys, from, to);
     }
   }
   for (const service of serviceConfigs) {
-    if (!units.has(service.name)) continue;
+    if (!requestedUnits.has(service.name)) continue;
     for (const dependency of service.default_dependencies) {
-      if (!units.has(dependency)) continue;
-      const key = `${dependency}\u0000${service.name}`;
-      if (edgeKeys.has(key)) continue;
-      edgeKeys.add(key);
-      edges.push([dependency, service.name]);
+      if (!requestedUnits.has(dependency)) continue;
+      addEdge(allEdges, allEdgeKeys, dependency, service.name);
     }
+  }
+  const units = new Set(
+    Array.from(requestedUnits).filter(
+      (unit) => !allowedServiceNames || allowedServiceNames.has(unit)
+    )
+  );
+  let edges = allEdges;
+  if (allowedServiceNames) {
+    const adjacency = new Map(
+      Array.from(requestedUnits).map((unit) => [unit, [] as string[]])
+    );
+    for (const [from, to] of allEdges) adjacency.get(from)?.push(to);
+    const projectedEdges: Array<readonly [string, string]> = [];
+    const projectedKeys = new Set<string>();
+    for (const source of Array.from(units)) {
+      const visited = new Set<string>();
+      const pending = [...(adjacency.get(source) ?? [])];
+      while (pending.length > 0) {
+        const target = pending.shift()!;
+        if (visited.has(target)) continue;
+        visited.add(target);
+        if (units.has(target)) {
+          addEdge(projectedEdges, projectedKeys, source, target);
+          continue;
+        }
+        pending.push(...(adjacency.get(target) ?? []));
+      }
+    }
+    edges = projectedEdges;
   }
   const orderedUnits = Array.from(units).sort((left, right) =>
     left.localeCompare(right)
@@ -874,6 +926,12 @@ export class ReleaseBusV2Reconciler {
         sha: await releaseBusGitHubApp.resolveRef(repository, 'main')
       }))
     );
+    for (const { repository, sha } of current) {
+      if (!/^[a-f0-9]{40}$/.test(sha))
+        throw new Error(
+          `Invalid SHA returned for ${repository}:main while fencing a production replan`
+        );
+    }
     const moved = current.find(({ repository, sha }) => {
       const base =
         repository === 'frontend'
@@ -892,57 +950,79 @@ export class ReleaseBusV2Reconciler {
         : train.backend_base_sha;
     const message = `${moved.repository} main moved from ${base} to ${moved.sha}; production composition must be rebuilt and requalified`;
     const operations = await this.repository.listOperations(train.id, {});
-    const active = operations.filter(
-      ({ external_id, status }) =>
-        ['DISPATCHED', 'RUNNING'].includes(status) ||
-        (status === 'PENDING' && external_id !== null)
+    const carriedOperationIds = new Set(
+      /; observing operations: ([^;]+)$/
+        .exec(train.recovery_message ?? '')?.[1]
+        ?.split(',')
+        .map((id) => id.trim())
+        .filter(Boolean) ?? []
     );
-    if (active.length === 0) throw new MainMovedError(message);
-    await Promise.all(
-      active.map(async (operation) => {
+    const observed = operations.filter(
+      (operation) =>
+        operationMayStillBeRunning(operation) ||
+        carriedOperationIds.has(operation.id)
+    );
+    if (observed.length === 0) throw new MainMovedError(message);
+    const results = await Promise.all(
+      observed.map(async (operation) => {
         const request = parseStoredJson<{
           readonly workflow?: unknown;
           readonly ref?: unknown;
           readonly inputs?: unknown;
         }>(operation.request_json);
+        const inputs = stringRecord(request?.inputs);
         if (
           !operation.repository ||
           !operation.environment ||
           !operation.expected_sha ||
           typeof request?.workflow !== 'string' ||
           typeof request.ref !== 'string' ||
-          !request.inputs ||
-          typeof request.inputs !== 'object'
+          !inputs
         )
           throw new Error(
             `Dispatched operation ${operation.id} has no immutable workflow identity`
           );
-        await releaseBusV2Operations.reconcileWorkflow({
-          idempotencyKey: operation.idempotency_key,
-          trainId: operation.train_id,
-          operationType: operation.operation_type,
-          repository: operation.repository,
-          workflow: request.workflow,
-          ref: request.ref,
-          environment: operation.environment,
-          service: operation.service,
-          expectedSha: operation.expected_sha,
-          artifactDigest: operation.artifact_digest,
-          inputs: request.inputs as Readonly<Record<string, string>>,
-          maxAttempts: operation.max_attempts
-        });
+        if (operationMayStillBeRunning(operation))
+          await releaseBusV2Operations.reconcileWorkflow({
+            idempotencyKey: operation.idempotency_key,
+            trainId: operation.train_id,
+            operationType: operation.operation_type,
+            repository: operation.repository,
+            workflow: request.workflow,
+            ref: request.ref,
+            environment: operation.environment,
+            service: operation.service,
+            expectedSha: operation.expected_sha,
+            artifactDigest: operation.artifact_digest,
+            inputs,
+            maxAttempts: operation.max_attempts
+          });
+        const refreshed =
+          (await this.repository.findOperation(
+            operation.idempotency_key,
+            {}
+          )) ?? operation;
+        if (operationMayStillBeRunning(refreshed))
+          return { id: operation.id, stillRunning: true };
+        if (!refreshed.external_id)
+          return { id: operation.id, stillRunning: false };
+        const run = await releaseBusGitHubApp.findWorkflowRun(
+          operation.repository,
+          request.workflow,
+          `${operation.idempotency_key}:a${refreshed.attempt}`,
+          refreshed.external_id
+        );
+        return {
+          id: operation.id,
+          stillRunning: run !== null && run.status !== 'completed'
+        };
       })
     );
-    const refreshed = await this.repository.listOperations(train.id, {});
-    if (
-      !refreshed.some(
-        ({ external_id, status }) =>
-          ['DISPATCHED', 'RUNNING'].includes(status) ||
-          (status === 'PENDING' && external_id !== null)
-      )
-    )
-      throw new MainMovedError(message);
-    const recoveryMessage = `${message}; waiting for already-dispatched orchestration to report terminal before the safe replan`;
+    const stillRunningIds = results
+      .filter(({ stillRunning }) => stillRunning)
+      .map(({ id }) => id);
+    if (stillRunningIds.length === 0) throw new MainMovedError(message);
+    const recoveryMessage = `${message}; waiting for already-dispatched orchestration to report terminal before the safe replan; observing operations: ${stillRunningIds.join(',')}`;
     if (train.recovery_message !== recoveryMessage)
       await this.transitionTrain(train, {
         status: train.status,

--- a/src/releaseBusV2/release-bus-v2.reconciler.ts
+++ b/src/releaseBusV2/release-bus-v2.reconciler.ts
@@ -3585,14 +3585,7 @@ export class ReleaseBusV2Reconciler {
     const current = await this.repository.findTrain(train.id, {});
     if (!current || TERMINAL_TRAINS.has(current.status)) return;
     const operations = await this.repository.listOperations(current.id, {});
-    if (
-      operations.some(
-        ({ external_id, status }) =>
-          ['DISPATCHED', 'RUNNING'].includes(status) ||
-          (status === 'PENDING' && external_id !== null)
-      )
-    )
-      return;
+    if (operations.some(operationMayStillBeRunning)) return;
     for (const operation of operations) {
       if (TERMINAL_OPERATIONS.has(operation.status)) continue;
       if (


### PR DESCRIPTION
## What changed

- Replan and requeue production trains when either immutable main base moves before qualification.
- Poll only already-dispatched preparation operations before replanning, then cancel undispatched durable operations transactionally so repeated reconciles do not create duplicate workflows.
- Filter backend deploy units and dependency edges by the target environment, preventing production-only services such as `releaseBus` from entering staging plans while preserving their production deployment.
- Dispatch staging E2E from an exact frontend ref (release branch, shared staging ref, or exact main) and use that same ref as the test source.
- Record the environment-filtered backend graph in manifests.

## Why

The live production incident exposed two adjacent liveness/safety gaps after the original qualification-yield fix: an immutable production composition could become stale when main moved before qualification, and a staging E2E workflow dispatched from newer main could expect scripts absent from the older exact deployed frontend. Separately, production-only backend units were retained in staging deployment graphs.

This change preserves exact-manifest and fail-closed semantics while ensuring stale work yields the single production lane and exact staging validation runs workflow code compatible with the deployed source.

## Validation

- `npm run check:changed` (5 suites, 113 tests)
- focused reconciler + acceptance tests (57 tests)
- `npm run build` (284 suites, 2,628 tests, full TypeScript build)
- full-source ESLint with zero warnings
- `npm --prefix src/api-serverless run build`
- deploy-config generation and clean generated diff


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved production recovery when the main branch changes during release qualification.
  - Prevented cancellation and requeueing until active deployment operations finish.
  - Ensured staging plans exclude production-only services.
  - Improved staging E2E reconciliation by selecting the exact release reference matching the expected revision.
  - Preserved correct backend-only staging behavior when the main branch has moved.

- **Tests**
  - Added acceptance coverage for production requeueing, orchestration reuse, exact staging manifests, and environment-specific deployment planning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->