### PR TITLE
Fix V2 qualification immutable workflow refs

### DIFF
--- a/src/releaseBusV2/release-bus-v2.acceptance.test.ts
+++ b/src/releaseBusV2/release-bus-v2.acceptance.test.ts
@@ -9,6 +9,7 @@ const mockHasActiveStagingRun = jest.fn();
 const mockHasStagingRunSince = jest.fn();
 const mockHasActiveProductionRun = jest.fn();
 const mockFindWorkflowRun = jest.fn();
+const mockImmutableRefs = new Map<string, string>();
 
 jest.mock('@/releaseBusV2/release-bus-v2.operations', () => ({
   releaseBusV2Operations: {
@@ -686,6 +687,16 @@ describe('Release Bus v2 offline acceptance harness', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockImmutableRefs.clear();
+    mockCreateRef.mockImplementation(
+      async (repository: string, ref: string, sha: string) => {
+        const key = `${repository}:${ref}`;
+        const existing = mockImmutableRefs.get(key);
+        if (existing && existing !== sha)
+          throw new Error('immutable release ref already points elsewhere');
+        mockImmutableRefs.set(key, sha);
+      }
+    );
     process.env.RELEASE_BUS_V2_MODE = 'STAGING';
     delete process.env.RELEASE_BUS_V2_BETA_ALLOWLIST;
     mockHasActiveStagingRun.mockResolvedValue(false);
@@ -1696,6 +1707,62 @@ describe('Release Bus v2 offline acceptance harness', () => {
     expect(state.repository.lock.owner_train_id).toBeNull();
     expect(state.repository.lock.lease_token).toBeNull();
     expect(mockResolveRefIfExists).not.toHaveBeenCalled();
+  });
+
+  it('rebinds the same immutable qualification ref safely after an idle-handshake retry', async () => {
+    const state = harness('SUCCEEDED');
+    state.repository.trains.set(
+      'train-1',
+      train('train-1', { lane: 'PRODUCTION_QUALIFICATION' })
+    );
+    mockHasActiveStagingRun
+      .mockResolvedValueOnce(true)
+      .mockResolvedValue(false);
+    const context = {
+      train: state.repository.trains.get('train-1')!,
+      memberships: [...state.repository.memberships],
+      candidates: Array.from(state.repository.candidates.values()),
+      dependencies: state.repository.dependencies
+    };
+
+    await (
+      state.reconciler as unknown as {
+        advanceStagingOrQualification(input: typeof context): Promise<void>;
+      }
+    ).advanceStagingOrQualification(context);
+
+    expect(state.repository.trains.get('train-1')?.status).toBe(
+      'WAITING_FOR_ENVIRONMENT'
+    );
+    expect(state.repository.lock.owner_train_id).toBeNull();
+
+    const retriedContext = {
+      ...context,
+      train: state.repository.trains.get('train-1')!
+    };
+    await (
+      state.reconciler as unknown as {
+        advanceStagingOrQualification(
+          input: typeof retriedContext
+        ): Promise<void>;
+      }
+    ).advanceStagingOrQualification(retriedContext);
+
+    expect(mockCreateRef).toHaveBeenCalledTimes(2);
+    expect(mockCreateRef).toHaveBeenNthCalledWith(
+      1,
+      'frontend',
+      'release-bus-v2/qualification-train-train-1-frontend',
+      FRONTEND_SHA
+    );
+    expect(mockCreateRef).toHaveBeenNthCalledWith(
+      2,
+      'frontend',
+      'release-bus-v2/qualification-train-train-1-frontend',
+      FRONTEND_SHA
+    );
+    expect(state.repository.trains.get('train-1')?.status).toBe('DEPLOYING');
+    expect(state.repository.lock.owner_train_id).toBe('train-1');
   });
 
   it('releases the production beta lock when the post-lock idle snapshot fails', async () => {

--- a/src/releaseBusV2/release-bus-v2.acceptance.test.ts
+++ b/src/releaseBusV2/release-bus-v2.acceptance.test.ts
@@ -1613,7 +1613,7 @@ describe('Release Bus v2 offline acceptance harness', () => {
     expect(state.repository.lock.owner_train_id).toBe('train-1');
   });
 
-  it('starts exact production qualification after unchanged staging matches the target', async () => {
+  it('binds the immutable frontend workflow ref before starting exact production qualification', async () => {
     const state = harness('SUCCEEDED');
     state.repository.trains.set(
       'train-1',
@@ -1650,6 +1650,11 @@ describe('Release Bus v2 offline acceptance harness', () => {
         backend_composed_sha: BACKEND_SHA
       })
     );
+    expect(mockCreateRef).toHaveBeenCalledWith(
+      'frontend',
+      'release-bus-v2/qualification-train-train-1-frontend',
+      FRONTEND_SHA
+    );
     expect(state.repository.lock.owner_train_id).toBe('train-1');
     expect(state.repository.events).toContainEqual(
       expect.objectContaining({
@@ -1662,6 +1667,35 @@ describe('Release Bus v2 offline acceptance harness', () => {
         })
       })
     );
+  });
+
+  it('fails before acquiring staging when the qualification workflow ref cannot be bound', async () => {
+    const state = harness('SUCCEEDED');
+    state.repository.trains.set(
+      'train-1',
+      train('train-1', { lane: 'PRODUCTION_QUALIFICATION' })
+    );
+    const context = {
+      train: state.repository.trains.get('train-1')!,
+      memberships: [...state.repository.memberships],
+      candidates: Array.from(state.repository.candidates.values()),
+      dependencies: state.repository.dependencies
+    };
+    mockCreateRef.mockRejectedValueOnce(
+      new Error('immutable qualification ref conflict')
+    );
+
+    await expect(
+      (
+        state.reconciler as unknown as {
+          advanceStagingOrQualification(input: typeof context): Promise<void>;
+        }
+      ).advanceStagingOrQualification(context)
+    ).rejects.toThrow('immutable qualification ref conflict');
+
+    expect(state.repository.lock.owner_train_id).toBeNull();
+    expect(state.repository.lock.lease_token).toBeNull();
+    expect(mockResolveRefIfExists).not.toHaveBeenCalled();
   });
 
   it('releases the production beta lock when the post-lock idle snapshot fails', async () => {

--- a/src/releaseBusV2/release-bus-v2.reconciler.ts
+++ b/src/releaseBusV2/release-bus-v2.reconciler.ts
@@ -1864,6 +1864,20 @@ export class ReleaseBusV2Reconciler {
     ].includes(train.status);
     const requiresBetaIdleHandshake =
       getReleaseBusV2Mode() === 'OFF' && requiresIdleHandshake;
+    if (
+      requiresIdleHandshake &&
+      relevantCandidates(context, 'frontend').length > 0
+    ) {
+      if (!train.frontend_composed_sha)
+        throw new Error(
+          'Frontend qualification has no exact composed SHA for its immutable workflow ref'
+        );
+      await releaseBusGitHubApp.createRef(
+        'frontend',
+        releaseBusV2Branch(train, 'frontend'),
+        train.frontend_composed_sha
+      );
+    }
     const workflowFenceStartedAt = requiresIdleHandshake ? Date.now() : null;
     const beforeLock = requiresIdleHandshake
       ? await this.captureStagingIdleSnapshot()

--- a/src/releaseBusV2/release-bus-v2.reconciler.ts
+++ b/src/releaseBusV2/release-bus-v2.reconciler.ts
@@ -1872,6 +1872,8 @@ export class ReleaseBusV2Reconciler {
         throw new Error(
           'Frontend qualification has no exact composed SHA for its immutable workflow ref'
         );
+      // createRef is retry-safe: an existing ref is accepted only when it
+      // already resolves to this exact SHA; a conflicting target fails closed.
       await releaseBusGitHubApp.createRef(
         'frontend',
         releaseBusV2Branch(train, 'frontend'),


### PR DESCRIPTION
## Issue

A production-qualification train can reuse already prepared immutable artifacts without running repository preparation for the qualification train itself. In that path, no qualification-scoped frontend ref is created. The deploy can finish from the artifact, but manifest-bound staging E2E then fails closed because it cannot check out a ref resolving to the exact deployed frontend SHA, pausing Release Bus v2 globally.

## Fix

Bind the qualification train's immutable frontend workflow ref before it starts the staging idle handshake or acquires the staging environment lock.

## Notable changes

- Reassert the immutable frontend ref invariant at the staging/qualification lane boundary.
- Fail before staging ownership when the exact ref cannot be created idempotently.
- Cover successful qualification binding and the fail-before-lock path in the offline acceptance harness.

## Validation

- `npm test -- src/releaseBusV2/release-bus-v2.acceptance.test.ts --runInBand` — 48/48 passed
- `npm run lint` — passed under Git Bash on Windows
- `tsc -p tsconfig.json --noEmit` — passed after installing the API workspace dependencies
- `git diff --check` — passed

## Risk

Low and isolated to Release Bus v2 orchestration. Existing staging and multi-candidate refs are rechecked idempotently; a conflicting ref fails before the environment lock or any deployment mutation.

## Review notes

Please focus on the placement of the ref invariant before the idle snapshot and lock acquisition. No architecture documentation update is required because this restores an existing orchestration invariant and does not change the deployed system shape.

Deployment after merge: redeploy the `releaseBus` Lambda only, then verify locks/workflows are idle before resuming the global Release Bus v2 control.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved exact production qualification by binding the frontend workflow to an immutable release reference before staging proceeds.
  - Added validation to prevent progression when the required frontend revision is unavailable.
  - Improved failure handling so staging locks are not acquired when immutable reference creation fails.
  - Added regression coverage for immutable reference conflicts and related qualification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->