### PR TITLE
Bootstrap cumulative staging from an exact clean-main baseline

### DIFF
--- a/src/releaseBusV2/release-bus-v2-cumulative-staging.test.ts
+++ b/src/releaseBusV2/release-bus-v2-cumulative-staging.test.ts
@@ -298,6 +298,110 @@ describe('Release Bus v2 cumulative admitted staging', () => {
     );
   });
 
+  it('bootstraps an exact clean-main reset without creating staging validation evidence', async () => {
+    const b = candidate('b2', 'backend', 'READY_FOR_STAGING', false);
+    const frontendSha = 'f'.repeat(40);
+    const backendSha = 'b'.repeat(40);
+    let state: ReleaseBusV2StagingStateRecord = {
+      id: 'current',
+      status: 'UNINITIALIZED',
+      current_manifest_id: null,
+      last_validated_manifest_id: null,
+      frontend_sha: null,
+      backend_sha: null,
+      frontend_staging_ref_sha: null,
+      backend_staging_ref_sha: null,
+      clean_main: false,
+      last_transition_train_id: null,
+      updated_at: 1,
+      row_version: 1
+    };
+    const updateStagingState = jest.fn(async () => {
+      state = {
+        ...state,
+        status: 'CLEAN_MAIN',
+        frontend_sha: frontendSha,
+        backend_sha: backendSha,
+        frontend_staging_ref_sha: frontendSha,
+        backend_staging_ref_sha: backendSha,
+        clean_main: true,
+        row_version: 2
+      };
+      return true;
+    });
+    const appendEvent = jest.fn(async () => undefined);
+    const findStagingValidatedManifestByShas = jest.fn();
+    const createTrain = jest.fn(async () => train('clean-main-plus-b'));
+    const repository = {
+      executeNativeQueriesInTransaction: async (
+        callback: (connection: unknown) => unknown
+      ) => callback({}),
+      acquireLock: async () => ({ lease_token: 'scheduler' }),
+      releaseLock: async () => true,
+      getStagingState: async () => state,
+      updateStagingState,
+      findStagingValidatedManifestByShas,
+      listControls: async () => [
+        { scope: 'ALL', paused: false },
+        { scope: 'STAGING', paused: false },
+        { scope: 'PRODUCTION', paused: false }
+      ],
+      listTrains: async () => [],
+      listCandidates: async (statuses: string[]) =>
+        statuses.includes('READY_FOR_STAGING') ? [b] : [],
+      listLiveStagingCandidates: async () => [],
+      listStagingTransitionRequests: async () => [],
+      listDependencies: async () => [],
+      createTrain,
+      updateCandidate: async () => true,
+      appendEvent
+    };
+    const service = new ReleaseBusV2Service(repository as never);
+
+    await expect(
+      service.claimLane('STAGING', frontendSha, backendSha, 'operator', {
+        frontendSha,
+        backendSha
+      })
+    ).resolves.toEqual(expect.objectContaining({ id: 'clean-main-plus-b' }));
+    expect(updateStagingState).toHaveBeenCalledWith(
+      1,
+      {
+        status: 'CLEAN_MAIN',
+        currentManifestId: null,
+        lastValidatedManifestId: null,
+        frontendSha,
+        backendSha,
+        frontendStagingRefSha: frontendSha,
+        backendStagingRefSha: backendSha,
+        cleanMain: true,
+        lastTransitionTrainId: null
+      },
+      expect.anything()
+    );
+    expect(appendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: 'CUMULATIVE_STAGING_STATE_BOOTSTRAPPED_FROM_CLEAN_MAIN',
+        payload: expect.objectContaining({
+          admitted_candidate_ids: [],
+          staging_validation_created: false
+        })
+      }),
+      expect.anything()
+    );
+    expect(findStagingValidatedManifestByShas).not.toHaveBeenCalled();
+    expect(createTrain).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stagingBaselineManifestId: null,
+        stagingTransition: expect.objectContaining({
+          baseline_state_version: 2,
+          baseline_manifest_id: null
+        })
+      }),
+      expect.anything()
+    );
+  });
+
   it('fences stale validation before it can overwrite a newer authoritative live manifest', async () => {
     const statements: string[] = [];
     const db = {

--- a/src/releaseBusV2/release-bus-v2.repository.ts
+++ b/src/releaseBusV2/release-bus-v2.repository.ts
@@ -535,7 +535,7 @@ export class ReleaseBusV2Repository extends LazyDbAccessCompatibleService {
       readonly frontendStagingRefSha: string | null;
       readonly backendStagingRefSha: string | null;
       readonly cleanMain: boolean;
-      readonly lastTransitionTrainId: string;
+      readonly lastTransitionTrainId: string | null;
     },
     ctx: RequestContext
   ): Promise<boolean> {

--- a/src/releaseBusV2/release-bus-v2.service.ts
+++ b/src/releaseBusV2/release-bus-v2.service.ts
@@ -946,6 +946,8 @@ export class ReleaseBusV2Service {
   private async bootstrapCumulativeStagingState(
     state: Awaited<ReturnType<ReleaseBusV2RepositoryClass['getStagingState']>>,
     stagingIdentity: ReleaseBusV2StagingIdentity | undefined,
+    frontendBaseSha: string,
+    backendBaseSha: string,
     ctx: RequestContext
   ): Promise<Awaited<
     ReturnType<ReleaseBusV2RepositoryClass['getStagingState']>
@@ -954,6 +956,47 @@ export class ReleaseBusV2Service {
     const frontendSha = stagingIdentity?.frontendSha;
     const backendSha = stagingIdentity?.backendSha;
     if (!frontendSha || !backendSha) return null;
+    if (
+      frontendSha === frontendBaseSha &&
+      backendSha === backendBaseSha &&
+      (await this.repository.listLiveStagingCandidates(ctx, true)).length === 0
+    ) {
+      if (
+        !(await this.repository.updateStagingState(
+          state.row_version,
+          {
+            status: 'CLEAN_MAIN',
+            currentManifestId: null,
+            lastValidatedManifestId: null,
+            frontendSha,
+            backendSha,
+            frontendStagingRefSha: frontendSha,
+            backendStagingRefSha: backendSha,
+            cleanMain: true,
+            lastTransitionTrainId: null
+          },
+          ctx
+        ))
+      )
+        throw new Error(
+          'Authoritative staging state changed during clean-main bootstrap'
+        );
+      await this.repository.appendEvent(
+        {
+          eventType: 'CUMULATIVE_STAGING_STATE_BOOTSTRAPPED_FROM_CLEAN_MAIN',
+          actor: 'release-bus-v2',
+          payload: {
+            frontend_sha: frontendSha,
+            backend_sha: backendSha,
+            current_manifest_id: null,
+            admitted_candidate_ids: [],
+            staging_validation_created: false
+          }
+        },
+        ctx
+      );
+      return this.repository.getStagingState(ctx, true);
+    }
     const manifest = await this.repository.findStagingValidatedManifestByShas(
       frontendSha,
       backendSha,
@@ -1099,6 +1142,8 @@ export class ReleaseBusV2Service {
             const bootstrapped = await this.bootstrapCumulativeStagingState(
               stagingState,
               stagingIdentity,
+              frontendBaseSha,
+              backendBaseSha,
               ctx
             );
             if (!bootstrapped) return null;


### PR DESCRIPTION
Summary:

- Initializes an UNINITIALIZED cumulative staging state as CLEAN_MAIN only when both exact 1a-staging refs equal the freshly fenced repository main SHAs and no candidate is currently live.
- Keeps current_manifest_id and last_validated_manifest_id null, so reset recovery does not fabricate candidate validation.
- Durably audits the exact FE/BE baseline and empty admitted set before the first ordinary cumulative staging claim.

Safety:

- Row-version CAS and the scheduler transaction fail closed on concurrent state change.
- Mismatched refs or any live candidate continue through the existing validated-manifest bootstrap path.
- Historical candidate staging evidence and production eligibility are unchanged.

Validation:

- Focused cumulative staging suite: 8/8 passed.
- TypeScript typecheck passed.
- Targeted ESLint passed for every changed file.

Operational context: both 1a-staging refs and deployed runtimes are exact current main; controls remain frozen pending the terminal clean-main E2E fence and this reviewed bootstrap.