### PR TITLE
Fix v2 qualification immutable workflow refs

### DIFF
--- a/src/releaseBusV2/release-bus-v2.reconciler.test.ts
+++ b/src/releaseBusV2/release-bus-v2.reconciler.test.ts
@@ -9,7 +9,8 @@ import {
   dagLayers,
   e2eWorkflowInputs,
   releaseTrainContributorGithubLogins,
-  releaseBusV2Branch
+  releaseBusV2Branch,
+  releaseBusV2WorkflowBranch
 } from '@/releaseBusV2/release-bus-v2.reconciler';
 import {
   normalizeDeployPlan,
@@ -407,5 +408,31 @@ describe('Release Bus v2 deterministic orchestration', () => {
         'frontend'
       )
     ).toBe('release-bus-v2/qualification-train-train-id-frontend');
+  });
+
+  it('runs qualification deploy and E2E workflows from the immutable parent production ref', () => {
+    expect(
+      releaseBusV2WorkflowBranch(
+        {
+          id: 'qualification-id',
+          lane: 'PRODUCTION_QUALIFICATION',
+          parent_train_id: 'production-id'
+        },
+        'frontend'
+      )
+    ).toBe('release-bus-v2/production-train-production-id-frontend');
+  });
+
+  it('fails closed when a qualification loses its immutable parent ref identity', () => {
+    expect(() =>
+      releaseBusV2WorkflowBranch(
+        {
+          id: 'qualification-id',
+          lane: 'PRODUCTION_QUALIFICATION',
+          parent_train_id: null
+        },
+        'frontend'
+      )
+    ).toThrow('Production qualification train is missing its parent');
   });
 });

--- a/src/releaseBusV2/release-bus-v2.reconciler.ts
+++ b/src/releaseBusV2/release-bus-v2.reconciler.ts
@@ -216,6 +216,23 @@ export function releaseBusV2Branch(
   return `release-bus-v2/${laneBranchSegment(train.lane)}-train-${train.id}-${repository}`;
 }
 
+export function releaseBusV2WorkflowBranch(
+  train: Pick<ReleaseBusV2TrainRecord, 'id' | 'lane' | 'parent_train_id'>,
+  repository: ReleaseBusV2Repository
+): string {
+  if (train.lane !== 'PRODUCTION_QUALIFICATION')
+    return releaseBusV2Branch(train, repository);
+  if (!train.parent_train_id)
+    throw new Error('Production qualification train is missing its parent');
+  // Qualification children inherit the exact parent composition/artifacts;
+  // they do not run composition and therefore never create a child release
+  // ref. Keep deploy and E2E tooling bound to the parent's immutable ref.
+  return releaseBusV2Branch(
+    { id: train.parent_train_id, lane: 'PRODUCTION' },
+    repository
+  );
+}
+
 export function dagLayers(
   units: readonly string[],
   edges: ReadonlyArray<readonly [string, string]>
@@ -3093,7 +3110,7 @@ export class ReleaseBusV2Reconciler {
         source_ref:
           environment === 'prod'
             ? 'main'
-            : releaseBusV2Branch(train, 'frontend'),
+            : releaseBusV2WorkflowBranch(train, 'frontend'),
         expected_sha: expectedSha,
         artifact_run_id: artifactRunId,
         artifact_train_id: artifactTrainId,
@@ -3129,7 +3146,7 @@ export class ReleaseBusV2Reconciler {
           : null)
     )
       throw new Error('E2E manifest does not match the exact train release');
-    const releaseBranch = releaseBusV2Branch(train, 'frontend');
+    const releaseBranch = releaseBusV2WorkflowBranch(train, 'frontend');
     let exactSourceRef = 'main';
     if (environment === 'staging') {
       const sourceRefs = [releaseBranch, '1a-staging', 'main'];


### PR DESCRIPTION
## Summary
- bind production-qualification frontend staging deploys and E2E to the immutable parent production ref
- fail closed when a qualification train loses its parent identity
- add regression coverage for the exact parent-ref contract

## Incident
- qualification train `041fbcb4-e235-47f1-bb68-3708886a993f` deployed FE `b28f42ede100d414051963f4cb088ecb8fbc3ea6` and BE `6c81ba5450de17b9384117573cfbebc5f47151d2` successfully
- E2E dispatch then failed because the child-scoped qualification ref was never created
- v2 failed closed and paused ALL; parent/candidates are safely terminal/requeued and every lock is free
- qualification children inherit the parent composition/artifacts, so their workflow source must be the existing parent production ref

## Validation
- `npm test -- --runInBand src/releaseBusV2/release-bus-v2.reconciler.test.ts` (18/18)
- `npx eslint --no-cache src/releaseBusV2/release-bus-v2.reconciler.ts src/releaseBusV2/release-bus-v2.reconciler.test.ts`
- `npx prettier --check src/releaseBusV2/release-bus-v2.reconciler.ts src/releaseBusV2/release-bus-v2.reconciler.test.ts`
- repository-wide local `tsc` reaches pre-existing missing optional API declarations; complete type gates are delegated to PR CI

## Deployment safety
- no lane/control mutation is part of this PR
- ALL remains paused while CI/review run
- deploy API first, then the releaseBus v2 reconciler, verify exact runtime SHA, controls/locks/candidates, and only then consider an audited ALL resume