### PR TITLE
Close PR CI source auto-fix loophole

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -60,20 +60,12 @@ jobs:
           fi
       - name: Lint
         run: |
-          npm run lint -- --max-warnings=0
-          if ! git diff --exit-code -- 'src/**/*.ts'; then
-            echo "::error::Lint --fix changed source files. Commit the fixes."
-            git diff --stat -- 'src/**/*.ts'
-            exit 1
-          fi
+          npm run lint:check
+          npm run ci:assert-source-clean
       - name: Format
         run: |
-          npm run format
-          if ! git diff --exit-code -- 'src/**/*.ts'; then
-            echo "::error::Format changed source files. Run 'npm run format' and commit."
-            git diff --stat -- 'src/**/*.ts'
-            exit 1
-          fi
+          npm run format:check
+          npm run ci:assert-source-clean
       - name: Build backend
         run: npm run build
       - name: Build API

--- a/package.json
+++ b/package.json
@@ -26,9 +26,12 @@
     "drop-media:backfill:live": "ts-node -r tsconfig-paths/register src/dropMediaSanitizer/backfill-existing-drop-media.ts --live",
     "check": "npm run format && npm run lint && npm run build",
     "check:changed": "node scripts/check-changed.mjs",
+    "ci:assert-source-clean": "node scripts/assert-pr-ci-source-clean.mjs",
     "format": "prettier --write \"src/**/*.ts\"",
+    "format:check": "prettier --check \"src/**/*.ts\"",
     "prelint": "npm run generate:deploy-config",
-    "lint": "NODE_OPTIONS=--max-old-space-size=8192 eslint \"src/**/*.ts\" --fix --max-warnings=0"
+    "lint": "NODE_OPTIONS=--max-old-space-size=8192 eslint \"src/**/*.ts\" --fix --max-warnings=0",
+    "lint:check": "NODE_OPTIONS=--max-old-space-size=8192 eslint \"src/**/*.ts\" --max-warnings=0"
   },
   "keywords": [],
   "author": "",

