### PR TITLE
Fix candidate-evidence preflight retry recovery

### DIFF
--- a/ops/deployment-bus/simple-release-bus-v2.md
+++ b/ops/deployment-bus/simple-release-bus-v2.md
@@ -112,11 +112,13 @@ only retry exception is a new explicit selection of an unchanged `FAILED`
 candidate whose latest candidate-evidence production train failed an immutable
 artifact preflight while containing only terminal compose/preflight operations.
 Release Bus locks the terminal train and its operation range, binds its durable
-claim to the candidate's current selection ID and exact historical
-staging train/manifest/E2E evidence, revalidates the unchanged branch head,
-creates a new production-selection identity, and records the failed train as
-the retry source. Any deploy, E2E, ref-mutation, unknown, or nonterminal
-operation makes the failure ineligible for this path.
+membership to the locked exact candidate row and exact historical staging
+train/manifest/E2E evidence, revalidates the unchanged branch head, creates a
+new production-selection identity, and records the failed train as the retry
+source. Selection IDs remain attempt-level audit provenance; eligibility does
+not trust an event payload as authoritative state. Any empty operation range,
+deploy, E2E, ref-mutation, unknown, or nonterminal operation makes the failure
+ineligible for this path.
 
 The selection must be transitively dependency-closed. A production-scoped
 prerequisite must either be selected in the same action or already be terminal

--- a/ops/deployment-bus/simple-release-bus-v2.md
+++ b/ops/deployment-bus/simple-release-bus-v2.md
@@ -107,7 +107,14 @@ Staging validation never creates production readiness. An operator explicitly
 selects one or more unchanged exact candidates through the Deploy UI or
 `POST /deploy/release-bus-v2/production-selections`. The action is atomic: all
 selected candidates share one `production_selection_id`, and every selected
-candidate must still be `STAGING_VALIDATED` at the submitted head SHA.
+candidate must still be `STAGING_VALIDATED` at the submitted head SHA. The
+only retry exception is a new explicit selection of an unchanged `FAILED`
+candidate whose latest candidate-evidence production train failed an immutable
+artifact preflight before any `ADVANCE_MAIN_*` operation existed. Release Bus
+revalidates the exact historical staging train/manifest/E2E evidence and branch
+head, creates a new production-selection identity, and records the failed train
+as the retry source. A post-main or ambiguous ref-mutation failure is never
+eligible for this path.
 
 The selection must be transitively dependency-closed. A production-scoped
 prerequisite must either be selected in the same action or already be terminal
@@ -164,14 +171,15 @@ explicitly.
 
 ## Failure behavior
 
-| Class                         | Behavior                                                                                                                                                                                                                                               |
-| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Candidate merge/test          | Before shared mutation, fail the cumulative train closed and leave the last validated admitted manifest live; mark only the new direct candidate `NEEDS_REBASE` as applicable                                                                          |
-| Infrastructure                | Bounded idempotent retry; no candidate isolation                                                                                                                                                                                                       |
-| Retryable deployment          | Retry only the failed operation; preserve successful sibling evidence                                                                                                                                                                                  |
-| Control plane                 | Fail the train, requeue candidates, pause automated claiming, release an environment lock once every operation is terminal, retain manual fallback                                                                                                     |
-| E2E                           | Keep the failed manifest unvalidated and restore/deploy/E2E the exact last validated live manifest under the same staging lock; commit no admission change until restoration validates                                                                 |
-| Production after main advance | Fail selected candidates closed, pause `PRODUCTION`, and block later production claims. `main` remains truthful and is never rewritten; an operator must prove the recorded exact main/runtime parity or complete an explicit rollback before resuming |
+| Class                         | Behavior                                                                                                                                                                                                                                                                |
+| ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Candidate merge/test          | Before shared mutation, fail the cumulative train closed and leave the last validated admitted manifest live; mark only the new direct candidate `NEEDS_REBASE` as applicable                                                                                           |
+| Infrastructure                | Bounded idempotent retry; no candidate isolation                                                                                                                                                                                                                        |
+| Retryable deployment          | Retry only the failed operation; preserve successful sibling evidence                                                                                                                                                                                                   |
+| Control plane                 | Fail the train, requeue candidates, pause automated claiming, release an environment lock once every operation is terminal, retain manual fallback                                                                                                                      |
+| E2E                           | Keep the failed manifest unvalidated and restore/deploy/E2E the exact last validated live manifest under the same staging lock; commit no admission change until restoration validates                                                                                  |
+| Production preflight          | Fail before shared mutation. A later explicit exact-SHA selection may retry only after the unchanged staging evidence is revalidated and the failed train proves no `ADVANCE_MAIN_*` operation was created; audit both selection identities and the failed source train |
+| Production after main advance | Fail selected candidates closed, pause `PRODUCTION`, and block later production claims. `main` remains truthful and is never rewritten; an operator must prove the recorded exact main/runtime parity or complete an explicit rollback before resuming                  |
 
 Every pending GitHub status must map to a visible candidate/train/operation state
 and recovery message. Duplicate callbacks and worker invocations reuse immutable

--- a/ops/deployment-bus/simple-release-bus-v2.md
+++ b/ops/deployment-bus/simple-release-bus-v2.md
@@ -110,11 +110,13 @@ selected candidates share one `production_selection_id`, and every selected
 candidate must still be `STAGING_VALIDATED` at the submitted head SHA. The
 only retry exception is a new explicit selection of an unchanged `FAILED`
 candidate whose latest candidate-evidence production train failed an immutable
-artifact preflight before any `ADVANCE_MAIN_*` operation existed. Release Bus
-revalidates the exact historical staging train/manifest/E2E evidence and branch
-head, creates a new production-selection identity, and records the failed train
-as the retry source. A post-main or ambiguous ref-mutation failure is never
-eligible for this path.
+artifact preflight while containing only terminal compose/preflight operations.
+Release Bus locks the terminal train and its operation range, binds its durable
+claim to the candidate's current selection ID and exact historical
+staging train/manifest/E2E evidence, revalidates the unchanged branch head,
+creates a new production-selection identity, and records the failed train as
+the retry source. Any deploy, E2E, ref-mutation, unknown, or nonterminal
+operation makes the failure ineligible for this path.
 
 The selection must be transitively dependency-closed. A production-scoped
 prerequisite must either be selected in the same action or already be terminal
@@ -171,15 +173,15 @@ explicitly.
 
 ## Failure behavior
 
