### PR TITLE
Repair Release Bus manifest status ledger

### DIFF
--- a/migrations/20260727211500-repair-release-bus-v2-manifest-status-ledger.js
+++ b/migrations/20260727211500-repair-release-bus-v2-manifest-status-ledger.js
@@ -1,0 +1,277 @@
+'use strict';
+
+const TRUNCATED_CANDIDATE_EVIDENCE_STATUS =
+  'PRODUCTION_CANDIDATE_EVIDENCE_QU';
+
+function affectedRows(result) {
+  return result && Number.isInteger(result.affectedRows)
+    ? result.affectedRows
+    : 'unknown';
+}
+
+function repair(db, label, sql) {
+  return db.runSql(sql).then(function (result) {
+    console.info(
+      `[release-bus-v2] restored ${affectedRows(result)} ${label} manifest status row(s)`
+    );
+  });
+}
+
+function selectRows(db, sql) {
+  return new Promise(function (resolve, reject) {
+    db.all(sql, function (error, rows) {
+      if (error) reject(error);
+      else resolve(rows);
+    });
+  });
+}
+
+function countedRows(result, column, purpose) {
+  const value = Array.isArray(result) ? result[0]?.[column] : undefined;
+  const count = Number(value);
+  if (!Number.isInteger(count) || count < 0)
+    throw new Error(
+      `Release Bus v2 manifest status repair could not verify the ${purpose} row count`
+    );
+  return count;
+}
+
+exports.up = function (db) {
+  // db-migrate-mysql wraps this migration in one transaction. This preflight
+  // also rejects contradictory or unknown evidence before the first update.
+  return selectRows(
+    db,
+      `SELECT COUNT(*) AS unclassified
+       FROM release_bus_v2_manifests manifest
+       WHERE manifest.status IN ('', '${TRUNCATED_CANDIDATE_EVIDENCE_STATUS}')
+         AND NOT (
+           (
+             JSON_UNQUOTE(JSON_EXTRACT(manifest.manifest_json, '$.scope')) =
+               'production-candidate-evidence-qualification'
+             AND JSON_UNQUOTE(JSON_EXTRACT(manifest.manifest_json, '$.qualification_policy')) =
+               'CANDIDATE_STAGING_EVIDENCE_V1'
+           )
+           OR (
+             manifest.status = ''
+             AND manifest.lane = 'PRODUCTION'
+             AND JSON_UNQUOTE(JSON_EXTRACT(manifest.manifest_json, '$.scope')) =
+               'production'
+           )
+           OR (
+             manifest.status = ''
+             AND manifest.lane IN ('STAGING', 'PRODUCTION_QUALIFICATION')
+             AND JSON_UNQUOTE(JSON_EXTRACT(manifest.manifest_json, '$.scope')) =
+               'staging'
+             AND (
+               (
+                 manifest.validated_at IS NULL
+                 AND EXISTS (
+                   SELECT 1
+                   FROM release_bus_v2_events failure_event
+                   WHERE failure_event.train_id = manifest.train_id
+                     AND failure_event.event_type IN (
+                       'STAGING_FINAL_FENCE_MISSING',
+                       'BETA_STAGING_FINAL_FENCE_MISSING',
+                       'STAGING_FINAL_FENCE_VIOLATED',
+                       'BETA_STAGING_FINAL_FENCE_VIOLATED',
+                       'CUMULATIVE_STAGING_ROLLBACK_STARTED'
+                     )
+                 )
+               )
+               OR (
+                 manifest.validated_at IS NOT NULL
+                 AND NOT EXISTS (
+                   SELECT 1
+                   FROM release_bus_v2_events failure_event
+                   WHERE failure_event.train_id = manifest.train_id
+                     AND failure_event.event_type IN (
+                       'STAGING_FINAL_FENCE_MISSING',
+                       'BETA_STAGING_FINAL_FENCE_MISSING',
+                       'STAGING_FINAL_FENCE_VIOLATED',
+                       'BETA_STAGING_FINAL_FENCE_VIOLATED',
+                       'CUMULATIVE_STAGING_ROLLBACK_STARTED'
+                     )
+                 )
+               )
+               OR (
+                 manifest.validated_at IS NULL
+                 AND EXISTS (
+                   SELECT 1
+                   FROM release_bus_v2_events deployed_event
+                   WHERE deployed_event.train_id = manifest.train_id
+                     AND deployed_event.event_type = 'TRAIN_STAGING_DEPLOYED'
+                 )
+                 AND NOT EXISTS (
+                   SELECT 1
+                   FROM release_bus_v2_events failure_event
+                   WHERE failure_event.train_id = manifest.train_id
+                     AND failure_event.event_type IN (
+                       'STAGING_FINAL_FENCE_MISSING',
+                       'BETA_STAGING_FINAL_FENCE_MISSING',
+                       'STAGING_FINAL_FENCE_VIOLATED',
+                       'BETA_STAGING_FINAL_FENCE_VIOLATED',
+                       'CUMULATIVE_STAGING_ROLLBACK_STARTED'
+                     )
+                 )
+               )
+             )
+           )
+         )`
+  )
+    .then(function (result) {
+      const unclassified = countedRows(
+        result,
+        'unclassified',
+        'preflight unclassified'
+      );
+      console.info(
+        `[release-bus-v2] manifest status ledger repair found ${unclassified} unclassified row(s) before mutation`
+      );
+      if (unclassified !== 0)
+        throw new Error(
+          `Release Bus v2 manifest status repair found ${unclassified} unclassified row(s) before mutation`
+        );
+    })
+    .then(function () {
+      return repair(
+        db,
+        'candidate-evidence qualification',
+        `UPDATE release_bus_v2_manifests
+     SET status = 'PRODUCTION_CANDIDATE_EVIDENCE_QUALIFIED',
+         updated_at = UNIX_TIMESTAMP(CURRENT_TIMESTAMP(3)) * 1000
+     WHERE status IN ('', '${TRUNCATED_CANDIDATE_EVIDENCE_STATUS}')
+       AND JSON_UNQUOTE(JSON_EXTRACT(manifest_json, '$.scope')) =
+         'production-candidate-evidence-qualification'
+       AND JSON_UNQUOTE(JSON_EXTRACT(manifest_json, '$.qualification_policy')) =
+         'CANDIDATE_STAGING_EVIDENCE_V1'`
+      );
+    })
+    .then(function () {
+      return repair(
+        db,
+        'production-deployed',
+        `UPDATE release_bus_v2_manifests
+         SET status = 'PRODUCTION_DEPLOYED',
+             updated_at = UNIX_TIMESTAMP(CURRENT_TIMESTAMP(3)) * 1000
+         WHERE status = ''
+           AND lane = 'PRODUCTION'
+           AND JSON_UNQUOTE(JSON_EXTRACT(manifest_json, '$.scope')) =
+             'production'`
+      );
+    })
+    .then(function () {
+      return repair(
+        db,
+        'failed staging',
+        `UPDATE release_bus_v2_manifests manifest
+         SET manifest.status = 'FAILED',
+             manifest.updated_at = UNIX_TIMESTAMP(CURRENT_TIMESTAMP(3)) * 1000
+         WHERE manifest.status = ''
+           AND manifest.lane IN ('STAGING', 'PRODUCTION_QUALIFICATION')
+           AND manifest.validated_at IS NULL
+           AND JSON_UNQUOTE(JSON_EXTRACT(manifest.manifest_json, '$.scope')) =
+             'staging'
+           AND EXISTS (
+             SELECT 1
+             FROM release_bus_v2_events event
+             WHERE event.train_id = manifest.train_id
+               AND event.event_type IN (
+                 'STAGING_FINAL_FENCE_MISSING',
+                 'BETA_STAGING_FINAL_FENCE_MISSING',
+                 'STAGING_FINAL_FENCE_VIOLATED',
+                 'BETA_STAGING_FINAL_FENCE_VIOLATED',
+                 'CUMULATIVE_STAGING_ROLLBACK_STARTED'
+               )
+           )`
+      );
+    })
+    .then(function () {
+      return repair(
+        db,
+        'staging-validated',
+        `UPDATE release_bus_v2_manifests
+         SET status = 'STAGING_VALIDATED',
+             updated_at = UNIX_TIMESTAMP(CURRENT_TIMESTAMP(3)) * 1000
+         WHERE status = ''
+           AND lane IN ('STAGING', 'PRODUCTION_QUALIFICATION')
+           AND validated_at IS NOT NULL
+           AND JSON_UNQUOTE(JSON_EXTRACT(manifest_json, '$.scope')) =
+             'staging'
+           AND NOT EXISTS (
+             SELECT 1
+             FROM release_bus_v2_events event
+             WHERE event.train_id = release_bus_v2_manifests.train_id
+               AND event.event_type IN (
+                 'STAGING_FINAL_FENCE_MISSING',
+                 'BETA_STAGING_FINAL_FENCE_MISSING',
+                 'STAGING_FINAL_FENCE_VIOLATED',
+                 'BETA_STAGING_FINAL_FENCE_VIOLATED',
+                 'CUMULATIVE_STAGING_ROLLBACK_STARTED'
+               )
+           )`
+      );
+    })
+    .then(function () {
+      return repair(
+        db,
+        'staging-deployed',
+        `UPDATE release_bus_v2_manifests manifest
+         SET manifest.status = 'STAGING_DEPLOYED',
+             manifest.updated_at = UNIX_TIMESTAMP(CURRENT_TIMESTAMP(3)) * 1000
+         WHERE manifest.status = ''
+           AND manifest.lane IN ('STAGING', 'PRODUCTION_QUALIFICATION')
+           AND manifest.validated_at IS NULL
+           AND JSON_UNQUOTE(JSON_EXTRACT(manifest.manifest_json, '$.scope')) =
+             'staging'
+           AND EXISTS (
+             SELECT 1
+             FROM release_bus_v2_events event
+             WHERE event.train_id = manifest.train_id
+               AND event.event_type = 'TRAIN_STAGING_DEPLOYED'
+           )
+           AND NOT EXISTS (
+             SELECT 1
+             FROM release_bus_v2_events failure_event
+             WHERE failure_event.train_id = manifest.train_id
+               AND failure_event.event_type IN (
+                 'STAGING_FINAL_FENCE_MISSING',
+                 'BETA_STAGING_FINAL_FENCE_MISSING',
+                 'STAGING_FINAL_FENCE_VIOLATED',
+                 'BETA_STAGING_FINAL_FENCE_VIOLATED',
+                 'CUMULATIVE_STAGING_ROLLBACK_STARTED'
+               )
+           )`
+      );
+    })
+    .then(function () {
+      return selectRows(
+        db,
+        `SELECT COUNT(*) AS remaining
+         FROM release_bus_v2_manifests
+         WHERE status = ''
+            OR status = '${TRUNCATED_CANDIDATE_EVIDENCE_STATUS}'`
+      );
+    })
+    .then(function (result) {
+      const remaining = countedRows(
+        result,
+        'remaining',
+        'remaining invalid'
+      );
+      console.info(
+        `[release-bus-v2] manifest status ledger repair left ${remaining} invalid row(s)`
+      );
+      if (remaining !== 0)
+        throw new Error(
+          `Release Bus v2 manifest status repair left ${remaining} unclassified row(s)`
+        );
+    });
+};
+
+exports.down = function () {
+  // Intentionally non-destructive. Restored immutable lifecycle status must
+  // survive an application rollback.
+  return Promise.resolve();
+};
+
+exports._meta = { version: 1 };

