### PR TITLE
Keep staging refs aligned with deployed runtime

### DIFF
--- a/.github/workflows/release-bus-v2-compose.yml
+++ b/.github/workflows/release-bus-v2-compose.yml
@@ -10,6 +10,7 @@ on:
       expected_sha: { type: string, required: true }
       candidate_shas: { type: string, required: true }
       release_branch: { type: string, required: true }
+      release_parent_sha: { type: string, required: false, default: '' }
 
 permissions:
   contents: read
@@ -28,6 +29,7 @@ jobs:
           EXPECTED_SHA: ${{ inputs.expected_sha }}
           OPERATION_KEY: ${{ inputs.operation_key }}
           RELEASE_BRANCH: ${{ inputs.release_branch }}
+          RELEASE_PARENT_SHA: ${{ inputs.release_parent_sha }}
           TRAIN_ID: ${{ inputs.release_train_id }}
         run: |
           set -euo pipefail
@@ -35,7 +37,8 @@ jobs:
           test "$BASE_SHA" = "$EXPECTED_SHA"
           [[ "$TRAIN_ID" =~ ^[A-Za-z0-9._-]{1,100}$ ]]
           [[ "$OPERATION_KEY" =~ ^rb2:[A-Za-z0-9:._-]+:a[1-9][0-9]*$ ]]
-          [[ "$RELEASE_BRANCH" =~ ^release-bus-v2/(staging|production|qualification)-train-[A-Za-z0-9._-]+$ ]]
+          [[ "$RELEASE_BRANCH" =~ ^release-bus-v2/(staging|production|qualification|rollback)-train-[A-Za-z0-9._-]+$ ]]
+          test -z "$RELEASE_PARENT_SHA" || [[ "$RELEASE_PARENT_SHA" =~ ^[a-f0-9]{40}$ ]]
           jq -e 'type == "array" and length > 0 and all(.[]; test("^[a-f0-9]{40}$"))' <<< "$CANDIDATE_SHAS"
       - name: Authorize exact v2 operation
         env:
@@ -64,6 +67,7 @@ jobs:
           BASE_SHA: ${{ inputs.base_sha }}
           CANDIDATE_SHAS: ${{ inputs.candidate_shas }}
           RELEASE_BRANCH: ${{ inputs.release_branch }}
+          RELEASE_PARENT_SHA: ${{ inputs.release_parent_sha }}
           RELEASE_BUS_GIT_EMAIL: ${{ vars.RELEASE_BUS_GIT_EMAIL || 'release-bus@users.noreply.github.com' }}
           RELEASE_BUS_GIT_NAME: ${{ vars.RELEASE_BUS_GIT_NAME || '6529 Release Bus' }}
           TRAIN_ID: ${{ inputs.release_train_id }}
@@ -73,6 +77,12 @@ jobs:
           if [ -n "$existing" ]; then
             git fetch --no-tags origin "$existing"
             git merge-base --is-ancestor "$BASE_SHA" "$existing"
+            if [ -n "${RELEASE_PARENT_SHA:-}" ]; then
+              git fetch --no-tags origin "$RELEASE_PARENT_SHA"
+              if [ "$existing" != "$RELEASE_PARENT_SHA" ]; then
+                test "$(git rev-parse "$existing^1")" = "$RELEASE_PARENT_SHA"
+              fi
+            fi
             excluded='[]'
             while IFS= read -r sha; do
               if ! git merge-base --is-ancestor "$sha" "$existing"; then
@@ -106,6 +116,22 @@ jobs:
               excluded="$(jq -c --arg sha "$sha" '. + [$sha]' <<< "$excluded")"
             fi
           done < <(jq -r '.[]' <<< "$CANDIDATE_SHAS")
+          scratch_sha="$(git rev-parse HEAD)"
+          if [ -n "${RELEASE_PARENT_SHA:-}" ] && [ "$scratch_sha" != "$RELEASE_PARENT_SHA" ]; then
+            git fetch --no-tags origin "$RELEASE_PARENT_SHA"
+            tree_sha="$(git rev-parse "$scratch_sha^{tree}")"
+            release_sha="$(
+              git commit-tree "$tree_sha" \
+                -p "$RELEASE_PARENT_SHA" \
+                -p "$scratch_sha" \
+                -m "Release Bus v2 train $TRAIN_ID: bind backend staging release" \
+                -m "Release-Parent-SHA: $RELEASE_PARENT_SHA" \
+                -m "Release-Composition-SHA: $scratch_sha" \
+                -m "Release-Bus-v2-Train: $TRAIN_ID" \
+                -m "Signed-off-by: $RELEASE_BUS_GIT_NAME <$RELEASE_BUS_GIT_EMAIL>"
+            )"
+            git reset --hard "$release_sha"
+          fi
           git fsck --no-dangling
           jq -n --arg composed_sha "$(git rev-parse HEAD)" --argjson excluded_shas "$excluded" '{composed_sha:$composed_sha,excluded_shas:$excluded_shas,reused:false}' > "$RUNNER_TEMP/composition.json"
       - name: Create scoped GitHub App token

--- a/.github/workflows/release-bus-v2-compose.yml
+++ b/.github/workflows/release-bus-v2-compose.yml
@@ -79,8 +79,10 @@ jobs:
             git merge-base --is-ancestor "$BASE_SHA" "$existing"
             if [ -n "${RELEASE_PARENT_SHA:-}" ]; then
               git fetch --no-tags origin "$RELEASE_PARENT_SHA"
-              if [ "$existing" != "$RELEASE_PARENT_SHA" ]; then
-                test "$(git rev-parse "$existing^1")" = "$RELEASE_PARENT_SHA"
+              existing_parent="$(git rev-parse --verify "$existing^1" 2>/dev/null || true)"
+              if [ "$existing_parent" != "$RELEASE_PARENT_SHA" ]; then
+                echo "Existing release branch does not have the recorded staging ref as its first parent" >&2
+                exit 1
               fi
             fi
             excluded='[]'
@@ -95,6 +97,29 @@ jobs:
           git config user.name "$RELEASE_BUS_GIT_NAME"
           git config user.email "$RELEASE_BUS_GIT_EMAIL"
           git switch -c "$RELEASE_BRANCH"
+          if [ -n "${RELEASE_PARENT_SHA:-}" ]; then
+            git fetch --no-tags origin "$RELEASE_PARENT_SHA"
+            case "$RELEASE_BRANCH" in
+              release-bus-v2/rollback-train-*)
+                # Rollback deliberately restores the validated BASE_SHA tree
+                # while retaining the failed release as its first parent.
+                ;;
+              *)
+                # Normal cumulative releases compose on the live staging
+                # parent, then merge current main and every admitted candidate.
+                # This makes content preservation structural, not an assumption
+                # about two independently-composed trees.
+                git reset --hard "$RELEASE_PARENT_SHA"
+                if ! git merge-base --is-ancestor "$BASE_SHA" HEAD; then
+                  git merge --no-ff --no-commit "$BASE_SHA"
+                  git -c core.hooksPath=/dev/null commit -s \
+                    -m "Release Bus v2 train $TRAIN_ID: merge backend base" \
+                    -m "Base-SHA: $BASE_SHA" \
+                    -m "Release-Bus-v2-Train: $TRAIN_ID"
+                fi
+                ;;
+            esac
+          fi
           excluded='[]'
           while IFS= read -r sha; do
             git fetch --no-tags origin "$sha"
@@ -117,19 +142,23 @@ jobs:
             fi
           done < <(jq -r '.[]' <<< "$CANDIDATE_SHAS")
           scratch_sha="$(git rev-parse HEAD)"
-          if [ -n "${RELEASE_PARENT_SHA:-}" ] && [ "$scratch_sha" != "$RELEASE_PARENT_SHA" ]; then
-            git fetch --no-tags origin "$RELEASE_PARENT_SHA"
+          if [ -n "${RELEASE_PARENT_SHA:-}" ]; then
+            case "$RELEASE_BRANCH" in
+              release-bus-v2/rollback-train-*) ;;
+              *) git merge-base --is-ancestor "$RELEASE_PARENT_SHA" "$scratch_sha" ;;
+            esac
             tree_sha="$(git rev-parse "$scratch_sha^{tree}")"
-            release_sha="$(
-              git commit-tree "$tree_sha" \
-                -p "$RELEASE_PARENT_SHA" \
-                -p "$scratch_sha" \
-                -m "Release Bus v2 train $TRAIN_ID: bind backend staging release" \
-                -m "Release-Parent-SHA: $RELEASE_PARENT_SHA" \
-                -m "Release-Composition-SHA: $scratch_sha" \
-                -m "Release-Bus-v2-Train: $TRAIN_ID" \
-                -m "Signed-off-by: $RELEASE_BUS_GIT_NAME <$RELEASE_BUS_GIT_EMAIL>"
-            )"
+            parent_args=(-p "$RELEASE_PARENT_SHA")
+            if [ "$scratch_sha" != "$RELEASE_PARENT_SHA" ]; then
+              parent_args+=(-p "$scratch_sha")
+            fi
+            release_sha="$(git commit-tree "$tree_sha" \
+              "${parent_args[@]}" \
+              -m "Release Bus v2 train $TRAIN_ID: bind backend staging release" \
+              -m "Release-Parent-SHA: $RELEASE_PARENT_SHA" \
+              -m "Release-Composition-SHA: $scratch_sha" \
+              -m "Release-Bus-v2-Train: $TRAIN_ID" \
+              -m "Signed-off-by: $RELEASE_BUS_GIT_NAME <$RELEASE_BUS_GIT_EMAIL>")"
             git reset --hard "$release_sha"
           fi
           git fsck --no-dangling

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -545,12 +545,22 @@ response proves there are no further live qualifications to yield.
 
 GitHub Actions performs exact composition, combined preflight, immutable
 packaging, backend DAG deployment, frontend deployment, and manifest-bound E2E.
-Frontend artifacts contain independently checksummed staging and production
-profiles inside one immutable aggregate. Frontend/backend preparation and
-independent backend DAG frontiers run concurrently; only shared environment
-mutation plus E2E ownership is serialized. Operation keys, workflow titles,
-workflow authorization, SHA/artifact checks, row versions, and callback
-identity make retries and duplicate reconciliation idempotent.
+For cumulative staging, each affected repository's immutable release commit has
+the recorded `1a-staging` head as its first parent and the composed candidate
+tree as its second parent. After preparation and the staging fence, the
+reconciler advances only affected `1a-staging` refs with non-force
+compare-and-swap operations before deployment. The branch heads, deployed
+runtime, manifest identity, and E2E inputs therefore describe the same combined
+state. A retry observes a completed ref operation and continues idempotently;
+an unexpected ref move fails closed and pauses only the staging lane. Rollback
+uses the same forward-only pattern with an immutable restore commit instead of
+rewinding a shared ref. Frontend artifacts contain independently checksummed
+staging and production profiles inside one immutable aggregate.
+Frontend/backend preparation and independent backend DAG frontiers run
+concurrently; only shared environment mutation plus E2E ownership is
+serialized. Operation keys, workflow titles, workflow authorization,
+SHA/artifact checks, row versions, and callback identity make retries and
+duplicate reconciliation idempotent.
 
 The staging manifest distinguishes deployed from validated state and binds E2E
 to exact frontend/backend tree SHAs, artifact digests, service operations, and

--- a/ops/deployment-bus/simple-release-bus-v2.md
+++ b/ops/deployment-bus/simple-release-bus-v2.md
@@ -59,18 +59,39 @@ register backend first and declare it as the frontend prerequisite.
 2. Frontend/backend composition and preparation run concurrently.
 3. A single exact PR merge-tree artifact is reused when eligible. Otherwise,
    each application runs one combined sharded preflight and one immutable build.
+   For an affected repository, the staging release commit has the recorded
+   current `1a-staging` SHA as its first parent and the dependency-closed
+   composition as its second parent, so the shared branch can only fast-forward
+   without losing the cumulative tree.
 4. Preparation may finish while another train owns staging.
-5. The train acquires the staging lock only for deployment plus E2E.
+5. The train acquires the staging lock and repeats the idle/ref snapshot.
    Under that lock it binds every unchanged repository to the exact current
    `1a-staging` ref, so a frontend-only or backend-only manifest describes the
    environment E2E actually sees rather than the unrelated `main` ref.
-6. Independent backend DAG frontier units deploy concurrently; dependency edges
+6. Before any deployment dispatch, each affected `1a-staging` ref advances to
+   the immutable release commit through a non-force compare-and-swap from its
+   recorded base. Unaffected repositories do not move. A stale base, moved ref,
+   or CAS conflict starts no train deployment, records exact drift, and pauses
+   only staging for serialized recovery.
+7. Independent backend DAG frontier units deploy concurrently; dependency edges
    serialize only required units. Dependent frontend deploys after backend.
-7. The controller persists `STAGING_DEPLOYED` with exact SHAs, artifact
+8. The controller persists `STAGING_DEPLOYED` with exact SHAs, artifact
    digests, services, operation runs, and timings.
-8. E2E receives and authorizes against that manifest identity. Staging remains
-   locked until E2E is terminal.
-9. Only E2E success produces `STAGING_VALIDATED`.
+9. E2E runs from an immutable ref at the exact frontend release SHA and receives
+   the paired manifest identity. Staging remains locked until E2E is terminal.
+10. Only E2E success plus exact agreement among both `1a-staging` refs,
+    deployed-runtime evidence, the manifest, and E2E produces
+    `STAGING_VALIDATED`.
+
+Ref-advance operations are durable. A crash after GitHub accepts a CAS but
+before the operation or train transition is stored re-reads the ref, records
+the completed mutation, and continues with the same deployment idempotency
+keys. A post-CAS deploy or E2E failure never validates the failed manifest.
+Rollback composes a new immutable restore commit whose first parent is the
+failed staging release and whose tree is the last validated release,
+CAS-advances `1a-staging` forward, redeploys that exact commit, and requires
+rollback E2E before releasing the staging lock. Recovery never force-pushes a
+shared ref backward or loses the failed train's durable intent.
 
 `STAGING_DEPLOYED` and `STAGING_VALIDATED` are separate milestones.
 `STAGING_VALIDATED` is historical certification. It does not mean the
@@ -145,13 +166,13 @@ explicitly.
 
 ## Failure behavior
 
-| Class                | Behavior                                                                                                                                                                               |
-| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Candidate merge/test | Before shared mutation, fail the cumulative train closed and leave the last validated admitted manifest live; mark only the new direct candidate `NEEDS_REBASE` as applicable          |
-| Infrastructure       | Bounded idempotent retry; no candidate isolation                                                                                                                                       |
-| Retryable deployment | Retry only the failed operation; preserve successful sibling evidence                                                                                                                  |
-| Control plane        | Fail the train, requeue candidates, pause automated claiming, release an environment lock once every operation is terminal, retain manual fallback                                     |
-| E2E                  | Keep the failed manifest unvalidated and restore/deploy/E2E the exact last validated live manifest under the same staging lock; commit no admission change until restoration validates |
+| Class                | Behavior                                                                                                                                                                                                           |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Candidate merge/test | Before shared mutation, fail the cumulative train closed and leave the last validated admitted manifest live; mark only the new direct candidate `NEEDS_REBASE` as applicable                                      |
+| Infrastructure       | Bounded idempotent retry; no candidate isolation                                                                                                                                                                   |
+| Retryable deployment | Retry only the failed operation at the same release SHA and idempotency key; preserve successful sibling evidence                                                                                                  |
+| Control plane        | Fail the train, requeue candidates, pause automated claiming, release an environment lock once every operation is terminal, retain manual fallback                                                                 |
+| E2E                  | Keep the failed manifest unvalidated and forward-CAS/deploy/E2E an immutable restore commit with the exact last validated tree under the same staging lock; commit no admission change until restoration validates |
 
 Every pending GitHub status must map to a visible candidate/train/operation state
 and recovery message. Duplicate callbacks and worker invocations reuse immutable

--- a/ops/deployment-bus/simple-release-bus-v2.md
+++ b/ops/deployment-bus/simple-release-bus-v2.md
@@ -62,7 +62,9 @@ register backend first and declare it as the frontend prerequisite.
    For an affected repository, the staging release commit has the recorded
    current `1a-staging` SHA as its first parent and the dependency-closed
    composition as its second parent, so the shared branch can only fast-forward
