### PR TITLE
Fix release contributor scoping

### DIFF
--- a/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.test.ts
+++ b/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.test.ts
@@ -393,7 +393,7 @@ describe('CiPipelineAlertService', () => {
     }
   );
 
-  it('adds mapped train contributors as real mentions and links unmapped contributors', async () => {
+  it('does not render or notify train-wide contributors on each deployment', async () => {
     identitiesRepository.getIdsByHandles.mockResolvedValue({
       GelatoGenesis: 'profile-gelato',
       ragne: 'profile-ragne'
@@ -420,28 +420,14 @@ describe('CiPipelineAlertService', () => {
       {}
     );
 
-    expect(identitiesRepository.getIdsByHandles).toHaveBeenCalledWith([
-      'GelatoGenesis',
-      'ragne'
-    ]);
+    expect(identitiesRepository.getIdsByHandles).not.toHaveBeenCalled();
     const createDropRequest =
       dropCreationApiService.createDrop.mock.calls[0][0].createDropRequest;
-    expect(createDropRequest.mentioned_users).toEqual([
-      {
-        mentioned_profile_id: 'profile-gelato',
-        handle_in_content: 'GelatoGenesis'
-      },
-      {
-        mentioned_profile_id: 'profile-ragne',
-        handle_in_content: 'ragne'
-      }
-    ]);
+    expect(createDropRequest.mentioned_users).toEqual([]);
     expect(createDropRequest.parts[0].content).toContain(
-      [
-        'Initiated by: Release Train',
-        'Contributors: @[GelatoGenesis], @[ragne], [@external-user](https://github.com/external-user)'
-      ].join('\n')
+      'Initiated by: Release Train'
     );
+    expect(createDropRequest.parts[0].content).not.toContain('Contributors:');
   });
 
   it('ignores contributor metadata for a manually initiated deployment', async () => {

--- a/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.ts
+++ b/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.ts
@@ -66,14 +66,8 @@ interface MentionedProfile {
   readonly handle: string;
 }
 
-interface AlertContributor {
-  readonly githubLogin: string;
-  readonly mention: MentionedProfile | null;
-}
-
 interface AlertMentions {
   readonly triggeredBy: MentionedProfile | null;
-  readonly contributors: AlertContributor[];
   readonly failureCc: MentionedProfile[];
   readonly all: MentionedProfile[];
 }
@@ -464,15 +458,6 @@ export class CiPipelineAlertService {
       request.triggered_by_github_login
     );
     const isReleaseTrain = isReleaseBusGitHubAppActor(triggeredByGithubLogin);
-    const contributorGithubLogins = this.getReleaseTrainContributors(request);
-    const contributorHandlesByGithubLogin = new Map(
-      contributorGithubLogins
-        .map((login): [string, string | undefined] => [
-          login,
-          GITHUB_TO_6529_HANDLES[login.toLowerCase()]?.trim()
-        ])
-        .filter((entry): entry is [string, string] => Boolean(entry[1]))
-    );
     const triggeredByHandle =
       triggeredByGithubLogin && !isReleaseTrain
         ? GITHUB_TO_6529_HANDLES[triggeredByGithubLogin.toLowerCase()]
@@ -495,7 +480,6 @@ export class CiPipelineAlertService {
         : [];
     const handlesToResolve = [
       ...(triggeredByHandle ? [triggeredByHandle] : []),
-      ...Array.from(contributorHandlesByGithubLogin.values()),
       ...failureHandles
     ].filter(
       (handle, index, handles) =>
@@ -506,10 +490,6 @@ export class CiPipelineAlertService {
     if (!handlesToResolve.length) {
       return {
         triggeredBy: null,
-        contributors: contributorGithubLogins.map((githubLogin) => ({
-          githubLogin,
-          mention: null
-        })),
         failureCc: [],
         all: []
       };
@@ -536,18 +516,6 @@ export class CiPipelineAlertService {
       );
     }
 
-    const contributors = contributorGithubLogins.map((githubLogin) => {
-      const handle = contributorHandlesByGithubLogin.get(githubLogin);
-      const mention = handle
-        ? (mentionsByNormalizedHandle.get(handle.toLowerCase()) ?? null)
-        : null;
-      if (handle && !mention) {
-        this.logger.warn(
-          `Skipping CI pipeline contributor mention for GitHub user ${githubLogin}; 6529 profile ${handle} is missing`
-        );
-      }
-      return { githubLogin, mention };
-    });
     const missingHandles = failureHandles.filter(
       (handle) => !mentionsByNormalizedHandle.has(handle.toLowerCase())
     );
@@ -560,20 +528,14 @@ export class CiPipelineAlertService {
       .map((handle) => mentionsByNormalizedHandle.get(handle.toLowerCase()))
       .filter((mention): mention is MentionedProfile => !!mention);
     // Profile IDs collapse handle aliases while preserving initiator-first order.
-    const all = [
-      ...(triggeredBy ? [triggeredBy] : []),
-      ...contributors
-        .map(({ mention }) => mention)
-        .filter((mention): mention is MentionedProfile => Boolean(mention)),
-      ...failureCc
-    ].filter(
+    const all = [...(triggeredBy ? [triggeredBy] : []), ...failureCc].filter(
       (mention, index, mentions) =>
         mentions.findIndex(
           (candidate) => candidate.profileId === mention.profileId
         ) === index
     );
 
-    return { triggeredBy, contributors, failureCc, all };
+    return { triggeredBy, failureCc, all };
   }
 
   private resolveWaveId(request: CiPipelineAlertRequest): string {
@@ -640,16 +602,6 @@ export class CiPipelineAlertService {
       ? truncate(sanitizeAlertText(description), MAX_ALERT_DESCRIPTION_LENGTH)
       : null;
     const triggeredBy = formatInitiator(request, mentions);
-    const contributorCredits = mentions.contributors
-      .map(({ githubLogin, mention }) =>
-        mention
-          ? `@[${mention.handle}]`
-          : formatMarkdownLink(
-              `@${githubLogin}`,
-              `https://github.com/${githubLogin}`
-            )
-      )
-      .join(', ');
     const lines = [
       formatAlertHeading(request),
       '',
@@ -659,7 +611,6 @@ export class CiPipelineAlertService {
       ...(branch ? [`Branch: ${branch}`] : []),
       ...(commit ? [`Commit: ${commit}`] : []),
       `Initiated by: ${triggeredBy}`,
-      ...(contributorCredits ? [`Contributors: ${contributorCredits}`] : []),
       `Run: ${formatRun(request)}`,
       ...failureMentionLines
     ];

--- a/src/release-notes/release-note-github.service.test.ts
+++ b/src/release-notes/release-note-github.service.test.ts
@@ -413,6 +413,79 @@ describe('ReleaseNoteGitHubService', () => {
     );
   });
 
+  it('does not add train-wide contributors to commit-range PR contexts', async () => {
+    (fetch as unknown as jest.Mock)
+      .mockResolvedValueOnce(
+        response({
+          id: 123,
+          name: 'Deploy api to prod',
+          display_title: 'Deploy api to prod',
+          head_sha: 'current-sha',
+          run_number: 45,
+          workflow_id: 82013288
+        })
+      )
+      .mockResolvedValueOnce(
+        response({
+          workflow_runs: [
+            {
+              id: 122,
+              name: 'Deploy api to prod',
+              display_title: 'Deploy api to prod',
+              head_sha: 'previous-sha',
+              run_number: 44,
+              workflow_id: 82013288
+            }
+          ]
+        })
+      )
+      .mockResolvedValueOnce(
+        response({
+          commits: [
+            {
+              sha: 'api-commit',
+              commit: { message: 'Improve API validation' }
+            }
+          ],
+          total_commits: 1
+        })
+      )
+      .mockResolvedValueOnce(
+        response([
+          {
+            number: 101,
+            html_url: 'https://github.com/example/pull/101',
+            title: 'Improve API validation',
+            body: null,
+            merged_at: '2026-07-13T10:00:00Z',
+            user: { login: 'pr-author', type: 'User' },
+            base: { ref: 'main' }
+          }
+        ])
+      )
+      .mockResolvedValueOnce(response([]))
+      .mockResolvedValueOnce(response([]));
+
+    const context = await new ReleaseNoteGitHubService().getReleaseContext({
+      ...request,
+      repo: '6529seize-backend',
+      workflow: 'Deploy a service',
+      run_number: '45',
+      sha: 'current-sha',
+      branch: 'main',
+      release_group_id: 'backend-release',
+      release_group_services: ['api'],
+      contributor_github_logins: ['release-train-contributor']
+    });
+
+    expect(context?.pull_requests).toEqual([
+      expect.objectContaining({
+        number: 101,
+        contributors: ['pr-author']
+      })
+    ]);
+  });
+
   it('keeps every PR when one changed-file list exceeds the enrichment cap', async () => {
     (fetch as unknown as jest.Mock).mockImplementation((url: string) => {
       if (url.endsWith('/actions/runs/123')) {

--- a/src/release-notes/release-note-github.service.test.ts
+++ b/src/release-notes/release-note-github.service.test.ts
@@ -174,7 +174,7 @@ describe('ReleaseNoteGitHubService', () => {
           url: 'https://github.com/6529-Collections/6529seize-backend/pull/1749',
           title: 'Link Main Stage winners to Meme cards',
           body: 'Adds the production mapping.',
-          contributors: ['Alice', 'ReleaseTrainUser', 'BOB', 'CAROL', 'Dave'],
+          contributors: ['Alice', 'bob', 'CAROL', 'Dave'],
           commit_messages: ['Link Main Stage winners to Meme cards'],
           changed_files: [
             {
@@ -614,7 +614,7 @@ describe('ReleaseNoteGitHubService', () => {
       expect.objectContaining({
         number: 1749,
         title: 'Keep release notes available',
-        contributors: ['pr-author', 'release-train-contributor'],
+        contributors: ['pr-author'],
         changed_files: [],
         changed_files_incomplete: true,
         commit_contributors_incomplete: true,

--- a/src/release-notes/release-note-github.service.ts
+++ b/src/release-notes/release-note-github.service.ts
@@ -145,7 +145,6 @@ function isHumanGithubUser(user: GitHubUser | null | undefined): boolean {
 
 function collectPullRequestContributors(
   pullRequest: GitHubPullRequest,
-  canonicalContributors: readonly string[],
   commits: readonly GitHubCommit[]
 ): string[] {
   const contributors: string[] = [];
@@ -169,7 +168,6 @@ function collectPullRequestContributors(
   if (isHumanGithubUser(pullRequest.user)) {
     addLogin(pullRequest.user?.login);
   }
-  canonicalContributors.forEach(addLogin);
   for (const commit of commits) {
     if (isHumanGithubUser(commit.author)) {
       addLogin(commit.author?.login);
@@ -388,8 +386,7 @@ export class ReleaseNoteGitHubService {
       repository,
       normalizeBranch(request.branch),
       commits,
-      request.release_group_services,
-      request.contributor_github_logins ?? []
+      request.release_group_services
     );
 
     return {
@@ -445,7 +442,6 @@ export class ReleaseNoteGitHubService {
           body: pullRequest.body,
           contributors: collectPullRequestContributors(
             pullRequest,
-            request.contributor_github_logins ?? [],
             commitResult.items
           ),
           commit_messages: [pullRequest.title],
@@ -559,8 +555,7 @@ export class ReleaseNoteGitHubService {
     repository: string,
     branch: string,
     commits: GitHubCommit[],
-    deployedServices: string[],
-    canonicalContributors: readonly string[]
+    deployedServices: string[]
   ): Promise<ReleasePullRequestContext[]> {
     const pullRequests = await this.collectPullRequests(
       repository,
@@ -570,8 +565,7 @@ export class ReleaseNoteGitHubService {
     const contexts = await this.buildPullRequestContexts(
       repository,
       Array.from(pullRequests.values()),
-      deployedServices,
-      canonicalContributors
+      deployedServices
     );
     return contexts.sort((a, b) => a.number - b.number);
   }
@@ -612,8 +606,7 @@ export class ReleaseNoteGitHubService {
   private async buildPullRequestContexts(
     repository: string,
     pullRequests: AggregatedPullRequest[],
-    deployedServices: string[],
-    canonicalContributors: readonly string[]
+    deployedServices: string[]
   ): Promise<ReleasePullRequestContext[]> {
     const contexts: ReleasePullRequestContext[] = [];
     for (
@@ -628,8 +621,7 @@ export class ReleaseNoteGitHubService {
             this.buildPullRequestContext(
               repository,
               pullRequest,
-              deployedServices,
-              canonicalContributors
+              deployedServices
             )
           )
       );
@@ -641,8 +633,7 @@ export class ReleaseNoteGitHubService {
   private async buildPullRequestContext(
     repository: string,
     aggregate: AggregatedPullRequest,
-    deployedServices: string[],
-    canonicalContributors: readonly string[]
+    deployedServices: string[]
   ): Promise<ReleasePullRequestContext> {
     const { pullRequest, commitMessages } = aggregate;
     const [fileResult, commitResult] = await Promise.all([
@@ -656,7 +647,6 @@ export class ReleaseNoteGitHubService {
       body: pullRequest.body,
       contributors: collectPullRequestContributors(
         pullRequest,
-        canonicalContributors,
         commitResult.items
       ),
       commit_messages: Array.from(commitMessages),


### PR DESCRIPTION
## Issue

Release Bus deployments pass one contributor list for the full cross-repository train. CI alerts rendered that list as real profile mentions on every service deployment, and release-note generation reused the same list for every individual PR. This caused notification spam and attributed unrelated train contributors to PRs they did not author.

## Fix

- Keep `Initiated by: Release Train` in CI alerts while omitting the train-wide contributor line and mention metadata.
- Build release-note credits only from the individual PR author and its human commit authors and committers.
- Continue accepting and forwarding train contributor metadata internally without using it as per-deployment or per-PR attribution.
- Add regression coverage for both contributor-scoping behaviors.

## Impact

CI deployment posts no longer notify every contributor in a release train. Release notes now credit contributors from the PR being described instead of contributors from unrelated candidates.

## Validation

- Focused CI alert and release-note suites: 46 tests passed.
- Repository lint passed.
- TypeScript compilation passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Release alerts no longer include contributor credits or generate contributor mentions; alert content now shows only initiator and failure-related contacts.
  * Pull request release-note contributor lists are now derived solely from the pull request author/metadata and commit authors/committers, with consistent casing normalization.
  * Train-wide contributors are no longer added to commit-range pull request contexts.
* **Tests**
  * Updated and added release-note and alert service assertions to match the new contributor/mention behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->