### PR TITLE
Retry unreported artifact preflight failures

### DIFF
--- a/src/releaseBusV2/release-bus-v2.acceptance.test.ts
+++ b/src/releaseBusV2/release-bus-v2.acceptance.test.ts
@@ -2123,6 +2123,61 @@ describe('Release Bus v2 offline acceptance harness', () => {
     ).toBe(true);
   });
 
+  it('requeues staging without globally pausing when artifact callback retries are exhausted', async () => {
+    const state = harness('SUCCEEDED');
+    state.repository.trains.set(
+      'train-1',
+      train('train-1', {
+        status: 'PREFLIGHTING',
+        frontend_artifact_digest: null
+      })
+    );
+    mockReconcileWorkflow.mockImplementation(async (spec) => {
+      const typed = spec as {
+        operationType: string;
+        service: string | null;
+      };
+      if (typed.operationType === 'PREPARE_ARTIFACT_FRONTEND') {
+        return {
+          ...operation(
+            'train-1',
+            'PREPARE_ARTIFACT_FRONTEND',
+            'frontend',
+            'callback-failed'
+          ),
+          status: 'FAILED' as const,
+          attempt: 3,
+          max_attempts: 3,
+          failure_class: 'INFRASTRUCTURE' as const,
+          failure_message:
+            'GitHub workflow concluded failure without a structured terminal callback'
+        };
+      }
+      throw new Error(`Unexpected operation ${typed.operationType}`);
+    });
+
+    await state.reconciler.runOnce('acceptance-preflight-callback-exhausted');
+
+    expect(state.repository.trains.get('train-1')).toEqual(
+      expect.objectContaining({
+        status: 'FAILED',
+        failure_class: 'INFRASTRUCTURE',
+        failure_message:
+          'GitHub workflow concluded failure without a structured terminal callback'
+      })
+    );
+    expect(
+      Array.from(state.repository.candidates.values()).map(
+        ({ status, current_train_id }) => ({ status, current_train_id })
+      )
+    ).toEqual([
+      { status: 'READY_FOR_STAGING', current_train_id: null },
+      { status: 'READY_FOR_STAGING', current_train_id: null }
+    ]);
+    expect(state.service.setPaused).not.toHaveBeenCalled();
+    expect(state.repository.lock.owner_train_id).toBeNull();
+  });
+
   it('requeues a production plan when candidate-bearing main moves before qualification', async () => {
     const state = harness('SUCCEEDED');
     process.env.RELEASE_BUS_V2_MODE = 'PRODUCTION';

--- a/src/releaseBusV2/release-bus-v2.operations.test.ts
+++ b/src/releaseBusV2/release-bus-v2.operations.test.ts
@@ -656,6 +656,76 @@ describe('Release Bus v2 exact operation callbacks', () => {
     });
   });
 
