### PR TITLE
Add surgical TDH data repair replay

### DIFF
--- a/src/backend.ts
+++ b/src/backend.ts
@@ -84,11 +84,18 @@ async function runRequestedLoopIfPresent() {
 async function start() {
   logger.info(`[CONFIG ${process.env.NODE_ENV}] [EXECUTING START SCRIPT...]`);
 
-  await dbMigrationsLoop.handler(
-    undefined as any,
-    undefined as any,
-    undefined as any
-  );
+  const requestedLoopName = getRequestedLoopName();
+  if (requestedLoopName === 'customReplayLoop') {
+    logger.info(
+      `[SKIPPING DB MIGRATIONS FOR SURGICAL LOOP] [${requestedLoopName}]`
+    );
+  } else {
+    await dbMigrationsLoop.handler(
+      undefined as any,
+      undefined as any,
+      undefined as any
+    );
+  }
 
   await runRequestedLoopIfPresent();
 

--- a/src/customReplayLoop/index.ts
+++ b/src/customReplayLoop/index.ts
@@ -1,6 +1,9 @@
 import { doInDbContext } from '../secrets';
 import { Logger } from '../logging';
 import * as sentryContext from '../sentry.context';
+import { ConsolidatedNFTOwner, NFTOwner } from '../entities/INFTOwner';
+import { Transaction } from '../entities/ITransaction';
+import { repairDuplicatedMemeTransfers } from './repair-duplicated-meme-transfers';
 
 const logger = Logger.get('CUSTOM_REPLAY_LOOP');
 
@@ -9,10 +12,17 @@ export const handler = sentryContext.wrapLambdaHandler(async () => {
     async () => {
       await replay();
     },
-    { logger }
+    {
+      logger,
+      entities: [Transaction, NFTOwner, ConsolidatedNFTOwner],
+      skipRedis: true
+    }
   );
 });
 
 async function replay() {
-  logger.info(`[CUSTOM REPLAY NOT IMPLEMENTED]`);
+  const apply = process.env.CUSTOM_REPLAY_APPLY === 'true';
+  logger.info(`[CUSTOM REPLAY MODE] [${apply ? 'APPLY' : 'DRY RUN'}]`);
+  const result = await repairDuplicatedMemeTransfers(apply);
+  logger.info(`[CUSTOM REPLAY COMPLETE] [RESULT ${result}]`);
 }

--- a/src/customReplayLoop/repair-duplicated-meme-transfers.test.ts
+++ b/src/customReplayLoop/repair-duplicated-meme-transfers.test.ts
@@ -1,0 +1,63 @@
+import {
+  classifyProdTdhRepairSnapshot,
+  ProdTdhRepairSnapshot
+} from './repair-duplicated-meme-transfers';
+
+function snapshot(value: number): ProdTdhRepairSnapshot {
+  const rows = [
+    { tokenId: 135, value },
+    { tokenId: 254, value }
+  ];
+  return {
+    transactions: rows,
+    recipientOwners: rows,
+    recipientConsolidatedOwners: rows,
+    senderOwners: []
+  };
+}
+
+describe('classifyProdTdhRepairSnapshot', () => {
+  it('recognizes the exact production state that needs repair', () => {
+    expect(classifyProdTdhRepairSnapshot(snapshot(2))).toBe('needs-repair');
+  });
+
+  it('recognizes an already repaired state', () => {
+    expect(classifyProdTdhRepairSnapshot(snapshot(1))).toBe('already-repaired');
+  });
+
+  it('rejects a partial repair', () => {
+    const partial: ProdTdhRepairSnapshot = {
+      ...snapshot(2),
+      recipientOwners: [
+        { tokenId: 135, value: 1 },
+        { tokenId: 254, value: 2 }
+      ]
+    };
+
+    expect(() => classifyProdTdhRepairSnapshot(partial)).toThrow(
+      '[RECIPIENT OWNERS] Expected token 135 value 2, found 1'
+    );
+  });
+
+  it('rejects missing target rows', () => {
+    const missing: ProdTdhRepairSnapshot = {
+      ...snapshot(2),
+      transactions: [{ tokenId: 135, value: 2 }]
+    };
+
+    expect(() => classifyProdTdhRepairSnapshot(missing)).toThrow(
+      '[TRANSACTIONS] Expected 2 rows, found 1'
+    );
+  });
+
+  it('rejects unexpected positive sender ownership', () => {
+    const unexpectedSenderOwner: ProdTdhRepairSnapshot = {
+      ...snapshot(2),
+      senderOwners: [{ tokenId: 135, value: 1 }]
+    };
+
+    expect(() => classifyProdTdhRepairSnapshot(unexpectedSenderOwner)).toThrow(
+      '[SENDER OWNERS] Expected no positive owner rows, found 1'
+    );
+  });
+});

--- a/src/customReplayLoop/repair-duplicated-meme-transfers.ts
+++ b/src/customReplayLoop/repair-duplicated-meme-transfers.ts
@@ -1,0 +1,314 @@
+import { EntityManager, In, Repository } from 'typeorm';
+import { getDataSource } from '../db';
+import { ConsolidatedNFTOwner, NFTOwner } from '../entities/INFTOwner';
+import { Transaction } from '../entities/ITransaction';
+import { Logger } from '../logging';
+
+const TRANSACTION_HASH =
+  '0xc58c1104651207ae9e32e208da08901d3df87fd63435ae4c7b0005b81000a25b';
+const MEMES_CONTRACT = '0x33fd426905f149f8376e227d0c9d3340aad17af1';
+const SENDER = '0x2ee4c45af89774c76a8a73178c281089a8771a00';
+const RECIPIENT = '0xbb78a151673fac1a0a2162abc7bee3a39b3767b5';
+const TOKEN_IDS = [135, 254] as const;
+const INCORRECT_BALANCE = 2;
+const CORRECT_BALANCE = 1;
+
+const logger = Logger.get('CUSTOM_REPLAY_TDH_DATA_REPAIR');
+
+type TokenValue = {
+  readonly tokenId: number;
+  readonly value: number;
+};
+
+export type ProdTdhRepairSnapshot = {
+  readonly transactions: TokenValue[];
+  readonly recipientOwners: TokenValue[];
+  readonly recipientConsolidatedOwners: TokenValue[];
+  readonly senderOwners: TokenValue[];
+};
+
+export type ProdTdhRepairState = 'needs-repair' | 'already-repaired';
+
+export type ProdTdhRepairResult =
+  'DRY_RUN_VERIFIED' | 'REPAIRED' | 'ALREADY_REPAIRED';
+
+function assertExpectedTokenValues(
+  label: string,
+  rows: TokenValue[],
+  expectedValue: number
+): void {
+  if (rows.length !== TOKEN_IDS.length) {
+    throw new Error(
+      `[${label}] Expected ${TOKEN_IDS.length} rows, found ${rows.length}`
+    );
+  }
+
+  for (const tokenId of TOKEN_IDS) {
+    const matchingRows = rows.filter((row) => row.tokenId === tokenId);
+    if (matchingRows.length !== 1) {
+      throw new Error(
+        `[${label}] Expected one row for token ${tokenId}, found ${matchingRows.length}`
+      );
+    }
+    if (matchingRows[0].value !== expectedValue) {
+      throw new Error(
+        `[${label}] Expected token ${tokenId} value ${expectedValue}, found ${matchingRows[0].value}`
+      );
+    }
+  }
+}
+
+function snapshotMatchesValue(
+  snapshot: ProdTdhRepairSnapshot,
+  expectedValue: number
+): boolean {
+  try {
+    assertExpectedTokenValues(
+      'TRANSACTIONS',
+      snapshot.transactions,
+      expectedValue
+    );
+    assertExpectedTokenValues(
+      'RECIPIENT OWNERS',
+      snapshot.recipientOwners,
+      expectedValue
+    );
+    assertExpectedTokenValues(
+      'RECIPIENT CONSOLIDATED OWNERS',
+      snapshot.recipientConsolidatedOwners,
+      expectedValue
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function classifyProdTdhRepairSnapshot(
+  snapshot: ProdTdhRepairSnapshot
+): ProdTdhRepairState {
+  if (snapshot.senderOwners.length > 0) {
+    throw new Error(
+      `[SENDER OWNERS] Expected no positive owner rows, found ${snapshot.senderOwners.length}`
+    );
+  }
+
+  if (snapshotMatchesValue(snapshot, CORRECT_BALANCE)) {
+    return 'already-repaired';
+  }
+
+  if (snapshotMatchesValue(snapshot, INCORRECT_BALANCE)) {
+    return 'needs-repair';
+  }
+
+  assertExpectedTokenValues(
+    'TRANSACTIONS',
+    snapshot.transactions,
+    INCORRECT_BALANCE
+  );
+  assertExpectedTokenValues(
+    'RECIPIENT OWNERS',
+    snapshot.recipientOwners,
+    INCORRECT_BALANCE
+  );
+  assertExpectedTokenValues(
+    'RECIPIENT CONSOLIDATED OWNERS',
+    snapshot.recipientConsolidatedOwners,
+    INCORRECT_BALANCE
+  );
+
+  throw new Error('[CUSTOM REPLAY] Unexpected repair state');
+}
+
+function toTokenValues<T>(
+  rows: T[],
+  tokenId: (row: T) => number,
+  value: (row: T) => number
+): TokenValue[] {
+  return rows.map((row) => ({
+    tokenId: Number(tokenId(row)),
+    value: Number(value(row))
+  }));
+}
+
+async function findTransactionsForUpdate(
+  manager: EntityManager
+): Promise<Transaction[]> {
+  return manager
+    .getRepository(Transaction)
+    .createQueryBuilder('tx')
+    .setLock('pessimistic_write')
+    .where('tx.transaction = :transactionHash', {
+      transactionHash: TRANSACTION_HASH
+    })
+    .andWhere('tx.from_address = :sender', { sender: SENDER })
+    .andWhere('tx.to_address = :recipient', {
+      recipient: RECIPIENT
+    })
+    .andWhere('tx.contract = :contract', {
+      contract: MEMES_CONTRACT
+    })
+    .andWhere('tx.token_id IN (:...tokenIds)', {
+      tokenIds: TOKEN_IDS
+    })
+    .orderBy('tx.token_id', 'ASC')
+    .getMany();
+}
+
+async function findOwnersForUpdate(
+  repository: Repository<NFTOwner>,
+  wallet: string
+): Promise<NFTOwner[]> {
+  return repository
+    .createQueryBuilder('owner')
+    .setLock('pessimistic_write')
+    .where('owner.wallet = :wallet', { wallet })
+    .andWhere('owner.contract = :contract', { contract: MEMES_CONTRACT })
+    .andWhere('owner.token_id IN (:...tokenIds)', { tokenIds: TOKEN_IDS })
+    .orderBy('owner.token_id', 'ASC')
+    .getMany();
+}
+
+async function findConsolidatedOwnersForUpdate(
+  manager: EntityManager
+): Promise<ConsolidatedNFTOwner[]> {
+  return manager
+    .getRepository(ConsolidatedNFTOwner)
+    .createQueryBuilder('owner')
+    .setLock('pessimistic_write')
+    .where('owner.consolidation_key = :consolidationKey', {
+      consolidationKey: RECIPIENT
+    })
+    .andWhere('owner.contract = :contract', { contract: MEMES_CONTRACT })
+    .andWhere('owner.token_id IN (:...tokenIds)', { tokenIds: TOKEN_IDS })
+    .orderBy('owner.token_id', 'ASC')
+    .getMany();
+}
+
+async function loadSnapshot(
+  manager: EntityManager
+): Promise<ProdTdhRepairSnapshot> {
+  const transactions = await findTransactionsForUpdate(manager);
+  const ownerRepository = manager.getRepository(NFTOwner);
+  const recipientOwners = await findOwnersForUpdate(ownerRepository, RECIPIENT);
+  const senderOwners = await findOwnersForUpdate(ownerRepository, SENDER);
+  const recipientConsolidatedOwners =
+    await findConsolidatedOwnersForUpdate(manager);
+
+  return {
+    transactions: toTokenValues(
+      transactions,
+      (row) => row.token_id,
+      (row) => row.token_count
+    ),
+    recipientOwners: toTokenValues(
+      recipientOwners,
+      (row) => row.token_id,
+      (row) => row.balance
+    ),
+    recipientConsolidatedOwners: toTokenValues(
+      recipientConsolidatedOwners,
+      (row) => row.token_id,
+      (row) => row.balance
+    ),
+    senderOwners: toTokenValues(
+      senderOwners,
+      (row) => row.token_id,
+      (row) => row.balance
+    )
+  };
+}
+
+function assertAffectedRows(
+  label: string,
+  affected: number | null | undefined
+): void {
+  if (affected !== TOKEN_IDS.length) {
+    throw new Error(
+      `[${label}] Expected to update ${TOKEN_IDS.length} rows, updated ${
+        affected ?? 0
+      }`
+    );
+  }
+}
+
+async function applyRepair(manager: EntityManager): Promise<void> {
+  const transactionUpdate = await manager.getRepository(Transaction).update(
+    {
+      transaction: TRANSACTION_HASH,
+      from_address: SENDER,
+      to_address: RECIPIENT,
+      contract: MEMES_CONTRACT,
+      token_id: In([...TOKEN_IDS]),
+      token_count: INCORRECT_BALANCE
+    },
+    { token_count: CORRECT_BALANCE }
+  );
+  assertAffectedRows('TRANSACTIONS', transactionUpdate.affected);
+
+  const ownerUpdate = await manager.getRepository(NFTOwner).update(
+    {
+      wallet: RECIPIENT,
+      contract: MEMES_CONTRACT,
+      token_id: In([...TOKEN_IDS]),
+      balance: INCORRECT_BALANCE
+    },
+    { balance: CORRECT_BALANCE }
+  );
+  assertAffectedRows('RECIPIENT OWNERS', ownerUpdate.affected);
+
+  const consolidatedOwnerUpdate = await manager
+    .getRepository(ConsolidatedNFTOwner)
+    .update(
+      {
+        consolidation_key: RECIPIENT,
+        contract: MEMES_CONTRACT,
+        token_id: In([...TOKEN_IDS]),
+        balance: INCORRECT_BALANCE
+      },
+      { balance: CORRECT_BALANCE }
+    );
+  assertAffectedRows(
+    'RECIPIENT CONSOLIDATED OWNERS',
+    consolidatedOwnerUpdate.affected
+  );
+}
+
+export async function repairDuplicatedMemeTransfers(
+  apply = false
+): Promise<ProdTdhRepairResult> {
+  return getDataSource().transaction(async (manager) => {
+    const before = await loadSnapshot(manager);
+    const state = classifyProdTdhRepairSnapshot(before);
+
+    if (state === 'already-repaired') {
+      logger.info('[CUSTOM REPLAY] Production TDH data is already repaired');
+      return 'ALREADY_REPAIRED';
+    }
+
+    if (!apply) {
+      logger.info(
+        `[CUSTOM REPLAY] [DRY RUN VERIFIED] Would update transaction, owner, and consolidated owner balances from ${INCORRECT_BALANCE} to ${CORRECT_BALANCE} for tokens ${TOKEN_IDS.join(
+          ','
+        )}`
+      );
+      return 'DRY_RUN_VERIFIED';
+    }
+
+    logger.info(
+      `[CUSTOM REPLAY] Repairing transaction ${TRANSACTION_HASH}, tokens ${TOKEN_IDS.join(
+        ','
+      )}`
+    );
+    await applyRepair(manager);
+
+    const after = await loadSnapshot(manager);
+    const afterState = classifyProdTdhRepairSnapshot(after);
+    if (afterState !== 'already-repaired') {
+      throw new Error('[CUSTOM REPLAY] Post-repair verification failed');
+    }
+
+    logger.info('[CUSTOM REPLAY] Production TDH data repair verified');
+    return 'REPAIRED';
+  });
+}


### PR DESCRIPTION
## What changed

- Implement a one-shot `customReplayLoop` repair for transaction `0xc58c1104651207ae9e32e208da08901d3df87fd63435ae4c7b0005b81000a25b`, Meme IDs 135 and 254.
- Make the replay dry-run by default; mutation requires `CUSTOM_REPLAY_APPLY=true`.
- Correct exactly two `transactions`, two `nft_owners`, and two consolidated-owner rows from `2` to `1` in one database transaction.
- Skip database migrations/schema sync and Redis when invoking this surgical loop through `backend.ts`.

## Why

Production stored `token_count = 2` for both ERC-1155 transfers even though the on-chain logs contain one unit of each. This overstates one wallet's production TDH by 93. Core's RPC-log-derived balances are correct.

## Safety

- The replay locks and validates the exact hash, contract, sender, recipient, token IDs, transaction counts, raw owner balances, consolidated-owner balances, and absence of positive sender ownership.
- The exact broken state applies once; the corrected state returns `ALREADY_REPAIRED`; any mixed or unexpected state aborts.
- Post-update verification occurs before commit. No ownership reset or TDH mutation is performed.

## Production runbook

```bash
CUSTOM_REPLAY_APPLY=false npm run backend:local -- customReplayLoop
CUSTOM_REPLAY_APPLY=true npm run backend:local -- customReplayLoop
CUSTOM_REPLAY_APPLY=false npm run backend:local -- customReplayLoop
```

Expected results: `DRY_RUN_VERIFIED`, then `REPAIRED`, then `ALREADY_REPAIRED`.

## Validation

- Focused repair-state test: 5 passing cases.
- Repository lint passed; unrelated formatter churn was excluded from this PR.