-| Class                         | Behavior                                                                                                                                                                                                                                                                |
-| ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Candidate merge/test          | Before shared mutation, fail the cumulative train closed and leave the last validated admitted manifest live; mark only the new direct candidate `NEEDS_REBASE` as applicable                                                                                           |
-| Infrastructure                | Bounded idempotent retry; no candidate isolation                                                                                                                                                                                                                        |
-| Retryable deployment          | Retry only the failed operation; preserve successful sibling evidence                                                                                                                                                                                                   |
-| Control plane                 | Fail the train, requeue candidates, pause automated claiming, release an environment lock once every operation is terminal, retain manual fallback                                                                                                                      |
-| E2E                           | Keep the failed manifest unvalidated and restore/deploy/E2E the exact last validated live manifest under the same staging lock; commit no admission change until restoration validates                                                                                  |
-| Production preflight          | Fail before shared mutation. A later explicit exact-SHA selection may retry only after the unchanged staging evidence is revalidated and the failed train proves no `ADVANCE_MAIN_*` operation was created; audit both selection identities and the failed source train |
-| Production after main advance | Fail selected candidates closed, pause `PRODUCTION`, and block later production claims. `main` remains truthful and is never rewritten; an operator must prove the recorded exact main/runtime parity or complete an explicit rollback before resuming                  |
+| Class                         | Behavior                                                                                                                                                                                                                                                                          |
+| ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Candidate merge/test          | Before shared mutation, fail the cumulative train closed and leave the last validated admitted manifest live; mark only the new direct candidate `NEEDS_REBASE` as applicable                                                                                                     |
+| Infrastructure                | Bounded idempotent retry; no candidate isolation                                                                                                                                                                                                                                  |
+| Retryable deployment          | Retry only the failed operation; preserve successful sibling evidence                                                                                                                                                                                                             |
+| Control plane                 | Fail the train, requeue candidates, pause automated claiming, release an environment lock once every operation is terminal, retain manual fallback                                                                                                                                |
+| E2E                           | Keep the failed manifest unvalidated and restore/deploy/E2E the exact last validated live manifest under the same staging lock; commit no admission change until restoration validates                                                                                            |
+| Production preflight          | Fail before shared mutation. A later explicit exact-SHA selection may retry only after the unchanged staging evidence is revalidated and the locked failed train contains only terminal compose/preflight operations; audit both selection identities and the failed source train |
+| Production after main advance | Fail selected candidates closed, pause `PRODUCTION`, and block later production claims. `main` remains truthful and is never rewritten; an operator must prove the recorded exact main/runtime parity or complete an explicit rollback before resuming                            |
 
 Every pending GitHub status must map to a visible candidate/train/operation state
 and recovery message. Duplicate callbacks and worker invocations reuse immutable

