### PR TITLE
fix: reduce drop write lock contention

### DIFF
--- a/src/drops/create-or-update-drop-use-case.test.ts
+++ b/src/drops/create-or-update-drop-use-case.test.ts
@@ -164,6 +164,64 @@ describe('CreateOrUpdateDropUseCase', () => {
     };
   }
 
+  it('does not increment inserted-drop metrics when editing a drop', async () => {
+    const dropsDb = {
+      findDropById: jest.fn().mockResolvedValue({
+        id: 'drop-1',
+        wave_id: 'wave-1',
+        author_id: 'author-profile',
+        drop_type: DropType.CHAT,
+        created_at: Date.now() - 1000,
+        updated_at: Date.now(),
+        serial_no: 1
+      }),
+      getDropGroupMentions: jest.fn().mockResolvedValue([]),
+      applyInsertedDropMetricsDelta: jest.fn().mockResolvedValue(undefined)
+    };
+    const wavesApiDb = {
+      findById: jest.fn().mockResolvedValue({
+        ...createSlowModeWave(),
+        type: WaveType.CHAT
+      })
+    };
+    const deleteDropUseCase = {
+      execute: jest.fn().mockResolvedValue(undefined)
+    };
+    const artCurationTokenWatchService = {
+      registerDrop: jest.fn().mockResolvedValue(undefined)
+    };
+    const useCase = createUseCaseWithMocks({
+      dropsDb,
+      wavesApiDb,
+      deleteDropUseCase,
+      artCurationTokenWatchService
+    });
+    jest.spyOn(useCase as any, 'validateReferences').mockResolvedValue({
+      validatedModel: createChatDropModel({ drop_id: 'drop-1' }),
+      groupIdsUserIsEligibleFor: []
+    });
+    jest
+      .spyOn(useCase as any, 'verifyChatLinksAreAllowed')
+      .mockReturnValue(undefined);
+    jest.spyOn(useCase as any, 'insertAllDropComponents').mockResolvedValue([]);
+    jest.spyOn(env, 'getIntOrNull').mockReturnValue(60_000);
+
+    await (useCase as any).createOrUpdateDrop(
+      createChatDropModel({ drop_id: 'drop-1' }),
+      false,
+      { connection: {} as any }
+    );
+
+    expect(deleteDropUseCase.execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        drop_id: 'drop-1',
+        deletion_purpose: 'UPDATE'
+      }),
+      expect.any(Object)
+    );
+    expect(dropsDb.applyInsertedDropMetricsDelta).not.toHaveBeenCalled();
+  });
+
   it('sanitizes structured drop fields without touching part content', () => {
     const model = {
       ...createChatDropModel(),

--- a/src/drops/create-or-update-drop.use-case.ts
+++ b/src/drops/create-or-update-drop.use-case.ts
@@ -547,6 +547,14 @@ export class CreateOrUpdateDropUseCase {
       },
       { timer, connection }
     );
+    await this.dropsDb.applyInsertedDropMetricsDelta(
+      {
+        wave_id: validatedModel.wave_id,
+        author_id: authorId,
+        drop_type: validatedModel.drop_type
+      },
+      { timer, connection }
+    );
     timer?.stop(`${CreateOrUpdateDropUseCase.name}->execute`);
     return {
       drop_id: dropId,
@@ -1544,7 +1552,8 @@ export class CreateOrUpdateDropUseCase {
           hide_link_preview: model.hide_link_preview,
           is_additional_action_promised: model.is_additional_action_promised
         },
-        connection
+        connection,
+        { deferMetrics: true }
       ),
       this.createDropReplyNotifications({ model, wave }, { timer, connection }),
       this.identitySubscriptionsDb.addIdentitySubscription(

--- a/src/drops/create-or-update-drop.use-case.ts
+++ b/src/drops/create-or-update-drop.use-case.ts
@@ -547,14 +547,16 @@ export class CreateOrUpdateDropUseCase {
       },
       { timer, connection }
     );
-    await this.dropsDb.applyInsertedDropMetricsDelta(
-      {
-        wave_id: validatedModel.wave_id,
-        author_id: authorId,
-        drop_type: validatedModel.drop_type
-      },
-      { timer, connection }
-    );
+    if (!preExistingDropId) {
+      await this.dropsDb.applyInsertedDropMetricsDelta(
+        {
+          wave_id: validatedModel.wave_id,
+          author_id: authorId,
+          drop_type: validatedModel.drop_type
+        },
+        { timer, connection }
+      );
+    }
     timer?.stop(`${CreateOrUpdateDropUseCase.name}->execute`);
     return {
       drop_id: dropId,

--- a/src/drops/drops-db.test.ts
+++ b/src/drops/drops-db.test.ts
@@ -328,6 +328,9 @@ describe('DropsDb', () => {
       chatDropsDelta: 1,
       participatoryDropsDelta: 0
     });
+    expect(execute.mock.calls[1]?.[2]).toEqual({
+      wrappedConnection: { connection }
+    });
     expect(execute.mock.calls[2]?.[0]).toContain(
       `insert into ${WAVE_DROPPER_METRICS_TABLE}`
     );
@@ -336,6 +339,9 @@ describe('DropsDb', () => {
       dropperId: 'author-1',
       chatDropsDelta: 1,
       participatoryDropsDelta: 0
+    });
+    expect(execute.mock.calls[2]?.[2]).toEqual({
+      wrappedConnection: { connection }
     });
 
     const directExecute = jest.fn().mockResolvedValue([]);

--- a/src/drops/drops-db.test.ts
+++ b/src/drops/drops-db.test.ts
@@ -274,6 +274,88 @@ describe('DropsDb', () => {
     });
   });
 
+  it('defers inserted drop metrics only when requested', async () => {
+    const connection = {};
+    const execute = jest.fn().mockResolvedValue([]);
+    const repo = new DropsDb(
+      () =>
+        ({
+          execute
+        }) as any
+    );
+    const newDropEntity = {
+      id: 'drop-1',
+      author_id: 'author-1',
+      title: null,
+      parts_count: 1,
+      wave_id: 'wave-1',
+      reply_to_drop_id: null,
+      reply_to_part_id: null,
+      created_at: 123,
+      updated_at: null,
+      serial_no: null,
+      drop_type: DropType.CHAT,
+      signature: null,
+      is_additional_action_promised: null
+    };
+
+    await repo.insertDrop(newDropEntity, { connection } as any, {
+      deferMetrics: true
+    });
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(execute.mock.calls[0]?.[0]).toContain(`insert into ${DROPS_TABLE}`);
+    expect(execute.mock.calls[0]?.[0]).not.toContain(WAVE_METRICS_TABLE);
+
+    await repo.applyInsertedDropMetricsDelta(
+      {
+        wave_id: 'wave-1',
+        author_id: 'author-1',
+        drop_type: DropType.CHAT
+      },
+      {
+        connection: { connection } as any,
+        timer: undefined
+      }
+    );
+
+    expect(execute).toHaveBeenCalledTimes(3);
+    expect(execute.mock.calls[1]?.[0]).toContain(
+      `insert into ${WAVE_METRICS_TABLE}`
+    );
+    expect(execute.mock.calls[1]?.[1]).toMatchObject({
+      waveId: 'wave-1',
+      chatDropsDelta: 1,
+      participatoryDropsDelta: 0
+    });
+    expect(execute.mock.calls[2]?.[0]).toContain(
+      `insert into ${WAVE_DROPPER_METRICS_TABLE}`
+    );
+    expect(execute.mock.calls[2]?.[1]).toMatchObject({
+      waveId: 'wave-1',
+      dropperId: 'author-1',
+      chatDropsDelta: 1,
+      participatoryDropsDelta: 0
+    });
+
+    const directExecute = jest.fn().mockResolvedValue([]);
+    const directRepo = new DropsDb(
+      () =>
+        ({
+          execute: directExecute
+        }) as any
+    );
+    await directRepo.insertDrop(newDropEntity, { connection } as any);
+
+    expect(directExecute).toHaveBeenCalledTimes(3);
+    expect(directExecute.mock.calls[1]?.[0]).toContain(
+      `insert into ${WAVE_METRICS_TABLE}`
+    );
+    expect(directExecute.mock.calls[2]?.[0]).toContain(
+      `insert into ${WAVE_DROPPER_METRICS_TABLE}`
+    );
+  });
+
   it('can force full drop metrics resyncs onto the write pool', async () => {
     const execute = jest.fn().mockResolvedValue([]);
     const repo = new DropsDb(

--- a/src/drops/drops.db.ts
+++ b/src/drops/drops.db.ts
@@ -549,6 +549,8 @@ export class DropsDb extends LazyDbAccessCompatibleService {
   ) {
     // These shared rows serialize concurrent drops in the same wave. Call this
     // at the transaction tail so their locks are released as soon as possible.
+    // Keep wave before dropper metrics in insert and delete paths to avoid lock
+    // order inversion.
     const timerName = `${this.constructor.name}->applyInsertedDropMetricsDelta`;
     ctx.timer?.start(timerName);
     try {
@@ -2043,9 +2045,8 @@ export class DropsDb extends LazyDbAccessCompatibleService {
       const chatDropsDelta = drop.drop_type === DropType.CHAT ? 1 : 0;
       const participatoryDropsDelta =
         drop.drop_type === DropType.PARTICIPATORY ? 1 : 0;
-      await Promise.all([
-        this.db.execute(
-          `
+      await this.db.execute(
+        `
           update ${WAVE_METRICS_TABLE} wm
           set wm.drops_count = greatest(wm.drops_count - :chatDropsDelta, 0),
               wm.participatory_drops_count = greatest(
@@ -2059,15 +2060,15 @@ export class DropsDb extends LazyDbAccessCompatibleService {
               )
           where wm.wave_id = :waveId
         `,
-          {
-            waveId: drop.wave_id,
-            chatDropsDelta,
-            participatoryDropsDelta
-          },
-          { wrappedConnection: ctx.connection }
-        ),
-        this.db.execute(
-          `
+        {
+          waveId: drop.wave_id,
+          chatDropsDelta,
+          participatoryDropsDelta
+        },
+        { wrappedConnection: ctx.connection }
+      );
+      await this.db.execute(
+        `
           update ${WAVE_DROPPER_METRICS_TABLE} wdm
           set wdm.drops_count = greatest(wdm.drops_count - :chatDropsDelta, 0),
               wdm.participatory_drops_count = greatest(
@@ -2083,15 +2084,14 @@ export class DropsDb extends LazyDbAccessCompatibleService {
           where wdm.wave_id = :waveId
             and wdm.dropper_id = :dropperId
         `,
-          {
-            waveId: drop.wave_id,
-            dropperId: drop.author_id,
-            chatDropsDelta,
-            participatoryDropsDelta
-          },
-          { wrappedConnection: ctx.connection }
-        )
-      ]);
+        {
+          waveId: drop.wave_id,
+          dropperId: drop.author_id,
+          chatDropsDelta,
+          participatoryDropsDelta
+        },
+        { wrappedConnection: ctx.connection }
+      );
     } finally {
       ctx.timer?.stop('dropsDb->applyDeletedDropMetricsDelta');
     }

--- a/src/drops/drops.db.ts
+++ b/src/drops/drops.db.ts
@@ -430,98 +430,50 @@ export class DropsDb extends LazyDbAccessCompatibleService {
 
   async insertDrop(
     newDropEntity: NewDropEntity,
-    connection: ConnectionWrapper<any>
+    connection: ConnectionWrapper<any>,
+    options: { deferMetrics?: boolean } = {}
   ) {
     const dropId = newDropEntity.id;
     const waveId = newDropEntity.wave_id;
     const replyToDropId = newDropEntity.reply_to_drop_id;
     const newDropSerialNo = newDropEntity.serial_no;
     const hideLinkPreview = newDropEntity.hide_link_preview ?? false;
-    const now = Time.currentMillis();
-    await Promise.all([
-      this.db.execute(
-        `
-            insert into ${WAVE_METRICS_TABLE}
-            (wave_id, drops_count, subscribers_count, participatory_drops_count, latest_drop_timestamp)
-            values (:waveId, ${
-              newDropEntity.drop_type === DropType.CHAT ? 1 : 0
-            }, 0, ${
-              newDropEntity.drop_type === DropType.PARTICIPATORY ? 1 : 0
-            }, :now)
-            on duplicate key update drops_count = (drops_count + ${
-              newDropEntity.drop_type === DropType.CHAT ? 1 : 0
-            }),
-                                    participatory_drops_count = (participatory_drops_count + ${
-                                      newDropEntity.drop_type ===
-                                      DropType.PARTICIPATORY
-                                        ? 1
-                                        : 0
-                                    }),
-                                    latest_drop_timestamp     = :now
-        `,
-        { waveId, now },
-        { wrappedConnection: connection }
-      ),
-      this.db.execute(
-        `
-            insert into ${WAVE_DROPPER_METRICS_TABLE}
-            (wave_id, dropper_id, drops_count, participatory_drops_count, latest_drop_timestamp)
-            values (:waveId, :dropperId, ${
-              newDropEntity.drop_type === DropType.CHAT ? 1 : 0
-            }, ${
-              newDropEntity.drop_type === DropType.PARTICIPATORY ? 1 : 0
-            }, :now)
-            on duplicate key update drops_count = (drops_count + ${
-              newDropEntity.drop_type === DropType.CHAT ? 1 : 0
-            }),
-                                    participatory_drops_count = (participatory_drops_count + ${
-                                      newDropEntity.drop_type ===
-                                      DropType.PARTICIPATORY
-                                        ? 1
-                                        : 0
-                                    }),
-                                    latest_drop_timestamp     = :now
-        `,
-        { waveId, dropperId: newDropEntity.author_id, now },
-        { wrappedConnection: connection }
-      ),
-      this.db.execute(
-        `insert into ${DROPS_TABLE} (id,
-                                     author_id,
-                                     drop_type,
-                                     wave_id,
-                                     created_at,
-                                     updated_at,
-                                     title,
-                                     parts_count,
-                                     signature,
-                                     is_additional_action_promised,
-                                     hide_link_preview,
-                                     reply_to_drop_id,
-                                     reply_to_part_id${
-                                       newDropSerialNo !== null
-                                         ? `, serial_no`
-                                         : ``
-                                     })
-         values (:id,
-                 :author_id,
-                 :drop_type,
-                 :wave_id,
-                 :created_at,
-                 :updated_at,
-                 :title,
-                 :parts_count,
-                 :signature,
-                 :is_additional_action_promised,
-                 :hide_link_preview,
-                 :reply_to_drop_id,
-                 :reply_to_part_id
-              ${newDropSerialNo !== null ? `, :serial_no` : ``})`,
+    await this.db.execute(
+      `insert into ${DROPS_TABLE} (id,
+                                   author_id,
+                                   drop_type,
+                                   wave_id,
+                                   created_at,
+                                   updated_at,
+                                   title,
+                                   parts_count,
+                                   signature,
+                                   is_additional_action_promised,
+                                   hide_link_preview,
+                                   reply_to_drop_id,
+                                   reply_to_part_id${
+                                     newDropSerialNo !== null
+                                       ? `, serial_no`
+                                       : ``
+                                   })
+       values (:id,
+               :author_id,
+               :drop_type,
+               :wave_id,
+               :created_at,
+               :updated_at,
+               :title,
+               :parts_count,
+               :signature,
+               :is_additional_action_promised,
+               :hide_link_preview,
+               :reply_to_drop_id,
+               :reply_to_part_id
+            ${newDropSerialNo !== null ? `, :serial_no` : ``})`,
 
-        { ...newDropEntity, hide_link_preview: hideLinkPreview },
-        { wrappedConnection: connection }
-      )
-    ]);
+      { ...newDropEntity, hide_link_preview: hideLinkPreview },
+      { wrappedConnection: connection }
+    );
     if (replyToDropId) {
       const serialNo = await this.db
         .oneOrNull<{
@@ -585,6 +537,62 @@ export class DropsDb extends LazyDbAccessCompatibleService {
         {},
         { wrappedConnection: connection }
       );
+    }
+    if (!options.deferMetrics) {
+      await this.applyInsertedDropMetricsDelta(newDropEntity, { connection });
+    }
+  }
+
+  async applyInsertedDropMetricsDelta(
+    drop: Pick<DropEntity, 'wave_id' | 'author_id' | 'drop_type'>,
+    ctx: RequestContext
+  ) {
+    // These shared rows serialize concurrent drops in the same wave. Call this
+    // at the transaction tail so their locks are released as soon as possible.
+    const timerName = `${this.constructor.name}->applyInsertedDropMetricsDelta`;
+    ctx.timer?.start(timerName);
+    try {
+      const now = Time.currentMillis();
+      const chatDropsDelta = drop.drop_type === DropType.CHAT ? 1 : 0;
+      const participatoryDropsDelta =
+        drop.drop_type === DropType.PARTICIPATORY ? 1 : 0;
+      await this.db.execute(
+        `
+          insert into ${WAVE_METRICS_TABLE}
+          (wave_id, drops_count, subscribers_count, participatory_drops_count, latest_drop_timestamp)
+          values (:waveId, :chatDropsDelta, 0, :participatoryDropsDelta, :now)
+          on duplicate key update drops_count = (drops_count + :chatDropsDelta),
+                                  participatory_drops_count = (participatory_drops_count + :participatoryDropsDelta),
+                                  latest_drop_timestamp = :now
+        `,
+        {
+          waveId: drop.wave_id,
+          chatDropsDelta,
+          participatoryDropsDelta,
+          now
+        },
+        { wrappedConnection: ctx.connection }
+      );
+      await this.db.execute(
+        `
+          insert into ${WAVE_DROPPER_METRICS_TABLE}
+          (wave_id, dropper_id, drops_count, participatory_drops_count, latest_drop_timestamp)
+          values (:waveId, :dropperId, :chatDropsDelta, :participatoryDropsDelta, :now)
+          on duplicate key update drops_count = (drops_count + :chatDropsDelta),
+                                  participatory_drops_count = (participatory_drops_count + :participatoryDropsDelta),
+                                  latest_drop_timestamp = :now
+        `,
+        {
+          waveId: drop.wave_id,
+          dropperId: drop.author_id,
+          chatDropsDelta,
+          participatoryDropsDelta,
+          now
+        },
+        { wrappedConnection: ctx.connection }
+      );
+    } finally {
+      ctx.timer?.stop(timerName);
     }
   }
 
@@ -2027,8 +2035,9 @@ export class DropsDb extends LazyDbAccessCompatibleService {
   ) {
     ctx.timer?.start('dropsDb->applyDeletedDropMetricsDelta');
     try {
-      // Mirrors insertDrop: CHAT increments drops_count, PARTICIPATORY increments
-      // participatory_drops_count, and WINNER only affects latest_drop_timestamp.
+      // Mirrors applyInsertedDropMetricsDelta: CHAT increments drops_count,
+      // PARTICIPATORY increments participatory_drops_count, and WINNER only
+      // affects latest_drop_timestamp.
       // This keeps DELETE fast; the async full resync is the authoritative repair
       // for stale counters, retries, and races.
       const chatDropsDelta = drop.drop_type === DropType.CHAT ? 1 : 0;


### PR DESCRIPTION
## Issue
Production `POST /api/drops` requests intermittently reached the API/Lambda timeout while users pasted and submitted text. Runtime evidence showed a row-lock convoy on the shared per-wave metrics rows; the database remained available and Lambda was not throttled.

## Fix
Move the `wave_metrics` and `wave_dropper_metrics` increments to the transaction tail for new drops. This keeps the same atomic transaction semantics while sharply reducing how long contended metric rows remain locked. Edits no longer increment current-drop counters, and insert/delete paths acquire the shared rows in one deterministic order.

Direct `insertDrop` callers keep the existing immediate metric behavior unless they explicitly opt into deferral.

## Notable changes
- extract a typed and timed `applyInsertedDropMetricsDelta` operation
- opt the full drop persistence transaction into deferred metrics updates
- apply the deferred increment only for new drops, not edits
- use deterministic wave-before-dropper metric lock ordering for insert and delete paths
- add regression coverage for deferred, direct-call, and update behavior

## Validation
- `npm run lint` — pass
- `npm run tsc -- --noEmit` — pass
- focused Jest suites for drop DB, create/update use case, and drop creation API — 83/83 pass
- full local build test phase — 2,692/2,721 pass; three unrelated Release Bus suites fail only in the Windows child-process harness because tool PATH/ref text is not normalized there. Linux PR CI is authoritative for those suites.

## Risk and rollback
Medium-low. New-drop metric writes remain in the same database transaction and use the same deltas; their ordering changes and edits stop over-counting current-drop totals. Roll back by reverting these commits and redeploying the API service.

## Deployment
Backend `api` service only. No schema migration, frontend change, or user-facing documentation change.

## Review notes
Please focus on transaction-tail ordering, unchanged rollback/atomicity for new drops, deterministic metric lock order, and compatibility for direct `insertDrop` callers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected drop metrics so they are recorded only for newly created drops, not when existing drops are edited.
  * Improved deferred metrics handling to prevent duplicate or premature counter updates.
* **Tests**
  * Added coverage for editing drops without incrementing insertion metrics.
  * Added tests verifying both deferred and immediate metrics updates during drop insertion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->