### PR TITLE
Fix Release Bus qualification manifest status persistence

### DIFF
--- a/migrations/20260727203000-widen-release-bus-v2-manifest-status.js
+++ b/migrations/20260727203000-widen-release-bus-v2-manifest-status.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const TRUNCATED_CANDIDATE_EVIDENCE_STATUS =
+  'PRODUCTION_CANDIDATE_EVIDENCE_QU';
+const CANDIDATE_EVIDENCE_STATUS =
+  'PRODUCTION_CANDIDATE_EVIDENCE_QUALIFIED';
+
+exports.up = function (db) {
+  return db
+    .runSql(
+      // The table is utf8mb4. Keep the widened column below the 255-byte
+      // one-byte length-prefix boundary so MySQL can apply this online.
+      'ALTER TABLE release_bus_v2_manifests MODIFY COLUMN status varchar(48) NOT NULL, ALGORITHM=INPLACE, LOCK=NONE'
+    )
+    .then(function () {
+      return db.runSql(
+        `UPDATE release_bus_v2_manifests
+         SET status = '${CANDIDATE_EVIDENCE_STATUS}',
+             updated_at = UNIX_TIMESTAMP(CURRENT_TIMESTAMP(3)) * 1000
+         WHERE status = '${TRUNCATED_CANDIDATE_EVIDENCE_STATUS}'
+           AND JSON_UNQUOTE(JSON_EXTRACT(manifest_json, '$.scope')) =
+             'production-candidate-evidence-qualification'
+           AND JSON_UNQUOTE(JSON_EXTRACT(manifest_json, '$.qualification_policy')) =
+             'CANDIDATE_STAGING_EVIDENCE_V1'`
+      );
+    })
+    .then(function (result) {
+      var repaired =
+        result && Number.isInteger(result.affectedRows)
+          ? result.affectedRows
+          : 'unknown';
+      console.info(
+        `[release-bus-v2] repaired ${repaired} truncated candidate-evidence qualification manifest status row(s)`
+      );
+    });
+};
+
+exports.down = function () {
+  // Intentionally non-destructive. Narrowing would truncate durable audit
+  // state, and the widened column remains compatible with older workers.
+  return Promise.resolve();
+};
+
+exports._meta = { version: 1 };