--- a/src/releaseBusV2/release-bus-v2-manifest-status-ledger-repair-migration.test.ts
+++ b/src/releaseBusV2/release-bus-v2-manifest-status-ledger-repair-migration.test.ts
@@ -1,0 +1,121 @@
+import path from 'node:path';
+
+type MigrationDb = {
+  runSql: (sql: string) => Promise<unknown>;
+  all: (
+    sql: string,
+    callback: (error: Error | null, rows?: unknown[]) => void
+  ) => void;
+};
+
+function loadMigration() {
+  return require(
+    path.resolve(
+      process.cwd(),
+      'migrations/20260727211500-repair-release-bus-v2-manifest-status-ledger.js'
+    )
+  ) as {
+    up: (db: MigrationDb) => Promise<void>;
+    down: () => Promise<void>;
+  };
+}
+
+describe('Release Bus v2 manifest status ledger repair migration', () => {
+  it('restores every lifecycle class and verifies no invalid row remains', async () => {
+    const migration = loadMigration();
+    const statements: string[] = [];
+    const log = jest.spyOn(console, 'info').mockImplementation();
+    await migration.up({
+      runSql: async (sql: string) => {
+        statements.push(sql);
+        return { affectedRows: 1 };
+      },
+      all: (sql, callback) => {
+        statements.push(sql);
+        callback(
+          null,
+          sql.includes('AS unclassified')
+            ? [{ unclassified: 0 }]
+            : [{ remaining: 0 }]
+        );
+      }
+    });
+
+    expect(statements).toHaveLength(7);
+    expect(statements[0]).toContain('COUNT(*) AS unclassified');
+    expect(statements[0]).toContain(
+      "deployed_event.event_type = 'TRAIN_STAGING_DEPLOYED'"
+    );
+    expect(statements[1]).toContain(
+      "status = 'PRODUCTION_CANDIDATE_EVIDENCE_QUALIFIED'"
+    );
+    expect(statements[2]).toContain("status = 'PRODUCTION_DEPLOYED'");
+    expect(statements[3]).toContain("manifest.status = 'FAILED'");
+    expect(statements[3]).toContain('manifest.validated_at IS NULL');
+    expect(statements[3]).toContain("'CUMULATIVE_STAGING_ROLLBACK_STARTED'");
+    expect(statements[4]).toContain("status = 'STAGING_VALIDATED'");
+    expect(statements[4]).toContain('AND NOT EXISTS');
+    expect(statements[5]).toContain("manifest.status = 'STAGING_DEPLOYED'");
+    expect(statements[5]).toContain(
+      "event.event_type = 'TRAIN_STAGING_DEPLOYED'"
+    );
+    expect(statements[5]).toContain(
+      'failure_event.train_id = manifest.train_id'
+    );
+    expect(statements[6]).toContain(
+      "status = 'PRODUCTION_CANDIDATE_EVIDENCE_QU'"
+    );
+    expect(log).toHaveBeenLastCalledWith(
+      '[release-bus-v2] manifest status ledger repair left 0 invalid row(s)'
+    );
+    log.mockRestore();
+    await expect(migration.down()).resolves.toBeUndefined();
+  });
+
+  it('fails closed when any blank or truncated status is unclassified', async () => {
+    const migration = loadMigration();
+    const log = jest.spyOn(console, 'info').mockImplementation();
+
+    await expect(
+      migration.up({
+        runSql: async (_sql: string) => {
+          return { affectedRows: 0 };
+        },
+        all: (sql, callback) => {
+          callback(
+            null,
+            sql.includes('AS unclassified')
+              ? [{ unclassified: 0 }]
+              : [{ remaining: 1 }]
+          );
+        }
+      })
+    ).rejects.toThrow(
+      'Release Bus v2 manifest status repair left 1 unclassified row(s)'
+    );
+    log.mockRestore();
+  });
+
+  it('fails before mutation when preflight finds contradictory evidence', async () => {
+    const migration = loadMigration();
+    const statements: string[] = [];
+    const log = jest.spyOn(console, 'info').mockImplementation();
+
+    await expect(
+      migration.up({
+        runSql: async (sql: string) => {
+          statements.push(sql);
+          return { affectedRows: 0 };
+        },
+        all: (sql, callback) => {
+          statements.push(sql);
+          callback(null, [{ unclassified: 1 }]);
+        }
+      })
+    ).rejects.toThrow(
+      'Release Bus v2 manifest status repair found 1 unclassified row(s) before mutation'
+    );
+    expect(statements).toHaveLength(1);
+    log.mockRestore();
+  });
+});

