### PR TITLE
DB: retire Release Bus v1 tables reversibly

### DIFF
--- a/migrations/20260724202500-retire-release-bus-v1-tables.js
+++ b/migrations/20260724202500-retire-release-bus-v1-tables.js
@@ -1,0 +1,55 @@
+'use strict';
+
+/*
+ * Reversible retirement phase for the Simple Release Bus v1 data model.
+ *
+ * The production runtime, routes, workflows, claimants, refs, and configuration
+ * are retired before this migration is allowed to run. An encrypted Aurora
+ * cluster snapshot is also required before deployment.
+ *
+ * MySQL executes a multi-table RENAME TABLE atomically. Keeping every row under
+ * a clearly retired name gives operators a forward-fix recovery window without
+ * leaving any legacy table name available to an accidental v1 claimant.
+ */
+var TABLE_RENAMES = [
+  ['release_ready_deployments', 'retired_release_bus_v1_ready_deployments'],
+  [
+    'release_candidate_dependencies',
+    'retired_release_bus_v1_candidate_dependencies'
+  ],
+  ['release_trains', 'retired_release_bus_v1_trains'],
+  ['release_train_items', 'retired_release_bus_v1_train_items'],
+  ['release_train_operations', 'retired_release_bus_v1_train_operations'],
+  ['release_train_evidence', 'retired_release_bus_v1_train_evidence'],
+  ['release_deployment_lanes', 'retired_release_bus_v1_deployment_lanes'],
+  ['release_bus_controls', 'retired_release_bus_v1_controls'],
+  ['release_train_events', 'retired_release_bus_v1_train_events']
+];
+
+function renameSql(pairs) {
+  return (
+    'RENAME TABLE ' +
+    pairs
+      .map(function (pair) {
+        return '`' + pair[0] + '` TO `' + pair[1] + '`';
+      })
+      .join(', ')
+  );
+}
+
+exports.up = function (db) {
+  return db.runSql(renameSql(TABLE_RENAMES));
+};
+
+exports.down = function (db) {
+  return db.runSql(
+    renameSql(
+      TABLE_RENAMES.map(function (pair) {
+        return [pair[1], pair[0]];
+      })
+    )
+  );
+};
+
+exports._meta = { version: 1 };
+

--- a/migrations/20260724202500-retire-release-bus-v1-tables.js
+++ b/migrations/20260724202500-retire-release-bus-v1-tables.js
@@ -11,9 +11,10 @@
  * a clearly retired name gives operators a forward-fix recovery window without
  * leaving any legacy table name available to an accidental v1 claimant.
  *
- * Precondition: all nine source tables exist and none of the retired target
- * names exist. A mismatch intentionally fails the whole atomic statement
- * closed; silently accepting a partial or ambiguous retirement is unsafe.
+ * Every pair is inspected before execution. A source-only pair is included in
+ * the one atomic rename, a target-only pair is already retired, and a pair
+ * absent on both sides was never present in that environment. If both names
+ * exist, the migration fails closed instead of guessing which copy is valid.
  */
 var TABLE_RENAMES = [
   ['release_ready_deployments', 'retired_release_bus_v1_ready_deployments'],
@@ -41,17 +42,63 @@ function renameSql(pairs) {
   );
 }
 