--- a/src/entities/IReleaseBusV2.ts
+++ b/src/entities/IReleaseBusV2.ts
@@ -254,7 +254,7 @@ export class ReleaseBusV2ManifestEntity {
   @Column({ type: 'varchar', length: 36 }) readonly train_id!: string;
   @Column({ type: 'varchar', length: 32 }) readonly lane!: ReleaseBusV2Lane;
   @Column({ type: 'char', length: 64 }) readonly identity_sha256!: string;
-  @Column({ type: 'varchar', length: 32 })
+  @Column({ type: 'varchar', length: 48 })
   readonly status!: ReleaseBusV2ManifestStatus;
   @Column({ type: 'char', length: 40, nullable: true, default: null })
   readonly frontend_sha!: string | null;

--- a/src/releaseBusV2/release-bus-v2-manifest-status-migration.test.ts
+++ b/src/releaseBusV2/release-bus-v2-manifest-status-migration.test.ts
@@ -1,0 +1,45 @@
+import path from 'node:path';
+
+describe('Release Bus v2 manifest status width migration', () => {
+  it('widens online before precisely repairing candidate-evidence manifests', async () => {
+    const migration = require(
+      path.resolve(
+        process.cwd(),
+        'migrations/20260727203000-widen-release-bus-v2-manifest-status.js'
+      )
+    ) as {
+      up: (db: { runSql: (sql: string) => Promise<unknown> }) => Promise<void>;
+      down: () => Promise<void>;
+    };
+    const statements: string[] = [];
+    const log = jest.spyOn(console, 'info').mockImplementation();
+    await migration.up({
+      runSql: async (sql: string) => {
+        statements.push(sql);
+        return sql.startsWith('UPDATE') ? { affectedRows: 1 } : [];
+      }
+    });
+
+    expect(statements).toHaveLength(2);
+    expect(statements[0]).toContain(
+      'MODIFY COLUMN status varchar(48) NOT NULL'
+    );
+    expect(statements[0]).toContain('ALGORITHM=INPLACE');
+    expect(statements[0]).toContain('LOCK=NONE');
+    expect(statements[1]).toContain(
+      "SET status = 'PRODUCTION_CANDIDATE_EVIDENCE_QUALIFIED'"
+    );
+    expect(statements[1]).toContain(
+      "WHERE status = 'PRODUCTION_CANDIDATE_EVIDENCE_QU'"
+    );
+    expect(statements[1]).toContain(
+      "'production-candidate-evidence-qualification'"
+    );
+    expect(statements[1]).toContain("'CANDIDATE_STAGING_EVIDENCE_V1'");
+    expect(log).toHaveBeenCalledWith(
+      '[release-bus-v2] repaired 1 truncated candidate-evidence qualification manifest status row(s)'
+    );
+    log.mockRestore();
+    await expect(migration.down()).resolves.toBeUndefined();
+  });
+});

--- a/src/releaseBusV2/release-bus-v2.repository.integration.test.ts
+++ b/src/releaseBusV2/release-bus-v2.repository.integration.test.ts
@@ -2,11 +2,14 @@ import 'reflect-metadata';
 import {
   RELEASE_BUS_V2_CONTROLS_TABLE,
   RELEASE_BUS_V2_LOCKS_TABLE,
+  RELEASE_BUS_V2_MANIFESTS_TABLE,
   RELEASE_BUS_V2_STAGING_STATE_TABLE
 } from '@/constants';
 import { ReleaseBusV2Repository } from '@/releaseBusV2/release-bus-v2.repository';
 import { ReleaseBusV2Service } from '@/releaseBusV2/release-bus-v2.service';
+import { dbSupplier } from '@/sql-executor';
 import { describeWithSeed } from '@/tests/_setup/seed';
+import path from 'node:path';
 
 jest.mock('@/releaseBusV2/release-bus-v2.github-app', () => ({
   releaseBusGitHubApp: {
@@ -755,6 +758,62 @@ describeWithSeed(
           staging_live_manifest_id: manifest.id
         })
       ]);
+    });
+
+    it('round-trips the full candidate-evidence qualification manifest status', async () => {
+      const manifest = await repository.createManifest(
+        {
+          train_id: 'candidate-evidence-train',
+          lane: 'PRODUCTION',
+          identity_sha256: 'e'.repeat(64),
+          status: 'PRODUCTION_CANDIDATE_EVIDENCE_QUALIFIED',
+          frontend_sha: SHA_A,
+          backend_sha: SHA_C,
+          frontend_artifact_digest: null,
+          backend_artifact_digest: null,
+          e2e_run_id: null,
+          manifest_json: {
+            schema_version: 2,
+            scope: 'production-candidate-evidence-qualification',
+            qualification_policy: 'CANDIDATE_STAGING_EVIDENCE_V1'
+          },
+          deployed_at: null,
+          validated_at: null
+        },
+        {}
+      );
+
+      await expect(repository.findManifest(manifest.id, {})).resolves.toEqual(
+        expect.objectContaining({
+          status: 'PRODUCTION_CANDIDATE_EVIDENCE_QUALIFIED'
+        })
+      );
+
+      await dbSupplier().execute(
+        `update ${RELEASE_BUS_V2_MANIFESTS_TABLE}
+         set status = 'PRODUCTION_CANDIDATE_EVIDENCE_QU'
+         where id = :id`,
+        { id: manifest.id }
+      );
+      const migration = require(
+        path.resolve(
+          process.cwd(),
+          'migrations/20260727203000-widen-release-bus-v2-manifest-status.js'
+        )
+      ) as {
+        up: (db: {
+          runSql: (sql: string) => Promise<unknown>;
+        }) => Promise<void>;
+      };
+      await migration.up({
+        runSql: async (sql: string) => dbSupplier().execute(sql)
+      });
+
+      await expect(repository.findManifest(manifest.id, {})).resolves.toEqual(
+        expect.objectContaining({
+          status: 'PRODUCTION_CANDIDATE_EVIDENCE_QUALIFIED'
+        })
+      );
     });
 
     it('atomically removes every candidate in a multi-candidate transition set', async () => {


### PR DESCRIPTION
## What changed

- widen `release_bus_v2_manifests.status` from 32 to 48 characters with an online, non-blocking schema migration that stays below utf8mb4's row-length-prefix boundary
- precisely repair only truncated rows whose immutable manifest JSON identifies the candidate-evidence qualification policy, and log the affected row count
- align the TypeORM entity schema with the durable database schema
- add migration-contract and real-database regressions, including a truncated-row-to-repaired-row migration

## Why

The candidate-evidence production beta completed successfully, but its 39-character qualification manifest status was stored as `PRODUCTION_CANDIDATE_EVIDENCE_QU` by the original `varchar(32)` column. The train, immutable manifest JSON, qualification evidence, and durable event remained intact, but the manifest API/UI status was false and future production trains would repeat the defect.

PRODUCTION automation is paused while this hotfix is reviewed and deployed. ALL and STAGING remain RUNNING.

## Validation

- focused migration + database integration tests — 18/18 passed
- `npm run lint` — passed
- full build and required GitHub CI will run on the exact final head