-   without losing the cumulative tree.
+   without losing the cumulative tree. Normal staging composition starts from
+   that recorded parent and merges current `main` plus every admitted candidate;
+   only rollback deliberately binds a last-validated replacement tree.
 4. Preparation may finish while another train owns staging.
 5. The train acquires the staging lock and repeats the idle/ref snapshot.
    Under that lock it binds every unchanged repository to the exact current

--- a/src/releaseBusV2/release-bus-v2-compose-workflow.test.ts
+++ b/src/releaseBusV2/release-bus-v2-compose-workflow.test.ts
@@ -33,6 +33,16 @@ function composeScript(): string {
 }
 
 describe('Release Bus v2 backend composition workflow', () => {
+  it('accepts immutable rollback branches for forward-only staging recovery', () => {
+    const workflow = readFileSync(
+      path.join(process.cwd(), '.github/workflows/release-bus-v2-compose.yml'),
+      'utf8'
+    );
+    expect(workflow).toContain(
+      '(staging|production|qualification|rollback)-train-'
+    );
+  });
+
   it('successfully reuses current main when every candidate is already an ancestor', () => {
     const root = mkdtempSync(
       path.join(tmpdir(), 'release-bus-v2-compose-ancestor-')
@@ -179,6 +189,93 @@ describe('Release Bus v2 backend composition workflow', () => {
       expect(
         runGit(repository, 'rev-list', '--parents', '-n', '1', 'HEAD')
       ).toBe(`${composedSha} ${baseSha} ${newCandidateSha}`);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('creates an immutable release commit that fast-forwards the exact staging parent', () => {
+    const root = mkdtempSync(
+      path.join(tmpdir(), 'release-bus-v2-compose-staging-parent-')
+    );
+    const origin = path.join(root, 'origin.git');
+    const repository = path.join(root, 'repository');
+    const runnerTemp = path.join(root, 'runner-temp');
+    try {
+      execFileSync('git', ['init', '--bare', origin]);
+      execFileSync('git', ['init', '--initial-branch=main', repository]);
+      mkdirSync(runnerTemp);
+      runGit(repository, 'config', 'user.name', 'Release Bus Test');
+      runGit(
+        repository,
+        'config',
+        'user.email',
+        'release-bus-test@example.com'
+      );
+      runGit(repository, 'remote', 'add', 'origin', origin);
+      writeFileSync(path.join(repository, 'main.txt'), 'main\n');
+      runGit(repository, 'add', 'main.txt');
+      runGit(repository, 'commit', '-m', 'main');
+      const baseSha = runGit(repository, 'rev-parse', 'HEAD');
+      runGit(repository, 'push', 'origin', 'main');
+
+      runGit(repository, 'switch', '-c', 'staging-parent', baseSha);
+      writeFileSync(path.join(repository, 'admitted-a.txt'), 'candidate a\n');
+      runGit(repository, 'add', 'admitted-a.txt');
+      runGit(repository, 'commit', '-m', 'staging candidate a');
+      const stagingParentSha = runGit(repository, 'rev-parse', 'HEAD');
+      runGit(repository, 'push', 'origin', 'staging-parent');
+
+      runGit(repository, 'switch', '-c', 'candidate-b', baseSha);
+      writeFileSync(path.join(repository, 'candidate-b.txt'), 'candidate b\n');
+      runGit(repository, 'add', 'candidate-b.txt');
+      runGit(repository, 'commit', '-m', 'candidate b');
+      const candidateSha = runGit(repository, 'rev-parse', 'HEAD');
+      runGit(repository, 'push', 'origin', 'candidate-b');
+      runGit(repository, 'switch', 'main');
+
+      execFileSync('bash', ['-c', composeScript()], {
+        cwd: repository,
+        env: {
+          ...process.env,
+          BASE_SHA: baseSha,
+          CANDIDATE_SHAS: JSON.stringify([stagingParentSha, candidateSha]),
+          RELEASE_BRANCH: 'release-bus-v2/staging-train-cumulative-backend',
+          RELEASE_BUS_GIT_EMAIL: 'release-bus-test@example.com',
+          RELEASE_BUS_GIT_NAME: 'Release Bus Test',
+          RELEASE_PARENT_SHA: stagingParentSha,
+          RUNNER_TEMP: runnerTemp,
+          TRAIN_ID: 'cumulative'
+        },
+        stdio: ['ignore', 'pipe', 'pipe']
+      });
+
+      const releaseSha = runGit(repository, 'rev-parse', 'HEAD');
+      const parents = runGit(
+        repository,
+        'rev-list',
+        '--parents',
+        '-n',
+        '1',
+        releaseSha
+      ).split(' ');
+      expect(parents).toHaveLength(3);
+      expect(parents[1]).toBe(stagingParentSha);
+      expect(
+        runGit(
+          repository,
+          'merge-base',
+          '--is-ancestor',
+          candidateSha,
+          releaseSha
+        )
+      ).toBe('');
+      expect(runGit(repository, 'show', `${releaseSha}:admitted-a.txt`)).toBe(
+        'candidate a'
+      );
+      expect(runGit(repository, 'show', `${releaseSha}:candidate-b.txt`)).toBe(
+        'candidate b'
+      );
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/src/releaseBusV2/release-bus-v2-compose-workflow.test.ts
+++ b/src/releaseBusV2/release-bus-v2-compose-workflow.test.ts
@@ -22,6 +22,8 @@ function composeScript(): string {
     path.join(process.cwd(), '.github/workflows/release-bus-v2-compose.yml'),
     'utf8'
   );
+  // This executes the workflow's shell verbatim; keep the expression coupled
+  // to the YAML step indentation so formatting drift fails the test loudly.
   const match = workflow.match(
     /\n {8}id: compose\n[\s\S]*?\n {8}run: \|\n([\s\S]*?)(?=\n {6}- )/
   );
@@ -276,6 +278,84 @@ describe('Release Bus v2 backend composition workflow', () => {
       expect(runGit(repository, 'show', `${releaseSha}:candidate-b.txt`)).toBe(
         'candidate b'
       );
+
+      const releaseBranch = 'release-bus-v2/staging-train-cumulative-backend';
+      runGit(
+        repository,
+        'push',
+        'origin',
+        `${releaseSha}:refs/heads/${releaseBranch}`
+      );
+      runGit(repository, 'switch', 'main');
+      execFileSync('bash', ['-c', composeScript()], {
+        cwd: repository,
+        env: {
+          ...process.env,
+          BASE_SHA: baseSha,
+          CANDIDATE_SHAS: JSON.stringify([stagingParentSha, candidateSha]),
+          RELEASE_BRANCH: releaseBranch,
+          RELEASE_BUS_GIT_EMAIL: 'release-bus-test@example.com',
+          RELEASE_BUS_GIT_NAME: 'Release Bus Test',
+          RELEASE_PARENT_SHA: stagingParentSha,
+          RUNNER_TEMP: runnerTemp,
+          TRAIN_ID: 'cumulative'
+        },
+        stdio: ['ignore', 'pipe', 'pipe']
+      });
+      expect(
+        JSON.parse(
+          readFileSync(path.join(runnerTemp, 'composition.json'), 'utf8')
+        )
+      ).toEqual({
+        composed_sha: releaseSha,
+        excluded_shas: [],
+        reused: true
+      });
+
+      expect(() =>
+        execFileSync('bash', ['-c', composeScript()], {
+          cwd: repository,
+          env: {
+            ...process.env,
+            BASE_SHA: baseSha,
+            CANDIDATE_SHAS: JSON.stringify([stagingParentSha, candidateSha]),
+            RELEASE_BRANCH: releaseBranch,
+            RELEASE_BUS_GIT_EMAIL: 'release-bus-test@example.com',
+            RELEASE_BUS_GIT_NAME: 'Release Bus Test',
+            RELEASE_PARENT_SHA: baseSha,
+            RUNNER_TEMP: runnerTemp,
+            TRAIN_ID: 'wrong-parent'
+          },
+          stdio: ['ignore', 'pipe', 'pipe']
+        })
+      ).toThrow();
+
+      runGit(repository, 'switch', '--detach', stagingParentSha);
+      const emptyBranch =
+        'release-bus-v2/staging-train-empty-cumulative-backend';
+      execFileSync('bash', ['-c', composeScript()], {
+        cwd: repository,
+        env: {
+          ...process.env,
+          BASE_SHA: stagingParentSha,
+          CANDIDATE_SHAS: JSON.stringify([stagingParentSha]),
+          RELEASE_BRANCH: emptyBranch,
+          RELEASE_BUS_GIT_EMAIL: 'release-bus-test@example.com',
+          RELEASE_BUS_GIT_NAME: 'Release Bus Test',
+          RELEASE_PARENT_SHA: stagingParentSha,
+          RUNNER_TEMP: runnerTemp,
+          TRAIN_ID: 'empty-cumulative'
+        },
+        stdio: ['ignore', 'pipe', 'pipe']
+      });
+      const emptyReleaseSha = runGit(repository, 'rev-parse', 'HEAD');
+      expect(emptyReleaseSha).not.toBe(stagingParentSha);
+      expect(
+        runGit(repository, 'rev-list', '--parents', '-n', '1', emptyReleaseSha)
+      ).toBe(`${emptyReleaseSha} ${stagingParentSha}`);
+      expect(
+        runGit(repository, 'show', '-s', '--format=%B', emptyReleaseSha)
+      ).toContain(`Release-Parent-SHA: ${stagingParentSha}`);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/src/releaseBusV2/release-bus-v2-cumulative-staging.test.ts
+++ b/src/releaseBusV2/release-bus-v2-cumulative-staging.test.ts
@@ -712,4 +712,53 @@ describe('Release Bus v2 cumulative admitted staging', () => {
       expect.anything()
     );
   });
+
+  it('does not classify an active train ref advance as manual drift', async () => {
+    const activeTrain = train('active-staging-train');
+    const updateStagingState = jest.fn(async () => true);
+    const setControl = jest.fn(async () => undefined);
+    const repository = {
+      executeNativeQueriesInTransaction: async (
+        callback: (connection: unknown) => unknown
+      ) => callback({}),
+      acquireLock: async () => ({ lease_token: 'scheduler' }),
+      releaseLock: async () => true,
+      listControls: async () => [
+        { scope: 'ALL', paused: false },
+        { scope: 'STAGING', paused: false },
+        { scope: 'PRODUCTION', paused: false }
+      ],
+      getStagingState: async () => ({
+        id: 'current',
+        status: 'LIVE',
+        current_manifest_id: 'manifest-live',
+        last_validated_manifest_id: 'manifest-live',
+        frontend_sha: '1'.repeat(40),
+        backend_sha: '2'.repeat(40),
+        frontend_staging_ref_sha: '3'.repeat(40),
+        backend_staging_ref_sha: '4'.repeat(40),
+        clean_main: false,
+        last_transition_train_id: 'previous',
+        updated_at: 1,
+        row_version: 11
+      }),
+      updateStagingState,
+      setControl,
+      appendEvent: jest.fn(async () => undefined),
+      listTrains: async () => [activeTrain]
+    };
+    const service = new ReleaseBusV2Service(repository as never);
+
+    await expect(
+      service.claimLane('STAGING', 'f'.repeat(40), 'b'.repeat(40), 'operator', {
+        // The live ref can already be at the train's target while the
+        // authoritative state transition is still committing.
+        frontendSha: '9'.repeat(40),
+        backendSha: '4'.repeat(40)
+      })
+    ).resolves.toEqual(activeTrain);
+
+    expect(updateStagingState).not.toHaveBeenCalled();
+    expect(setControl).not.toHaveBeenCalled();
+  });
 });

--- a/src/releaseBusV2/release-bus-v2-cumulative-staging.test.ts
+++ b/src/releaseBusV2/release-bus-v2-cumulative-staging.test.ts
@@ -628,4 +628,88 @@ describe('Release Bus v2 cumulative admitted staging', () => {
       expect.anything()
     );
   });
+
+  it('surfaces manual 1a-staging drift without revoking historical validation evidence', async () => {
+    const historicalManifest = 'historical-manifest-a';
+    const currentManifest = 'manifest-live';
+    const updateStagingState = jest.fn(async () => true);
+    const setControl = jest.fn(async () => undefined);
+    const appendEvent = jest.fn(async () => undefined);
+    const createTrain = jest.fn();
+    const repository = {
+      executeNativeQueriesInTransaction: async (
+        callback: (connection: unknown) => unknown
+      ) => callback({}),
+      acquireLock: async () => ({ lease_token: 'scheduler' }),
+      releaseLock: async () => true,
+      getStagingState: async () => ({
+        id: 'current',
+        status: 'LIVE',
+        current_manifest_id: currentManifest,
+        last_validated_manifest_id: historicalManifest,
+        frontend_sha: '1'.repeat(40),
+        backend_sha: '2'.repeat(40),
+        frontend_staging_ref_sha: '3'.repeat(40),
+        backend_staging_ref_sha: '4'.repeat(40),
+        clean_main: false,
+        last_transition_train_id: 'previous',
+        updated_at: 1,
+        row_version: 11
+      }),
+      updateStagingState,
+      setControl,
+      appendEvent,
+      listControls: async () => [
+        { scope: 'ALL', paused: false },
+        { scope: 'STAGING', paused: false },
+        { scope: 'PRODUCTION', paused: false }
+      ],
+      listTrains: async () => [],
+      listCandidates: async () => [
+        candidate('b2', 'backend', 'READY_FOR_STAGING', false)
+      ],
+      listLiveStagingCandidates: async () => [],
+      listStagingTransitionRequests: async () => [],
+      listDependencies: async () => [],
+      createTrain
+    };
+    const service = new ReleaseBusV2Service(repository as never);
+
+    await expect(
+      service.claimLane('STAGING', 'f'.repeat(40), 'b'.repeat(40), 'operator', {
+        frontendSha: '9'.repeat(40),
+        backendSha: '4'.repeat(40)
+      })
+    ).resolves.toBeNull();
+
+    expect(createTrain).not.toHaveBeenCalled();
+    expect(updateStagingState).toHaveBeenCalledWith(
+      11,
+      expect.objectContaining({
+        status: 'ROLLBACK_FAILED',
+        currentManifestId: null,
+        lastValidatedManifestId: historicalManifest,
+        frontendStagingRefSha: '9'.repeat(40),
+        backendStagingRefSha: '4'.repeat(40)
+      }),
+      expect.anything()
+    );
+    expect(setControl).toHaveBeenCalledWith(
+      'STAGING',
+      true,
+      expect.stringContaining('drift'),
+      'release-bus-v2',
+      expect.anything()
+    );
+    expect(appendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: 'STAGING_REF_DRIFT_DETECTED',
+        payload: expect.objectContaining({
+          current_manifest_id: currentManifest,
+          production_evidence_preserved: true
+        })
+      }),
+      expect.anything()
+    );
+  });
 });

--- a/src/releaseBusV2/release-bus-v2.acceptance.test.ts
+++ b/src/releaseBusV2/release-bus-v2.acceptance.test.ts
@@ -1281,6 +1281,479 @@ describe('Release Bus v2 offline acceptance harness', () => {
     );
   });
 
+  it('CAS-advances the exact paired staging release before any coupled deployment', async () => {
+    const state = harness('SUCCEEDED');
+    const frontendBase = 'e'.repeat(40);
+    const backendBase = 'f'.repeat(40);
+    const exactTrain = train('train-1', {
+      staging_policy: 'CUMULATIVE_ADMITTED_SET_V1',
+      staging_baseline_manifest_id: 'baseline-manifest',
+      staging_transition_json: {
+        actor: 'acceptance',
+        requested_at: 1,
+        baseline_state_version: 1,
+        baseline_manifest_id: 'baseline-manifest',
+        baseline_frontend_sha: frontendBase,
+        baseline_backend_sha: backendBase,
+        observed_frontend_staging_sha: frontendBase,
+        observed_backend_staging_sha: backendBase,
+        new_candidate_ids: ['backend-candidate', 'frontend-candidate'],
+        carried_candidate_ids: []
+      }
+    });
+    state.repository.trains.set(exactTrain.id, exactTrain);
+    state.repository.memberships.splice(
+      0,
+      state.repository.memberships.length,
+      ...state.repository.memberships.map((membership) => ({
+        ...membership,
+        candidate_role: 'NEW'
+      }))
+    );
+    const refs = new Map([
+      ['frontend', frontendBase],
+      ['backend', backendBase]
+    ]);
+    mockResolveRefIfExists.mockImplementation(async (repository: string) =>
+      refs.get(repository)
+    );
+    mockResolveRef.mockImplementation(async (repository: string) =>
+      refs.get(repository)
+    );
+    mockUpdateRef.mockImplementation(
+      async (
+        repository: string,
+        ref: string,
+        expectedOldSha: string,
+        newSha: string
+      ) => {
+        expect(ref).toBe('1a-staging');
+        expect(refs.get(repository)).toBe(expectedOldSha);
+        refs.set(repository, newSha);
+      }
+    );
+    const context = {
+      train: exactTrain,
+      memberships: [...state.repository.memberships],
+      candidates: Array.from(state.repository.candidates.values()),
+      dependencies: state.repository.dependencies
+    };
+
+    await (
+      state.reconciler as unknown as {
+        advanceStagingOrQualification(input: typeof context): Promise<void>;
+      }
+    ).advanceStagingOrQualification(context);
+
+    expect(mockUpdateRef.mock.calls).toEqual([
+      ['backend', '1a-staging', backendBase, BACKEND_SHA],
+      ['frontend', '1a-staging', frontendBase, FRONTEND_SHA]
+    ]);
+    expect(refs).toEqual(
+      new Map([
+        ['frontend', FRONTEND_SHA],
+        ['backend', BACKEND_SHA]
+      ])
+    );
+    expect(mockReconcileWorkflow).not.toHaveBeenCalled();
+    expect(state.repository.trains.get(exactTrain.id)?.status).toBe(
+      'DEPLOYING'
+    );
+    expect(state.repository.operations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          operation_type: 'ADVANCE_STAGING_RELEASE_BACKEND',
+          expected_sha: BACKEND_SHA,
+          status: 'SUCCEEDED'
+        }),
+        expect.objectContaining({
+          operation_type: 'ADVANCE_STAGING_RELEASE_FRONTEND',
+          expected_sha: FRONTEND_SHA,
+          status: 'SUCCEEDED'
+        })
+      ])
+    );
+  });
+
+  it('moves only the affected repository for a single-repo cumulative train', async () => {
+    const state = harness('SUCCEEDED');
+    const frontendBase = 'e'.repeat(40);
+    const backendBase = 'f'.repeat(40);
+    const exactTrain = train('train-1', {
+      frontend_composed_sha: frontendBase,
+      staging_policy: 'CUMULATIVE_ADMITTED_SET_V1',
+      staging_baseline_manifest_id: 'baseline-manifest',
+      staging_transition_json: {
+        actor: 'acceptance',
+        requested_at: 1,
+        baseline_state_version: 1,
+        baseline_manifest_id: 'baseline-manifest',
+        baseline_frontend_sha: frontendBase,
+        baseline_backend_sha: backendBase,
+        observed_frontend_staging_sha: frontendBase,
+        observed_backend_staging_sha: backendBase,
+        new_candidate_ids: ['backend-candidate'],
+        carried_candidate_ids: ['frontend-candidate']
+      }
+    });
+    state.repository.trains.set(exactTrain.id, exactTrain);
+    state.repository.memberships.splice(
+      0,
+      state.repository.memberships.length,
+      ...state.repository.memberships.map((membership) => ({
+        ...membership,
+        candidate_role:
+          membership.candidate_id === 'backend-candidate'
+            ? 'NEW'
+            : 'CARRY_FORWARD'
+      }))
+    );
+    const refs = new Map([
+      ['frontend', frontendBase],
+      ['backend', backendBase]
+    ]);
+    mockResolveRefIfExists.mockImplementation(async (repository: string) =>
+      refs.get(repository)
+    );
+    mockResolveRef.mockImplementation(async (repository: string) =>
+      refs.get(repository)
+    );
+    mockUpdateRef.mockImplementation(
+      async (
+        repository: string,
+        _ref: string,
+        expectedOldSha: string,
+        newSha: string
+      ) => {
+        expect(refs.get(repository)).toBe(expectedOldSha);
+        refs.set(repository, newSha);
+      }
+    );
+    const context = {
+      train: exactTrain,
+      memberships: [...state.repository.memberships],
+      candidates: Array.from(state.repository.candidates.values()),
+      dependencies: state.repository.dependencies
+    };
+
+    await (
+      state.reconciler as unknown as {
+        advanceStagingOrQualification(input: typeof context): Promise<void>;
+      }
+    ).advanceStagingOrQualification(context);
+
+    expect(mockUpdateRef).toHaveBeenCalledTimes(1);
+    expect(mockUpdateRef).toHaveBeenCalledWith(
+      'backend',
+      '1a-staging',
+      backendBase,
+      BACKEND_SHA
+    );
+    expect(refs.get('frontend')).toBe(frontendBase);
+  });
+
+  it('fails a moved staging CAS closed before deployment dispatch', async () => {
+    const state = harness('SUCCEEDED');
+    const frontendBase = 'e'.repeat(40);
+    const backendBase = 'f'.repeat(40);
+    const backendDrift = '9'.repeat(40);
+    const exactTrain = train('train-1', {
+      frontend_composed_sha: frontendBase,
+      staging_policy: 'CUMULATIVE_ADMITTED_SET_V1',
+      staging_baseline_manifest_id: 'baseline-manifest',
+      staging_transition_json: {
+        actor: 'acceptance',
+        requested_at: 1,
+        baseline_state_version: 1,
+        baseline_manifest_id: 'baseline-manifest',
+        baseline_frontend_sha: frontendBase,
+        baseline_backend_sha: backendBase,
+        observed_frontend_staging_sha: frontendBase,
+        observed_backend_staging_sha: backendBase,
+        new_candidate_ids: ['backend-candidate'],
+        carried_candidate_ids: ['frontend-candidate']
+      }
+    });
+    state.repository.trains.set(exactTrain.id, exactTrain);
+    state.repository.memberships.splice(
+      0,
+      state.repository.memberships.length,
+      ...state.repository.memberships.map((membership) => ({
+        ...membership,
+        candidate_role:
+          membership.candidate_id === 'backend-candidate'
+            ? 'NEW'
+            : 'CARRY_FORWARD'
+      }))
+    );
+    const refs = new Map([
+      ['frontend', frontendBase],
+      ['backend', backendBase]
+    ]);
+    mockResolveRefIfExists.mockImplementation(async (repository: string) =>
+      refs.get(repository)
+    );
+    mockResolveRef.mockImplementation(async (repository: string) =>
+      refs.get(repository)
+    );
+    mockUpdateRef.mockImplementation(async (repository: string) => {
+      refs.set(repository, backendDrift);
+      throw new Error('non-fast-forward staging update rejected');
+    });
+    const context = {
+      train: exactTrain,
+      memberships: [...state.repository.memberships],
+      candidates: Array.from(state.repository.candidates.values()),
+      dependencies: state.repository.dependencies
+    };
+
+    await expect(
+      (
+        state.reconciler as unknown as {
+          advanceStagingOrQualification(input: typeof context): Promise<void>;
+        }
+      ).advanceStagingOrQualification(context)
+    ).rejects.toThrow(
+      `backend 1a-staging moved from ${backendBase} to ${backendDrift}`
+    );
+
+    expect(mockReconcileWorkflow).not.toHaveBeenCalled();
+    expect(state.repository.trains.get(exactTrain.id)?.status).toBe('PREPARED');
+    expect(state.repository.operations).toContainEqual(
+      expect.objectContaining({
+        operation_type: 'ADVANCE_STAGING_RELEASE_BACKEND',
+        status: 'CANCELLED',
+        failure_class: 'INTERACTION'
+      })
+    );
+  });
+
+  it('self-drains a crash after staging CAS without repeating the ref mutation', async () => {
+    const state = harness('SUCCEEDED');
+    const frontendBase = 'e'.repeat(40);
+    const backendBase = 'f'.repeat(40);
+    const exactTrain = train('train-1', {
+      frontend_composed_sha: frontendBase,
+      staging_policy: 'CUMULATIVE_ADMITTED_SET_V1',
+      staging_baseline_manifest_id: 'baseline-manifest',
+      staging_transition_json: {
+        actor: 'acceptance',
+        requested_at: 1,
+        baseline_state_version: 1,
+        baseline_manifest_id: 'baseline-manifest',
+        baseline_frontend_sha: frontendBase,
+        baseline_backend_sha: backendBase,
+        observed_frontend_staging_sha: frontendBase,
+        observed_backend_staging_sha: backendBase,
+        new_candidate_ids: ['backend-candidate'],
+        carried_candidate_ids: ['frontend-candidate']
+      }
+    });
+    state.repository.trains.set(exactTrain.id, exactTrain);
+    state.repository.memberships.splice(
+      0,
+      state.repository.memberships.length,
+      ...state.repository.memberships.map((membership) => ({
+        ...membership,
+        candidate_role:
+          membership.candidate_id === 'backend-candidate'
+            ? 'NEW'
+            : 'CARRY_FORWARD'
+      }))
+    );
+    state.repository.operations.push({
+      ...operation(
+        exactTrain.id,
+        'ADVANCE_STAGING_RELEASE_BACKEND',
+        'backend',
+        'unused'
+      ),
+      id: 'stranded-staging-cas',
+      idempotency_key: `rb2:${exactTrain.id}:advance-staging:release:backend`,
+      environment: 'staging',
+      expected_sha: BACKEND_SHA,
+      artifact_digest: null,
+      external_id: null,
+      status: 'PENDING',
+      request_json: {
+        ref: '1a-staging',
+        expected_old_sha: backendBase,
+        phase: 'release'
+      },
+      completed_at: null
+    });
+    const refs = new Map([
+      ['frontend', frontendBase],
+      // GitHub accepted the CAS before the worker crashed, but the durable
+      // operation did not yet record success.
+      ['backend', BACKEND_SHA]
+    ]);
+    mockResolveRefIfExists.mockImplementation(async (repository: string) =>
+      refs.get(repository)
+    );
+    mockResolveRef.mockImplementation(async (repository: string) =>
+      refs.get(repository)
+    );
+    const context = {
+      train: exactTrain,
+      memberships: [...state.repository.memberships],
+      candidates: Array.from(state.repository.candidates.values()),
+      dependencies: state.repository.dependencies
+    };
+
+    await (
+      state.reconciler as unknown as {
+        advanceStagingOrQualification(input: typeof context): Promise<void>;
+      }
+    ).advanceStagingOrQualification(context);
+
+    expect(mockUpdateRef).not.toHaveBeenCalled();
+    expect(state.repository.operations).toContainEqual(
+      expect.objectContaining({
+        id: 'stranded-staging-cas',
+        status: 'SUCCEEDED',
+        external_id: BACKEND_SHA
+      })
+    );
+    expect(state.repository.trains.get(exactTrain.id)?.status).toBe(
+      'DEPLOYING'
+    );
+    expect(mockReconcileWorkflow).not.toHaveBeenCalled();
+  });
+
+  it('rolls staging refs forward from the failed release to immutable restore commits', async () => {
+    const state = harness('SUCCEEDED');
+    const frontendRestoreRelease = '7'.repeat(40);
+    const backendRestoreRelease = '8'.repeat(40);
+    const exactTrain = train('train-1', {
+      status: 'STAGING_ROLLING_BACK',
+      staging_policy: 'CUMULATIVE_ADMITTED_SET_V1',
+      staging_baseline_manifest_id: 'baseline-manifest'
+    });
+    state.repository.trains.set(exactTrain.id, exactTrain);
+    state.repository.memberships.splice(
+      0,
+      state.repository.memberships.length,
+      ...state.repository.memberships.map((membership) => ({
+        ...membership,
+        candidate_role: 'NEW'
+      }))
+    );
+    const refs = new Map([
+      ['frontend', FRONTEND_SHA],
+      ['backend', BACKEND_SHA]
+    ]);
+    mockResolveRef.mockImplementation(async (repository: string) =>
+      refs.get(repository)
+    );
+    mockUpdateRef.mockImplementation(
+      async (
+        repository: string,
+        ref: string,
+        expectedOldSha: string,
+        newSha: string
+      ) => {
+        expect(ref).toBe('1a-staging');
+        expect(refs.get(repository)).toBe(expectedOldSha);
+        refs.set(repository, newSha);
+      }
+    );
+    const context = {
+      train: exactTrain,
+      memberships: [...state.repository.memberships],
+      candidates: Array.from(state.repository.candidates.values()),
+      dependencies: state.repository.dependencies
+    };
+
+    await (
+      state.reconciler as unknown as {
+        advanceCumulativeRollbackRefs(
+          input: typeof context,
+          frontendReleaseSha: string,
+          backendReleaseSha: string
+        ): Promise<void>;
+      }
+    ).advanceCumulativeRollbackRefs(
+      context,
+      frontendRestoreRelease,
+      backendRestoreRelease
+    );
+
+    expect(mockUpdateRef.mock.calls).toEqual([
+      ['backend', '1a-staging', BACKEND_SHA, backendRestoreRelease],
+      ['frontend', '1a-staging', FRONTEND_SHA, frontendRestoreRelease]
+    ]);
+    expect(state.repository.operations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          operation_type: 'ADVANCE_STAGING_ROLLBACK_BACKEND',
+          expected_sha: backendRestoreRelease,
+          status: 'SUCCEEDED'
+        }),
+        expect.objectContaining({
+          operation_type: 'ADVANCE_STAGING_ROLLBACK_FRONTEND',
+          expected_sha: frontendRestoreRelease,
+          status: 'SUCCEEDED'
+        })
+      ])
+    );
+  });
+
+  it('preserves candidate identity when rolling back a historical manifest without candidate_id fields', async () => {
+    const state = harness('SUCCEEDED');
+    const baselineManifestId = 'historical-baseline-manifest';
+    const backendCandidate =
+      state.repository.candidates.get('backend-candidate')!;
+    const exactTrain = train('train-1', {
+      status: 'STAGING_ROLLING_BACK',
+      staging_policy: 'CUMULATIVE_ADMITTED_SET_V1',
+      staging_baseline_manifest_id: baselineManifestId
+    });
+    state.repository.manifests.set(baselineManifestId, {
+      id: baselineManifestId,
+      train_id: 'historical-train',
+      lane: 'STAGING',
+      identity_sha256: 'e'.repeat(64),
+      status: 'STAGING_VALIDATED',
+      frontend_sha: FRONTEND_SHA,
+      backend_sha: BACKEND_SHA,
+      frontend_artifact_digest: FRONTEND_DIGEST,
+      backend_artifact_digest: BACKEND_DIGEST,
+      e2e_run_id: 'historical-e2e',
+      manifest_json: {
+        candidates: [
+          {
+            repository: backendCandidate.repository,
+            pr_number: backendCandidate.pr_number,
+            head_sha: backendCandidate.head_sha
+          }
+        ]
+      },
+      deployed_at: 1,
+      validated_at: 2,
+      created_at: 1,
+      updated_at: 2
+    });
+    const context = {
+      train: exactTrain,
+      memberships: [...state.repository.memberships],
+      candidates: Array.from(state.repository.candidates.values()),
+      dependencies: state.repository.dependencies
+    };
+
+    await expect(
+      (
+        state.reconciler as unknown as {
+          cumulativeRollbackBaseline(
+            input: typeof context
+          ): Promise<{ candidateIds: readonly string[] }>;
+        }
+      ).cumulativeRollbackBaseline(context)
+    ).resolves.toEqual(
+      expect.objectContaining({ candidateIds: [backendCandidate.id] })
+    );
+  });
+
   it('transactionally yields exact production qualification when an unchanged repository differs in staging', async () => {
     const state = harness('SUCCEEDED');
     state.repository.trains.set(
@@ -3062,7 +3535,10 @@ describe('Release Bus v2 offline acceptance harness', () => {
   it('runs staging E2E from the immutable exact-composition release ref', async () => {
     const state = harness('SUCCEEDED');
     const manifestId = 'exact-workflow-manifest';
-    const exactTrain = train('train-1', { manifest_id: manifestId });
+    const exactTrain = train('train-1', {
+      manifest_id: manifestId,
+      staging_policy: 'CUMULATIVE_ADMITTED_SET_V1'
+    });
     state.repository.trains.set(exactTrain.id, exactTrain);
     state.repository.manifests.set(manifestId, {
       id: manifestId,
@@ -3075,7 +3551,10 @@ describe('Release Bus v2 offline acceptance harness', () => {
       frontend_artifact_digest: FRONTEND_DIGEST,
       backend_artifact_digest: BACKEND_DIGEST,
       e2e_run_id: null,
-      manifest_json: {},
+      manifest_json: {
+        frontend_staging_ref_sha: FRONTEND_SHA,
+        backend_staging_ref_sha: BACKEND_SHA
+      },
       deployed_at: 2,
       validated_at: null,
       created_at: 2,
@@ -3083,8 +3562,13 @@ describe('Release Bus v2 offline acceptance harness', () => {
     });
     const releaseRef = `release-bus-v2/staging-train-${exactTrain.id}-frontend`;
     mockResolveRefIfExists.mockImplementation(
-      async (repository: string, ref: string) =>
-        repository === 'frontend' && ref === releaseRef ? FRONTEND_SHA : null
+      async (repository: string, ref: string) => {
+        if (repository === 'frontend' && ref === releaseRef)
+          return FRONTEND_SHA;
+        if (ref === '1a-staging')
+          return repository === 'frontend' ? FRONTEND_SHA : BACKEND_SHA;
+        return null;
+      }
     );
     mockReconcileWorkflow.mockResolvedValue(
       operation(exactTrain.id, 'E2E_STAGING', 'frontend', 'exact-e2e')
@@ -3116,6 +3600,62 @@ describe('Release Bus v2 offline acceptance harness', () => {
         })
       })
     );
+  });
+
+  it('refuses cumulative E2E when a staging ref no longer matches the manifest', async () => {
+    const state = harness('SUCCEEDED');
+    const manifestId = 'moved-staging-ref-manifest';
+    const exactTrain = train('train-1', {
+      manifest_id: manifestId,
+      staging_policy: 'CUMULATIVE_ADMITTED_SET_V1'
+    });
+    state.repository.trains.set(exactTrain.id, exactTrain);
+    state.repository.manifests.set(manifestId, {
+      id: manifestId,
+      train_id: exactTrain.id,
+      lane: 'STAGING',
+      identity_sha256: 'e'.repeat(64),
+      status: 'STAGING_DEPLOYED',
+      frontend_sha: FRONTEND_SHA,
+      backend_sha: BACKEND_SHA,
+      frontend_artifact_digest: FRONTEND_DIGEST,
+      backend_artifact_digest: BACKEND_DIGEST,
+      e2e_run_id: null,
+      manifest_json: {
+        frontend_staging_ref_sha: FRONTEND_SHA,
+        backend_staging_ref_sha: BACKEND_SHA
+      },
+      deployed_at: 2,
+      validated_at: null,
+      created_at: 2,
+      updated_at: 2
+    });
+    mockResolveRefIfExists.mockImplementation(
+      async (repository: string, ref: string) => {
+        if (ref !== '1a-staging') return null;
+        return repository === 'frontend' ? '9'.repeat(40) : BACKEND_SHA;
+      }
+    );
+    const context = {
+      train: exactTrain,
+      memberships: [...state.repository.memberships],
+      candidates: Array.from(state.repository.candidates.values()),
+      dependencies: state.repository.dependencies
+    };
+
+    await expect(
+      (
+        state.reconciler as unknown as {
+          reconcileE2E(
+            input: typeof context,
+            environment: 'staging'
+          ): Promise<ReleaseBusV2OperationRecord>;
+        }
+      ).reconcileE2E(context, 'staging')
+    ).rejects.toThrow(
+      'E2E refused a staging manifest whose 1a-staging refs no longer match'
+    );
+    expect(mockReconcileWorkflow).not.toHaveBeenCalled();
   });
 
   it('binds a single-candidate fast path to its immutable release ref before preflight', async () => {

--- a/src/releaseBusV2/release-bus-v2.acceptance.test.ts
+++ b/src/releaseBusV2/release-bus-v2.acceptance.test.ts
@@ -1528,6 +1528,73 @@ describe('Release Bus v2 offline acceptance harness', () => {
     );
   });
 
+  it('retries an unchanged staging ref after transient CAS transport failure', async () => {
+    const state = harness('SUCCEEDED');
+    const baseSha = 'f'.repeat(40);
+    const targetSha = '8'.repeat(40);
+    const exactTrain = train('transient-staging-cas', {
+      staging_policy: 'CUMULATIVE_ADMITTED_SET_V1'
+    });
+    state.repository.trains.set(exactTrain.id, exactTrain);
+    let currentSha = baseSha;
+    const infrastructureError = new Error('GitHub returned 503');
+    infrastructureError.name = 'ReleaseBusGitHubInfrastructureError';
+    mockUpdateRef
+      .mockRejectedValueOnce(infrastructureError)
+      .mockImplementationOnce(async () => {
+        currentSha = targetSha;
+      });
+    mockResolveRef.mockImplementation(async () => currentSha);
+    const advance = () =>
+      (
+        state.reconciler as unknown as {
+          advanceStagingRef(
+            input: ReleaseBusV2TrainRecord,
+            repository: 'backend',
+            observedSha: string,
+            baseSha: string,
+            targetSha: string,
+            phase: 'release'
+          ): Promise<void>;
+        }
+      ).advanceStagingRef(
+        exactTrain,
+        'backend',
+        baseSha,
+        baseSha,
+        targetSha,
+        'release'
+      );
+
+    await expect(advance()).rejects.toThrow('GitHub returned 503');
+    expect(
+      state.repository.operations.find(
+        ({ operation_type }) =>
+          operation_type === 'ADVANCE_STAGING_RELEASE_BACKEND'
+      )
+    ).toEqual(
+      expect.objectContaining({
+        status: 'PENDING',
+        failure_class: null,
+        completed_at: null
+      })
+    );
+
+    await expect(advance()).resolves.toBeUndefined();
+    expect(mockUpdateRef).toHaveBeenCalledTimes(2);
+    expect(
+      state.repository.operations.find(
+        ({ operation_type }) =>
+          operation_type === 'ADVANCE_STAGING_RELEASE_BACKEND'
+      )
+    ).toEqual(
+      expect.objectContaining({
+        status: 'SUCCEEDED',
+        external_id: targetSha
+      })
+    );
+  });
+
   it('self-drains a crash after staging CAS without repeating the ref mutation', async () => {
     const state = harness('SUCCEEDED');
     const frontendBase = 'e'.repeat(40);
@@ -1694,6 +1761,107 @@ describe('Release Bus v2 offline acceptance harness', () => {
           operation_type: 'ADVANCE_STAGING_ROLLBACK_FRONTEND',
           expected_sha: frontendRestoreRelease,
           status: 'SUCCEEDED'
+        })
+      ])
+    );
+  });
+
+  it('resumes rollback when one staging CAS applied before the worker crashed', async () => {
+    const state = harness('SUCCEEDED');
+    const frontendRestoreRelease = '7'.repeat(40);
+    const backendRestoreRelease = '8'.repeat(40);
+    const exactTrain = train('train-1', {
+      status: 'STAGING_ROLLING_BACK',
+      staging_policy: 'CUMULATIVE_ADMITTED_SET_V1',
+      staging_baseline_manifest_id: 'baseline-manifest'
+    });
+    state.repository.trains.set(exactTrain.id, exactTrain);
+    state.repository.memberships.splice(
+      0,
+      state.repository.memberships.length,
+      ...state.repository.memberships.map((membership) => ({
+        ...membership,
+        candidate_role: 'NEW'
+      }))
+    );
+    state.repository.operations.push({
+      ...operation(
+        exactTrain.id,
+        'ADVANCE_STAGING_ROLLBACK_BACKEND',
+        'backend',
+        'unused'
+      ),
+      id: 'stranded-rollback-cas',
+      idempotency_key: `rb2:${exactTrain.id}:advance-staging:rollback:backend`,
+      environment: 'staging',
+      expected_sha: backendRestoreRelease,
+      artifact_digest: null,
+      external_id: null,
+      status: 'PENDING',
+      request_json: {
+        ref: '1a-staging',
+        expected_old_sha: BACKEND_SHA,
+        phase: 'rollback'
+      },
+      completed_at: null
+    });
+    const refs = new Map([
+      ['frontend', FRONTEND_SHA],
+      ['backend', backendRestoreRelease]
+    ]);
+    mockResolveRef.mockImplementation(async (repository: string) =>
+      refs.get(repository)
+    );
+    mockUpdateRef.mockImplementation(
+      async (
+        repository: string,
+        _ref: string,
+        expectedOldSha: string,
+        newSha: string
+      ) => {
+        expect(refs.get(repository)).toBe(expectedOldSha);
+        refs.set(repository, newSha);
+      }
+    );
+    const context = {
+      train: exactTrain,
+      memberships: [...state.repository.memberships],
+      candidates: Array.from(state.repository.candidates.values()),
+      dependencies: state.repository.dependencies
+    };
+
+    await (
+      state.reconciler as unknown as {
+        advanceCumulativeRollbackRefs(
+          input: typeof context,
+          frontendReleaseSha: string,
+          backendReleaseSha: string
+        ): Promise<void>;
+      }
+    ).advanceCumulativeRollbackRefs(
+      context,
+      frontendRestoreRelease,
+      backendRestoreRelease
+    );
+
+    expect(mockUpdateRef).toHaveBeenCalledTimes(1);
+    expect(mockUpdateRef).toHaveBeenCalledWith(
+      'frontend',
+      '1a-staging',
+      FRONTEND_SHA,
+      frontendRestoreRelease
+    );
+    expect(state.repository.operations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'stranded-rollback-cas',
+          status: 'SUCCEEDED',
+          external_id: backendRestoreRelease
+        }),
+        expect.objectContaining({
+          operation_type: 'ADVANCE_STAGING_ROLLBACK_FRONTEND',
+          status: 'SUCCEEDED',
+          external_id: frontendRestoreRelease
         })
       ])
     );

--- a/src/releaseBusV2/release-bus-v2.reconciler.test.ts
+++ b/src/releaseBusV2/release-bus-v2.reconciler.test.ts
@@ -54,7 +54,7 @@ function candidate(
 }
 
 describe('Release Bus v2 deterministic orchestration', () => {
-  it('omits removal candidates from composition but redeploys their exact runtime units', () => {
+  it('keeps carried candidates in composition without spuriously redeploying their runtime units', () => {
     const carried = candidate('carried', 'a'.repeat(40));
     const removed = {
       ...candidate('removed', 'b'.repeat(40)),
@@ -113,10 +113,7 @@ describe('Release Bus v2 deterministic orchestration', () => {
     };
 
     expect(relevantCandidates(context)).toEqual([carried]);
-    expect(stagingDeploymentCandidates(context, 'backend')).toEqual([
-      carried,
-      removed
-    ]);
+    expect(stagingDeploymentCandidates(context, 'backend')).toEqual([removed]);
   });
 
   it('keeps the admitted state unchanged while a failed cumulative train enters rollback', async () => {

--- a/src/releaseBusV2/release-bus-v2.reconciler.ts
+++ b/src/releaseBusV2/release-bus-v2.reconciler.ts
@@ -1406,13 +1406,13 @@ export class ReleaseBusV2Reconciler {
         ? candidates[0]
         : null;
     const releaseFastCandidate = releaseParentSha ? null : fastCandidate;
-    let composedSha =
-      storedComposedSha ??
-      (releaseParentSha
-        ? null
-        : candidates.length === 0
+    let initialComposedSha: string | null | undefined = null;
+    if (!releaseParentSha)
+      initialComposedSha =
+        candidates.length === 0
           ? baseSha
-          : prEvidence(releaseFastCandidate ?? candidates[0])?.merge_sha);
+          : prEvidence(releaseFastCandidate ?? candidates[0])?.merge_sha;
+    let composedSha = storedComposedSha ?? initialComposedSha;
     if (
       !storedComposedSha &&
       !releaseFastCandidate &&
@@ -3278,29 +3278,20 @@ export class ReleaseBusV2Reconciler {
       stagingDeploymentCandidates(context, 'frontend').length > 0;
     const hasBackend =
       stagingDeploymentCandidates(context, 'backend').length > 0;
-    if (
-      train.lane === 'STAGING' &&
-      train.staging_policy === 'CUMULATIVE_ADMITTED_SET_V1'
-    ) {
-      const frontendBase = cumulativeStagingReleaseParent(context, 'frontend');
-      const backendBase = cumulativeStagingReleaseParent(context, 'backend');
-      if (
-        (hasFrontend &&
-          ![frontendBase, frontendTarget].includes(frontendStaging)) ||
-        (!hasFrontend && frontendStaging !== frontendTarget)
-      )
-        throw new StagingRefMovedError(
-          `frontend 1a-staging moved outside train ${train.id}'s exact ${frontendBase} -> ${frontendTarget} release intent`
-        );
-      if (
-        (hasBackend &&
-          ![backendBase, backendTarget].includes(backendStaging)) ||
-        (!hasBackend && backendStaging !== backendTarget)
-      )
-        throw new StagingRefMovedError(
-          `backend 1a-staging moved outside train ${train.id}'s exact ${backendBase} -> ${backendTarget} release intent`
-        );
-    }
+    this.assertCumulativeStagingRefIntent(
+      context,
+      'frontend',
+      hasFrontend,
+      frontendStaging,
+      frontendTarget
+    );
+    this.assertCumulativeStagingRefIntent(
+      context,
+      'backend',
+      hasBackend,
+      backendStaging,
+      backendTarget
+    );
     if (train.lane === 'PRODUCTION_QUALIFICATION') {
       // Candidate-bearing repositories are about to be deployed to their
       // composed targets. Only unchanged counterparts must already match the
@@ -3320,6 +3311,29 @@ export class ReleaseBusV2Reconciler {
       frontendFromExistingStaging: train.lane === 'STAGING' && !hasFrontend,
       backendFromExistingStaging: train.lane === 'STAGING' && !hasBackend
     };
+  }
+
+  private assertCumulativeStagingRefIntent(
+    context: TrainContext,
+    repository: ReleaseBusV2Repository,
+    affected: boolean,
+    stagingSha: string,
+    targetSha: string
+  ): void {
+    const train = context.train;
+    if (
+      train.lane !== 'STAGING' ||
+      train.staging_policy !== 'CUMULATIVE_ADMITTED_SET_V1'
+    )
+      return;
+    const baseSha = cumulativeStagingReleaseParent(context, repository);
+    const matchesIntent = affected
+      ? [baseSha, targetSha].includes(stagingSha)
+      : stagingSha === targetSha;
+    if (!matchesIntent)
+      throw new StagingRefMovedError(
+        `${repository} 1a-staging moved outside train ${train.id}'s exact ${baseSha} -> ${targetSha} release intent`
+      );
   }
 
   private async advanceCumulativeStagingRefs(
@@ -3373,7 +3387,7 @@ export class ReleaseBusV2Reconciler {
       train.id,
       `advance-staging:${phase}:${repository}`
     );
-    let operation = await this.repository.getOrCreateOperation(
+    const operation = await this.repository.getOrCreateOperation(
       {
         idempotencyKey: key,
         trainId: train.id,
@@ -3392,94 +3406,150 @@ export class ReleaseBusV2Reconciler {
       },
       {}
     );
-    if (operation.status === 'SUCCEEDED') {
-      const current = await releaseBusGitHubApp.resolveRef(
+    if (operation.status === 'SUCCEEDED')
+      return this.verifyCompletedStagingRef(repository, targetSha, phase);
+    if (observedSha !== baseSha && observedSha !== targetSha)
+      return this.rejectStagingRefDrift(
+        operation,
+        repository,
+        baseSha,
+        observedSha,
+        phase,
+        'before'
+      );
+    if (observedSha === baseSha)
+      await this.attemptStagingRefCas(
+        operation,
+        repository,
+        baseSha,
+        targetSha,
+        phase
+      );
+    await this.recordStagingRefSuccess(
+      operation,
+      repository,
+      baseSha,
+      targetSha,
+      phase
+    );
+  }
+
+  private async verifyCompletedStagingRef(
+    repository: ReleaseBusV2Repository,
+    targetSha: string,
+    phase: 'release' | 'rollback'
+  ): Promise<void> {
+    const current = await releaseBusGitHubApp.resolveRef(
+      repository,
+      '1a-staging'
+    );
+    if (current !== targetSha)
+      throw new StagingRefMovedError(
+        `${repository} 1a-staging moved after exact ${phase} CAS from ${targetSha} to ${current}`
+      );
+  }
+
+  private async terminalizeStagingRefOperation(
+    operation: ReleaseBusV2OperationRecord,
+    repository: ReleaseBusV2Repository,
+    status: 'CANCELLED' | 'FAILED',
+    failureClass: ReleaseBusV2FailureClass,
+    failureMessage: string
+  ): Promise<void> {
+    if (
+      !(await this.repository.updateOperation(
+        operation.id,
+        operation.row_version,
+        {
+          status,
+          failureClass,
+          failureMessage,
+          completedAt: Date.now()
+        },
+        {}
+      ))
+    )
+      throw new Error(
+        `${repository} staging-ref operation changed concurrently`
+      );
+  }
+
+  private async rejectStagingRefDrift(
+    operation: ReleaseBusV2OperationRecord,
+    repository: ReleaseBusV2Repository,
+    baseSha: string,
+    observedSha: string | null,
+    phase: 'release' | 'rollback',
+    timing: 'before' | 'during'
+  ): Promise<never> {
+    if (!TERMINAL_OPERATIONS.has(operation.status))
+      await this.terminalizeStagingRefOperation(
+        operation,
+        repository,
+        'CANCELLED',
+        'INTERACTION',
+        `${repository} 1a-staging moved to ${observedSha} ${timing} exact ${phase} CAS`
+      );
+    throw new StagingRefMovedError(
+      `${repository} 1a-staging moved from ${baseSha} to ${observedSha} ${timing} exact ${phase} CAS`
+    );
+  }
+
+  private async attemptStagingRefCas(
+    operation: ReleaseBusV2OperationRecord,
+    repository: ReleaseBusV2Repository,
+    baseSha: string,
+    targetSha: string,
+    phase: 'release' | 'rollback'
+  ): Promise<void> {
+    try {
+      await releaseBusGitHubApp.updateRef(
+        repository,
+        '1a-staging',
+        baseSha,
+        targetSha
+      );
+      return;
+    } catch (error) {
+      const afterFailure = await releaseBusGitHubApp.resolveRef(
         repository,
         '1a-staging'
       );
-      if (current !== targetSha)
-        throw new StagingRefMovedError(
-          `${repository} 1a-staging moved after exact ${phase} CAS from ${targetSha} to ${current}`
+      if (afterFailure === targetSha) return;
+      if (afterFailure !== baseSha)
+        return this.rejectStagingRefDrift(
+          operation,
+          repository,
+          baseSha,
+          afterFailure,
+          phase,
+          'during'
         );
-      return;
-    }
-    if (observedSha !== baseSha && observedSha !== targetSha) {
-      if (!TERMINAL_OPERATIONS.has(operation.status))
-        await this.repository.updateOperation(
-          operation.id,
-          operation.row_version,
-          {
-            status: 'CANCELLED',
-            failureClass: 'INTERACTION',
-            failureMessage: `${repository} 1a-staging moved to ${observedSha} before exact ${phase} CAS`,
-            completedAt: Date.now()
-          },
-          {}
-        );
+      if (isGitHubInfrastructureError(error)) throw error;
+      const message =
+        error instanceof Error
+          ? error.message
+          : `Failed to advance ${repository} 1a-staging`;
+      await this.terminalizeStagingRefOperation(
+        operation,
+        repository,
+        'FAILED',
+        'CONTROL_PLANE',
+        message
+      );
       throw new StagingRefMovedError(
-        `${repository} 1a-staging moved from ${baseSha} to ${observedSha} before exact ${phase} CAS`
+        `${repository} exact ${phase} CAS was rejected while 1a-staging remained ${baseSha}: ${message}`
       );
     }
-    if (observedSha === baseSha) {
-      try {
-        await releaseBusGitHubApp.updateRef(
-          repository,
-          '1a-staging',
-          baseSha,
-          targetSha
-        );
-      } catch (error) {
-        const afterFailure = await releaseBusGitHubApp.resolveRef(
-          repository,
-          '1a-staging'
-        );
-        if (afterFailure !== targetSha) {
-          const message =
-            error instanceof Error
-              ? error.message
-              : `Failed to advance ${repository} 1a-staging`;
-          if (afterFailure !== baseSha) {
-            if (
-              !(await this.repository.updateOperation(
-                operation.id,
-                operation.row_version,
-                {
-                  status: 'CANCELLED',
-                  failureClass: 'INTERACTION',
-                  failureMessage: `${repository} 1a-staging moved to ${afterFailure} during exact ${phase} CAS`,
-                  completedAt: Date.now()
-                },
-                {}
-              ))
-            )
-              throw new Error(
-                `${repository} staging-ref operation changed concurrently`
-              );
-            throw new StagingRefMovedError(
-              `${repository} 1a-staging moved from ${baseSha} to ${afterFailure} during exact ${phase} CAS`
-            );
-          }
-          if (isGitHubInfrastructureError(error)) throw error;
-          if (
-            !(await this.repository.updateOperation(
-              operation.id,
-              operation.row_version,
-              {
-                status: 'FAILED',
-                failureClass: 'CONTROL_PLANE',
-                failureMessage: message,
-                completedAt: Date.now()
-              },
-              {}
-            ))
-          )
-            throw new Error(
-              `${repository} staging-ref operation changed concurrently`
-            );
-          throw error;
-        }
-      }
-    }
+  }
+
+  private async recordStagingRefSuccess(
+    operation: ReleaseBusV2OperationRecord,
+    repository: ReleaseBusV2Repository,
+    baseSha: string,
+    targetSha: string,
+    phase: 'release' | 'rollback'
+  ): Promise<void> {
     if (
       !(await this.repository.updateOperation(
         operation.id,
@@ -3501,7 +3571,6 @@ export class ReleaseBusV2Reconciler {
       throw new Error(
         `${repository} staging-ref operation changed concurrently`
       );
-    operation = (await this.repository.findOperation(key, {})) ?? operation;
   }
 
   private async captureStagingIdleSnapshot(fence?: {
@@ -4498,44 +4567,12 @@ export class ReleaseBusV2Reconciler {
     const manifest = await this.repository.findManifest(train.manifest_id, {});
     if (!manifest)
       throw new Error('Exact release manifest does not exist before E2E');
-    if (
-      manifest.frontend_sha !== train.frontend_composed_sha ||
-      manifest.backend_sha !== train.backend_composed_sha ||
-      manifest.frontend_artifact_digest !==
-        (stagingDeploymentCandidates(context, 'frontend').length
-          ? train.frontend_artifact_digest
-          : null) ||
-      manifest.backend_artifact_digest !==
-        (stagingDeploymentCandidates(context, 'backend').length
-          ? train.backend_artifact_digest
-          : null)
-    )
-      throw new Error('E2E manifest does not match the exact train release');
+    this.assertE2EManifestMatchesTrain(context, manifest);
+    if (environment === 'staging')
+      await this.assertCumulativeStagingE2ERefParity(train, manifest);
     const releaseBranch = releaseBusV2Branch(train, 'frontend');
     let exactSourceRef = 'main';
     if (environment === 'staging') {
-      if (
-        train.lane === 'STAGING' &&
-        train.staging_policy === 'CUMULATIVE_ADMITTED_SET_V1'
-      ) {
-        const identity = parseStoredJson<{
-          frontend_staging_ref_sha?: unknown;
-          backend_staging_ref_sha?: unknown;
-        }>(manifest.manifest_json);
-        const [frontendStaging, backendStaging] = await Promise.all([
-          releaseBusGitHubApp.resolveRefIfExists('frontend', '1a-staging'),
-          releaseBusGitHubApp.resolveRefIfExists('backend', '1a-staging')
-        ]);
-        if (
-          identity?.frontend_staging_ref_sha !== manifest.frontend_sha ||
-          identity.backend_staging_ref_sha !== manifest.backend_sha ||
-          frontendStaging !== manifest.frontend_sha ||
-          backendStaging !== manifest.backend_sha
-        )
-          throw new StagingRefMovedError(
-            'E2E refused a staging manifest whose 1a-staging refs no longer match its exact release SHAs'
-          );
-      }
       const sourceRefs = [releaseBranch, '1a-staging', 'main'];
       const sourceShas = await Promise.all(
         sourceRefs.map((ref) =>
@@ -4577,6 +4614,54 @@ export class ReleaseBusV2Reconciler {
       maxAttempts: 2
     };
     return releaseBusV2Operations.reconcileWorkflow(spec);
+  }
+
+  private assertE2EManifestMatchesTrain(
+    context: TrainContext,
+    manifest: ReleaseBusV2ManifestRecord
+  ): void {
+    const train = context.train;
+    if (
+      manifest.frontend_sha !== train.frontend_composed_sha ||
+      manifest.backend_sha !== train.backend_composed_sha ||
+      manifest.frontend_artifact_digest !==
+        (stagingDeploymentCandidates(context, 'frontend').length
+          ? train.frontend_artifact_digest
+          : null) ||
+      manifest.backend_artifact_digest !==
+        (stagingDeploymentCandidates(context, 'backend').length
+          ? train.backend_artifact_digest
+          : null)
+    )
+      throw new Error('E2E manifest does not match the exact train release');
+  }
+
+  private async assertCumulativeStagingE2ERefParity(
+    train: ReleaseBusV2TrainRecord,
+    manifest: ReleaseBusV2ManifestRecord
+  ): Promise<void> {
+    if (
+      train.lane !== 'STAGING' ||
+      train.staging_policy !== 'CUMULATIVE_ADMITTED_SET_V1'
+    )
+      return;
+    const identity = parseStoredJson<{
+      frontend_staging_ref_sha?: unknown;
+      backend_staging_ref_sha?: unknown;
+    }>(manifest.manifest_json);
+    const [frontendStaging, backendStaging] = await Promise.all([
+      releaseBusGitHubApp.resolveRefIfExists('frontend', '1a-staging'),
+      releaseBusGitHubApp.resolveRefIfExists('backend', '1a-staging')
+    ]);
+    if (
+      identity?.frontend_staging_ref_sha !== manifest.frontend_sha ||
+      identity.backend_staging_ref_sha !== manifest.backend_sha ||
+      frontendStaging !== manifest.frontend_sha ||
+      backendStaging !== manifest.backend_sha
+    )
+      throw new StagingRefMovedError(
+        'E2E refused a staging manifest whose 1a-staging refs no longer match its exact release SHAs'
+      );
   }
 
   private async artifactSource(trainId: string): Promise<ArtifactSource> {
@@ -4670,7 +4755,10 @@ export class ReleaseBusV2Reconciler {
       // either their composed tree or their unchanged base tree.
       frontend_sha: train.frontend_composed_sha,
       backend_sha: train.backend_composed_sha,
-      ...(stagingRefs ?? {}),
+      frontend_staging_ref_sha:
+        stagingRefs?.frontend_staging_ref_sha ?? undefined,
+      backend_staging_ref_sha:
+        stagingRefs?.backend_staging_ref_sha ?? undefined,
       frontend_artifact_digest: hasFrontend
         ? train.frontend_artifact_digest
         : null,

--- a/src/releaseBusV2/release-bus-v2.reconciler.ts
+++ b/src/releaseBusV2/release-bus-v2.reconciler.ts
@@ -107,6 +107,8 @@ type StagingIdleSnapshot = {
 type StagingIdleHandshakeSnapshot = StagingIdleSnapshot & {
   readonly workflow_fence_started_at: number;
   readonly verified_at: number;
+  readonly expected_frontend_staging_sha?: string;
+  readonly expected_backend_staging_sha?: string;
 };
 
 type StagingEnvironmentBinding = {
@@ -148,6 +150,14 @@ class MainMovedError extends Error {
   }
 }
 
+class StagingRefMovedError extends Error {
+  public constructor(message: string) {
+    super(message);
+    this.name = 'StagingRefMovedError';
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
 function isGitHubInfrastructureError(error: unknown): error is Error {
   const infrastructureType: unknown = ReleaseBusGitHubInfrastructureError;
   return (
@@ -166,6 +176,9 @@ function isOptimisticConcurrencyConflict(error: unknown): error is Error {
       error.message === 'Release Bus v2 train changed concurrently' ||
       error.message === 'Candidate changed concurrently' ||
       /^(frontend|backend) main operation changed concurrently$/.test(
+        error.message
+      ) ||
+      /^(frontend|backend) staging-ref operation changed concurrently$/.test(
         error.message
       ) ||
       /^Candidate .* changed during deterministic isolation$/.test(
@@ -585,12 +598,7 @@ export function stagingDeploymentCandidates(
     context.train.staging_policy !== 'CUMULATIVE_ADMITTED_SET_V1'
   )
     return relevantCandidates(context, repository);
-  const deployRoles = new Set([
-    'NEW',
-    'CARRY_FORWARD',
-    'REMOVAL',
-    'ABSORPTION'
-  ]);
+  const deployRoles = new Set(['NEW', 'REMOVAL', 'ABSORPTION']);
   // Removal/absorption candidates are intentionally excluded from the
   // composition (AUDIT_ONLY) but still identify runtime units that must be
   // redeployed from the new cumulative composition to scrub their old bytes.
@@ -604,6 +612,29 @@ export function stagingDeploymentCandidates(
       included.has(candidate.id) &&
       (!repository || candidate.repository === repository)
   );
+}
+
+function cumulativeStagingReleaseParent(
+  context: TrainContext,
+  repository: ReleaseBusV2Repository
+): string | null {
+  if (
+    context.train.lane !== 'STAGING' ||
+    context.train.staging_policy !== 'CUMULATIVE_ADMITTED_SET_V1'
+  )
+    return null;
+  const transition = parseStoredJson<ReleaseBusV2StagingTransition>(
+    context.train.staging_transition_json
+  );
+  const sha =
+    repository === 'frontend'
+      ? transition?.observed_frontend_staging_sha
+      : transition?.observed_backend_staging_sha;
+  if (!sha || !/^[a-f0-9]{40}$/.test(sha))
+    throw new Error(
+      `Cumulative staging has no exact ${repository} release parent`
+    );
+  return sha;
 }
 
 export function candidateUnavailableForTrainUpdate(
@@ -846,6 +877,10 @@ export class ReleaseBusV2Reconciler {
         if (isOptimisticConcurrencyConflict(error)) continue;
         if (error instanceof MainMovedError) {
           await this.cancelForMovedMain(train, error.message);
+          continue;
+        }
+        if (error instanceof StagingRefMovedError) {
+          await this.failStagingForRefDrift(train, error.message);
           continue;
         }
         if (isGitHubInfrastructureError(error)) {
@@ -1343,6 +1378,10 @@ export class ReleaseBusV2Reconciler {
     const train = context.train;
     const candidates = relevantCandidates(context, repository);
     const deployCandidates = stagingDeploymentCandidates(context, repository);
+    const releaseParentSha = cumulativeStagingReleaseParent(
+      context,
+      repository
+    );
     const baseSha =
       repository === 'frontend'
         ? train.frontend_base_sha
@@ -1351,7 +1390,7 @@ export class ReleaseBusV2Reconciler {
     if (deployCandidates.length === 0) {
       return {
         repository,
-        composedSha: baseSha,
+        composedSha: releaseParentSha ?? baseSha,
         artifactDigest: null,
         pending: false,
         failedOperation: null
@@ -1366,12 +1405,19 @@ export class ReleaseBusV2Reconciler {
       canUseSingleCandidateFastPath(candidates[0], baseSha)
         ? candidates[0]
         : null;
+    const releaseFastCandidate = releaseParentSha ? null : fastCandidate;
     let composedSha =
       storedComposedSha ??
-      (candidates.length === 0
-        ? baseSha
-        : prEvidence(fastCandidate ?? candidates[0])?.merge_sha);
-    if (!storedComposedSha && !fastCandidate && candidates.length > 0) {
+      (releaseParentSha
+        ? null
+        : candidates.length === 0
+          ? baseSha
+          : prEvidence(releaseFastCandidate ?? candidates[0])?.merge_sha);
+    if (
+      !storedComposedSha &&
+      !releaseFastCandidate &&
+      (candidates.length > 0 || releaseParentSha)
+    ) {
       const compose = await releaseBusV2Operations.reconcileWorkflow({
         idempotencyKey: operationKey(train.id, `compose:${repository}`),
         trainId: train.id,
@@ -1390,9 +1436,12 @@ export class ReleaseBusV2Reconciler {
           base_sha: baseSha,
           expected_sha: baseSha,
           candidate_shas: JSON.stringify(
-            candidates.map(({ head_sha }) => head_sha)
+            candidates.length > 0
+              ? candidates.map(({ head_sha }) => head_sha)
+              : [baseSha]
           ),
-          release_branch: releaseBusV2Branch(train, repository)
+          release_branch: releaseBusV2Branch(train, repository),
+          release_parent_sha: releaseParentSha ?? ''
         }
       });
       if (compose.status === 'FAILED')
@@ -1429,7 +1478,7 @@ export class ReleaseBusV2Reconciler {
         };
     }
     if (!composedSha) throw new Error(`Missing ${repository} composed SHA`);
-    if (fastCandidate || candidates.length === 0) {
+    if (releaseFastCandidate || candidates.length === 0) {
       // The compose workflow creates the immutable release ref for multi-PR
       // trains. The single-PR fast path skips that workflow, so bind the same
       // lane-scoped ref here before any artifact preparation or deployment.
@@ -1466,8 +1515,8 @@ export class ReleaseBusV2Reconciler {
       };
     const graph =
       repository === 'backend' ? backendGraph(deployCandidates) : null;
-    const evidence = fastCandidate
-      ? reusablePrArtifact(fastCandidate, repository, graph?.units ?? [])
+    const evidence = releaseFastCandidate
+      ? reusablePrArtifact(releaseFastCandidate, repository, graph?.units ?? [])
       : null;
     const operationType = `PREPARE_ARTIFACT_${repository.toUpperCase()}`;
     const betaInfrastructureFailureInjection =
@@ -2063,12 +2112,26 @@ export class ReleaseBusV2Reconciler {
     if (!manifest?.frontend_sha || !manifest.backend_sha)
       throw new Error('Cumulative rollback baseline identity is incomplete');
     const body = parseStoredJson<{
-      candidates?: Array<{ candidate_id?: string }>;
+      candidates?: Array<{
+        candidate_id?: string;
+        repository?: ReleaseBusV2Repository;
+        pr_number?: number;
+        head_sha?: string;
+      }>;
     }>(manifest.manifest_json);
     const candidateIds = Array.from(
       new Set(
         (body?.candidates ?? [])
-          .map(({ candidate_id }) => candidate_id)
+          .map(
+            ({ candidate_id, repository, pr_number, head_sha }) =>
+              candidate_id ??
+              context.candidates.find(
+                (candidate) =>
+                  candidate.repository === repository &&
+                  candidate.pr_number === pr_number &&
+                  candidate.head_sha === head_sha
+              )?.id
+          )
           .filter((id): id is string => Boolean(id))
       )
     );
@@ -2098,22 +2161,29 @@ export class ReleaseBusV2Reconciler {
         : baseline.graph.units.length > 0;
     const composedSha =
       repository === 'frontend' ? baseline.frontendSha : baseline.backendSha;
+    const releaseParentSha =
+      repository === 'frontend'
+        ? train.frontend_composed_sha
+        : train.backend_composed_sha;
+    if (!releaseParentSha)
+      throw new Error(
+        `Cumulative rollback has no ${repository} release parent`
+      );
     if (!selected)
       return {
         repository,
-        composedSha,
+        composedSha: releaseParentSha,
         artifactDigest: null,
         pending: false,
         failedOperation: null
       };
     const branch = this.rollbackBranch(train, repository);
-    await releaseBusGitHubApp.createRef(repository, branch, composedSha);
-    const operation = await releaseBusV2Operations.reconcileWorkflow({
-      idempotencyKey: operationKey(train.id, `rollback:prepare:${repository}`),
+    const composition = await releaseBusV2Operations.reconcileWorkflow({
+      idempotencyKey: operationKey(train.id, `rollback:compose:${repository}`),
       trainId: train.id,
-      operationType: `ROLLBACK_PREPARE_ARTIFACT_${repository.toUpperCase()}`,
+      operationType: `ROLLBACK_COMPOSE_${repository.toUpperCase()}`,
       repository,
-      workflow: 'release-bus-v2-preflight.yml',
+      workflow: 'release-bus-v2-compose.yml',
       ref: 'main',
       environment: 'orchestration',
       service: null,
@@ -2123,8 +2193,51 @@ export class ReleaseBusV2Reconciler {
         release_train_id: train.id,
         release_train_revision: 'rollback-1',
         operation_key: 'replaced-by-reconciler',
-        source_ref: branch,
+        base_sha: composedSha,
         expected_sha: composedSha,
+        candidate_shas: JSON.stringify([composedSha]),
+        release_branch: branch,
+        release_parent_sha: releaseParentSha
+      },
+      maxAttempts: 3
+    });
+    if (composition.status === 'FAILED')
+      return {
+        repository,
+        composedSha: '',
+        artifactDigest: null,
+        pending: false,
+        failedOperation: composition
+      };
+    if (composition.status !== 'SUCCEEDED')
+      return {
+        repository,
+        composedSha: '',
+        artifactDigest: null,
+        pending: true,
+        failedOperation: null
+      };
+    const rollbackSha = await releaseBusGitHubApp.resolveRef(
+      repository,
+      branch
+    );
+    const operation = await releaseBusV2Operations.reconcileWorkflow({
+      idempotencyKey: operationKey(train.id, `rollback:prepare:${repository}`),
+      trainId: train.id,
+      operationType: `ROLLBACK_PREPARE_ARTIFACT_${repository.toUpperCase()}`,
+      repository,
+      workflow: 'release-bus-v2-preflight.yml',
+      ref: 'main',
+      environment: 'orchestration',
+      service: null,
+      expectedSha: rollbackSha,
+      artifactDigest: null,
+      inputs: {
+        release_train_id: train.id,
+        release_train_revision: 'rollback-1',
+        operation_key: 'replaced-by-reconciler',
+        source_ref: branch,
+        expected_sha: rollbackSha,
         deploy_units:
           repository === 'backend'
             ? JSON.stringify(baseline.graph.units)
@@ -2140,7 +2253,7 @@ export class ReleaseBusV2Reconciler {
     });
     return {
       repository,
-      composedSha,
+      composedSha: rollbackSha,
       artifactDigest: operation.artifact_digest,
       pending: !['SUCCEEDED', 'FAILED'].includes(operation.status),
       failedOperation: operation.status === 'FAILED' ? operation : null
@@ -2150,7 +2263,9 @@ export class ReleaseBusV2Reconciler {
   private async reconcileCumulativeRollbackDeployments(
     context: TrainContext,
     frontendArtifact: ReleaseBusV2OperationRecord | null,
-    backendArtifact: ReleaseBusV2OperationRecord | null
+    backendArtifact: ReleaseBusV2OperationRecord | null,
+    frontendReleaseSha: string,
+    backendReleaseSha: string
   ): Promise<DeployResult> {
     const train = context.train;
     const baseline = await this.cumulativeRollbackBaseline(context);
@@ -2187,7 +2302,7 @@ export class ReleaseBusV2Reconciler {
             ref: 'main',
             environment: 'staging',
             service: unit,
-            expectedSha: baseline.backendSha,
+            expectedSha: backendReleaseSha,
             artifactDigest: backendArtifact.artifact_digest,
             inputs: {
               environment: 'staging',
@@ -2195,7 +2310,7 @@ export class ReleaseBusV2Reconciler {
               release_train_id: train.id,
               release_train_revision: 'rollback-1',
               operation_key: 'replaced-by-reconciler',
-              expected_sha: baseline.backendSha,
+              expected_sha: backendReleaseSha,
               artifact_run_id: backendArtifact.external_id,
               artifact_train_id: train.id,
               artifact_digest: backendArtifact.artifact_digest,
@@ -2234,14 +2349,14 @@ export class ReleaseBusV2Reconciler {
         ref: 'main',
         environment: 'staging',
         service: null,
-        expectedSha: baseline.frontendSha,
+        expectedSha: frontendReleaseSha,
         artifactDigest: frontendArtifact.artifact_digest,
         inputs: {
           release_train_id: train.id,
           release_train_revision: 'rollback-1',
           operation_key: 'replaced-by-reconciler',
           source_ref: this.rollbackBranch(train, 'frontend'),
-          expected_sha: baseline.frontendSha,
+          expected_sha: frontendReleaseSha,
           artifact_run_id: frontendArtifact.external_id,
           artifact_train_id: train.id,
           artifact_digest: frontendArtifact.artifact_digest,
@@ -2261,10 +2376,56 @@ export class ReleaseBusV2Reconciler {
     };
   }
 
+  private async advanceCumulativeRollbackRefs(
+    context: TrainContext,
+    frontendReleaseSha: string,
+    backendReleaseSha: string
+  ): Promise<void> {
+    const train = context.train;
+    const selected = (['backend', 'frontend'] as const).filter(
+      (repository) =>
+        stagingDeploymentCandidates(context, repository).length > 0
+    );
+    const current = await Promise.all(
+      selected.map(async (repository) => ({
+        repository,
+        observedSha: await releaseBusGitHubApp.resolveRef(
+          repository,
+          '1a-staging'
+        ),
+        baseSha:
+          repository === 'frontend'
+            ? train.frontend_composed_sha
+            : train.backend_composed_sha,
+        targetSha:
+          repository === 'frontend' ? frontendReleaseSha : backendReleaseSha
+      }))
+    );
+    const invalid = current.find(
+      ({ observedSha, baseSha, targetSha }) =>
+        !baseSha || (observedSha !== baseSha && observedSha !== targetSha)
+    );
+    if (invalid)
+      throw new StagingRefMovedError(
+        `${invalid.repository} 1a-staging moved outside rollback intent ${invalid.baseSha} -> ${invalid.targetSha}`
+      );
+    for (const item of current)
+      await this.advanceStagingRef(
+        train,
+        item.repository,
+        item.observedSha,
+        item.baseSha!,
+        item.targetSha,
+        'rollback'
+      );
+  }
+
   private async createCumulativeRollbackManifest(
     context: TrainContext,
     frontendArtifact: ReleaseBusV2OperationRecord | null,
-    backendArtifact: ReleaseBusV2OperationRecord | null
+    backendArtifact: ReleaseBusV2OperationRecord | null,
+    frontendReleaseSha: string,
+    backendReleaseSha: string
   ): Promise<ReleaseBusV2ManifestRecord> {
     const baseline = await this.cumulativeRollbackBaseline(context);
     const operations = await this.repository.listOperations(
@@ -2277,8 +2438,10 @@ export class ReleaseBusV2Reconciler {
       scope: 'cumulative-staging-rollback',
       staging_policy: 'RESTORE_VALIDATED_STAGING_V1',
       source_manifest_id: baseline.manifest.id,
-      frontend_sha: baseline.frontendSha,
-      backend_sha: baseline.backendSha,
+      frontend_sha: frontendReleaseSha,
+      backend_sha: backendReleaseSha,
+      frontend_staging_ref_sha: frontendReleaseSha,
+      backend_staging_ref_sha: backendReleaseSha,
       frontend_artifact_digest: frontendArtifact?.artifact_digest ?? null,
       backend_artifact_digest: backendArtifact?.artifact_digest ?? null,
       candidates: baseline.candidateIds
@@ -2289,8 +2452,8 @@ export class ReleaseBusV2Reconciler {
         lane: context.train.lane,
         identity_sha256: sha256(identity),
         status: 'STAGING_DEPLOYED',
-        frontend_sha: baseline.frontendSha,
-        backend_sha: baseline.backendSha,
+        frontend_sha: frontendReleaseSha,
+        backend_sha: backendReleaseSha,
         frontend_artifact_digest: frontendArtifact?.artifact_digest ?? null,
         backend_artifact_digest: backendArtifact?.artifact_digest ?? null,
         e2e_run_id: null,
@@ -2330,14 +2493,15 @@ export class ReleaseBusV2Reconciler {
 
   private async reconcileCumulativeRollbackE2E(
     context: TrainContext,
-    manifest: ReleaseBusV2ManifestRecord
+    manifest: ReleaseBusV2ManifestRecord,
+    frontendReleaseSha: string,
+    backendReleaseSha: string
   ): Promise<ReleaseBusV2OperationRecord> {
-    const baseline = await this.cumulativeRollbackBaseline(context);
     const sourceRef = this.rollbackBranch(context.train, 'frontend');
     await releaseBusGitHubApp.createRef(
       'frontend',
       sourceRef,
-      baseline.frontendSha
+      frontendReleaseSha
     );
     return releaseBusV2Operations.reconcileWorkflow({
       idempotencyKey: operationKey(context.train.id, 'rollback:e2e:staging'),
@@ -2348,18 +2512,18 @@ export class ReleaseBusV2Reconciler {
       ref: sourceRef,
       environment: 'staging',
       service: null,
-      expectedSha: baseline.frontendSha,
+      expectedSha: frontendReleaseSha,
       artifactDigest: manifest.identity_sha256,
       inputs: e2eWorkflowInputs('staging', {
         release_train_id: context.train.id,
         release_train_revision: 'rollback-1',
         operation_key: 'replaced-by-reconciler',
         staging_source_ref: sourceRef,
-        expected_sha: baseline.frontendSha,
+        expected_sha: frontendReleaseSha,
         release_manifest_id: manifest.id,
         release_manifest_identity_sha256: manifest.identity_sha256,
-        frontend_sha: baseline.frontendSha,
-        backend_sha: baseline.backendSha,
+        frontend_sha: frontendReleaseSha,
+        backend_sha: backendReleaseSha,
         frontend_artifact_digest: manifest.frontend_artifact_digest ?? '',
         backend_artifact_digest: manifest.backend_artifact_digest ?? ''
       }),
@@ -2403,10 +2567,19 @@ export class ReleaseBusV2Reconciler {
           operation_type === 'ROLLBACK_PREPARE_ARTIFACT_BACKEND' &&
           status === 'SUCCEEDED'
       ) ?? null;
+    const frontendReleaseSha = frontendPreparation.composedSha;
+    const backendReleaseSha = backendPreparation.composedSha;
+    await this.advanceCumulativeRollbackRefs(
+      context,
+      frontendReleaseSha,
+      backendReleaseSha
+    );
     const deployed = await this.reconcileCumulativeRollbackDeployments(
       context,
       frontendArtifact,
-      backendArtifact
+      backendArtifact,
+      frontendReleaseSha,
+      backendReleaseSha
     );
     if (deployed.failedOperation) {
       await this.failCumulativeStagingRollback(
@@ -2430,7 +2603,9 @@ export class ReleaseBusV2Reconciler {
     manifest ??= await this.createCumulativeRollbackManifest(
       context,
       frontendArtifact,
-      backendArtifact
+      backendArtifact,
+      frontendReleaseSha,
+      backendReleaseSha
     );
     if (train.manifest_id !== manifest.id) {
       await this.transitionTrain(train, {
@@ -2443,7 +2618,12 @@ export class ReleaseBusV2Reconciler {
       });
       return;
     }
-    const e2e = await this.reconcileCumulativeRollbackE2E(context, manifest);
+    const e2e = await this.reconcileCumulativeRollbackE2E(
+      context,
+      manifest,
+      frontendReleaseSha,
+      backendReleaseSha
+    );
     if (e2e.status === 'FAILED') {
       await this.failCumulativeStagingRollback(
         context,
@@ -2462,8 +2642,8 @@ export class ReleaseBusV2Reconciler {
       }));
     if (
       !stable ||
-      stable.frontend_staging_sha !== handshake.frontend_staging_sha ||
-      stable.backend_staging_sha !== handshake.backend_staging_sha
+      stable.frontend_staging_sha !== frontendReleaseSha ||
+      stable.backend_staging_sha !== backendReleaseSha
     ) {
       await this.failCumulativeStagingRollback(
         context,
@@ -2509,10 +2689,10 @@ export class ReleaseBusV2Reconciler {
               trainId: train.id,
               expectedStateVersion: lockedState.row_version,
               manifestId: manifest.id,
-              frontendSha: baseline.frontendSha,
-              backendSha: baseline.backendSha,
-              frontendStagingRefSha: stable.frontend_staging_sha!,
-              backendStagingRefSha: stable.backend_staging_sha!,
+              frontendSha: frontendReleaseSha,
+              backendSha: backendReleaseSha,
+              frontendStagingRefSha: frontendReleaseSha,
+              backendStagingRefSha: backendReleaseSha,
               admittedCandidateIds: baseline.candidateIds,
               removedCandidateIds: [],
               newCandidateIds: []
@@ -2890,6 +3070,16 @@ export class ReleaseBusV2Reconciler {
           actor: 'release-bus-v2',
           payload: {
             ...afterLock,
+            expected_frontend_staging_sha:
+              train.lane === 'STAGING' &&
+              train.staging_policy === 'CUMULATIVE_ADMITTED_SET_V1'
+                ? environmentBinding.frontendSha
+                : afterLock.frontend_staging_sha,
+            expected_backend_staging_sha:
+              train.lane === 'STAGING' &&
+              train.staging_policy === 'CUMULATIVE_ADMITTED_SET_V1'
+                ? environmentBinding.backendSha
+                : afterLock.backend_staging_sha,
             staging_lock: 'owned',
             workflow_fence_started_at: workflowFenceStartedAt,
             verified_at: Date.now()
@@ -2905,6 +3095,16 @@ export class ReleaseBusV2Reconciler {
             actor: 'release-bus-v2-beta',
             payload: {
               ...afterLock,
+              expected_frontend_staging_sha:
+                train.lane === 'STAGING' &&
+                train.staging_policy === 'CUMULATIVE_ADMITTED_SET_V1'
+                  ? environmentBinding.frontendSha
+                  : afterLock.frontend_staging_sha,
+              expected_backend_staging_sha:
+                train.lane === 'STAGING' &&
+                train.staging_policy === 'CUMULATIVE_ADMITTED_SET_V1'
+                  ? environmentBinding.backendSha
+                  : afterLock.backend_staging_sha,
               beta_test_id: getReleaseBusV2BetaAllowlist()[0]?.test_id,
               staging_lock: 'owned',
               workflow_fence_started_at: workflowFenceStartedAt,
@@ -2914,6 +3114,15 @@ export class ReleaseBusV2Reconciler {
           {}
         );
       }
+      if (
+        train.lane === 'STAGING' &&
+        train.staging_policy === 'CUMULATIVE_ADMITTED_SET_V1'
+      )
+        await this.advanceCumulativeStagingRefs(
+          context,
+          afterLock,
+          environmentBinding
+        );
     }
     const sourceTrainId = train.parent_train_id ?? train.id;
     if (['PREPARED', 'WAITING_FOR_ENVIRONMENT'].includes(train.status)) {
@@ -3069,6 +3278,29 @@ export class ReleaseBusV2Reconciler {
       stagingDeploymentCandidates(context, 'frontend').length > 0;
     const hasBackend =
       stagingDeploymentCandidates(context, 'backend').length > 0;
+    if (
+      train.lane === 'STAGING' &&
+      train.staging_policy === 'CUMULATIVE_ADMITTED_SET_V1'
+    ) {
+      const frontendBase = cumulativeStagingReleaseParent(context, 'frontend');
+      const backendBase = cumulativeStagingReleaseParent(context, 'backend');
+      if (
+        (hasFrontend &&
+          ![frontendBase, frontendTarget].includes(frontendStaging)) ||
+        (!hasFrontend && frontendStaging !== frontendTarget)
+      )
+        throw new StagingRefMovedError(
+          `frontend 1a-staging moved outside train ${train.id}'s exact ${frontendBase} -> ${frontendTarget} release intent`
+        );
+      if (
+        (hasBackend &&
+          ![backendBase, backendTarget].includes(backendStaging)) ||
+        (!hasBackend && backendStaging !== backendTarget)
+      )
+        throw new StagingRefMovedError(
+          `backend 1a-staging moved outside train ${train.id}'s exact ${backendBase} -> ${backendTarget} release intent`
+        );
+    }
     if (train.lane === 'PRODUCTION_QUALIFICATION') {
       // Candidate-bearing repositories are about to be deployed to their
       // composed targets. Only unchanged counterparts must already match the
@@ -3088,6 +3320,188 @@ export class ReleaseBusV2Reconciler {
       frontendFromExistingStaging: train.lane === 'STAGING' && !hasFrontend,
       backendFromExistingStaging: train.lane === 'STAGING' && !hasBackend
     };
+  }
+
+  private async advanceCumulativeStagingRefs(
+    context: TrainContext,
+    snapshot: StagingIdleSnapshot,
+    binding: StagingEnvironmentBinding
+  ): Promise<void> {
+    const selected = (['backend', 'frontend'] as const)
+      .filter(
+        (repository) =>
+          stagingDeploymentCandidates(context, repository).length > 0
+      )
+      .map((repository) => ({
+        repository,
+        observedSha:
+          repository === 'frontend'
+            ? snapshot.frontend_staging_sha
+            : snapshot.backend_staging_sha,
+        baseSha: cumulativeStagingReleaseParent(context, repository),
+        targetSha:
+          repository === 'frontend' ? binding.frontendSha : binding.backendSha
+      }));
+    const invalid = selected.find(
+      ({ observedSha, baseSha, targetSha }) =>
+        observedSha !== baseSha && observedSha !== targetSha
+    );
+    if (invalid)
+      throw new StagingRefMovedError(
+        `${invalid.repository} 1a-staging moved from expected ${invalid.baseSha} to ${invalid.observedSha}; exact train ${context.train.id} was not deployed`
+      );
+    for (const item of selected)
+      await this.advanceStagingRef(
+        context.train,
+        item.repository,
+        item.observedSha,
+        item.baseSha!,
+        item.targetSha,
+        'release'
+      );
+  }
+
+  private async advanceStagingRef(
+    train: ReleaseBusV2TrainRecord,
+    repository: ReleaseBusV2Repository,
+    observedSha: string | null,
+    baseSha: string,
+    targetSha: string,
+    phase: 'release' | 'rollback'
+  ): Promise<void> {
+    const key = operationKey(
+      train.id,
+      `advance-staging:${phase}:${repository}`
+    );
+    let operation = await this.repository.getOrCreateOperation(
+      {
+        idempotencyKey: key,
+        trainId: train.id,
+        operationType: `ADVANCE_STAGING_${phase.toUpperCase()}_${repository.toUpperCase()}`,
+        repository,
+        service: null,
+        environment: 'staging',
+        expectedSha: targetSha,
+        artifactDigest: null,
+        request: {
+          ref: '1a-staging',
+          expected_old_sha: baseSha,
+          phase
+        },
+        maxAttempts: 3
+      },
+      {}
+    );
+    if (operation.status === 'SUCCEEDED') {
+      const current = await releaseBusGitHubApp.resolveRef(
+        repository,
+        '1a-staging'
+      );
+      if (current !== targetSha)
+        throw new StagingRefMovedError(
+          `${repository} 1a-staging moved after exact ${phase} CAS from ${targetSha} to ${current}`
+        );
+      return;
+    }
+    if (observedSha !== baseSha && observedSha !== targetSha) {
+      if (!TERMINAL_OPERATIONS.has(operation.status))
+        await this.repository.updateOperation(
+          operation.id,
+          operation.row_version,
+          {
+            status: 'CANCELLED',
+            failureClass: 'INTERACTION',
+            failureMessage: `${repository} 1a-staging moved to ${observedSha} before exact ${phase} CAS`,
+            completedAt: Date.now()
+          },
+          {}
+        );
+      throw new StagingRefMovedError(
+        `${repository} 1a-staging moved from ${baseSha} to ${observedSha} before exact ${phase} CAS`
+      );
+    }
+    if (observedSha === baseSha) {
+      try {
+        await releaseBusGitHubApp.updateRef(
+          repository,
+          '1a-staging',
+          baseSha,
+          targetSha
+        );
+      } catch (error) {
+        const afterFailure = await releaseBusGitHubApp.resolveRef(
+          repository,
+          '1a-staging'
+        );
+        if (afterFailure !== targetSha) {
+          const message =
+            error instanceof Error
+              ? error.message
+              : `Failed to advance ${repository} 1a-staging`;
+          if (afterFailure !== baseSha) {
+            if (
+              !(await this.repository.updateOperation(
+                operation.id,
+                operation.row_version,
+                {
+                  status: 'CANCELLED',
+                  failureClass: 'INTERACTION',
+                  failureMessage: `${repository} 1a-staging moved to ${afterFailure} during exact ${phase} CAS`,
+                  completedAt: Date.now()
+                },
+                {}
+              ))
+            )
+              throw new Error(
+                `${repository} staging-ref operation changed concurrently`
+              );
+            throw new StagingRefMovedError(
+              `${repository} 1a-staging moved from ${baseSha} to ${afterFailure} during exact ${phase} CAS`
+            );
+          }
+          if (isGitHubInfrastructureError(error)) throw error;
+          if (
+            !(await this.repository.updateOperation(
+              operation.id,
+              operation.row_version,
+              {
+                status: 'FAILED',
+                failureClass: 'CONTROL_PLANE',
+                failureMessage: message,
+                completedAt: Date.now()
+              },
+              {}
+            ))
+          )
+            throw new Error(
+              `${repository} staging-ref operation changed concurrently`
+            );
+          throw error;
+        }
+      }
+    }
+    if (
+      !(await this.repository.updateOperation(
+        operation.id,
+        operation.row_version,
+        {
+          status: 'SUCCEEDED',
+          externalId: targetSha,
+          result: {
+            ref: '1a-staging',
+            base_sha: baseSha,
+            release_sha: targetSha,
+            phase
+          },
+          completedAt: Date.now()
+        },
+        {}
+      ))
+    )
+      throw new Error(
+        `${repository} staging-ref operation changed concurrently`
+      );
+    operation = (await this.repository.findOperation(key, {})) ?? operation;
   }
 
   private async captureStagingIdleSnapshot(fence?: {
@@ -3317,10 +3731,14 @@ export class ReleaseBusV2Reconciler {
       since: handshake.workflow_fence_started_at,
       ignoredRunIds: operationRunIds
     });
+    const expectedFrontend =
+      handshake.expected_frontend_staging_sha ?? handshake.frontend_staging_sha;
+    const expectedBackend =
+      handshake.expected_backend_staging_sha ?? handshake.backend_staging_sha;
     const stable =
       currentSnapshot !== null &&
-      currentSnapshot.frontend_staging_sha === handshake.frontend_staging_sha &&
-      currentSnapshot.backend_staging_sha === handshake.backend_staging_sha;
+      currentSnapshot.frontend_staging_sha === expectedFrontend &&
+      currentSnapshot.backend_staging_sha === expectedBackend;
     if (!stable) {
       if (train.manifest_id)
         await this.repository.updateManifestStatus(
@@ -3344,18 +3762,11 @@ export class ReleaseBusV2Reconciler {
         },
         {}
       );
+      const message =
+        'Shared staging refs or deploy/E2E workflows changed after the idle handshake; successful E2E cannot validate a mixed environment';
       if (train.staging_policy === 'CUMULATIVE_ADMITTED_SET_V1')
-        await this.beginCumulativeStagingRollback(
-          train,
-          'CONTROL_PLANE',
-          'Shared staging refs or deploy/E2E workflows changed after the idle handshake; successful E2E cannot validate a mixed environment'
-        );
-      else
-        await this.failTrain(
-          train,
-          'CONTROL_PLANE',
-          'Shared staging refs or deploy/E2E workflows changed after the idle handshake; successful E2E cannot validate a mixed environment'
-        );
+        throw new StagingRefMovedError(message);
+      await this.failTrain(train, 'CONTROL_PLANE', message);
       return false;
     }
     await this.repository.appendEvent(
@@ -3388,11 +3799,19 @@ export class ReleaseBusV2Reconciler {
     const operations = await this.repository.listOperations(trainId, {});
     const runIds = new Set(
       operations
+        .filter(
+          ({ operation_type }) => !operation_type.startsWith('ADVANCE_STAGING_')
+        )
         .map(({ external_id }) => external_id)
         .filter((runId): runId is string => runId !== null)
     );
     const previousAttempts = operations.flatMap((operation) => {
-      if (operation.attempt <= 1 || operation.repository === null) return [];
+      if (
+        operation.attempt <= 1 ||
+        operation.repository === null ||
+        operation.operation_type.startsWith('ADVANCE_STAGING_')
+      )
+        return [];
       const request = parseStoredJson<{ workflow?: unknown }>(
         operation.request_json
       );
@@ -3448,14 +3867,20 @@ export class ReleaseBusV2Reconciler {
       Number(payload.verified_at) < 1 ||
       Number(payload.workflow_fence_started_at) > Number(payload.verified_at) ||
       !this.isOptionalSha(payload.frontend_staging_sha) ||
-      !this.isOptionalSha(payload.backend_staging_sha)
+      !this.isOptionalSha(payload.backend_staging_sha) ||
+      !this.isOptionalSha(payload.expected_frontend_staging_sha) ||
+      !this.isOptionalSha(payload.expected_backend_staging_sha)
     )
       return null;
     return {
       workflow_fence_started_at: Number(payload.workflow_fence_started_at),
       verified_at: Number(payload.verified_at),
       frontend_staging_sha: payload.frontend_staging_sha ?? null,
-      backend_staging_sha: payload.backend_staging_sha ?? null
+      backend_staging_sha: payload.backend_staging_sha ?? null,
+      expected_frontend_staging_sha:
+        payload.expected_frontend_staging_sha ?? undefined,
+      expected_backend_staging_sha:
+        payload.expected_backend_staging_sha ?? undefined
     };
   }
 
@@ -4089,6 +4514,28 @@ export class ReleaseBusV2Reconciler {
     const releaseBranch = releaseBusV2Branch(train, 'frontend');
     let exactSourceRef = 'main';
     if (environment === 'staging') {
+      if (
+        train.lane === 'STAGING' &&
+        train.staging_policy === 'CUMULATIVE_ADMITTED_SET_V1'
+      ) {
+        const identity = parseStoredJson<{
+          frontend_staging_ref_sha?: unknown;
+          backend_staging_ref_sha?: unknown;
+        }>(manifest.manifest_json);
+        const [frontendStaging, backendStaging] = await Promise.all([
+          releaseBusGitHubApp.resolveRefIfExists('frontend', '1a-staging'),
+          releaseBusGitHubApp.resolveRefIfExists('backend', '1a-staging')
+        ]);
+        if (
+          identity?.frontend_staging_ref_sha !== manifest.frontend_sha ||
+          identity.backend_staging_ref_sha !== manifest.backend_sha ||
+          frontendStaging !== manifest.frontend_sha ||
+          backendStaging !== manifest.backend_sha
+        )
+          throw new StagingRefMovedError(
+            'E2E refused a staging manifest whose 1a-staging refs no longer match its exact release SHAs'
+          );
+      }
       const sourceRefs = [releaseBranch, '1a-staging', 'main'];
       const sourceShas = await Promise.all(
         sourceRefs.map((ref) =>
@@ -4167,6 +4614,41 @@ export class ReleaseBusV2Reconciler {
     status: ReleaseBusV2ManifestStatus
   ): Promise<ReleaseBusV2ManifestRecord> {
     const train = context.train;
+    const requiresStagingBranchParity =
+      train.lane === 'STAGING' &&
+      train.staging_policy === 'CUMULATIVE_ADMITTED_SET_V1';
+    const handshake = requiresStagingBranchParity
+      ? await this.findStagingIdleHandshake(train.id)
+      : null;
+    const observedStagingRefs = requiresStagingBranchParity
+      ? await Promise.all([
+          releaseBusGitHubApp.resolveRefIfExists('frontend', '1a-staging'),
+          releaseBusGitHubApp.resolveRefIfExists('backend', '1a-staging')
+        ])
+      : null;
+    const stagingRefs = requiresStagingBranchParity
+      ? {
+          frontend_staging_ref_sha: observedStagingRefs?.[0] ?? null,
+          backend_staging_ref_sha: observedStagingRefs?.[1] ?? null
+        }
+      : null;
+    const expectedFrontendStaging =
+      handshake?.expected_frontend_staging_sha ??
+      handshake?.frontend_staging_sha;
+    const expectedBackendStaging =
+      handshake?.expected_backend_staging_sha ?? handshake?.backend_staging_sha;
+    if (
+      requiresStagingBranchParity &&
+      (expectedFrontendStaging !== train.frontend_composed_sha ||
+        expectedBackendStaging !== train.backend_composed_sha ||
+        !stagingRefs?.frontend_staging_ref_sha ||
+        !stagingRefs.backend_staging_ref_sha ||
+        stagingRefs.frontend_staging_ref_sha !== train.frontend_composed_sha ||
+        stagingRefs.backend_staging_ref_sha !== train.backend_composed_sha)
+    )
+      throw new StagingRefMovedError(
+        'Staging manifest refused 1a-staging refs that do not match the exact deployed release'
+      );
     const hasFrontend =
       (train.lane === 'STAGING'
         ? stagingDeploymentCandidates(context, 'frontend')
@@ -4188,6 +4670,7 @@ export class ReleaseBusV2Reconciler {
       // either their composed tree or their unchanged base tree.
       frontend_sha: train.frontend_composed_sha,
       backend_sha: train.backend_composed_sha,
+      ...(stagingRefs ?? {}),
       frontend_artifact_digest: hasFrontend
         ? train.frontend_artifact_digest
         : null,
@@ -4196,6 +4679,7 @@ export class ReleaseBusV2Reconciler {
         : null,
       candidates: relevantCandidates(context).map(
         ({ id, repository, pr_number, head_sha }) => ({
+          candidate_id: id,
           repository,
           pr_number,
           head_sha,
@@ -4305,7 +4789,17 @@ export class ReleaseBusV2Reconciler {
     )
       throw new Error('Cumulative staging transition fence is malformed');
     const handshake = await this.findStagingIdleHandshake(train.id);
-    if (!handshake?.frontend_staging_sha || !handshake.backend_staging_sha)
+    const frontendStagingSha =
+      handshake?.expected_frontend_staging_sha ??
+      handshake?.frontend_staging_sha;
+    const backendStagingSha =
+      handshake?.expected_backend_staging_sha ?? handshake?.backend_staging_sha;
+    if (
+      !frontendStagingSha ||
+      !backendStagingSha ||
+      frontendStagingSha !== train.frontend_composed_sha ||
+      backendStagingSha !== train.backend_composed_sha
+    )
       throw new Error('Cumulative staging validation lost its ref fence');
     const admittedCandidateIds = relevantCandidates(context).map(
       ({ id }) => id
@@ -4328,8 +4822,8 @@ export class ReleaseBusV2Reconciler {
             manifestId: train.manifest_id!,
             frontendSha: train.frontend_composed_sha!,
             backendSha: train.backend_composed_sha!,
-            frontendStagingRefSha: handshake.frontend_staging_sha!,
-            backendStagingRefSha: handshake.backend_staging_sha!,
+            frontendStagingRefSha: frontendStagingSha,
+            backendStagingRefSha: backendStagingSha,
             admittedCandidateIds,
             removedCandidateIds,
             newCandidateIds: transition.new_candidate_ids ?? []
@@ -4401,8 +4895,8 @@ export class ReleaseBusV2Reconciler {
               carried_candidate_ids: transition.carried_candidate_ids ?? [],
               frontend_sha: train.frontend_composed_sha,
               backend_sha: train.backend_composed_sha,
-              frontend_staging_ref_sha: handshake.frontend_staging_sha,
-              backend_staging_ref_sha: handshake.backend_staging_sha
+              frontend_staging_ref_sha: frontendStagingSha,
+              backend_staging_ref_sha: backendStagingSha
             }
           },
           { connection }
@@ -4759,6 +5253,102 @@ export class ReleaseBusV2Reconciler {
     // Release ownership only after the train and every operation are terminal.
     // If a mutation outcome is still ambiguous, the nonterminal operation
     // deliberately retains the lease until reconciliation can prove its state.
+    await this.releaseTerminalEnvironmentLocks();
+  }
+
+  private async failStagingForRefDrift(
+    train: ReleaseBusV2TrainRecord,
+    message: string
+  ): Promise<void> {
+    const current = await this.repository.findTrain(train.id, {});
+    if (!current || TERMINAL_TRAINS.has(current.status)) return;
+    const context = await this.loadContext(current);
+    const statusCandidates = stagingStatusCandidates(context);
+    const deploymentStarted = [
+      'DEPLOYING',
+      'STAGING_DEPLOYED',
+      'E2E_RUNNING'
+    ].includes(current.status);
+    const [frontendStagingSha, backendStagingSha] = await Promise.all([
+      releaseBusGitHubApp.resolveRefIfExists('frontend', '1a-staging'),
+      releaseBusGitHubApp.resolveRefIfExists('backend', '1a-staging')
+    ]);
+    await this.repository.executeNativeQueriesInTransaction(
+      async (connection) => {
+        const ctx = { connection };
+        const state = await this.repository.getStagingState(ctx, true);
+        if (
+          state.status !== 'ROLLBACK_FAILED' ||
+          state.last_transition_train_id !== current.id
+        ) {
+          if (
+            !(await this.repository.updateStagingState(
+              state.row_version,
+              {
+                status: 'ROLLBACK_FAILED',
+                currentManifestId: null,
+                lastValidatedManifestId: state.last_validated_manifest_id,
+                frontendSha: null,
+                backendSha: null,
+                frontendStagingRefSha: frontendStagingSha,
+                backendStagingRefSha: backendStagingSha,
+                cleanMain: false,
+                lastTransitionTrainId: current.id
+              },
+              ctx
+            ))
+          )
+            throw new Error(
+              'Authoritative staging state changed while recording ref drift'
+            );
+        }
+        await this.repository.appendEvent(
+          {
+            trainId: current.id,
+            eventType: 'STAGING_REF_DRIFT_DETECTED',
+            actor: 'release-bus-v2',
+            payload: {
+              failure_message: message,
+              frontend_staging_sha: frontendStagingSha,
+              backend_staging_sha: backendStagingSha,
+              deployment_started: deploymentStarted,
+              recover_with: 'SERIALIZED_MANUAL_STAGING_RECOVERY'
+            }
+          },
+          ctx
+        );
+      }
+    );
+    await this.updateCandidateStatuses(
+      statusCandidates,
+      'READY_FOR_STAGING',
+      null,
+      false
+    );
+    const controls = await this.repository.listControls({});
+    if (!controls.some(({ scope, paused }) => scope === 'STAGING' && paused))
+      await this.service.setPaused(
+        'STAGING',
+        true,
+        `Exact 1a-staging CAS failed in train ${current.id}: ${message}`,
+        'release-bus-v2'
+      );
+    await this.publishCandidateStatuses(
+      statusCandidates,
+      'error',
+      `Staging ref drift prevented deployment: ${message}`
+    );
+    await this.transitionTrain(current, {
+      status: 'FAILED',
+      failureClass: 'CONTROL_PLANE',
+      failureMessage: message,
+      recoveryMessage: `${
+        deploymentStarted
+          ? 'Train deployment may have started; runtime identity is not being guessed.'
+          : 'No train deployment started.'
+      } STAGING alone is paused with exact ref intent retained for serialized recovery; production and manual fallback controls are unchanged`,
+      completedAt: Date.now()
+    });
     await this.releaseTerminalEnvironmentLocks();
   }
 

--- a/src/releaseBusV2/release-bus-v2.reconciler.ts
+++ b/src/releaseBusV2/release-bus-v2.reconciler.ts
@@ -61,6 +61,12 @@ const TERMINAL_OPERATIONS = new Set<ReleaseBusV2OperationRecord['status']>([
   'FAILED',
   'CANCELLED'
 ]);
+const STAGING_REF_OPERATION_TYPES = new Set([
+  'ADVANCE_STAGING_RELEASE_FRONTEND',
+  'ADVANCE_STAGING_RELEASE_BACKEND',
+  'ADVANCE_STAGING_ROLLBACK_FRONTEND',
+  'ADVANCE_STAGING_ROLLBACK_BACKEND'
+]);
 // The lock is renewed every minute, but its expiry must also outlive the
 // longest deployment/E2E workflow during a temporary control-plane outage.
 // Workflow timeouts are at most 90 minutes, so two hours prevents overlapping
@@ -194,6 +200,10 @@ function operationMayStillBeRunning(
     ['DISPATCHED', 'RUNNING'].includes(operation.status) ||
     (operation.status === 'PENDING' && operation.external_id !== null)
   );
+}
+
+function isStagingRefOperation(operationType: string): boolean {
+  return STAGING_REF_OPERATION_TYPES.has(operationType);
 }
 
 function stringRecord(value: unknown): Readonly<Record<string, string>> | null {
@@ -2405,6 +2415,9 @@ export class ReleaseBusV2Reconciler {
       ({ observedSha, baseSha, targetSha }) =>
         !baseSha || (observedSha !== baseSha && observedSha !== targetSha)
     );
+    // targetSha is accepted because GitHub may have applied one repository's
+    // CAS before the worker crashed; advanceStagingRef records that leg as
+    // succeeded and continues the still-pending repository.
     if (invalid)
       throw new StagingRefMovedError(
         `${invalid.repository} 1a-staging moved outside rollback intent ${invalid.baseSha} -> ${invalid.targetSha}`
@@ -3511,10 +3524,18 @@ export class ReleaseBusV2Reconciler {
       );
       return;
     } catch (error) {
-      const afterFailure = await releaseBusGitHubApp.resolveRef(
-        repository,
-        '1a-staging'
-      );
+      let afterFailure: string;
+      try {
+        afterFailure = await releaseBusGitHubApp.resolveRef(
+          repository,
+          '1a-staging'
+        );
+      } catch (resolveError) {
+        // Preserve the write as first cause when transport failed before GitHub
+        // could prove whether the exact CAS applied.
+        if (isGitHubInfrastructureError(error)) throw error;
+        throw resolveError;
+      }
       if (afterFailure === targetSha) return;
       if (afterFailure !== baseSha)
         return this.rejectStagingRefDrift(
@@ -3537,9 +3558,10 @@ export class ReleaseBusV2Reconciler {
         'CONTROL_PLANE',
         message
       );
-      throw new StagingRefMovedError(
-        `${repository} exact ${phase} CAS was rejected while 1a-staging remained ${baseSha}: ${message}`
-      );
+      // An unchanged ref is not drift. The caller handles a deterministic
+      // rejection as a control-plane failure/rollback without falsely raising
+      // STAGING_REF_DRIFT_DETECTED.
+      throw error;
     }
   }
 
@@ -3868,9 +3890,7 @@ export class ReleaseBusV2Reconciler {
     const operations = await this.repository.listOperations(trainId, {});
     const runIds = new Set(
       operations
-        .filter(
-          ({ operation_type }) => !operation_type.startsWith('ADVANCE_STAGING_')
-        )
+        .filter(({ operation_type }) => !isStagingRefOperation(operation_type))
         .map(({ external_id }) => external_id)
         .filter((runId): runId is string => runId !== null)
     );
@@ -3878,7 +3898,7 @@ export class ReleaseBusV2Reconciler {
       if (
         operation.attempt <= 1 ||
         operation.repository === null ||
-        operation.operation_type.startsWith('ADVANCE_STAGING_')
+        isStagingRefOperation(operation.operation_type)
       )
         return [];
       const request = parseStoredJson<{ workflow?: unknown }>(

--- a/src/releaseBusV2/release-bus-v2.service.ts
+++ b/src/releaseBusV2/release-bus-v2.service.ts
@@ -1109,6 +1109,65 @@ export class ReleaseBusV2Service {
             !['LIVE', 'CLEAN_MAIN'].includes(stagingState.status)
           )
             return null;
+          if (
+            stagingState &&
+            stagingIdentity?.frontendSha &&
+            stagingIdentity.backendSha &&
+            (stagingState.frontend_staging_ref_sha !==
+              stagingIdentity.frontendSha ||
+              stagingState.backend_staging_ref_sha !==
+                stagingIdentity.backendSha)
+          ) {
+            const message =
+              'Manual/shared-ref drift changed 1a-staging outside the authoritative validated staging identity';
+            if (
+              !(await this.repository.updateStagingState(
+                stagingState.row_version,
+                {
+                  status: 'ROLLBACK_FAILED',
+                  currentManifestId: null,
+                  lastValidatedManifestId:
+                    stagingState.last_validated_manifest_id,
+                  frontendSha: null,
+                  backendSha: null,
+                  frontendStagingRefSha: stagingIdentity.frontendSha,
+                  backendStagingRefSha: stagingIdentity.backendSha,
+                  cleanMain: false,
+                  lastTransitionTrainId: 'staging-ref-drift'
+                },
+                ctx
+              ))
+            )
+              throw new Error(
+                'Authoritative staging state changed while recording manual ref drift'
+              );
+            await this.repository.setControl(
+              'STAGING',
+              true,
+              message,
+              'release-bus-v2',
+              ctx
+            );
+            await this.repository.appendEvent(
+              {
+                eventType: 'STAGING_REF_DRIFT_DETECTED',
+                actor: 'release-bus-v2',
+                payload: {
+                  expected_frontend_staging_sha:
+                    stagingState.frontend_staging_ref_sha,
+                  expected_backend_staging_sha:
+                    stagingState.backend_staging_ref_sha,
+                  observed_frontend_staging_sha: stagingIdentity.frontendSha,
+                  observed_backend_staging_sha: stagingIdentity.backendSha,
+                  current_manifest_id: stagingState.current_manifest_id,
+                  production_evidence_preserved: true,
+                  recover_with: 'SERIALIZED_MANUAL_STAGING_RECOVERY'
+                }
+              },
+              ctx
+            );
+            return null;
+          }
           await this.refreshDependencyHolds(lane, ctx, betaAllowlist);
           const readyCandidates = (
             await this.repository.listCandidates(


### PR DESCRIPTION
## Issue

- Managed Release Bus v2 staging could deploy and validate an exact cumulative runtime without advancing the affected repositories' shared `1a-staging` refs to that same immutable release.
- That allowed branch, runtime, manifest, and E2E identity to diverge, with ambiguous recovery after ref drift or a crash around mutation.

## Fix

- Compose each affected cumulative staging release as a forward-only immutable commit whose first parent is the recorded `1a-staging` SHA and whose tree is the dependency-closed candidate composition.
- Under the staging lock, CAS-advance only affected `1a-staging` refs before deployment, and require exact ref/runtime/manifest/E2E parity before validation.
- Persist ref advances as durable operations so a crash after GitHub accepts the CAS self-drains without repeating or guessing the mutation.

## Changes

- Add `release_parent_sha` to backend/frontend composition dispatch and validate reused immutable branches against the exact first parent.
- Remove carry-forward-only candidates from the deployment set while retaining them in cumulative composition.
- Record exact staging-ref identity in manifests and refuse manifest creation or E2E after drift.
- Detect manual/shared-ref drift before new claims, preserve the last validated manifest and candidate evidence, and pause only `STAGING`.
- Roll back forward: compose immutable restore commits from the failed release, CAS the affected refs, redeploy, and require rollback E2E before releasing staging.
- Preserve candidate identity when restoring historical manifests created before `candidate_id` was stored.
- Document the state-machine and zero-downtime ordering in the durable operations guide and architecture reference.

## Validation

- `npm run lint`
- `npm run build` — 292 suites and 2,679 tests passed after rebasing onto current `main`
- Focused Release Bus v2 suite — 87 tests passed
- `npm run tsc -- --noEmit`
- Latest Sonar follow-up refactor — ESLint, 80 focused tests, TypeScript, and diff check passed
- Composition workflow YAML parse
- `git diff --check`
- Clean merge-tree proof with candidate-evidence production PR #1847; its production fast-path guard and this staging-parent guard compose without conflict

## Risk

- Level: High
- Why: this changes the serialized shared-staging control plane and recovery behavior, although all ref mutations are non-force CAS operations and validation remains fail-closed.
- Rollback: pause `STAGING`; if needed deliberately switch v2 `OFF`, perform the documented serialized manual restore, and redeploy the prior `releaseBus` version. Never infer runtime identity or rewind a shared ref.

## Deployment

1. Merge the frontend companion first so its compose workflow accepts `release_parent_sha`.
2. Merge this PR so the backend compose workflow has the same contract.
3. Run the fresh release-bus status helper and require no active staging train or staging mutation/E2E.
4. Deploy only the backend `releaseBus` Lambda. No DB migration or API deployment is required.
5. Treat this as an internal operational release and use the release-note opt-out.

No staging or production mutation is part of this PR phase.

## Review Notes

- Frontend companion: 6529-Collections/6529seize-frontend#3484.
- Focus on compose → fence/lock → CAS → deploy callback → manifest → E2E sequencing, partial paired-CAS recovery, and forward-only rollback.
- This intentionally does not restore exact-combined-manifest production qualification. Candidate-evidence production PR #1847 remains the production policy and merge-tree combines cleanly.
- No Reset Staging control is added.