+function presentTableNames(db) {
+  var names = TABLE_RENAMES.reduce(function (all, pair) {
+    return all.concat(pair);
+  }, []);
+  var literals = names
+    .map(function (name) {
+      return "'" + name + "'";
+    })
+    .join(', ');
+
+  return db
+    .runSql(
+      'SELECT table_name AS table_name FROM information_schema.tables ' +
+        'WHERE table_schema = DATABASE() AND table_name IN (' +
+        literals +
+        ')'
+    )
+    .then(function (rows) {
+      return new Set(
+        (rows || []).map(function (row) {
+          return row.table_name;
+        })
+      );
+    });
+}
+
+function migrate(db, pairs) {
+  return presentTableNames(db).then(function (present) {
+    var pending = pairs.filter(function (pair) {
+      var sourceExists = present.has(pair[0]);
+      var targetExists = present.has(pair[1]);
+      if (sourceExists && targetExists) {
+        throw new Error(
+          'Ambiguous Release Bus v1 table retirement state: both `' +
+            pair[0] +
+            '` and `' +
+            pair[1] +
+            '` exist'
+        );
+      }
+      return sourceExists && !targetExists;
+    });
+    if (pending.length === 0) return Promise.resolve();
+    return db.runSql(renameSql(pending));
+  });
+}
+
 exports.up = function (db) {
-  return db.runSql(renameSql(TABLE_RENAMES));
+  return migrate(db, TABLE_RENAMES);
 };
 
 exports.down = function (db) {
-  return db.runSql(
-    renameSql(
-      TABLE_RENAMES.map(function (pair) {
-        return [pair[1], pair[0]];
-      })
-    )
+  return migrate(
+    db,
+    TABLE_RENAMES.map(function (pair) {
+      return [pair[1], pair[0]];
+    })
   );
 };
 

--- a/migrations/20260724202500-retire-release-bus-v1-tables.js
+++ b/migrations/20260724202500-retire-release-bus-v1-tables.js
@@ -10,6 +10,10 @@
  * MySQL executes a multi-table RENAME TABLE atomically. Keeping every row under
  * a clearly retired name gives operators a forward-fix recovery window without
  * leaving any legacy table name available to an accidental v1 claimant.
+ *
+ * Precondition: all nine source tables exist and none of the retired target
+ * names exist. A mismatch intentionally fails the whole atomic statement
+ * closed; silently accepting a partial or ambiguous retirement is unsafe.
  */
 var TABLE_RENAMES = [
   ['release_ready_deployments', 'retired_release_bus_v1_ready_deployments'],
@@ -52,4 +56,3 @@ exports.down = function (db) {
 };
 
 exports._meta = { version: 1 };
-

--- a/src/releaseBusV2/release-bus-v1-retirement.test.ts
+++ b/src/releaseBusV2/release-bus-v1-retirement.test.ts
@@ -1,5 +1,13 @@
 import fs from 'node:fs';
+import { createRequire } from 'node:module';
 import path from 'node:path';
+
+type RetirementMigration = {
+  up(db: { runSql(sql: string): Promise<void> }): Promise<void>;
+  down(db: { runSql(sql: string): Promise<void> }): Promise<void>;
+};
+
+const requireModule = createRequire(__filename);
 
 function read(relativePath: string): string {
   return fs.readFileSync(
@@ -37,26 +45,49 @@ describe('Release Bus v1 retirement', () => {
     );
   });
 
-  it('retires legacy tables atomically and reversibly before deletion', () => {
+  it('retires legacy tables atomically and reversibly before deletion', async () => {
     const migration = read(
       'migrations/20260724202500-retire-release-bus-v1-tables.js'
     );
+    const executableMigration = requireModule(
+      path.resolve(
+        __dirname,
+        '../../migrations/20260724202500-retire-release-bus-v1-tables.js'
+      )
+    ) as RetirementMigration;
+    const statements: string[] = [];
+    const db = {
+      runSql: jest.fn(async (sql: string) => {
+        statements.push(sql);
+      })
+    };
 
     expect(migration).toContain('RENAME TABLE');
     expect(migration).toContain('exports.down');
     expect(migration).not.toMatch(/\bDROP\s+TABLE\b/i);
-    for (const table of [
-      'release_ready_deployments',
-      'release_candidate_dependencies',
-      'release_trains',
-      'release_train_items',
-      'release_train_operations',
-      'release_train_evidence',
-      'release_deployment_lanes',
-      'release_bus_controls',
-      'release_train_events'
-    ]) {
-      expect(migration).toContain(`'${table}'`);
+    await executableMigration.up(db);
+    await executableMigration.down(db);
+
+    expect(statements).toHaveLength(2);
+    expect(statements[0]).toMatch(/^RENAME TABLE /);
+    expect(statements[1]).toMatch(/^RENAME TABLE /);
+    const pairs = [
+      ['release_ready_deployments', 'retired_release_bus_v1_ready_deployments'],
+      [
+        'release_candidate_dependencies',
+        'retired_release_bus_v1_candidate_dependencies'
+      ],
+      ['release_trains', 'retired_release_bus_v1_trains'],
+      ['release_train_items', 'retired_release_bus_v1_train_items'],
+      ['release_train_operations', 'retired_release_bus_v1_train_operations'],
+      ['release_train_evidence', 'retired_release_bus_v1_train_evidence'],
+      ['release_deployment_lanes', 'retired_release_bus_v1_deployment_lanes'],
+      ['release_bus_controls', 'retired_release_bus_v1_controls'],
+      ['release_train_events', 'retired_release_bus_v1_train_events']
+    ];
+    for (const [active, retired] of pairs) {
+      expect(statements[0]).toContain(`\`${active}\` TO \`${retired}\``);
+      expect(statements[1]).toContain(`\`${retired}\` TO \`${active}\``);
     }
   });
 });

--- a/src/releaseBusV2/release-bus-v1-retirement.test.ts
+++ b/src/releaseBusV2/release-bus-v1-retirement.test.ts
@@ -36,4 +36,27 @@ describe('Release Bus v1 retirement', () => {
       /RELEASE_READY_DEPLOYMENTS_TABLE|RELEASE_TRAINS_TABLE|RELEASE_BUS_CONTROLS_TABLE/
     );
   });
+
+  it('retires legacy tables atomically and reversibly before deletion', () => {
+    const migration = read(
+      'migrations/20260724202500-retire-release-bus-v1-tables.js'
+    );
+
+    expect(migration).toContain('RENAME TABLE');
+    expect(migration).toContain('exports.down');
+    expect(migration).not.toMatch(/\bDROP\s+TABLE\b/i);
+    for (const table of [
+      'release_ready_deployments',
+      'release_candidate_dependencies',
+      'release_trains',
+      'release_train_items',
+      'release_train_operations',
+      'release_train_evidence',
+      'release_deployment_lanes',
+      'release_bus_controls',
+      'release_train_events'
+    ]) {
+      expect(migration).toContain(`'${table}'`);
+    }
+  });
 });

--- a/src/releaseBusV2/release-bus-v1-retirement.test.ts
+++ b/src/releaseBusV2/release-bus-v1-retirement.test.ts
@@ -3,8 +3,8 @@ import { createRequire } from 'node:module';
 import path from 'node:path';
 
 type RetirementMigration = {
-  up(db: { runSql(sql: string): Promise<void> }): Promise<void>;
-  down(db: { runSql(sql: string): Promise<void> }): Promise<void>;
+  up(db: { runSql(sql: string): Promise<unknown> }): Promise<void>;
+  down(db: { runSql(sql: string): Promise<unknown> }): Promise<void>;
 };
 
 const requireModule = createRequire(__filename);
@@ -55,22 +55,9 @@ describe('Release Bus v1 retirement', () => {
         '../../migrations/20260724202500-retire-release-bus-v1-tables.js'
       )
     ) as RetirementMigration;
-    const statements: string[] = [];
-    const db = {
-      runSql: jest.fn(async (sql: string) => {
-        statements.push(sql);
-      })
-    };
-
     expect(migration).toContain('RENAME TABLE');
     expect(migration).toContain('exports.down');
     expect(migration).not.toMatch(/\bDROP\s+TABLE\b/i);
-    await executableMigration.up(db);
-    await executableMigration.down(db);
-
-    expect(statements).toHaveLength(2);
-    expect(statements[0]).toMatch(/^RENAME TABLE /);
-    expect(statements[1]).toMatch(/^RENAME TABLE /);
     const pairs = [
       ['release_ready_deployments', 'retired_release_bus_v1_ready_deployments'],
       [
@@ -85,9 +72,50 @@ describe('Release Bus v1 retirement', () => {
       ['release_bus_controls', 'retired_release_bus_v1_controls'],
       ['release_train_events', 'retired_release_bus_v1_train_events']
     ];
+    const executeWithTables = async (
+      direction: 'up' | 'down',
+      tables: string[]
+    ) => {
+      const statements: string[] = [];
+      const db = {
+        runSql: jest.fn(async (sql: string) => {
+          statements.push(sql);
+          return sql.startsWith('SELECT ')
+            ? tables.map((table_name) => ({ table_name }))
+            : undefined;
+        })
+      };
+      await executableMigration[direction](db);
+      return statements;
+    };
+    const up = await executeWithTables(
+      'up',
+      pairs.map(([active]) => active)
+    );
+    const down = await executeWithTables(
+      'down',
+      pairs.map(([, retired]) => retired)
+    );
+
+    expect(up).toHaveLength(2);
+    expect(down).toHaveLength(2);
+    expect(up[0]).toMatch(/^SELECT /);
+    expect(down[0]).toMatch(/^SELECT /);
+    expect(up[1]).toMatch(/^RENAME TABLE /);
+    expect(down[1]).toMatch(/^RENAME TABLE /);
     for (const [active, retired] of pairs) {
-      expect(statements[0]).toContain(`\`${active}\` TO \`${retired}\``);
-      expect(statements[1]).toContain(`\`${retired}\` TO \`${active}\``);
+      expect(up[1]).toContain(`\`${active}\` TO \`${retired}\``);
+      expect(down[1]).toContain(`\`${retired}\` TO \`${active}\``);
     }
+
+    await expect(
+      executeWithTables('up', [pairs[0][0], pairs[0][1]])
+    ).rejects.toThrow('Ambiguous Release Bus v1 table retirement state');
+    await expect(
+      executeWithTables(
+        'up',
+        pairs.map(([, retired]) => retired)
+      )
+    ).resolves.toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary
- atomically rename all nine Simple Release Bus v1 tables to retired names after the v1 runtime/routes/workflows/refs/config were removed
- preserve every row for a forward-fix recovery window and provide the exact reverse rename
- add a regression proving this phase remains reversible and contains no destructive table drop

## Safety sequence
- V1 API/runtime/infrastructure removal is already live from backend PR #1831 and frontend PR #3455
- production train `ed832d14-ad8c-4b20-8765-4a5d8750a02e` is terminal `PRODUCTION_DEPLOYED`; production E2E `30123201268` succeeded
- encrypted Aurora snapshot `release-bus-v1-retirement-20260724-2021z` is `available` at 100%
- deployment remains blocked until exact-head CI/bot review is green and live V2 controls/locks are reverified
- irreversible deletion will be a separate follow-up only after this reversible phase is deployed and V2/manual fallback are proven healthy

## Validation
- `node --check migrations/20260724202500-retire-release-bus-v1-tables.js`
- `npm test -- --runInBand src/releaseBusV2/release-bus-v1-retirement.test.ts`
- `npm run check:changed`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Retired legacy Release Bus v1 database tables by renaming them instead of deleting them.
  * Added support for safely reversing the retirement changes.

* **Tests**
  * Added coverage confirming all expected legacy tables are handled and no data is directly dropped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->