--- a/src/releaseBusV2/release-bus-v2.repository.integration.test.ts
+++ b/src/releaseBusV2/release-bus-v2.repository.integration.test.ts
@@ -816,6 +816,218 @@ describeWithSeed(
       );
     });
 
+    it('deterministically restores blank manifest lifecycle statuses', async () => {
+      const inputs = [
+        {
+          train_id: 'repair-candidate-evidence',
+          lane: 'PRODUCTION' as const,
+          identity_sha256: '1'.repeat(64),
+          status: 'PRODUCTION_CANDIDATE_EVIDENCE_QUALIFIED' as const,
+          validated_at: null,
+          manifest_json: {
+            schema_version: 2,
+            scope: 'production-candidate-evidence-qualification',
+            qualification_policy: 'CANDIDATE_STAGING_EVIDENCE_V1'
+          }
+        },
+        {
+          train_id: 'repair-production',
+          lane: 'PRODUCTION' as const,
+          identity_sha256: '2'.repeat(64),
+          status: 'PRODUCTION_DEPLOYED' as const,
+          validated_at: null,
+          manifest_json: { schema_version: 2, scope: 'production' }
+        },
+        {
+          train_id: 'repair-staging-validated',
+          lane: 'STAGING' as const,
+          identity_sha256: '3'.repeat(64),
+          status: 'STAGING_VALIDATED' as const,
+          validated_at: 2,
+          manifest_json: { schema_version: 2, scope: 'staging' }
+        },
+        {
+          train_id: 'repair-staging-deployed',
+          lane: 'PRODUCTION_QUALIFICATION' as const,
+          identity_sha256: '4'.repeat(64),
+          status: 'STAGING_DEPLOYED' as const,
+          validated_at: null,
+          manifest_json: { schema_version: 2, scope: 'staging' }
+        },
+        {
+          train_id: 'repair-staging-failed',
+          lane: 'STAGING' as const,
+          identity_sha256: '5'.repeat(64),
+          status: 'FAILED' as const,
+          validated_at: null,
+          manifest_json: { schema_version: 2, scope: 'staging' }
+        }
+      ];
+      const manifests = [];
+      for (const input of inputs) {
+        manifests.push(
+          await repository.createManifest(
+            {
+              ...input,
+              frontend_sha: SHA_A,
+              backend_sha: SHA_C,
+              frontend_artifact_digest: null,
+              backend_artifact_digest: null,
+              e2e_run_id: null,
+              deployed_at: 1
+            },
+            {}
+          )
+        );
+      }
+      await repository.appendEvent(
+        {
+          trainId: 'repair-staging-deployed',
+          eventType: 'TRAIN_STAGING_DEPLOYED'
+        },
+        {}
+      );
+      await repository.appendEvent(
+        {
+          trainId: 'repair-staging-validated',
+          eventType: 'TRAIN_STAGING_DEPLOYED'
+        },
+        {}
+      );
+      await repository.appendEvent(
+        {
+          trainId: 'repair-staging-failed',
+          eventType: 'STAGING_FINAL_FENCE_VIOLATED'
+        },
+        {}
+      );
+      for (const manifest of manifests) {
+        await dbSupplier().execute(
+          `update ${RELEASE_BUS_V2_MANIFESTS_TABLE}
+           set status = '' where id = :id`,
+          { id: manifest.id }
+        );
+      }
+      const migration = require(
+        path.resolve(
+          process.cwd(),
+          'migrations/20260727211500-repair-release-bus-v2-manifest-status-ledger.js'
+        )
+      ) as {
+        up: (db: {
+          runSql: (sql: string) => Promise<unknown>;
+          all: (
+            sql: string,
+            callback: (error: Error | null, rows?: unknown[]) => void
+          ) => void;
+        }) => Promise<void>;
+      };
+      await migration.up({
+        runSql: async (sql: string) => dbSupplier().execute(sql),
+        all: (sql, callback) => {
+          dbSupplier()
+            .execute(sql)
+            .then(
+              (rows) => callback(null, rows),
+              (error) =>
+                callback(
+                  error instanceof Error ? error : new Error(String(error))
+                )
+            );
+        }
+      });
+
+      await expect(
+        Promise.all(
+          manifests.map(async ({ id }) => {
+            const manifest = await repository.findManifest(id, {});
+            return manifest?.status;
+          })
+        )
+      ).resolves.toEqual([
+        'PRODUCTION_CANDIDATE_EVIDENCE_QUALIFIED',
+        'PRODUCTION_DEPLOYED',
+        'STAGING_VALIDATED',
+        'STAGING_DEPLOYED',
+        'FAILED'
+      ]);
+    });
+
+    it('rejects contradictory validated and failed manifest evidence', async () => {
+      const manifest = await repository.createManifest(
+        {
+          train_id: 'repair-contradictory-staging',
+          lane: 'STAGING',
+          identity_sha256: '6'.repeat(64),
+          status: 'STAGING_VALIDATED',
+          frontend_sha: SHA_A,
+          backend_sha: SHA_C,
+          frontend_artifact_digest: null,
+          backend_artifact_digest: null,
+          e2e_run_id: 'contradictory-e2e',
+          manifest_json: { schema_version: 2, scope: 'staging' },
+          deployed_at: 1,
+          validated_at: 2
+        },
+        {}
+      );
+      await repository.appendEvent(
+        {
+          trainId: manifest.train_id,
+          eventType: 'TRAIN_STAGING_DEPLOYED'
+        },
+        {}
+      );
+      await repository.appendEvent(
+        {
+          trainId: manifest.train_id,
+          eventType: 'STAGING_FINAL_FENCE_VIOLATED'
+        },
+        {}
+      );
+      await dbSupplier().execute(
+        `update ${RELEASE_BUS_V2_MANIFESTS_TABLE}
+         set status = '' where id = :id`,
+        { id: manifest.id }
+      );
+      const migration = require(
+        path.resolve(
+          process.cwd(),
+          'migrations/20260727211500-repair-release-bus-v2-manifest-status-ledger.js'
+        )
+      ) as {
+        up: (db: {
+          runSql: (sql: string) => Promise<unknown>;
+          all: (
+            sql: string,
+            callback: (error: Error | null, rows?: unknown[]) => void
+          ) => void;
+        }) => Promise<void>;
+      };
+
+      await expect(
+        migration.up({
+          runSql: async (sql: string) => dbSupplier().execute(sql),
+          all: (sql, callback) => {
+            dbSupplier()
+              .execute(sql)
+              .then(
+                (rows) => callback(null, rows),
+                (error) =>
+                  callback(
+                    error instanceof Error ? error : new Error(String(error))
+                  )
+              );
+          }
+        })
+      ).rejects.toThrow(
+        'Release Bus v2 manifest status repair found 1 unclassified row(s) before mutation'
+      );
+      await expect(repository.findManifest(manifest.id, {})).resolves.toEqual(
+        expect.objectContaining({ status: '' })
+      );
+    });
+
     it('atomically removes every candidate in a multi-candidate transition set', async () => {
       const candidates = await Promise.all([
         repository.createCandidate(


### PR DESCRIPTION
## What changed

- add a fail-closed migration that restores blank/truncated Release Bus v2 manifest statuses from immutable manifest scope, validation timestamps, and exact lifecycle events
- restore candidate-evidence qualification, production-deployed, failed staging, staging-validated, and staging-deployed records without changing any already-valid status
- log affected counts per lifecycle class and abort if any blank/truncated row remains unclassified
- add migration contract tests and a real database regression covering all five restored statuses

## Why

Deploying PR #1853 exposed a TypeORM schema-synchronization behavior: changing the manifest status column width caused every existing status value to become an empty string before the targeted candidate-evidence backfill ran. Release Bus automation was immediately fail-closed by pausing ALL. Immutable manifest JSON, train state, events, evidence, refs, and runtime were not lost.

This repair reconstructs only the damaged status column from durable evidence. It does not mutate candidate evidence, current-live staging state, production runtime, refs, or release intent.

## Live safety

- ALL PAUSED, PRODUCTION PAUSED
- no active train and all Release Bus locks free at discovery
- API/reconciler deployment of #1853 stopped; only its successful dbMigrationsLoop run `30301121302` crossed the live boundary
- automation will remain paused until this migration is reviewed, deployed, and the complete ledger is independently verified

## Validation

- focused migration + repository integration tests — 20/20 passed
- `npm run lint` — passed
- full build and required GitHub CI will run on the exact final head


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Repaired missing or blank release manifest lifecycle statuses using available manifest and event history.
  * Added validation to detect and report any remaining unclassified manifest statuses.
  * Preserved correct status recovery across production and staging release lanes.

* **Tests**
  * Added coverage for successful status restoration, validation failures, and migration execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->