### PR TITLE
Fix cumulative carry-forward status preservation

### DIFF
--- a/src/releaseBusV2/release-bus-v2-cumulative-staging.test.ts
+++ b/src/releaseBusV2/release-bus-v2-cumulative-staging.test.ts
@@ -330,6 +330,45 @@ describe('Release Bus v2 cumulative admitted staging', () => {
     );
   });
 
+  it('does not invent staging certification when a terminal carry-forward row has no historical evidence', async () => {
+    const stuck = {
+      ...candidate('a1', 'frontend', 'STAGING_BUILDING', false),
+      current_train_id: 'train-cumulative',
+      row_version: 10
+    };
+    const terminalTrain = {
+      ...train('train-cumulative'),
+      status: 'FAILED' as const
+    };
+    const updateCandidate = jest.fn(async () => true);
+    const repository = {
+      listCandidates: async () => [stuck],
+      executeNativeQueriesInTransaction: async (
+        callback: (connection: unknown) => unknown
+      ) => callback({}),
+      findCandidateById: async () => stuck,
+      findTrain: async () => terminalTrain,
+      listTrainCandidates: async () => [
+        {
+          train_id: terminalTrain.id,
+          candidate_id: stuck.id,
+          candidate_role: 'CARRY_FORWARD',
+          disposition: 'INCLUDED'
+        }
+      ],
+      listProductionManifestsForCandidate: async () => [],
+      updateCandidate,
+      appendEvent: async () => undefined
+    };
+    const service = new ReleaseBusV2Service(repository as never);
+
+    await expect(
+      service.repairTerminalCumulativeCarryForwardStatuses('reconciler')
+    ).resolves.toEqual([]);
+    expect(updateCandidate).not.toHaveBeenCalled();
+    expect(mockEnsureCommitStatus).not.toHaveBeenCalled();
+  });
+
   it('restores preserved legacy production intent on carry-forward repair', async () => {
     const stuck = {
       ...candidate('a1', 'frontend', 'STAGING_BUILDING', true),

--- a/src/releaseBusV2/release-bus-v2-cumulative-staging.test.ts
+++ b/src/releaseBusV2/release-bus-v2-cumulative-staging.test.ts
@@ -225,6 +225,9 @@ describe('Release Bus v2 cumulative admitted staging', () => {
       appendEvent
     };
     const service = new ReleaseBusV2Service(repository as never);
+    mockEnsureCommitStatus.mockRejectedValueOnce(
+      new Error('transient GitHub failure')
+    );
 
     await expect(
       service.repairTerminalCumulativeCarryForwardStatuses('reconciler')
@@ -324,6 +327,126 @@ describe('Release Bus v2 cumulative admitted staging', () => {
       'pending',
       'Release Bus v2: ready for candidate evidence production',
       'Release Bus v2'
+    );
+  });
+
+  it('restores preserved legacy production intent on carry-forward repair', async () => {
+    const stuck = {
+      ...candidate('a1', 'frontend', 'STAGING_BUILDING', true),
+      current_train_id: 'train-cumulative',
+      production_requested_at: 2,
+      production_requested_by: 'operator',
+      production_selection_id: null,
+      row_version: 10
+    };
+    const validatedTrain = {
+      ...train('train-cumulative'),
+      status: 'STAGING_VALIDATED' as const
+    };
+    const updateCandidate = jest.fn(async () => true);
+    const repository = {
+      listCandidates: async () => [stuck],
+      executeNativeQueriesInTransaction: async (
+        callback: (connection: unknown) => unknown
+      ) => callback({}),
+      findCandidateById: async () => stuck,
+      findTrain: async () => validatedTrain,
+      listTrainCandidates: async () => [
+        {
+          train_id: validatedTrain.id,
+          candidate_id: stuck.id,
+          candidate_role: 'CARRY_FORWARD',
+          disposition: 'INCLUDED'
+        }
+      ],
+      listProductionManifestsForCandidate: async () => [],
+      updateCandidate,
+      appendEvent: async () => undefined
+    };
+    const service = new ReleaseBusV2Service(repository as never);
+
+    await service.repairTerminalCumulativeCarryForwardStatuses('reconciler');
+
+    expect(updateCandidate).toHaveBeenCalledWith(
+      stuck.id,
+      stuck.row_version,
+      expect.objectContaining({
+        status: 'READY_FOR_PRODUCTION',
+        currentTrainId: null
+      }),
+      expect.anything()
+    );
+  });
+
+  it('restores exact terminal production deployment evidence on carry-forward repair', async () => {
+    const stuck = {
+      ...candidate('a1', 'frontend', 'STAGING_BUILDING', true),
+      current_train_id: 'train-cumulative',
+      production_requested_at: 2,
+      production_requested_by: 'operator',
+      production_selection_id: 'selection-a',
+      row_version: 10
+    };
+    const validatedTrain = {
+      ...train('train-cumulative'),
+      status: 'STAGING_VALIDATED' as const
+    };
+    const updateCandidate = jest.fn(async () => true);
+    const repository = {
+      listCandidates: async () => [stuck],
+      executeNativeQueriesInTransaction: async (
+        callback: (connection: unknown) => unknown
+      ) => callback({}),
+      findCandidateById: async () => stuck,
+      findTrain: async () => validatedTrain,
+      listTrainCandidates: async () => [
+        {
+          train_id: validatedTrain.id,
+          candidate_id: stuck.id,
+          candidate_role: 'CARRY_FORWARD',
+          disposition: 'INCLUDED'
+        }
+      ],
+      listProductionManifestsForCandidate: async () => [
+        {
+          train_id: 'production-train',
+          manifest_json: {
+            candidates: [
+              {
+                candidate_id: stuck.id,
+                repository: stuck.repository,
+                pr_number: stuck.pr_number,
+                head_sha: stuck.head_sha
+              }
+            ],
+            operations: [
+              { type: 'E2E_PROD', workflow_run_id: 'production-e2e-run' }
+            ]
+          }
+        }
+      ],
+      listOperations: async () => [
+        {
+          operation_type: 'E2E_PROD',
+          status: 'SUCCEEDED',
+          external_id: 'production-e2e-run'
+        }
+      ],
+      updateCandidate,
+      appendEvent: async () => undefined
+    };
+    const service = new ReleaseBusV2Service(repository as never);
+
+    await service.repairTerminalCumulativeCarryForwardStatuses('reconciler');
+
+    expect(updateCandidate).toHaveBeenCalledWith(
+      stuck.id,
+      stuck.row_version,
+      expect.objectContaining({
+        status: 'PRODUCTION_DEPLOYED',
+        currentTrainId: null
+      }),
+      expect.anything()
     );
   });
 

--- a/src/releaseBusV2/release-bus-v2-cumulative-staging.test.ts
+++ b/src/releaseBusV2/release-bus-v2-cumulative-staging.test.ts
@@ -190,7 +190,7 @@ describe('Release Bus v2 cumulative admitted staging', () => {
     );
   });
 
-  it('repairs a terminal cumulative carry-forward status without changing staging evidence or live membership', async () => {
+  it('repairs a failed terminal cumulative carry-forward status without changing staging evidence or live membership', async () => {
     const stuck = {
       ...candidate('a1', 'frontend', 'STAGING_BUILDING', true),
       current_train_id: 'train-cumulative',
@@ -199,9 +199,9 @@ describe('Release Bus v2 cumulative admitted staging', () => {
       staging_live_manifest_id: 'manifest-cumulative',
       row_version: 10
     };
-    const validatedTrain = {
+    const terminalTrain = {
       ...train('train-cumulative'),
-      status: 'STAGING_VALIDATED' as const
+      status: 'FAILED' as const
     };
     const updateCandidate = jest.fn(async () => true);
     const appendEvent = jest.fn(async () => undefined);
@@ -211,10 +211,10 @@ describe('Release Bus v2 cumulative admitted staging', () => {
         callback: (connection: unknown) => unknown
       ) => callback({}),
       findCandidateById: async () => stuck,
-      findTrain: async () => validatedTrain,
+      findTrain: async () => terminalTrain,
       listTrainCandidates: async () => [
         {
-          train_id: validatedTrain.id,
+          train_id: terminalTrain.id,
           candidate_id: stuck.id,
           candidate_role: 'CARRY_FORWARD',
           disposition: 'INCLUDED'
@@ -254,7 +254,7 @@ describe('Release Bus v2 cumulative admitted staging', () => {
     );
     expect(appendEvent).toHaveBeenCalledWith(
       expect.objectContaining({
-        trainId: validatedTrain.id,
+        trainId: terminalTrain.id,
         candidateId: stuck.id,
         eventType: 'TERMINAL_CUMULATIVE_CARRY_FORWARD_STATUS_REPAIRED',
         payload: expect.objectContaining({

--- a/src/releaseBusV2/release-bus-v2-cumulative-staging.test.ts
+++ b/src/releaseBusV2/release-bus-v2-cumulative-staging.test.ts
@@ -8,10 +8,12 @@ import type {
 } from '@/releaseBusV2/release-bus-v2.types';
 
 const mockRefContainsCommit = jest.fn();
+const mockEnsureCommitStatus = jest.fn();
 
 jest.mock('@/releaseBusV2/release-bus-v2.github-app', () => ({
   releaseBusGitHubApp: {
-    refContainsCommit: (...args: unknown[]) => mockRefContainsCommit(...args)
+    refContainsCommit: (...args: unknown[]) => mockRefContainsCommit(...args),
+    ensureCommitStatus: (...args: unknown[]) => mockEnsureCommitStatus(...args)
   }
 }));
 
@@ -87,6 +89,8 @@ describe('Release Bus v2 cumulative admitted staging', () => {
     process.env.RELEASE_BUS_V2_MODE = 'PRODUCTION';
     mockRefContainsCommit.mockReset();
     mockRefContainsCommit.mockResolvedValue(true);
+    mockEnsureCommitStatus.mockReset();
+    mockEnsureCommitStatus.mockResolvedValue(undefined);
   });
 
   afterEach(() => {
@@ -183,6 +187,143 @@ describe('Release Bus v2 cumulative admitted staging', () => {
         }
       }),
       expect.anything()
+    );
+  });
+
+  it('repairs a terminal cumulative carry-forward status without changing staging evidence or live membership', async () => {
+    const stuck = {
+      ...candidate('a1', 'frontend', 'STAGING_BUILDING', true),
+      current_train_id: 'train-cumulative',
+      staging_validated_train_id: 'train-original-validation',
+      staging_validated_manifest_id: 'manifest-original-validation',
+      staging_live_manifest_id: 'manifest-cumulative',
+      row_version: 10
+    };
+    const validatedTrain = {
+      ...train('train-cumulative'),
+      status: 'STAGING_VALIDATED' as const
+    };
+    const updateCandidate = jest.fn(async () => true);
+    const appendEvent = jest.fn(async () => undefined);
+    const repository = {
+      listCandidates: async () => [stuck],
+      executeNativeQueriesInTransaction: async (
+        callback: (connection: unknown) => unknown
+      ) => callback({}),
+      findCandidateById: async () => stuck,
+      findTrain: async () => validatedTrain,
+      listTrainCandidates: async () => [
+        {
+          train_id: validatedTrain.id,
+          candidate_id: stuck.id,
+          candidate_role: 'CARRY_FORWARD',
+          disposition: 'INCLUDED'
+        }
+      ],
+      listProductionManifestsForCandidate: async () => [],
+      updateCandidate,
+      appendEvent
+    };
+    const service = new ReleaseBusV2Service(repository as never);
+
+    await expect(
+      service.repairTerminalCumulativeCarryForwardStatuses('reconciler')
+    ).resolves.toEqual([
+      expect.objectContaining({
+        id: stuck.id,
+        status: 'STAGING_VALIDATED',
+        current_train_id: null,
+        staging_validated_train_id: stuck.staging_validated_train_id,
+        staging_validated_manifest_id: stuck.staging_validated_manifest_id,
+        staging_live_state: 'LIVE',
+        staging_live_manifest_id: stuck.staging_live_manifest_id
+      })
+    ]);
+    expect(updateCandidate).toHaveBeenCalledWith(
+      stuck.id,
+      stuck.row_version,
+      {
+        status: 'STAGING_VALIDATED',
+        currentTrainId: null,
+        holdReason: null
+      },
+      expect.anything()
+    );
+    expect(appendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        trainId: validatedTrain.id,
+        candidateId: stuck.id,
+        eventType: 'TERMINAL_CUMULATIVE_CARRY_FORWARD_STATUS_REPAIRED',
+        payload: expect.objectContaining({
+          incorrect_status: 'STAGING_BUILDING',
+          restored_status: 'STAGING_VALIDATED',
+          staging_validated_manifest_id: stuck.staging_validated_manifest_id,
+          staging_live_state: 'LIVE'
+        })
+      }),
+      expect.anything()
+    );
+    expect(mockEnsureCommitStatus).toHaveBeenCalledWith(
+      stuck.repository,
+      stuck.head_sha,
+      'success',
+      'Exact v2 staging manifest validated; production is explicit',
+      'Release Bus v2'
+    );
+  });
+
+  it('restores preserved candidate-evidence production intent on carry-forward repair', async () => {
+    const stuck = {
+      ...candidate('a1', 'frontend', 'STAGING_BUILDING', true),
+      current_train_id: 'train-cumulative',
+      production_requested_at: 2,
+      production_requested_by: 'operator',
+      production_selection_id: 'selection-a',
+      row_version: 10
+    };
+    const validatedTrain = {
+      ...train('train-cumulative'),
+      status: 'STAGING_VALIDATED' as const
+    };
+    const updateCandidate = jest.fn(async () => true);
+    const repository = {
+      listCandidates: async () => [stuck],
+      executeNativeQueriesInTransaction: async (
+        callback: (connection: unknown) => unknown
+      ) => callback({}),
+      findCandidateById: async () => stuck,
+      findTrain: async () => validatedTrain,
+      listTrainCandidates: async () => [
+        {
+          train_id: validatedTrain.id,
+          candidate_id: stuck.id,
+          candidate_role: 'CARRY_FORWARD',
+          disposition: 'INCLUDED'
+        }
+      ],
+      listProductionManifestsForCandidate: async () => [],
+      updateCandidate,
+      appendEvent: async () => undefined
+    };
+    const service = new ReleaseBusV2Service(repository as never);
+
+    await service.repairTerminalCumulativeCarryForwardStatuses('reconciler');
+
+    expect(updateCandidate).toHaveBeenCalledWith(
+      stuck.id,
+      stuck.row_version,
+      expect.objectContaining({
+        status: 'READY_FOR_CANDIDATE_EVIDENCE_PRODUCTION',
+        currentTrainId: null
+      }),
+      expect.anything()
+    );
+    expect(mockEnsureCommitStatus).toHaveBeenCalledWith(
+      stuck.repository,
+      stuck.head_sha,
+      'pending',
+      'Release Bus v2: ready for candidate evidence production',
+      'Release Bus v2'
     );
   });
 

--- a/src/releaseBusV2/release-bus-v2.acceptance.test.ts
+++ b/src/releaseBusV2/release-bus-v2.acceptance.test.ts
@@ -590,6 +590,7 @@ function harness(e2eStatus: 'RUNNING' | 'SUCCEEDED' | 'FAILED') {
   );
   const service = {
     claimLane: jest.fn(async () => null),
+    repairTerminalCumulativeCarryForwardStatuses: jest.fn(async () => []),
     setPaused: jest.fn(
       async (
         scope: ReleaseBusV2ControlRecord['scope'],

--- a/src/releaseBusV2/release-bus-v2.acceptance.test.ts
+++ b/src/releaseBusV2/release-bus-v2.acceptance.test.ts
@@ -1022,6 +1022,33 @@ describe('Release Bus v2 offline acceptance harness', () => {
     );
   });
 
+  it('continues unrelated reconciliation after a carry repair row-version race', async () => {
+    const state = harness('SUCCEEDED');
+    process.env.RELEASE_BUS_V2_MODE = 'STAGING';
+    state.repository.trains.set(
+      'train-1',
+      train('train-1', { status: 'CANCELLED', completed_at: 2 })
+    );
+    state.service.repairTerminalCumulativeCarryForwardStatuses.mockRejectedValueOnce(
+      new Error('Candidate changed concurrently')
+    );
+
+    await expect(
+      state.reconciler.runOnce('acceptance-carry-repair-race')
+    ).resolves.toEqual({
+      mode: 'STAGING',
+      claimed: [],
+      advanced: []
+    });
+    expect(state.service.claimLane).toHaveBeenCalledWith(
+      'STAGING',
+      FRONTEND_SHA,
+      BACKEND_SHA,
+      'acceptance-carry-repair-race:staging',
+      { frontendSha: FRONTEND_SHA, backendSha: BACKEND_SHA }
+    );
+  });
+
   it('repairs an allowlisted production candidate after its exact merged branch is deleted', async () => {
     const state = harness('SUCCEEDED');
     const candidateId = '11111111-1111-4111-8111-111111111111';

--- a/src/releaseBusV2/release-bus-v2.reconciler.test.ts
+++ b/src/releaseBusV2/release-bus-v2.reconciler.test.ts
@@ -4,6 +4,7 @@ import {
   backendReleaseNoteGroups,
   canUseSingleCandidateFastPath,
   candidateUnavailableForTrainUpdate,
+  candidateStatusMutationCandidates,
   deletedProductionCandidateCanRetainReadiness,
   candidateExclusionClosure,
   dagLayers,
@@ -118,6 +119,64 @@ describe('Release Bus v2 deterministic orchestration', () => {
       carried,
       removed
     ]);
+  });
+
+  it('mutates only new candidate statuses during cumulative staging preparation', () => {
+    const carried = candidate('carried', 'a'.repeat(40));
+    const added = candidate('added', 'b'.repeat(40));
+    const stagingTrain: ReleaseBusV2TrainRecord = {
+      id: 'train-cumulative-statuses',
+      lane: 'STAGING',
+      status: 'CLAIMED',
+      frontend_base_sha: 'c'.repeat(40),
+      backend_base_sha: 'd'.repeat(40),
+      frontend_composed_sha: null,
+      backend_composed_sha: null,
+      frontend_artifact_digest: null,
+      backend_artifact_digest: null,
+      manifest_id: null,
+      parent_train_id: null,
+      qualification_identity_sha256: null,
+      qualification_train_id: null,
+      staging_policy: 'CUMULATIVE_ADMITTED_SET_V1',
+      staging_baseline_manifest_id: 'manifest-before',
+      staging_transition_json: null,
+      failure_class: null,
+      failure_message: null,
+      recovery_message: null,
+      phase_started_at: 1,
+      completed_at: null,
+      created_at: 1,
+      updated_at: 1,
+      row_version: 1
+    };
+    const context = {
+      train: stagingTrain,
+      memberships: [
+        {
+          id: 'membership-carried',
+          train_id: stagingTrain.id,
+          candidate_id: carried.id,
+          sequence: 1,
+          disposition: 'INCLUDED',
+          candidate_role: 'CARRY_FORWARD',
+          created_at: 1
+        },
+        {
+          id: 'membership-added',
+          train_id: stagingTrain.id,
+          candidate_id: added.id,
+          sequence: 2,
+          disposition: 'INCLUDED',
+          candidate_role: 'NEW',
+          created_at: 1
+        }
+      ],
+      candidates: [carried, added],
+      dependencies: []
+    };
+
+    expect(candidateStatusMutationCandidates(context)).toEqual([added]);
   });
 
   it('keeps the admitted state unchanged while a failed cumulative train enters rollback', async () => {

--- a/src/releaseBusV2/release-bus-v2.reconciler.ts
+++ b/src/releaseBusV2/release-bus-v2.reconciler.ts
@@ -766,10 +766,18 @@ export class ReleaseBusV2Reconciler {
       !isPaused('PRODUCTION') &&
       (mode === 'PRODUCTION' ||
         releaseBusV2BetaAllowsLaneInMode(mode, betaAllowlist, 'PRODUCTION'));
-    if (stagingEnabled)
-      await this.service.repairTerminalCumulativeCarryForwardStatuses(
-        'release-bus-v2-reconciler'
-      );
+    if (stagingEnabled) {
+      try {
+        await this.service.repairTerminalCumulativeCarryForwardStatuses(
+          'release-bus-v2-reconciler'
+        );
+      } catch (error) {
+        // A concurrent row-version winner will be observed on the next tick
+        // and must not delay unrelated train advancement. Other failures stay
+        // fail-closed and propagate.
+        if (!isOptimisticConcurrencyConflict(error)) throw error;
+      }
+    }
     if (stagingEnabled || productionEnabled) {
       try {
         await this.reconcileQueuedCandidateHeads(betaAllowlist, mode);

--- a/src/releaseBusV2/release-bus-v2.reconciler.ts
+++ b/src/releaseBusV2/release-bus-v2.reconciler.ts
@@ -564,7 +564,7 @@ export function relevantCandidates(
   );
 }
 
-function stagingStatusCandidates(
+export function stagingStatusCandidates(
   context: TrainContext
 ): ReleaseBusV2CandidateRecord[] {
   if (
@@ -578,6 +578,14 @@ function stagingStatusCandidates(
       .map(({ candidate_id }) => candidate_id)
   );
   return relevantCandidates(context).filter(({ id }) => mutable.has(id));
+}
+
+export function candidateStatusMutationCandidates(
+  context: TrainContext
+): ReleaseBusV2CandidateRecord[] {
+  return context.train.lane === 'STAGING'
+    ? stagingStatusCandidates(context)
+    : relevantCandidates(context);
 }
 
 export function stagingDeploymentCandidates(
@@ -758,6 +766,10 @@ export class ReleaseBusV2Reconciler {
       !isPaused('PRODUCTION') &&
       (mode === 'PRODUCTION' ||
         releaseBusV2BetaAllowsLaneInMode(mode, betaAllowlist, 'PRODUCTION'));
+    if (stagingEnabled)
+      await this.service.repairTerminalCumulativeCarryForwardStatuses(
+        'release-bus-v2-reconciler'
+      );
     if (stagingEnabled || productionEnabled) {
       try {
         await this.reconcileQueuedCandidateHeads(betaAllowlist, mode);
@@ -1154,7 +1166,7 @@ export class ReleaseBusV2Reconciler {
       return;
     }
     await this.updateCandidateStatuses(
-      relevantCandidates(context),
+      candidateStatusMutationCandidates(context),
       candidateStatusForBuild(train.lane),
       train.id
     );

--- a/src/releaseBusV2/release-bus-v2.service.ts
+++ b/src/releaseBusV2/release-bus-v2.service.ts
@@ -975,6 +975,8 @@ export class ReleaseBusV2Service {
   public async repairTerminalCumulativeCarryForwardStatuses(
     actor: string
   ): Promise<readonly ReleaseBusV2CandidateRecord[]> {
+    // Each repaired row leaves STAGING_BUILDING, so later ticks deterministically
+    // drain any backlog beyond this bounded transaction batch.
     const stuck = await this.repository.listCandidates(
       ['STAGING_BUILDING'],
       500,
@@ -1079,7 +1081,9 @@ export class ReleaseBusV2Service {
       );
       if (result) repaired.push(result);
     }
-    await Promise.all(
+    // GitHub status is advisory after the durable repair. A transient publish
+    // failure must not abort the reconciler tick after the database committed.
+    await Promise.allSettled(
       repaired.map((candidate) => {
         const published = candidateRegistrationStatus(candidate);
         return releaseBusGitHubApp.ensureCommitStatus(

--- a/src/releaseBusV2/release-bus-v2.service.ts
+++ b/src/releaseBusV2/release-bus-v2.service.ts
@@ -998,8 +998,7 @@ export class ReleaseBusV2Service {
             return null;
           const train = await this.repository.findTrain(
             current.current_train_id,
-            ctx,
-            true
+            ctx
           );
           if (
             !train ||

--- a/src/releaseBusV2/release-bus-v2.service.ts
+++ b/src/releaseBusV2/release-bus-v2.service.ts
@@ -1006,7 +1006,7 @@ export class ReleaseBusV2Service {
             !train ||
             train.lane !== 'STAGING' ||
             train.staging_policy !== 'CUMULATIVE_ADMITTED_SET_V1' ||
-            train.status !== 'STAGING_VALIDATED'
+            !TERMINAL_TRAIN_STATUSES.has(train.status)
           )
             return null;
           const membership = (

--- a/src/releaseBusV2/release-bus-v2.service.ts
+++ b/src/releaseBusV2/release-bus-v2.service.ts
@@ -282,6 +282,16 @@ function candidateRegistrationStatus(candidate: ReleaseBusV2CandidateRecord): {
   };
 }
 
+function restoredCarryForwardStatus(
+  candidate: ReleaseBusV2CandidateRecord,
+  hasProductionDeployment: boolean
+): ReleaseBusV2CandidateStatus {
+  if (hasProductionDeployment) return 'PRODUCTION_DEPLOYED';
+  if (candidate.production_requested_at === null) return 'STAGING_VALIDATED';
+  if (candidate.production_selection_id) return CANDIDATE_EVIDENCE_READY_STATUS;
+  return 'READY_FOR_PRODUCTION';
+}
+
 export class ReleaseBusV2Service {
   public constructor(
     private readonly repository: ReleaseBusV2RepositoryClass = releaseBusV2Repository
@@ -1009,15 +1019,15 @@ export class ReleaseBusV2Service {
             !TERMINAL_TRAIN_STATUSES.has(train.status)
           )
             return null;
-          const membership = (
+          const isCarryForwardMember = (
             await this.repository.listTrainCandidates(train.id, ctx)
-          ).find(
+          ).some(
             (item) =>
               item.candidate_id === current.id &&
               item.candidate_role === 'CARRY_FORWARD' &&
               item.disposition === 'INCLUDED'
           );
-          if (!membership) return null;
+          if (!isCarryForwardMember) return null;
 
           const hasProductionDeployment =
             await this.hasExactProductionDeploymentManifestEvidence(
@@ -1030,14 +1040,10 @@ export class ReleaseBusV2Service {
             current.staging_validated_manifest_id !== null;
           if (!hasProductionDeployment && !hasHistoricalStagingCertification)
             return null;
-          const restoredStatus: ReleaseBusV2CandidateStatus =
+          const restoredStatus = restoredCarryForwardStatus(
+            current,
             hasProductionDeployment
-              ? 'PRODUCTION_DEPLOYED'
-              : current.production_requested_at === null
-                ? 'STAGING_VALIDATED'
-                : current.production_selection_id
-                  ? CANDIDATE_EVIDENCE_READY_STATUS
-                  : 'READY_FOR_PRODUCTION';
+          );
           if (
             !(await this.repository.updateCandidate(
               current.id,
@@ -1050,9 +1056,7 @@ export class ReleaseBusV2Service {
               ctx
             ))
           )
-            throw new Error(
-              'Cumulative carry-forward candidate changed concurrently'
-            );
+            throw new Error('Candidate changed concurrently');
           await this.repository.appendEvent(
             {
               trainId: train.id,

--- a/src/releaseBusV2/release-bus-v2.service.ts
+++ b/src/releaseBusV2/release-bus-v2.service.ts
@@ -1024,6 +1024,12 @@ export class ReleaseBusV2Service {
               current,
               ctx
             );
+          const hasHistoricalStagingCertification =
+            current.superseded_at === null &&
+            current.staging_validated_train_id !== null &&
+            current.staging_validated_manifest_id !== null;
+          if (!hasProductionDeployment && !hasHistoricalStagingCertification)
+            return null;
           const restoredStatus: ReleaseBusV2CandidateStatus =
             hasProductionDeployment
               ? 'PRODUCTION_DEPLOYED'
@@ -1065,7 +1071,9 @@ export class ReleaseBusV2Service {
                   current.staging_live_manifest_id ?? null,
                 production_selection_id:
                   current.production_selection_id ?? null,
-                exact_production_deployment_evidence: hasProductionDeployment
+                exact_production_deployment_evidence: hasProductionDeployment,
+                historical_staging_certification:
+                  hasHistoricalStagingCertification
               }
             },
             ctx

--- a/src/releaseBusV2/release-bus-v2.service.ts
+++ b/src/releaseBusV2/release-bus-v2.service.ts
@@ -924,6 +924,14 @@ export class ReleaseBusV2Service {
       candidate.superseded_at !== null
     )
       return false;
+    return this.hasExactProductionDeploymentManifestEvidence(candidate, ctx);
+  }
+
+  private async hasExactProductionDeploymentManifestEvidence(
+    candidate: ReleaseBusV2CandidateRecord,
+    ctx: RequestContext
+  ): Promise<boolean> {
+    if (candidate.superseded_at !== null) return false;
     const manifests = await this.repository.listProductionManifestsForCandidate(
       candidate.id,
       ctx
@@ -962,6 +970,129 @@ export class ReleaseBusV2Service {
       if (matchingE2e.length === 1) return true;
     }
     return false;
+  }
+
+  public async repairTerminalCumulativeCarryForwardStatuses(
+    actor: string
+  ): Promise<readonly ReleaseBusV2CandidateRecord[]> {
+    const stuck = await this.repository.listCandidates(
+      ['STAGING_BUILDING'],
+      500,
+      {}
+    );
+    const repaired: ReleaseBusV2CandidateRecord[] = [];
+    for (const candidate of stuck) {
+      const result = await this.repository.executeNativeQueriesInTransaction(
+        async (connection): Promise<ReleaseBusV2CandidateRecord | null> => {
+          const ctx: RequestContext = { connection };
+          const current = await this.repository.findCandidateById(
+            candidate.id,
+            ctx,
+            true
+          );
+          if (
+            !current ||
+            current.status !== 'STAGING_BUILDING' ||
+            current.current_train_id === null
+          )
+            return null;
+          const train = await this.repository.findTrain(
+            current.current_train_id,
+            ctx,
+            true
+          );
+          if (
+            !train ||
+            train.lane !== 'STAGING' ||
+            train.staging_policy !== 'CUMULATIVE_ADMITTED_SET_V1' ||
+            train.status !== 'STAGING_VALIDATED'
+          )
+            return null;
+          const membership = (
+            await this.repository.listTrainCandidates(train.id, ctx)
+          ).find(
+            (item) =>
+              item.candidate_id === current.id &&
+              item.candidate_role === 'CARRY_FORWARD' &&
+              item.disposition === 'INCLUDED'
+          );
+          if (!membership) return null;
+
+          const hasProductionDeployment =
+            await this.hasExactProductionDeploymentManifestEvidence(
+              current,
+              ctx
+            );
+          const restoredStatus: ReleaseBusV2CandidateStatus =
+            hasProductionDeployment
+              ? 'PRODUCTION_DEPLOYED'
+              : current.production_requested_at === null
+                ? 'STAGING_VALIDATED'
+                : current.production_selection_id
+                  ? CANDIDATE_EVIDENCE_READY_STATUS
+                  : 'READY_FOR_PRODUCTION';
+          if (
+            !(await this.repository.updateCandidate(
+              current.id,
+              current.row_version,
+              {
+                status: restoredStatus,
+                currentTrainId: null,
+                holdReason: null
+              },
+              ctx
+            ))
+          )
+            throw new Error(
+              'Cumulative carry-forward candidate changed concurrently'
+            );
+          await this.repository.appendEvent(
+            {
+              trainId: train.id,
+              candidateId: current.id,
+              eventType: 'TERMINAL_CUMULATIVE_CARRY_FORWARD_STATUS_REPAIRED',
+              actor,
+              payload: {
+                head_sha: current.head_sha,
+                incorrect_status: current.status,
+                restored_status: restoredStatus,
+                staging_validated_train_id: current.staging_validated_train_id,
+                staging_validated_manifest_id:
+                  current.staging_validated_manifest_id,
+                staging_live_state: current.staging_live_state ?? null,
+                staging_live_manifest_id:
+                  current.staging_live_manifest_id ?? null,
+                production_selection_id:
+                  current.production_selection_id ?? null,
+                exact_production_deployment_evidence: hasProductionDeployment
+              }
+            },
+            ctx
+          );
+          return {
+            ...current,
+            status: restoredStatus,
+            current_train_id: null,
+            hold_reason: null,
+            row_version: current.row_version + 1
+          };
+        }
+      );
+      if (result) repaired.push(result);
+    }
+    await Promise.all(
+      repaired.map((candidate) => {
+        const published = candidateRegistrationStatus(candidate);
+        return releaseBusGitHubApp.ensureCommitStatus(
+          candidate.repository,
+          candidate.head_sha,
+          published.state,
+          published.description,
+          'Release Bus v2'
+        );
+      })
+    );
+    return repaired;
   }
 
   public async revokeProductionReadiness(


### PR DESCRIPTION
## What changed

- Restrict cumulative staging preparation status mutations to `NEW` train members; carry-forward candidates retain their historical certification and production intent.
- Add an idempotent reconciler repair for carry-forward candidates already left in `STAGING_BUILDING` by a terminal validated cumulative train.
- Preserve exact staging evidence, authoritative live membership, and candidate-evidence/legacy production intent while writing a durable repair audit event.

## Root cause

`advancePreparation()` updated every included cumulative-train candidate to `STAGING_BUILDING`. Later cumulative phases correctly updated only `NEW` members, so carried candidates could remain stuck after the train reached `STAGING_VALIDATED`.

## Impact

Ordinary cumulative staging trains no longer corrupt carried candidates historical state. The repair self-drains the already-observed live row without changing staging refs, runtime, validation evidence, or admitted membership.

## Validation

- Full `src/releaseBusV2` suite: 12 suites / 188 tests passed.
- Focused ESLint on all changed files passed.
- TypeScript invocation reached unrelated nested `api-serverless` dependency declaration gaps; the touched files compile through Jest/ts-jest and CI will run the repository complete build environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery for cumulative carry-forward candidates stuck during staging, with restoration based on available production deployment evidence or historical certification.
  * Preserves staging evidence and live membership while repairing candidate statuses and readiness.
  * Updates commit checks to reflect repaired readiness, and avoids mutating carried-forward candidates during staging preparation.
  * Ensures a failed repair due to a row-version race doesn’t block unrelated reconciliation work.

* **Tests**
  * Added unit and acceptance coverage for the new repair flow and candidate selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->