--- a/scripts/assert-pr-ci-source-clean.mjs
+++ b/scripts/assert-pr-ci-source-clean.mjs
@@ -2,7 +2,7 @@
 import { spawnSync } from 'node:child_process';
 
 const result = spawnSync(
-  'git',
+  '/usr/bin/git',
   ['status', '--porcelain=v1', '--untracked-files=all', '--', 'src'],
   {
     encoding: 'utf8',

--- a/scripts/assert-pr-ci-source-clean.mjs
+++ b/scripts/assert-pr-ci-source-clean.mjs
@@ -1,0 +1,36 @@
+/* eslint-env node */
+import { spawnSync } from 'node:child_process';
+
+const result = spawnSync(
+  'git',
+  ['status', '--porcelain=v1', '--untracked-files=all', '--', 'src'],
+  {
+    encoding: 'utf8',
+    shell: false,
+    stdio: ['ignore', 'pipe', 'pipe']
+  }
+);
+
+if (result.error) {
+  console.error(
+    `Could not inspect the source worktree: ${result.error.message}`
+  );
+  process.exit(1);
+}
+
+if (result.status !== 0) {
+  const detail = result.stderr.trim();
+  console.error(detail || 'Could not inspect the source worktree.');
+  process.exit(result.status ?? 1);
+}
+
+const changedSourceFiles = result.stdout.trim();
+if (changedSourceFiles) {
+  console.error(
+    'Source files changed during CI. Check-only lint and format commands must not mutate the workspace, and generated source must be committed.'
+  );
+  console.error(changedSourceFiles);
+  process.exit(1);
+}
+
+console.log('Source worktree is clean.');

--- a/scripts/assert-pr-ci-source-clean.mjs
+++ b/scripts/assert-pr-ci-source-clean.mjs
@@ -2,7 +2,7 @@
 import { spawnSync } from 'node:child_process';
 
 const result = spawnSync(
-  '/usr/bin/git',
+  'git', // NOSONAR -- CI owns PATH; shell is disabled and every argument is fixed.
   ['status', '--porcelain=v1', '--untracked-files=all', '--', 'src'],
   {
     encoding: 'utf8',

--- a/scripts/assert-pr-ci-source-clean.test.ts
+++ b/scripts/assert-pr-ci-source-clean.test.ts
@@ -1,0 +1,116 @@
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+type RunResult = {
+  readonly status: number | null;
+  readonly stderr: string;
+  readonly stdout: string;
+};
+
+const guardPath = path.join(
+  process.cwd(),
+  'scripts/assert-pr-ci-source-clean.mjs'
+);
+
+function run(command: string, args: readonly string[], cwd: string): RunResult {
+  const result = spawnSync(command, args, {
+    cwd,
+    encoding: 'utf8',
+    shell: false,
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  return {
+    status: result.status,
+    stderr: result.stderr,
+    stdout: result.stdout
+  };
+}
+
+function runGit(repoRoot: string, ...args: string[]): void {
+  const result = run('git', args, repoRoot);
+  if (result.status !== 0) {
+    throw new Error(result.stderr || `git ${args.join(' ')} failed`);
+  }
+}
+
+function createFixtureRepository(): string {
+  const repoRoot = mkdtempSync(path.join(tmpdir(), 'pr-ci-source-guard-'));
+  mkdirSync(path.join(repoRoot, 'src/nested'), { recursive: true });
+  writeFileSync(
+    path.join(repoRoot, 'src/alchemy-sdk.ts'),
+    'export const direct = true;\n'
+  );
+  writeFileSync(
+    path.join(repoRoot, 'src/nested/example.ts'),
+    'export const nested = true;\n'
+  );
+  runGit(repoRoot, 'init', '--quiet');
+  runGit(repoRoot, 'config', 'user.name', 'CI Source Guard');
+  runGit(repoRoot, 'config', 'user.email', 'ci-source-guard@example.com');
+  runGit(repoRoot, 'add', 'src');
+  runGit(repoRoot, 'commit', '--quiet', '-m', 'fixture');
+  return repoRoot;
+}
+
+function runGuard(repoRoot: string): RunResult {
+  return run(process.execPath, [guardPath], repoRoot);
+}
+
+describe('PR CI source worktree guard', () => {
+  let repoRoot: string;
+
+  beforeEach(() => {
+    repoRoot = createFixtureRepository();
+  });
+
+  afterEach(() => {
+    rmSync(repoRoot, { recursive: true, force: true });
+  });
+
+  it('accepts a clean source worktree', () => {
+    expect(runGuard(repoRoot)).toMatchObject({
+      status: 0,
+      stderr: '',
+      stdout: 'Source worktree is clean.\n'
+    });
+  });
+
+  it.each(['src/alchemy-sdk.ts', 'src/nested/example.ts'])(
+    'rejects a tracked change at %s',
+    (fileName) => {
+      writeFileSync(
+        path.join(repoRoot, fileName),
+        'export const changed = true;\n'
+      );
+
+      const result = runGuard(repoRoot);
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain('Source files changed during CI.');
+      expect(result.stderr).toContain(fileName);
+    }
+  );
+
+  it.each(['src/direct-untracked.ts', 'src/nested/untracked.ts'])(
+    'rejects an untracked source file at %s',
+    (fileName) => {
+      writeFileSync(
+        path.join(repoRoot, fileName),
+        'export const untracked = true;\n'
+      );
+
+      const result = runGuard(repoRoot);
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain('Source files changed during CI.');
+      expect(result.stderr).toContain(fileName);
+    }
+  );
+});


### PR DESCRIPTION
## What changed

- run ESLint and Prettier in check-only mode in the backend PR workflow
- fail closed if any tracked or untracked file anywhere under `src` changes during either check
- add deterministic regression coverage for direct `src/alchemy-sdk.ts`-style paths and nested source paths
- preserve the existing deploy-workflow and OpenAPI generated-file checks

## Root cause

PR #1842 reached main with an unformatted direct `src/alchemy-sdk.ts` change because CI ran ESLint with `--fix`, then fenced mutations with the Git pathspec `src/**/*.ts`. That Git pathspec omitted direct `src/*.ts` files, so the runner silently built and tested an uncommitted auto-fixed workspace.

## Validation

- focused source-guard regression: 1 suite / 5 tests passed
- `npm run lint:check`
- `npm run format:check`
- `npm run ci:assert-source-clean`
- full backend build: 296 suites / 2,720 tests passed, TypeScript compilation green
- API build green
- focused Prettier, ESLint, and `git diff --check` green

Workflow-only change; no application deployment is required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI Improvements**
  * Linting and formatting checks now run in verification-only mode.
  * CI detects and reports unexpected source-file changes during checks, helping prevent altered code from passing unnoticed.

* **Tests**
  * Added coverage for clean, modified, and newly created source files during CI validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->