+  it('bounded-retries a failed artifact preparation whose terminal callback was not stored', async () => {
+    const state = repositoryFor(operation());
+    const service = new ReleaseBusV2Operations(state.repository as never);
+    mockFindWorkflowRun.mockResolvedValue({
+      id: 12345,
+      status: 'completed',
+      conclusion: 'failure'
+    });
+
+    await service.reconcileWorkflow({
+      idempotencyKey: 'rb2:train-id:prepare:frontend',
+      trainId: 'train-id',
+      operationType: 'PREPARE_ARTIFACT_FRONTEND',
+      repository: 'frontend',
+      workflow: 'release-bus-v2-preflight.yml',
+      ref: 'release-bus-v2/staging-train-train-id-frontend',
+      environment: 'orchestration',
+      service: null,
+      expectedSha: 'a'.repeat(40),
+      artifactDigest: null,
+      inputs: {}
+    });
+
+    expect(state.current()).toMatchObject({
+      status: 'RETRY_WAIT',
+      attempt: 1,
+      external_id: '12345',
+      failure_class: 'INFRASTRUCTURE',
+      failure_message:
+        'GitHub workflow concluded failure without a structured terminal callback',
+      completed_at: null
+    });
+  });
+
+  it('still fails closed when a mutating workflow omits its terminal callback', async () => {
+    const state = repositoryFor(
+      operation({
+        idempotency_key: 'rb2:train-id:deploy:frontend',
+        operation_type: 'DEPLOY_FRONTEND',
+        environment: 'staging'
+      })
+    );
+    const service = new ReleaseBusV2Operations(state.repository as never);
+    mockFindWorkflowRun.mockResolvedValue({
+      id: 12345,
+      status: 'completed',
+      conclusion: 'failure'
+    });
+
+    await service.reconcileWorkflow({
+      idempotencyKey: 'rb2:train-id:deploy:frontend',
+      trainId: 'train-id',
+      operationType: 'DEPLOY_FRONTEND',
+      repository: 'frontend',
+      workflow: 'deploy-release-bus-v2.yml',
+      ref: 'main',
+      environment: 'staging',
+      service: null,
+      expectedSha: 'a'.repeat(40),
+      artifactDigest: 'b'.repeat(64),
+      inputs: {}
+    });
+
+    expect(state.current()).toMatchObject({
+      status: 'FAILED',
+      failure_class: 'CONTROL_PLANE',
+      completed_at: expect.any(Number)
+    });
+  });
+
   it('rejects authorization after an operation reaches a terminal state', async () => {
     const state = repositoryFor(operation({ status: 'FAILED' }));
     const service = new ReleaseBusV2Operations(state.repository as never);

--- a/src/releaseBusV2/release-bus-v2.operations.ts
+++ b/src/releaseBusV2/release-bus-v2.operations.ts
@@ -185,7 +185,7 @@ function transportRetryState(result: unknown): {
 }
 
 function unreportedWorkflowFailureClass(
-  _operationType: string,
+  operationType: string,
   conclusion: string | null
 ): ReleaseBusV2FailureClass {
   if (
@@ -193,6 +193,12 @@ function unreportedWorkflowFailureClass(
       conclusion ?? ''
     )
   )
+    return 'INFRASTRUCTURE';
+  if (operationType.startsWith('PREPARE_ARTIFACT_') && conclusion === 'failure')
+    // Artifact preparation cannot mutate shared staging or production state.
+    // Its run also concludes failure when otherwise-successful artifact work
+    // cannot deliver the terminal callback (for example during an intentional
+    // fast-off). A bounded retry is safe and recovers the missing evidence.
     return 'INFRASTRUCTURE';
   // Every v2 workflow that reaches its trusted authorization boundary emits a
   // structured terminal report. A completed run without one is therefore a


### PR DESCRIPTION
## What changed

- classify a failed `PREPARE_ARTIFACT_*` workflow with no stored terminal callback as bounded `INFRASTRUCTURE` retry
- retain `CONTROL_PLANE` fail-closed behavior for successful runs that omit callbacks and for all staging/production mutation operations
- add operation and reconciler acceptance coverage proving retry exhaustion requeues exact staging candidates, releases locks, and does not globally pause Release Bus

## Root cause

Frontend preflight run `30260530660` for train `e0eb71d5-30c0-4574-b403-a81f9b53106b` completed artifact verification and upload, but its terminal callback reached the API after the owner fast-off and was rejected with HTTP 403. The generic unreported-workflow classifier treated that preparation-only failure as `CONTROL_PLANE`, causing `failTrain()` to pause `ALL` after STAGING was re-enabled. Artifact preparation cannot mutate shared staging or production, so bounded retry is the safe recovery contract.

## Safety boundary

This does not weaken ambiguity handling for deployment, E2E, or ref/main operations. Those continue to fail closed as `CONTROL_PLANE`. No migration or API contract change is included.

## Validation

- focused operation + reconciler acceptance: 2 suites, 70 tests passed
- `npm run lint -- --quiet`
- `npm run build`: 292 suites, 2,665 tests passed, TypeScript build passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved failure classification for failed artifact preparation workflows, identifying them as infrastructure failures.
  * Added safer handling when workflow completion data is unavailable, including appropriate retry or failure states and recorded run details.
  * Prevented unnecessary global pauses when artifact-preflight retries are exhausted.
  * Ensured affected releases and candidates return to the correct queue states and that durable locks are released.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->