### PR TITLE
Fix V2 fast-path immutable release refs

### DIFF
--- a/src/releaseBus/release-bus.github-app.test.ts
+++ b/src/releaseBus/release-bus.github-app.test.ts
@@ -15,6 +15,85 @@ jest.mock('node-fetch', () => {
   return { ...actual, __esModule: true, default: jest.fn() };
 });
 
+function appWithCachedToken(): ReleaseBusGitHubApp {
+  const app = new ReleaseBusGitHubApp();
+  (
+    app as unknown as {
+      cachedToken: { value: string; expiresAt: number };
+    }
+  ).cachedToken = { value: 'test-token', expiresAt: Date.now() + 120_000 };
+  return app;
+}
+
+describe('GitHub immutable release refs', () => {
+  const ref = 'release-bus-v2/staging-train-train-id-frontend';
+  const exactSha = 'a'.repeat(40);
+
+  afterEach(() => {
+    (fetch as jest.MockedFunction<typeof fetch>).mockReset();
+  });
+
+  it('creates an absent immutable release ref without force', async () => {
+    const fetchMock = fetch as jest.MockedFunction<typeof fetch>;
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ ref: `refs/heads/${ref}` }), {
+        status: 201
+      })
+    );
+
+    await appWithCachedToken().createRef('frontend', ref, exactSha);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain('/git/refs');
+    expect(fetchMock.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({
+          ref: `refs/heads/${ref}`,
+          sha: exactSha
+        })
+      })
+    );
+  });
+
+  it('is idempotent only when a racing ref resolves to the exact SHA', async () => {
+    const fetchMock = fetch as jest.MockedFunction<typeof fetch>;
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ message: 'Reference already exists' }), {
+          status: 422
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ object: { sha: exactSha } }))
+      );
+
+    await expect(
+      appWithCachedToken().createRef('frontend', ref, exactSha)
+    ).resolves.toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('fails closed when a racing ref resolves to another SHA', async () => {
+    const fetchMock = fetch as jest.MockedFunction<typeof fetch>;
+    fetchMock
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ message: 'Reference already exists' }), {
+          status: 422
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ object: { sha: 'b'.repeat(40) } }))
+      );
+
+    await expect(
+      appWithCachedToken().createRef('frontend', ref, exactSha)
+    ).rejects.toThrow(
+      'Failed to create frontend ref release-bus-v2/staging-train-train-id-frontend: Reference already exists'
+    );
+  });
+});
+
 describe('GitHub pull request qualification evidence', () => {
   it('reads checks from the PR head and binds the artifact to its merge tree', async () => {
     const headSha = 'a'.repeat(40);

--- a/src/releaseBusV2/release-bus-v2.acceptance.test.ts
+++ b/src/releaseBusV2/release-bus-v2.acceptance.test.ts
@@ -2,6 +2,7 @@ const mockReconcileWorkflow = jest.fn();
 const mockEnsureCommitStatus = jest.fn();
 const mockResolveRef = jest.fn();
 const mockResolveRefIfExists = jest.fn();
+const mockCreateRef = jest.fn();
 const mockRefContainsCommit = jest.fn();
 const mockUpdateRef = jest.fn();
 const mockHasActiveStagingRun = jest.fn();
@@ -20,6 +21,7 @@ jest.mock('@/releaseBus/release-bus.github-app', () => ({
     ensureCommitStatus: (...args: unknown[]) => mockEnsureCommitStatus(...args),
     resolveRef: (...args: unknown[]) => mockResolveRef(...args),
     resolveRefIfExists: (...args: unknown[]) => mockResolveRefIfExists(...args),
+    createRef: (...args: unknown[]) => mockCreateRef(...args),
     refContainsCommit: (...args: unknown[]) => mockRefContainsCommit(...args),
     updateRef: (...args: unknown[]) => mockUpdateRef(...args),
     hasActiveStagingMutationOrE2ERun: (...args: unknown[]) =>
@@ -2955,6 +2957,130 @@ describe('Release Bus v2 offline acceptance harness', () => {
         })
       })
     );
+  });
+
+  it('binds a single-candidate fast path to its immutable release ref before preflight', async () => {
+    const state = harness('SUCCEEDED');
+    const exactTrain = train('single-fast-path', {
+      frontend_composed_sha: null,
+      backend_composed_sha: null,
+      frontend_artifact_digest: null,
+      backend_artifact_digest: null
+    });
+    const frontendCandidate = {
+      ...state.repository.candidates.get('frontend-candidate')!,
+      current_train_id: exactTrain.id,
+      pr_evidence_json: {
+        base_sha: exactTrain.frontend_base_sha!,
+        merge_sha: FRONTEND_SHA,
+        checks_run_id: '100',
+        checks_completed_at: 1,
+        artifact_run_id: '100',
+        artifact_name: `release-bus-v2-pr-${FRONTEND_SHA}`,
+        artifact_digest: FRONTEND_DIGEST
+      }
+    };
+    const context = {
+      train: exactTrain,
+      memberships: [
+        {
+          ...state.repository.memberships.find(
+            ({ candidate_id }) => candidate_id === 'frontend-candidate'
+          )!,
+          train_id: exactTrain.id
+        }
+      ],
+      candidates: [frontendCandidate],
+      dependencies: []
+    };
+    mockReconcileWorkflow.mockResolvedValueOnce(
+      operation(
+        exactTrain.id,
+        'PREPARE_ARTIFACT_FRONTEND',
+        'frontend',
+        'fast-preflight'
+      )
+    );
+
+    await (
+      state.reconciler as unknown as {
+        prepareRepository(
+          input: typeof context,
+          repository: 'frontend'
+        ): Promise<unknown>;
+      }
+    ).prepareRepository(context, 'frontend');
+
+    expect(mockCreateRef).toHaveBeenCalledWith(
+      'frontend',
+      `release-bus-v2/staging-train-${exactTrain.id}-frontend`,
+      FRONTEND_SHA
+    );
+    expect(mockCreateRef.mock.invocationCallOrder[0]).toBeLessThan(
+      mockReconcileWorkflow.mock.invocationCallOrder[0]!
+    );
+    expect(mockReconcileWorkflow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        operationType: 'PREPARE_ARTIFACT_FRONTEND',
+        expectedSha: FRONTEND_SHA,
+        inputs: expect.objectContaining({
+          source_ref: frontendCandidate.branch_name,
+          expected_sha: FRONTEND_SHA
+        })
+      })
+    );
+  });
+
+  it('fails closed before preflight when a fast-path immutable ref conflicts', async () => {
+    const state = harness('SUCCEEDED');
+    const exactTrain = train('single-fast-path-conflict', {
+      frontend_composed_sha: null,
+      backend_composed_sha: null,
+      frontend_artifact_digest: null,
+      backend_artifact_digest: null
+    });
+    const frontendCandidate = {
+      ...state.repository.candidates.get('frontend-candidate')!,
+      current_train_id: exactTrain.id,
+      pr_evidence_json: {
+        base_sha: exactTrain.frontend_base_sha!,
+        merge_sha: FRONTEND_SHA,
+        checks_run_id: '100',
+        checks_completed_at: 1,
+        artifact_run_id: '100',
+        artifact_name: `release-bus-v2-pr-${FRONTEND_SHA}`,
+        artifact_digest: FRONTEND_DIGEST
+      }
+    };
+    const context = {
+      train: exactTrain,
+      memberships: [
+        {
+          ...state.repository.memberships.find(
+            ({ candidate_id }) => candidate_id === 'frontend-candidate'
+          )!,
+          train_id: exactTrain.id
+        }
+      ],
+      candidates: [frontendCandidate],
+      dependencies: []
+    };
+    mockCreateRef.mockRejectedValueOnce(
+      new Error('immutable release ref already points elsewhere')
+    );
+
+    await expect(
+      (
+        state.reconciler as unknown as {
+          prepareRepository(
+            input: typeof context,
+            repository: 'frontend'
+          ): Promise<unknown>;
+        }
+      ).prepareRepository(context, 'frontend')
+    ).rejects.toThrow('immutable release ref already points elsewhere');
+
+    expect(mockReconcileWorkflow).not.toHaveBeenCalled();
   });
 
   it('runs backend-only staging E2E from the exact shared staging ref when main moved', async () => {

--- a/src/releaseBusV2/release-bus-v2.reconciler.ts
+++ b/src/releaseBusV2/release-bus-v2.reconciler.ts
@@ -1338,6 +1338,18 @@ export class ReleaseBusV2Reconciler {
         };
     }
     if (!composedSha) throw new Error(`Missing ${repository} composed SHA`);
+    if (fastCandidate) {
+      // The compose workflow creates the immutable release ref for multi-PR
+      // trains. The single-PR fast path skips that workflow, so bind the same
+      // lane-scoped ref here before any artifact preparation or deployment.
+      // createRef is idempotent only when an existing ref already resolves to
+      // this exact SHA; a moved or conflicting ref fails closed.
+      await releaseBusGitHubApp.createRef(
+        repository,
+        releaseBusV2Branch(train, repository),
+        composedSha
+      );
+    }
     if (compositionOnly)
       return {
         repository,


### PR DESCRIPTION
## Summary
- create the lane-scoped immutable release ref for single-candidate fast-path trains before preflight
- keep exact-SHA retries idempotent and reject conflicting/moved refs before workflow dispatch
- add acceptance and GitHub API regression coverage for creation, retry races, conflict fencing, and preflight ordering

## Incident
A single frontend candidate reused its exact green merge-tree artifact and deployed successfully, but no compose workflow ran to create the immutable release ref. Staging E2E then could not resolve a workflow ref at the deployed SHA and V2 correctly paused ALL.

## Validation
- `npm run check:changed`
- targeted Jest: 87 tests passed before the final assertion-only adjustment
- targeted Jest after adjustment: 71 tests passed

## Release notes
Internal operational fix; do not publish a user-facing release note.