--- a/src/alchemy-sdk.ts
+++ b/src/alchemy-sdk.ts
@@ -389,7 +389,8 @@ async function postNftRest<T>(
 function toAlchemyError(e: unknown, context: string): Error {
   if (e instanceof AxiosError) {
     const data = e.response?.data as
-      { message?: string; error?: string | { message?: string } } | undefined;
+      | { message?: string; error?: string | { message?: string } }
+      | undefined;
     const nestedMessage =
       typeof data?.error === 'string' ? data.error : data?.error?.message;
     const message =

--- a/src/releaseBusV2/release-bus-v2.repository.ts
+++ b/src/releaseBusV2/release-bus-v2.repository.ts
@@ -1334,15 +1334,12 @@ export class ReleaseBusV2Repository extends LazyDbAccessCompatibleService {
   public async listEvents(
     trainId: string,
     limit: number,
-    ctx: RequestContext,
-    forUpdate = false
+    ctx: RequestContext
   ): Promise<ReleaseBusV2EventRecord[]> {
     const boundedLimit = Math.max(1, Math.min(limit, 500));
     return this.db.execute<ReleaseBusV2EventRecord>(
       `select * from ${RELEASE_BUS_V2_EVENTS_TABLE}
-       where train_id = :trainId order by created_at desc limit ${boundedLimit}${
-         forUpdate ? ' for update' : ''
-       }`,
+       where train_id = :trainId order by created_at desc limit ${boundedLimit}`,
       { trainId },
       dbOptions(ctx)
     );

--- a/src/releaseBusV2/release-bus-v2.repository.ts
+++ b/src/releaseBusV2/release-bus-v2.repository.ts
@@ -941,11 +941,14 @@ export class ReleaseBusV2Repository extends LazyDbAccessCompatibleService {
 
   public async listOperations(
     trainId: string,
-    ctx: RequestContext
+    ctx: RequestContext,
+    forUpdate = false
   ): Promise<ReleaseBusV2OperationRecord[]> {
     return this.db.execute<ReleaseBusV2OperationRecord>(
       `select * from ${RELEASE_BUS_V2_OPERATIONS_TABLE}
-       where train_id = :trainId order by created_at asc, id asc`,
+       where train_id = :trainId order by created_at asc, id asc${
+         forUpdate ? ' for update' : ''
+       }`,
       { trainId },
       dbOptions(ctx)
     );
@@ -1241,7 +1244,8 @@ export class ReleaseBusV2Repository extends LazyDbAccessCompatibleService {
 
   public async findLatestProductionTrainForCandidate(
     candidateId: string,
-    ctx: RequestContext
+    ctx: RequestContext,
+    forUpdate = false
   ): Promise<ReleaseBusV2TrainRecord | null> {
     return this.db.oneOrNull<ReleaseBusV2TrainRecord>(
       `select train.* from ${RELEASE_BUS_V2_TRAINS_TABLE} train
@@ -1251,7 +1255,7 @@ export class ReleaseBusV2Repository extends LazyDbAccessCompatibleService {
          and membership.disposition = 'INCLUDED'
          and train.lane = 'PRODUCTION'
        order by train.created_at desc, train.id desc
-       limit 1`,
+       limit 1${forUpdate ? ' for update' : ''}`,
       { candidateId },
       dbOptions(ctx)
     );
@@ -1330,12 +1334,15 @@ export class ReleaseBusV2Repository extends LazyDbAccessCompatibleService {
   public async listEvents(
     trainId: string,
     limit: number,
-    ctx: RequestContext
+    ctx: RequestContext,
+    forUpdate = false
   ): Promise<ReleaseBusV2EventRecord[]> {
     const boundedLimit = Math.max(1, Math.min(limit, 500));
     return this.db.execute<ReleaseBusV2EventRecord>(
       `select * from ${RELEASE_BUS_V2_EVENTS_TABLE}
-       where train_id = :trainId order by created_at desc limit ${boundedLimit}`,
+       where train_id = :trainId order by created_at desc limit ${boundedLimit}${
+         forUpdate ? ' for update' : ''
+       }`,
       { trainId },
       dbOptions(ctx)
     );

--- a/src/releaseBusV2/release-bus-v2.repository.ts
+++ b/src/releaseBusV2/release-bus-v2.repository.ts
@@ -1239,6 +1239,24 @@ export class ReleaseBusV2Repository extends LazyDbAccessCompatibleService {
     );
   }
 
+  public async findLatestProductionTrainForCandidate(
+    candidateId: string,
+    ctx: RequestContext
+  ): Promise<ReleaseBusV2TrainRecord | null> {
+    return this.db.oneOrNull<ReleaseBusV2TrainRecord>(
+      `select train.* from ${RELEASE_BUS_V2_TRAINS_TABLE} train
+       inner join ${RELEASE_BUS_V2_TRAIN_CANDIDATES_TABLE} membership
+         on membership.train_id = train.id
+       where membership.candidate_id = :candidateId
+         and membership.disposition = 'INCLUDED'
+         and train.lane = 'PRODUCTION'
+       order by train.created_at desc, train.id desc
+       limit 1`,
+      { candidateId },
+      dbOptions(ctx)
+    );
+  }
+
   public async updateManifestStatus(
     id: string,
     status: ReleaseBusV2ManifestStatus,

--- a/src/releaseBusV2/release-bus-v2.service.test.ts
+++ b/src/releaseBusV2/release-bus-v2.service.test.ts
@@ -188,6 +188,7 @@ function selectionRepository(
     findCandidateById: jest.fn(
       async (id: string) => candidates.get(id) ?? null
     ),
+    findLatestProductionTrainForCandidate: jest.fn(async () => null),
     findTrain: jest.fn(async (id: string) => {
       const item = Array.from(candidates.values()).find(
         ({ staging_validated_train_id }) => staging_validated_train_id === id
@@ -385,6 +386,146 @@ describe('Release Bus v2 explicit production opt-in', () => {
       }),
       expect.anything()
     );
+  });
+
+  it('permits an explicit exact-evidence retry after a pre-main candidate preflight failure', async () => {
+    const failed = {
+      ...validatedCandidate('candidate-retry', 'backend', '4', 112),
+      status: 'FAILED' as const,
+      production_requested_at: 10,
+      production_requested_by: 'operator',
+      production_selection_id: 'failed-selection'
+    };
+    const failedTrain = {
+      id: 'failed-pre-main-production-train',
+      lane: 'PRODUCTION',
+      status: 'FAILED',
+      failure_class: 'CANDIDATE',
+      completed_at: 20,
+      qualification_policy: 'CANDIDATE_STAGING_EVIDENCE_V1'
+    };
+    const state = selectionRepository([failed]);
+    const originalListOperations =
+      state.repository.listOperations.getMockImplementation()!;
+    state.repository.findLatestProductionTrainForCandidate.mockResolvedValue(
+      failedTrain as never
+    );
+    state.repository.listOperations.mockImplementation(
+      async (trainId: string) =>
+        trainId === failedTrain.id
+          ? [
+              {
+                id: 'failed-preflight',
+                operation_type: 'PREPARE_ARTIFACT_BACKEND',
+                status: 'FAILED',
+                external_id: '100'
+              }
+            ]
+          : originalListOperations(trainId)
+    );
+    mockResolveRef.mockResolvedValue(failed.head_sha);
+    const service = new ReleaseBusV2Service(state.repository as never);
+
+    const selected = await service.markSelectionReadyForProduction(
+      [
+        {
+          candidateId: failed.id,
+          expectedHeadSha: failed.head_sha,
+          expectedRowVersion: failed.row_version
+        }
+      ],
+      'operator'
+    );
+
+    expect(selected).toEqual([
+      expect.objectContaining({
+        id: failed.id,
+        status: 'READY_FOR_CANDIDATE_EVIDENCE_PRODUCTION',
+        staging_validated_train_id: failed.staging_validated_train_id,
+        staging_validated_manifest_id: failed.staging_validated_manifest_id
+      })
+    ]);
+    expect(selected[0]?.production_selection_id).not.toBe(
+      failed.production_selection_id
+    );
+    expect(state.appendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: 'PRODUCTION_SELECTION_READY',
+        payload: expect.objectContaining({
+          retry_sources: [
+            {
+              candidate_id: failed.id,
+              failed_train_id: failedTrain.id
+            }
+          ]
+        })
+      }),
+      expect.anything()
+    );
+    expect(state.appendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        candidateId: failed.id,
+        eventType: 'CANDIDATE_PRE_MAIN_PRODUCTION_RETRY_READY',
+        payload: expect.objectContaining({
+          failed_train_id: failedTrain.id,
+          head_sha: failed.head_sha
+        })
+      }),
+      expect.anything()
+    );
+  });
+
+  it('rejects retry after any production main-ref mutation operation was created', async () => {
+    const failed = {
+      ...validatedCandidate('candidate-post-main', 'backend', '5', 113),
+      status: 'FAILED' as const,
+      production_requested_at: 10,
+      production_requested_by: 'operator',
+      production_selection_id: 'post-main-selection'
+    };
+    const failedTrain = {
+      id: 'failed-post-main-production-train',
+      lane: 'PRODUCTION',
+      status: 'FAILED',
+      failure_class: 'CANDIDATE',
+      completed_at: 20,
+      qualification_policy: 'CANDIDATE_STAGING_EVIDENCE_V1'
+    };
+    const state = selectionRepository([failed]);
+    state.repository.findLatestProductionTrainForCandidate.mockResolvedValue(
+      failedTrain as never
+    );
+    state.repository.listOperations.mockResolvedValue([
+      {
+        id: 'failed-preflight',
+        operation_type: 'PREPARE_ARTIFACT_BACKEND',
+        status: 'FAILED',
+        external_id: '100'
+      },
+      {
+        id: 'main-advanced',
+        operation_type: 'ADVANCE_MAIN_BACKEND',
+        status: 'SUCCEEDED',
+        external_id: failed.head_sha
+      }
+    ]);
+    const service = new ReleaseBusV2Service(state.repository as never);
+
+    await expect(
+      service.markSelectionReadyForProduction(
+        [
+          {
+            candidateId: failed.id,
+            expectedHeadSha: failed.head_sha,
+            expectedRowVersion: failed.row_version
+          }
+        ],
+        'operator'
+      )
+    ).rejects.toThrow(
+      'Failed candidate is not eligible for an exact pre-main production retry'
+    );
+    expect(mockResolveRef).not.toHaveBeenCalled();
   });
 
   it('atomically selects A+C from independently validated A+B+C and preserves B', async () => {

--- a/src/releaseBusV2/release-bus-v2.service.test.ts
+++ b/src/releaseBusV2/release-bus-v2.service.test.ts
@@ -346,7 +346,6 @@ function configureRetrySource(
       readonly external_id: string;
     }[];
     readonly evidence?: readonly unknown[];
-    readonly productionSelectionId?: string | null;
   }
 ) {
   const train = {
@@ -365,16 +364,6 @@ function configureRetrySource(
   state.repository.findLatestProductionTrainForCandidate.mockResolvedValue(
     train as never
   );
-  state.repository.listEvents.mockResolvedValue([
-    {
-      event_type: 'TRAIN_CLAIMED',
-      payload_json: {
-        candidate_ids: [candidate.id],
-        production_selection_id:
-          options.productionSelectionId ?? candidate.production_selection_id
-      }
-    }
-  ]);
   state.repository.listOperations.mockImplementation(async (trainId: string) =>
     trainId === train.id
       ? (options.operations as never)
@@ -475,15 +464,6 @@ describe('Release Bus v2 explicit production opt-in', () => {
     state.repository.findLatestProductionTrainForCandidate.mockResolvedValue(
       failedTrain as never
     );
-    state.repository.listEvents.mockResolvedValue([
-      {
-        event_type: 'TRAIN_CLAIMED',
-        payload_json: {
-          candidate_ids: [failed.id],
-          production_selection_id: failed.production_selection_id
-        }
-      }
-    ]);
     state.repository.listOperations.mockImplementation(
       async (trainId: string) =>
         trainId === failedTrain.id
@@ -531,12 +511,6 @@ describe('Release Bus v2 explicit production opt-in', () => {
     );
     expect(state.repository.listOperations).toHaveBeenCalledWith(
       failedTrain.id,
-      expect.objectContaining({ connection: expect.anything() }),
-      true
-    );
-    expect(state.repository.listEvents).toHaveBeenCalledWith(
-      failedTrain.id,
-      200,
       expect.objectContaining({ connection: expect.anything() }),
       true
     );
@@ -588,15 +562,6 @@ describe('Release Bus v2 explicit production opt-in', () => {
     state.repository.findLatestProductionTrainForCandidate.mockResolvedValue(
       failedTrain as never
     );
-    state.repository.listEvents.mockResolvedValue([
-      {
-        event_type: 'TRAIN_CLAIMED',
-        payload_json: {
-          candidate_ids: [failed.id],
-          production_selection_id: failed.production_selection_id
-        }
-      }
-    ]);
     state.repository.listOperations.mockResolvedValue([
       {
         id: 'failed-preflight',
@@ -738,19 +703,14 @@ describe('Release Bus v2 explicit production opt-in', () => {
         'operator'
       )
     ).rejects.toThrow(
-      'Failed candidate retry source does not match its exact selection and staging evidence'
+      'Failed candidate retry source does not match its exact staging evidence'
     );
     expect(mockResolveRef).not.toHaveBeenCalled();
   });
 
-  it('rejects a failed train claimed for a different production selection', async () => {
+  it('rejects a failed train with no durable pre-main operations', async () => {
     const failed = {
-      ...validatedCandidate(
-        'candidate-selection-mismatch',
-        'backend',
-        '9',
-        119
-      ),
+      ...validatedCandidate('candidate-empty-operations', 'backend', '9', 119),
       status: 'FAILED' as const,
       production_requested_at: 10,
       production_requested_by: 'operator',
@@ -758,16 +718,8 @@ describe('Release Bus v2 explicit production opt-in', () => {
     };
     const state = selectionRepository([failed]);
     configureRetrySource(state, failed, {
-      trainId: 'failed-for-another-selection',
-      productionSelectionId: 'different-selection',
-      operations: [
-        {
-          id: 'failed-preflight',
-          operation_type: 'PREPARE_ARTIFACT_BACKEND',
-          status: 'FAILED',
-          external_id: '203'
-        }
-      ]
+      trainId: 'failed-without-operations',
+      operations: []
     });
     const service = new ReleaseBusV2Service(state.repository as never);
 
@@ -783,7 +735,7 @@ describe('Release Bus v2 explicit production opt-in', () => {
         'operator'
       )
     ).rejects.toThrow(
-      'Failed candidate retry source does not match its exact selection and staging evidence'
+      'Failed candidate is not eligible for an exact pre-main production retry'
     );
     expect(mockResolveRef).not.toHaveBeenCalled();
   });

--- a/src/releaseBusV2/release-bus-v2.service.test.ts
+++ b/src/releaseBusV2/release-bus-v2.service.test.ts
@@ -272,6 +272,7 @@ function selectionRepository(
     listProductionManifestsForCandidate: jest.fn(async (id: string) =>
       Array.from(productionManifests.get(id) ?? [])
     ),
+    listEvents: jest.fn(async (): Promise<unknown[]> => []),
     createTrain,
     executeNativeQueriesInTransaction: jest.fn(
       async (callback: (connection: unknown) => Promise<unknown>) =>
@@ -317,6 +318,69 @@ function selectionRepository(
     appendEvent
   };
   return { candidates, repository, appendEvent, createTrain };
+}
+
+function retryQualificationEvidence(candidate: ReleaseBusV2CandidateRecord) {
+  return {
+    candidate_id: candidate.id,
+    repository: candidate.repository,
+    pr_number: candidate.pr_number,
+    head_sha: candidate.head_sha,
+    staging_train_id: candidate.staging_validated_train_id,
+    staging_manifest_id: candidate.staging_validated_manifest_id,
+    staging_manifest_identity_sha256: 'e'.repeat(64),
+    staging_e2e_operation_id: `e2e-operation-${candidate.id}`,
+    staging_e2e_run_id: `e2e-${candidate.id}`
+  };
+}
+
+function configureRetrySource(
+  state: ReturnType<typeof selectionRepository>,
+  candidate: ReleaseBusV2CandidateRecord,
+  options: {
+    readonly trainId: string;
+    readonly operations: readonly {
+      readonly id: string;
+      readonly operation_type: string;
+      readonly status: string;
+      readonly external_id: string;
+    }[];
+    readonly evidence?: readonly unknown[];
+    readonly productionSelectionId?: string | null;
+  }
+) {
+  const train = {
+    id: options.trainId,
+    lane: 'PRODUCTION',
+    status: 'FAILED',
+    failure_class: 'CANDIDATE',
+    completed_at: 20,
+    qualification_policy: 'CANDIDATE_STAGING_EVIDENCE_V1',
+    qualification_evidence_json: options.evidence ?? [
+      retryQualificationEvidence(candidate)
+    ]
+  };
+  const originalListOperations =
+    state.repository.listOperations.getMockImplementation()!;
+  state.repository.findLatestProductionTrainForCandidate.mockResolvedValue(
+    train as never
+  );
+  state.repository.listEvents.mockResolvedValue([
+    {
+      event_type: 'TRAIN_CLAIMED',
+      payload_json: {
+        candidate_ids: [candidate.id],
+        production_selection_id:
+          options.productionSelectionId ?? candidate.production_selection_id
+      }
+    }
+  ]);
+  state.repository.listOperations.mockImplementation(async (trainId: string) =>
+    trainId === train.id
+      ? (options.operations as never)
+      : originalListOperations(trainId)
+  );
+  return train;
 }
 
 describe('Release Bus v2 explicit production opt-in', () => {
@@ -402,7 +466,8 @@ describe('Release Bus v2 explicit production opt-in', () => {
       status: 'FAILED',
       failure_class: 'CANDIDATE',
       completed_at: 20,
-      qualification_policy: 'CANDIDATE_STAGING_EVIDENCE_V1'
+      qualification_policy: 'CANDIDATE_STAGING_EVIDENCE_V1',
+      qualification_evidence_json: [retryQualificationEvidence(failed)]
     };
     const state = selectionRepository([failed]);
     const originalListOperations =
@@ -410,6 +475,15 @@ describe('Release Bus v2 explicit production opt-in', () => {
     state.repository.findLatestProductionTrainForCandidate.mockResolvedValue(
       failedTrain as never
     );
+    state.repository.listEvents.mockResolvedValue([
+      {
+        event_type: 'TRAIN_CLAIMED',
+        payload_json: {
+          candidate_ids: [failed.id],
+          production_selection_id: failed.production_selection_id
+        }
+      }
+    ]);
     state.repository.listOperations.mockImplementation(
       async (trainId: string) =>
         trainId === failedTrain.id
@@ -447,6 +521,24 @@ describe('Release Bus v2 explicit production opt-in', () => {
     ]);
     expect(selected[0]?.production_selection_id).not.toBe(
       failed.production_selection_id
+    );
+    expect(
+      state.repository.findLatestProductionTrainForCandidate
+    ).toHaveBeenLastCalledWith(
+      failed.id,
+      expect.objectContaining({ connection: expect.anything() }),
+      true
+    );
+    expect(state.repository.listOperations).toHaveBeenCalledWith(
+      failedTrain.id,
+      expect.objectContaining({ connection: expect.anything() }),
+      true
+    );
+    expect(state.repository.listEvents).toHaveBeenCalledWith(
+      failedTrain.id,
+      200,
+      expect.objectContaining({ connection: expect.anything() }),
+      true
     );
     expect(state.appendEvent).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -489,12 +581,22 @@ describe('Release Bus v2 explicit production opt-in', () => {
       status: 'FAILED',
       failure_class: 'CANDIDATE',
       completed_at: 20,
-      qualification_policy: 'CANDIDATE_STAGING_EVIDENCE_V1'
+      qualification_policy: 'CANDIDATE_STAGING_EVIDENCE_V1',
+      qualification_evidence_json: [retryQualificationEvidence(failed)]
     };
     const state = selectionRepository([failed]);
     state.repository.findLatestProductionTrainForCandidate.mockResolvedValue(
       failedTrain as never
     );
+    state.repository.listEvents.mockResolvedValue([
+      {
+        event_type: 'TRAIN_CLAIMED',
+        payload_json: {
+          candidate_ids: [failed.id],
+          production_selection_id: failed.production_selection_id
+        }
+      }
+    ]);
     state.repository.listOperations.mockResolvedValue([
       {
         id: 'failed-preflight',
@@ -526,6 +628,228 @@ describe('Release Bus v2 explicit production opt-in', () => {
       'Failed candidate is not eligible for an exact pre-main production retry'
     );
     expect(mockResolveRef).not.toHaveBeenCalled();
+  });
+
+  it('rejects a failed candidate that still belongs to an active train', async () => {
+    const failed = {
+      ...validatedCandidate('candidate-active-failure', 'backend', '6', 114),
+      status: 'FAILED' as const,
+      current_train_id: 'active-train',
+      production_requested_at: 10,
+      production_requested_by: 'operator',
+      production_selection_id: 'active-selection'
+    };
+    const state = selectionRepository([failed]);
+    const service = new ReleaseBusV2Service(state.repository as never);
+
+    await expect(
+      service.markSelectionReadyForProduction(
+        [
+          {
+            candidateId: failed.id,
+            expectedHeadSha: failed.head_sha,
+            expectedRowVersion: failed.row_version
+          }
+        ],
+        'operator'
+      )
+    ).rejects.toThrow('not staging validated');
+    expect(
+      state.repository.findLatestProductionTrainForCandidate
+    ).not.toHaveBeenCalled();
+  });
+
+  it('rejects a failed train without a failed immutable preflight', async () => {
+    const failed = {
+      ...validatedCandidate('candidate-no-preflight', 'backend', '7', 115),
+      status: 'FAILED' as const,
+      production_requested_at: 10,
+      production_requested_by: 'operator',
+      production_selection_id: 'no-preflight-selection'
+    };
+    const state = selectionRepository([failed]);
+    configureRetrySource(state, failed, {
+      trainId: 'failed-without-preflight',
+      operations: [
+        {
+          id: 'compose-only',
+          operation_type: 'COMPOSE_BACKEND',
+          status: 'SUCCEEDED',
+          external_id: '200'
+        }
+      ]
+    });
+    const service = new ReleaseBusV2Service(state.repository as never);
+
+    await expect(
+      service.markSelectionReadyForProduction(
+        [
+          {
+            candidateId: failed.id,
+            expectedHeadSha: failed.head_sha,
+            expectedRowVersion: failed.row_version
+          }
+        ],
+        'operator'
+      )
+    ).rejects.toThrow(
+      'Failed candidate is not eligible for an exact pre-main production retry'
+    );
+    expect(mockResolveRef).not.toHaveBeenCalled();
+  });
+
+  it('rejects a retry source whose qualified head does not match the candidate', async () => {
+    const failed = {
+      ...validatedCandidate('candidate-mismatched-retry', 'backend', '8', 116),
+      status: 'FAILED' as const,
+      production_requested_at: 10,
+      production_requested_by: 'operator',
+      production_selection_id: 'mismatched-selection'
+    };
+    const state = selectionRepository([failed]);
+    configureRetrySource(state, failed, {
+      trainId: 'failed-with-mismatched-head',
+      evidence: [
+        {
+          ...retryQualificationEvidence(failed),
+          head_sha: '9'.repeat(40)
+        }
+      ],
+      operations: [
+        {
+          id: 'failed-preflight',
+          operation_type: 'PREPARE_ARTIFACT_BACKEND',
+          status: 'FAILED',
+          external_id: '201'
+        }
+      ]
+    });
+    const service = new ReleaseBusV2Service(state.repository as never);
+
+    await expect(
+      service.markSelectionReadyForProduction(
+        [
+          {
+            candidateId: failed.id,
+            expectedHeadSha: failed.head_sha,
+            expectedRowVersion: failed.row_version
+          }
+        ],
+        'operator'
+      )
+    ).rejects.toThrow(
+      'Failed candidate retry source does not match its exact selection and staging evidence'
+    );
+    expect(mockResolveRef).not.toHaveBeenCalled();
+  });
+
+  it('rejects a failed train claimed for a different production selection', async () => {
+    const failed = {
+      ...validatedCandidate(
+        'candidate-selection-mismatch',
+        'backend',
+        '9',
+        119
+      ),
+      status: 'FAILED' as const,
+      production_requested_at: 10,
+      production_requested_by: 'operator',
+      production_selection_id: 'current-selection'
+    };
+    const state = selectionRepository([failed]);
+    configureRetrySource(state, failed, {
+      trainId: 'failed-for-another-selection',
+      productionSelectionId: 'different-selection',
+      operations: [
+        {
+          id: 'failed-preflight',
+          operation_type: 'PREPARE_ARTIFACT_BACKEND',
+          status: 'FAILED',
+          external_id: '203'
+        }
+      ]
+    });
+    const service = new ReleaseBusV2Service(state.repository as never);
+
+    await expect(
+      service.markSelectionReadyForProduction(
+        [
+          {
+            candidateId: failed.id,
+            expectedHeadSha: failed.head_sha,
+            expectedRowVersion: failed.row_version
+          }
+        ],
+        'operator'
+      )
+    ).rejects.toThrow(
+      'Failed candidate retry source does not match its exact selection and staging evidence'
+    );
+    expect(mockResolveRef).not.toHaveBeenCalled();
+  });
+
+  it('atomically mixes a normal validated candidate with one exact pre-main retry', async () => {
+    const normal = validatedCandidate(
+      'candidate-normal-selection',
+      'frontend',
+      'a',
+      117
+    );
+    const failed = {
+      ...validatedCandidate('candidate-retry-selection', 'backend', 'b', 118),
+      status: 'FAILED' as const,
+      production_requested_at: 10,
+      production_requested_by: 'operator',
+      production_selection_id: 'mixed-failed-selection'
+    };
+    const state = selectionRepository([normal, failed]);
+    const failedTrain = configureRetrySource(state, failed, {
+      trainId: 'failed-mixed-selection-train',
+      operations: [
+        {
+          id: 'failed-preflight',
+          operation_type: 'PREPARE_ARTIFACT_BACKEND',
+          status: 'FAILED',
+          external_id: '202'
+        }
+      ]
+    });
+    mockResolveRef.mockImplementation(
+      async (_repository: string, branch: string) =>
+        [normal, failed].find((item) => item.branch_name === branch)?.head_sha
+    );
+    const service = new ReleaseBusV2Service(state.repository as never);
+
+    const selected = await service.markSelectionReadyForProduction(
+      [normal, failed].map((item) => ({
+        candidateId: item.id,
+        expectedHeadSha: item.head_sha,
+        expectedRowVersion: item.row_version
+      })),
+      'operator'
+    );
+
+    expect(
+      selected
+        .map(({ id }) => id)
+        .sort((left, right) => left.localeCompare(right))
+    ).toEqual(
+      [normal.id, failed.id].sort((left, right) => left.localeCompare(right))
+    );
+    expect(state.appendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: 'PRODUCTION_SELECTION_READY',
+        payload: expect.objectContaining({
+          retry_sources: [
+            {
+              candidate_id: failed.id,
+              failed_train_id: failedTrain.id
+            }
+          ]
+        })
+      }),
+      expect.anything()
+    );
   });
 
   it('atomically selects A+C from independently validated A+B+C and preserves B', async () => {

--- a/src/releaseBusV2/release-bus-v2.service.ts
+++ b/src/releaseBusV2/release-bus-v2.service.ts
@@ -49,6 +49,12 @@ const TERMINAL_TRAIN_STATUSES = new Set([
 const TERMINAL_OPERATION_STATUSES = new Set<
   ReleaseBusV2OperationRecord['status']
 >(['SUCCEEDED', 'FAILED', 'CANCELLED']);
+const PRE_MAIN_PRODUCTION_OPERATION_TYPES = new Set([
+  'COMPOSE_BACKEND',
+  'COMPOSE_FRONTEND',
+  'PREPARE_ARTIFACT_BACKEND',
+  'PREPARE_ARTIFACT_FRONTEND'
+]);
 const REQUIRED_MAINTENANCE_LOCKS = new Set([
   'scheduler',
   'staging-environment',
@@ -314,7 +320,8 @@ export class ReleaseBusV2Service {
       );
     const train = await this.repository.findLatestProductionTrainForCandidate(
       candidate.id,
-      ctx
+      ctx,
+      Boolean(ctx.connection)
     );
     if (
       !train ||
@@ -327,16 +334,56 @@ export class ReleaseBusV2Service {
         'CONFLICT',
         'Failed candidate is not eligible for an exact pre-main production retry'
       );
-    const operations = await this.repository.listOperations(train.id, ctx);
+    const evidence =
+      parseStoredJson<readonly ReleaseBusV2CandidateStagingEvidence[]>(
+        train.qualification_evidence_json
+      ) ?? [];
+    const exactEvidence = evidence.filter(
+      (item) =>
+        item.candidate_id === candidate.id &&
+        item.repository === candidate.repository &&
+        item.pr_number === candidate.pr_number &&
+        item.head_sha === candidate.head_sha &&
+        item.staging_train_id === candidate.staging_validated_train_id &&
+        item.staging_manifest_id === candidate.staging_validated_manifest_id
+    );
+    const claimEvents = (
+      await this.repository.listEvents(
+        train.id,
+        200,
+        ctx,
+        Boolean(ctx.connection)
+      )
+    ).filter(({ event_type }) => event_type === 'TRAIN_CLAIMED');
+    const claim = parseStoredJson<{
+      readonly candidate_ids?: readonly string[];
+      readonly production_selection_id?: string;
+    }>(claimEvents.length === 1 ? claimEvents[0]?.payload_json : null);
+    if (
+      exactEvidence.length !== 1 ||
+      claim?.production_selection_id !== candidate.production_selection_id ||
+      !claim.candidate_ids?.includes(candidate.id)
+    )
+      throw new ReleaseBusV2ProductionSelectionError(
+        'CONFLICT',
+        'Failed candidate retry source does not match its exact selection and staging evidence'
+      );
+    const operations = await this.repository.listOperations(
+      train.id,
+      ctx,
+      Boolean(ctx.connection)
+    );
     const failedPreflight = operations.some(
       (operation) =>
         operation.operation_type.startsWith('PREPARE_ARTIFACT_') &&
         operation.status === 'FAILED'
     );
-    const productionRefMutationStarted = operations.some((operation) =>
-      operation.operation_type.startsWith('ADVANCE_MAIN_')
+    const onlyTerminalPreMainOperations = operations.every(
+      (operation) =>
+        PRE_MAIN_PRODUCTION_OPERATION_TYPES.has(operation.operation_type) &&
+        TERMINAL_OPERATION_STATUSES.has(operation.status)
     );
-    if (!failedPreflight || productionRefMutationStarted)
+    if (!failedPreflight || !onlyTerminalPreMainOperations)
       throw new ReleaseBusV2ProductionSelectionError(
         'CONFLICT',
         'Failed candidate is not eligible for an exact pre-main production retry'
@@ -809,12 +856,12 @@ export class ReleaseBusV2Service {
               qualification_policy: CANDIDATE_STAGING_EVIDENCE_POLICY,
               candidate_ids: locked.map(({ id }) => id),
               candidate_evidence: evidence,
-              retry_sources: locked
-                .filter(({ id }) => retrySourceByCandidateId.has(id))
-                .map(({ id }) => ({
-                  candidate_id: id,
-                  failed_train_id: retrySourceByCandidateId.get(id)
-                }))
+              retry_sources: locked.flatMap(({ id }) => {
+                const failedTrainId = retrySourceByCandidateId.get(id);
+                return failedTrainId
+                  ? [{ candidate_id: id, failed_train_id: failedTrainId }]
+                  : [];
+              })
             }
           },
           ctx

--- a/src/releaseBusV2/release-bus-v2.service.ts
+++ b/src/releaseBusV2/release-bus-v2.service.ts
@@ -297,6 +297,53 @@ export class ReleaseBusV2Service {
     private readonly repository: ReleaseBusV2RepositoryClass = releaseBusV2Repository
   ) {}
 
+  private async resolvePreMainProductionRetrySource(
+    candidate: ReleaseBusV2CandidateRecord,
+    ctx: RequestContext
+  ): Promise<string | null> {
+    if (candidate.status === 'STAGING_VALIDATED') return null;
+    if (
+      candidate.status !== 'FAILED' ||
+      candidate.current_train_id !== null ||
+      candidate.production_selection_id === null ||
+      candidate.production_selection_id === undefined
+    )
+      throw new ReleaseBusV2ProductionSelectionError(
+        'CONFLICT',
+        'The exact candidate SHA is not staging validated'
+      );
+    const train = await this.repository.findLatestProductionTrainForCandidate(
+      candidate.id,
+      ctx
+    );
+    if (
+      !train ||
+      train.status !== 'FAILED' ||
+      train.completed_at === null ||
+      train.failure_class !== 'CANDIDATE' ||
+      train.qualification_policy !== CANDIDATE_STAGING_EVIDENCE_POLICY
+    )
+      throw new ReleaseBusV2ProductionSelectionError(
+        'CONFLICT',
+        'Failed candidate is not eligible for an exact pre-main production retry'
+      );
+    const operations = await this.repository.listOperations(train.id, ctx);
+    const failedPreflight = operations.some(
+      (operation) =>
+        operation.operation_type.startsWith('PREPARE_ARTIFACT_') &&
+        operation.status === 'FAILED'
+    );
+    const productionRefMutationStarted = operations.some((operation) =>
+      operation.operation_type.startsWith('ADVANCE_MAIN_')
+    );
+    if (!failedPreflight || productionRefMutationStarted)
+      throw new ReleaseBusV2ProductionSelectionError(
+        'CONFLICT',
+        'Failed candidate is not eligible for an exact pre-main production retry'
+      );
+    return train.id;
+  }
+
   public async register(
     input: ReleaseBusV2RegisterInput,
     actor: string
@@ -614,14 +661,12 @@ export class ReleaseBusV2Service {
           'CONFLICT',
           'Candidate changed; refresh before marking production ready'
         );
-      if (
-        candidate.status !== 'STAGING_VALIDATED' ||
-        candidate.superseded_at !== null
-      )
+      if (candidate.superseded_at !== null)
         throw new ReleaseBusV2ProductionSelectionError(
           'CONFLICT',
           'The exact candidate SHA is not staging validated'
         );
+      await this.resolvePreMainProductionRetrySource(candidate, {});
       if (candidate.head_sha !== expected.expectedHeadSha.toLowerCase())
         throw new ReleaseBusV2ProductionSelectionError(
           'CONFLICT',
@@ -649,6 +694,7 @@ export class ReleaseBusV2Service {
       async (connection) => {
         const ctx: RequestContext = { connection };
         const locked: ReleaseBusV2CandidateRecord[] = [];
+        const retrySourceByCandidateId = new Map<string, string>();
         const orderedIds = Array.from(selectedIds).sort((left, right) =>
           left.localeCompare(right)
         );
@@ -690,7 +736,6 @@ export class ReleaseBusV2Service {
               'Candidate changed; refresh before marking production ready'
             );
           if (
-            candidate.status !== 'STAGING_VALIDATED' ||
             !candidate.staging_validated_manifest_id ||
             candidate.superseded_at !== null
           )
@@ -698,6 +743,12 @@ export class ReleaseBusV2Service {
               'CONFLICT',
               'The exact candidate SHA is not staging validated'
             );
+          const retrySource = await this.resolvePreMainProductionRetrySource(
+            candidate,
+            ctx
+          );
+          if (retrySource)
+            retrySourceByCandidateId.set(candidate.id, retrySource);
           if (candidate.head_sha !== expected.expectedHeadSha.toLowerCase())
             throw new ReleaseBusV2ProductionSelectionError(
               'CONFLICT',
@@ -757,7 +808,13 @@ export class ReleaseBusV2Service {
               production_selection_id: selectionId,
               qualification_policy: CANDIDATE_STAGING_EVIDENCE_POLICY,
               candidate_ids: locked.map(({ id }) => id),
-              candidate_evidence: evidence
+              candidate_evidence: evidence,
+              retry_sources: locked
+                .filter(({ id }) => retrySourceByCandidateId.has(id))
+                .map(({ id }) => ({
+                  candidate_id: id,
+                  failed_train_id: retrySourceByCandidateId.get(id)
+                }))
             }
           },
           ctx
@@ -772,6 +829,8 @@ export class ReleaseBusV2Service {
                 head_sha: candidate.head_sha,
                 production_selection_id: selectionId,
                 qualification_policy: CANDIDATE_STAGING_EVIDENCE_POLICY,
+                retry_source_train_id:
+                  retrySourceByCandidateId.get(candidate.id) ?? null,
                 staging_evidence: evidence.find(
                   ({ candidate_id }) => candidate_id === candidate.id
                 )
@@ -779,6 +838,27 @@ export class ReleaseBusV2Service {
             },
             ctx
           );
+        for (const candidate of locked) {
+          const failedTrainId = retrySourceByCandidateId.get(candidate.id);
+          if (!failedTrainId) continue;
+          await this.repository.appendEvent(
+            {
+              candidateId: candidate.id,
+              eventType: 'CANDIDATE_PRE_MAIN_PRODUCTION_RETRY_READY',
+              actor,
+              payload: {
+                failed_train_id: failedTrainId,
+                head_sha: candidate.head_sha,
+                production_selection_id: selectionId,
+                qualification_policy: CANDIDATE_STAGING_EVIDENCE_POLICY,
+                staging_evidence: evidence.find(
+                  ({ candidate_id }) => candidate_id === candidate.id
+                )
+              }
+            },
+            ctx
+          );
+        }
         const updated: ReleaseBusV2CandidateRecord[] = [];
         for (const candidate of locked) {
           const current = await this.repository.findCandidateById(

--- a/src/releaseBusV2/release-bus-v2.service.ts
+++ b/src/releaseBusV2/release-bus-v2.service.ts
@@ -347,26 +347,10 @@ export class ReleaseBusV2Service {
         item.staging_train_id === candidate.staging_validated_train_id &&
         item.staging_manifest_id === candidate.staging_validated_manifest_id
     );
-    const claimEvents = (
-      await this.repository.listEvents(
-        train.id,
-        200,
-        ctx,
-        Boolean(ctx.connection)
-      )
-    ).filter(({ event_type }) => event_type === 'TRAIN_CLAIMED');
-    const claim = parseStoredJson<{
-      readonly candidate_ids?: readonly string[];
-      readonly production_selection_id?: string;
-    }>(claimEvents.length === 1 ? claimEvents[0]?.payload_json : null);
-    if (
-      exactEvidence.length !== 1 ||
-      claim?.production_selection_id !== candidate.production_selection_id ||
-      !claim.candidate_ids?.includes(candidate.id)
-    )
+    if (exactEvidence.length !== 1)
       throw new ReleaseBusV2ProductionSelectionError(
         'CONFLICT',
-        'Failed candidate retry source does not match its exact selection and staging evidence'
+        'Failed candidate retry source does not match its exact staging evidence'
       );
     const operations = await this.repository.listOperations(
       train.id,
@@ -383,7 +367,11 @@ export class ReleaseBusV2Service {
         PRE_MAIN_PRODUCTION_OPERATION_TYPES.has(operation.operation_type) &&
         TERMINAL_OPERATION_STATUSES.has(operation.status)
     );
-    if (!failedPreflight || !onlyTerminalPreMainOperations)
+    if (
+      operations.length === 0 ||
+      !failedPreflight ||
+      !onlyTerminalPreMainOperations
+    )
       throw new ReleaseBusV2ProductionSelectionError(
         'CONFLICT',
         'Failed candidate is not eligible for an exact pre-main production retry'
@@ -766,6 +754,10 @@ export class ReleaseBusV2Service {
             candidateId,
             await this.repository.findCandidateById(candidateId, ctx, true)
           );
+        // The exact candidate rows remain locked until the new selection is
+        // committed. A production claim must change one of those rows from a
+        // ready state while holding the scheduler lease, so no newer train can
+        // include a FAILED retry candidate between this lookup and its update.
         for (const selectedId of orderedIds) {
           const candidate = lockedById.get(selectedId) ?? null;
           if (!candidate)


### PR DESCRIPTION
## Summary
- fix the latent current-main Prettier violation that blocked immutable production preflight
- permit a new explicit exact-SHA production selection only after a terminal candidate-evidence preflight failure that created no ADVANCE_MAIN operation
- revalidate unchanged branch and exact staging train/manifest/E2E evidence, issue a new selection identity, and audit the failed source train
- keep post-main or ambiguous ref-mutation failures non-retryable

## Safety
- no schema migration
- no implicit retry: the operator must submit a new exact production selection
- any ADVANCE_MAIN operation, changed head, supersession, missing evidence, non-candidate failure, or nonterminal train fails closed
- production remains paused during rollout

## Tests
- npm test -- --runInBand src/releaseBusV2/release-bus-v2.service.test.ts (24 passed)
- npm test -- --runInBand src/releaseBusV2 (passed)
- npm run lint
- npm run format -- --check
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for retrying eligible production candidates after certain immutable-artifact preflight failures.
  * Retries require unchanged, validated staging evidence and a precise candidate selection.
  * Production selection events now record retry source details for improved traceability.

* **Bug Fixes**
  * Prevented retries when candidates have conflicting, incomplete, active, or otherwise ineligible production operations.
  * Ensured production selection and retry handling remain atomic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->