### PR TITLE
Fix Release Bus production replan coalescing

### DIFF
--- a/ops/deployment-bus/simple-release-bus-v2.md
+++ b/ops/deployment-bus/simple-release-bus-v2.md
@@ -151,6 +151,13 @@ exact reason. Revoked, superseded, moved, stale-evidence, dependency-incomplete,
 or concurrently owned candidates are never inferred from staging and are not
 silently included.
 
+If `PRODUCTION_REPLAN_INTENT_SCAN_FAILED_CLOSED` reports the 500-row scan cap,
+no replacement may claim. Wait for production ownership to drain, inspect every
+explicit ready/held intent, and use the authenticated revoke/cancel actions
+only for owner-authorized stale intents until the bounded scan is complete.
+Otherwise deploy a separately reviewed cap/pagination change. Never edit the
+ledger, discard intent, or split a dependency set merely to unblock the queue.
+
 The replacement boundary closes as soon as any `ADVANCE_MAIN_*` succeeds, a
 production deploy is dispatched, or production E2E exists. After that boundary,
 the original exact set remains frozen and only that train may resume or recover;

--- a/ops/deployment-bus/simple-release-bus-v2.md
+++ b/ops/deployment-bus/simple-release-bus-v2.md
@@ -138,6 +138,24 @@ candidate/repository/PR/head identity and successful production E2E. Omitted
 unrelated candidates keep their staging evidence and separate production
 intent.
 
+If either production base moves before irreversible production mutation, the
+old train is cancelled without changing its immutable membership and its exact
+explicit intents move to `WAITING_FOR_PRODUCTION_REPLAN`. The next scheduler
+transaction creates a new replacement selection and train from every currently
+eligible explicit production intent, including compatible selections committed
+after the old train was claimed. It locks and rechecks exact heads, staging
+train/manifest/E2E evidence, dependencies, ownership, and both current
+production bases. Audit events map every included candidate and source
+selection/train to the replacement and retain every omitted intent with its
+exact reason. Revoked, superseded, moved, stale-evidence, dependency-incomplete,
+or concurrently owned candidates are never inferred from staging and are not
+silently included.
+
+The replacement boundary closes as soon as any `ADVANCE_MAIN_*` succeeds, a
+production deploy is dispatched, or production E2E exists. After that boundary,
+the original exact set remains frozen and only that train may resume or recover;
+an active train is never broadened in place.
+
 New production trains use `CANDIDATE_STAGING_EVIDENCE_V1`:
 
 - resolve and persist, per selected candidate, candidate ID, repository, PR,
@@ -186,16 +204,17 @@ explicitly.
 
 ## Failure behavior
 
-| Class                         | Behavior                                                                                                                                                                                                                                                                          |
-| ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Candidate merge/test          | Before shared mutation, fail the cumulative train closed and leave the last validated admitted manifest live; mark only the new direct candidate `NEEDS_REBASE` as applicable                                                                                                     |
-| Ordinary staging preflight    | After already-running workflows drain, fail the affected repository's NEW candidate group once, hold only dependants, and return independent repository candidates to the next train; never dispatch subset-isolation workflows |
-| Infrastructure                | Bounded idempotent retry; no candidate isolation                                                                                                                                                                                                                                  |
-| Retryable deployment          | Retry only the failed operation; preserve successful sibling evidence                                                                                                                                                                                                             |
-| Control plane                 | Fail the train, requeue candidates, pause automated claiming, release an environment lock once every operation is terminal, retain manual fallback                                                                                                                                |
-| E2E                           | Keep the failed manifest unvalidated and restore/deploy/E2E the exact last validated live manifest under the same staging lock; commit no admission change until restoration validates                                                                                            |
-| Production preflight          | Fail before shared mutation. A later explicit exact-SHA selection may retry only after the unchanged staging evidence is revalidated and the locked failed train contains only terminal compose/preflight operations; audit both selection identities and the failed source train |
-| Production after main advance | Fail selected candidates closed, pause `PRODUCTION`, and block later production claims. `main` remains truthful and is never rewritten; an operator must prove the recorded exact main/runtime parity or complete an explicit rollback before resuming                            |
+| Class                         | Behavior                                                                                                                                                                                                                                                                                             |
+| ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Candidate merge/test          | Before shared mutation, fail the cumulative train closed and leave the last validated admitted manifest live; mark only the new direct candidate `NEEDS_REBASE` as applicable                                                                                                                        |
+| Ordinary staging preflight    | After already-running workflows drain, fail the affected repository's NEW candidate group once, hold only dependants, and return independent repository candidates to the next train; never dispatch subset-isolation workflows                                                                      |
+| Infrastructure                | Bounded idempotent retry; no candidate isolation                                                                                                                                                                                                                                                     |
+| Retryable deployment          | Retry only the failed operation; preserve successful sibling evidence                                                                                                                                                                                                                                |
+| Control plane                 | Fail the train, requeue candidates, pause automated claiming, release an environment lock once every operation is terminal, retain manual fallback                                                                                                                                                   |
+| E2E                           | Keep the failed manifest unvalidated and restore/deploy/E2E the exact last validated live manifest under the same staging lock; commit no admission change until restoration validates                                                                                                               |
+| Production preflight          | Fail before shared mutation. A later explicit exact-SHA selection may retry only after the unchanged staging evidence is revalidated and the locked failed train contains only terminal compose/preflight operations; audit both selection identities and the failed source train                    |
+| Production base moved         | Before irreversible mutation, transactionally preserve explicit intent and form a new audited replacement from all currently eligible dependency-closed selections; retain every omission reason. After irreversible mutation, freeze the original exact set and pause production for exact recovery |
+| Production after main advance | Fail selected candidates closed, pause `PRODUCTION`, and block later production claims. `main` remains truthful and is never rewritten; an operator must prove the recorded exact main/runtime parity or complete an explicit rollback before resuming                                               |
 
 Every pending GitHub status must map to a visible candidate/train/operation state
 and recovery message. Duplicate callbacks and worker invocations reuse immutable

--- a/ops/deployment-bus/simple-release-bus-v2.md
+++ b/ops/deployment-bus/simple-release-bus-v2.md
@@ -161,7 +161,10 @@ ledger, discard intent, or split a dependency set merely to unblock the queue.
 The replacement boundary closes as soon as any `ADVANCE_MAIN_*` succeeds, a
 production deploy is dispatched, or production E2E exists. After that boundary,
 the original exact set remains frozen and only that train may resume or recover;
-an active train is never broadened in place.
+an active train is never broadened in place. A nonterminal dispatched operation
+retains the production-environment lease while it drains. Once all recorded
+work is terminal, the frozen/paused train releases that lease; the active train
+and paused `PRODUCTION` control still block every new claim until exact recovery.
 
 New production trains use `CANDIDATE_STAGING_EVIDENCE_V1`:
 

--- a/ops/skills/deploy-6529/SKILL.md
+++ b/ops/skills/deploy-6529/SKILL.md
@@ -49,7 +49,9 @@ through the documented fallback.
    source selection/train mapping and every omitted intent reason. It must never
    infer candidates from staging. After any successful main advance, production
    deploy dispatch, or production E2E, the original exact set is frozen and may
-   only resume or recover unchanged.
+   only resume or recover unchanged. Retain its production lease only while
+   dispatched work remains nonterminal; after terminal drain, release the lease
+   while the paused train/control continue blocking new claims.
    If `PRODUCTION_REPLAN_INTENT_SCAN_FAILED_CLOSED` reaches its bounded cap,
    stop claiming; after ownership drains, revoke/cancel only owner-authorized
    stale intents or deploy a separately reviewed pagination/cap change. Never

--- a/ops/skills/deploy-6529/SKILL.md
+++ b/ops/skills/deploy-6529/SKILL.md
@@ -50,6 +50,10 @@ through the documented fallback.
    infer candidates from staging. After any successful main advance, production
    deploy dispatch, or production E2E, the original exact set is frozen and may
    only resume or recover unchanged.
+   If `PRODUCTION_REPLAN_INTENT_SCAN_FAILED_CLOSED` reaches its bounded cap,
+   stop claiming; after ownership drains, revoke/cancel only owner-authorized
+   stale intents or deploy a separately reviewed pagination/cap change. Never
+   edit the ledger or silently drop intent.
    During an API-before-reconciler rolling upgrade, the selection parks at
    `READY_FOR_CANDIDATE_EVIDENCE_PRODUCTION`; never rewrite it to the legacy
    ready status to make an older worker claim it.

--- a/ops/skills/deploy-6529/SKILL.md
+++ b/ops/skills/deploy-6529/SKILL.md
@@ -14,11 +14,11 @@ description: Route and execute 6529 backend, frontend, or coupled staging and pr
    mode, or incomplete controls. Never infer mode from files or old output.
 3. Route by the fresh v2 result:
 
-| Mode | Staging | Production |
-| --- | --- | --- |
-| `OFF` | Serialized manual fallback | Serialized manual fallback with explicit owner authorization; staging evidence is not required |
-| `STAGING` | Register the exact candidate with v2 | Manual fallback only; production automation is disabled |
-| `PRODUCTION` | Register the exact candidate with v2 | Explicitly mark an exact `STAGING_VALIDATED` candidate ready for v2 production |
+| Mode         | Staging                              | Production                                                                                     |
+| ------------ | ------------------------------------ | ---------------------------------------------------------------------------------------------- |
+| `OFF`        | Serialized manual fallback           | Serialized manual fallback with explicit owner authorization; staging evidence is not required |
+| `STAGING`    | Register the exact candidate with v2 | Manual fallback only; production automation is disabled                                        |
+| `PRODUCTION` | Register the exact candidate with v2 | Explicitly mark an exact `STAGING_VALIDATED` candidate ready for v2 production                 |
 
 When mode is active, stop if `ALL` or the target lane is paused. In `OFF`, v2
 controls are non-authoritative and do not prohibit manual staging or production
@@ -43,6 +43,13 @@ through the documented fallback.
    branch still equals its exact staging-validated SHA. Staging validation never
    schedules production automatically. Omitted candidates retain their
    validation evidence and any separate production intent.
+   A pre-mutation production replan may create a new audited replacement from
+   all currently eligible explicit selections, including a compatible selection
+   recorded after the source train was claimed. Verify the replacement event's
+   source selection/train mapping and every omitted intent reason. It must never
+   infer candidates from staging. After any successful main advance, production
+   deploy dispatch, or production E2E, the original exact set is frozen and may
+   only resume or recover unchanged.
    During an API-before-reconciler rolling upgrade, the selection parks at
    `READY_FOR_CANDIDATE_EVIDENCE_PRODUCTION`; never rewrite it to the legacy
    ready status to make an older worker claim it.

--- a/src/releaseBusV2/release-bus-v2.acceptance.test.ts
+++ b/src/releaseBusV2/release-bus-v2.acceptance.test.ts
@@ -590,6 +590,75 @@ function harness(e2eStatus: 'RUNNING' | 'SUCCEEDED' | 'FAILED') {
   );
   const service = {
     claimLane: jest.fn(async () => null),
+    preserveProductionIntentsForSafeReplan: jest.fn(
+      async ({
+        trainId,
+        reason
+      }: {
+        readonly trainId: string;
+        readonly reason: string;
+      }) => {
+        const currentTrain = repository.trains.get(trainId);
+        if (!currentTrain)
+          return { status: 'NOOP', trainId, reason: 'missing train' } as const;
+        const irreversible = repository.operations.find(
+          (item) =>
+            item.train_id === trainId &&
+            ((item.operation_type.startsWith('ADVANCE_MAIN_') &&
+              item.status === 'SUCCEEDED') ||
+              (item.environment === 'prod' &&
+                item.operation_type.startsWith('DEPLOY_') &&
+                item.external_id !== null) ||
+              (item.operation_type === 'E2E_PROD' &&
+                item.status !== 'CANCELLED'))
+        );
+        if (irreversible) {
+          repository.trains.set(trainId, {
+            ...currentTrain,
+            status: 'PAUSED',
+            recovery_message: 'Original exact membership remains frozen',
+            row_version: currentTrain.row_version + 1
+          });
+          return {
+            status: 'FROZEN',
+            trainId,
+            reason: `irreversible ${irreversible.operation_type}`
+          } as const;
+        }
+        const candidateIds = repository.memberships
+          .filter(
+            (membership) =>
+              membership.train_id === trainId &&
+              membership.disposition === 'INCLUDED'
+          )
+          .map(({ candidate_id }) => candidate_id);
+        for (const candidateId of candidateIds) {
+          const current = repository.candidates.get(candidateId);
+          if (!current) continue;
+          repository.candidates.set(candidateId, {
+            ...current,
+            status: 'WAITING_FOR_PRODUCTION_REPLAN',
+            current_train_id: null,
+            hold_reason: reason,
+            row_version: current.row_version + 1
+          });
+        }
+        repository.trains.set(trainId, {
+          ...currentTrain,
+          status: 'CANCELLED',
+          failure_class: 'INTERACTION',
+          failure_message: reason,
+          completed_at: Date.now(),
+          row_version: currentTrain.row_version + 1
+        });
+        return {
+          status: 'REPLANNED',
+          trainId,
+          candidateIds,
+          sourceSelectionIds: []
+        } as const;
+      }
+    ),
     repairTerminalCumulativeCarryForwardStatuses: jest.fn(async () => []),
     setPaused: jest.fn(
       async (
@@ -2411,8 +2480,8 @@ describe('Release Bus v2 offline acceptance harness', () => {
         ({ status, current_train_id }) => ({ status, current_train_id })
       )
     ).toEqual([
-      { status: 'READY_FOR_PRODUCTION', current_train_id: null },
-      { status: 'READY_FOR_PRODUCTION', current_train_id: null }
+      { status: 'WAITING_FOR_PRODUCTION_REPLAN', current_train_id: null },
+      { status: 'WAITING_FOR_PRODUCTION_REPLAN', current_train_id: null }
     ]);
     expect(mockReconcileWorkflow).not.toHaveBeenCalled();
     expect(state.repository.lock.owner_train_id).toBeNull();
@@ -2459,7 +2528,7 @@ describe('Release Bus v2 offline acceptance harness', () => {
     );
     expect(state.repository.candidates.get('backend-candidate')).toEqual(
       expect.objectContaining({
-        status: 'READY_FOR_PRODUCTION',
+        status: 'WAITING_FOR_PRODUCTION_REPLAN',
         current_train_id: null
       })
     );
@@ -2608,7 +2677,8 @@ describe('Release Bus v2 offline acceptance harness', () => {
     expect(
       Array.from(state.repository.candidates.values()).every(
         ({ status, current_train_id }) =>
-          status === 'READY_FOR_PRODUCTION' && current_train_id === null
+          status === 'WAITING_FOR_PRODUCTION_REPLAN' &&
+          current_train_id === null
       )
     ).toBe(true);
     expect(mockReconcileWorkflow).toHaveBeenCalledTimes(4);

--- a/src/releaseBusV2/release-bus-v2.github-app.test.ts
+++ b/src/releaseBusV2/release-bus-v2.github-app.test.ts
@@ -15,8 +15,8 @@ jest.mock('node-fetch', () => {
   return { ...actual, __esModule: true, default: jest.fn() };
 });
 
-function appWithCachedToken(): ReleaseBusGitHubApp {
-  const app = new ReleaseBusGitHubApp();
+function appWithCachedToken(requestTimeoutMs?: number): ReleaseBusGitHubApp {
+  const app = new ReleaseBusGitHubApp(requestTimeoutMs);
   (
     app as unknown as {
       cachedToken: { value: string; expiresAt: number };
@@ -54,6 +54,32 @@ describe('GitHub immutable release refs', () => {
         })
       })
     );
+  });
+
+  it('aborts a GitHub request at the configured request deadline', async () => {
+    const fetchMock = fetch as jest.MockedFunction<typeof fetch>;
+    fetchMock.mockImplementationOnce(
+      (_url, options) =>
+        new Promise((_resolve, reject) => {
+          options?.signal?.addEventListener(
+            'abort',
+            () => {
+              const error = new Error('aborted');
+              error.name = 'AbortError';
+              reject(error);
+            },
+            { once: true }
+          );
+        })
+    );
+
+    await expect(
+      appWithCachedToken(5).resolveRef('frontend', 'main')
+    ).rejects.toMatchObject({
+      name: ReleaseBusGitHubInfrastructureError.name,
+      message: 'GitHub request timed out after 5ms'
+    });
+    expect(fetchMock.mock.calls[0]?.[1]?.signal).toBeDefined();
   });
 
   it('is idempotent only when a racing ref resolves to the exact SHA', async () => {

--- a/src/releaseBusV2/release-bus-v2.github-app.ts
+++ b/src/releaseBusV2/release-bus-v2.github-app.ts
@@ -118,11 +118,13 @@ const MAX_WORKFLOW_LABEL_LENGTH = 500;
 const MAX_STAGING_FENCE_PAGES = 10;
 const MAX_PULL_REQUEST_COMMIT_PAGES = 3;
 const GITHUB_PAGE_SIZE = 100;
+const GITHUB_REQUEST_TIMEOUT_MS = 15_000;
 
 export class ReleaseBusGitHubInfrastructureError extends Error {
   public constructor(message: string) {
     super(message);
     this.name = 'ReleaseBusGitHubInfrastructureError';
+    Object.setPrototypeOf(this, new.target.prototype);
   }
 }
 
@@ -216,6 +218,10 @@ export class ReleaseBusGitHubApp {
     readonly expiresAt: number;
   } | null = null;
 
+  public constructor(
+    private readonly requestTimeoutMs = GITHUB_REQUEST_TIMEOUT_MS
+  ) {}
+
   private get owner(): string {
     return process.env.RELEASE_BUS_GITHUB_ORG ?? '6529-Collections';
   }
@@ -233,14 +239,15 @@ export class ReleaseBusGitHubApp {
       throw new Error('GitHub App credentials are not configured');
     let response: Response;
     try {
-      response = await fetch(
+      response = await this.fetchWithTimeout(
         `https://api.github.com/app/installations/${installationId}/access_tokens`,
         {
           method: 'POST',
           headers: this.headers(appJwt(appId, privateKey))
         }
       );
-    } catch {
+    } catch (error) {
+      if (error instanceof ReleaseBusGitHubInfrastructureError) throw error;
       throw new ReleaseBusGitHubInfrastructureError(
         'GitHub App token request failed before a response was received'
       );
@@ -264,6 +271,49 @@ export class ReleaseBusGitHubApp {
     };
   }
 
+  private async fetchWithTimeout(
+    url: string,
+    options: RequestInit = {}
+  ): Promise<Response> {
+    const controller = new AbortController();
+    const outerSignal = options.signal;
+    let timedOut = false;
+    const timeoutId = setTimeout(() => {
+      timedOut = true;
+      controller.abort();
+    }, this.requestTimeoutMs);
+    timeoutId.unref();
+
+    const onOuterAbort = () => controller.abort();
+    if (outerSignal) {
+      if (outerSignal.aborted) {
+        clearTimeout(timeoutId);
+        controller.abort();
+      } else {
+        outerSignal.addEventListener('abort', onOuterAbort, { once: true });
+      }
+    }
+
+    try {
+      return await fetch(url, {
+        ...options,
+        signal: controller.signal as RequestInit['signal']
+      });
+    } catch (error) {
+      if (error instanceof Error && error.name === 'AbortError') {
+        throw new ReleaseBusGitHubInfrastructureError(
+          timedOut
+            ? `GitHub request timed out after ${this.requestTimeoutMs}ms`
+            : 'GitHub request was aborted'
+        );
+      }
+      throw error;
+    } finally {
+      clearTimeout(timeoutId);
+      outerSignal?.removeEventListener('abort', onOuterAbort);
+    }
+  }
+
   private async request(
     repository: ReleaseBusV2Repository,
     path: string,
@@ -271,14 +321,15 @@ export class ReleaseBusGitHubApp {
   ): Promise<Response> {
     const token = await this.token();
     try {
-      return await fetch(
+      return await this.fetchWithTimeout(
         `https://api.github.com/repos/${this.owner}/${REPOSITORIES[repository]}${path}`,
         {
           ...options,
           headers: { ...this.headers(token), ...(options.headers ?? {}) }
         }
       );
-    } catch {
+    } catch (error) {
+      if (error instanceof ReleaseBusGitHubInfrastructureError) throw error;
       throw new ReleaseBusGitHubInfrastructureError(
         `GitHub ${repository} request failed before a response was received`
       );
@@ -291,11 +342,12 @@ export class ReleaseBusGitHubApp {
   ): Promise<Response> {
     const token = await this.token();
     try {
-      return await fetch(`https://api.github.com${path}`, {
+      return await this.fetchWithTimeout(`https://api.github.com${path}`, {
         ...options,
         headers: { ...this.headers(token), ...(options.headers ?? {}) }
       });
-    } catch {
+    } catch (error) {
+      if (error instanceof ReleaseBusGitHubInfrastructureError) throw error;
       throw new ReleaseBusGitHubInfrastructureError(
         'GitHub organization request failed before a response was received'
       );

--- a/src/releaseBusV2/release-bus-v2.reconciler.ts
+++ b/src/releaseBusV2/release-bus-v2.reconciler.ts
@@ -5424,60 +5424,35 @@ export class ReleaseBusV2Reconciler {
     train: ReleaseBusV2TrainRecord,
     message: string
   ): Promise<void> {
-    const current = await this.repository.findTrain(train.id, {});
-    if (!current || TERMINAL_TRAINS.has(current.status)) return;
-    const operations = await this.repository.listOperations(current.id, {});
-    if (operations.some(operationMayStillBeRunning)) return;
-    for (const operation of operations) {
-      if (TERMINAL_OPERATIONS.has(operation.status)) continue;
-      if (
-        !(await this.repository.updateOperation(
-          operation.id,
-          operation.row_version,
-          {
-            status: 'CANCELLED',
-            failureClass: 'INTERACTION',
-            failureMessage: message,
-            completedAt: Date.now()
-          },
-          {}
-        ))
-      )
-        throw new Error('Release Bus v2 operation changed concurrently');
-    }
-    const context = await this.loadContext(current);
-    await this.updateCandidateStatuses(
-      relevantCandidates(context),
-      current.qualification_policy === CANDIDATE_STAGING_EVIDENCE_POLICY
-        ? CANDIDATE_EVIDENCE_READY_STATUS
-        : 'READY_FOR_PRODUCTION',
-      null,
-      false
-    );
-    const lease = (await this.repository.listLocks({})).find(
-      (lock) =>
-        lock.name === 'production-environment' &&
-        lock.owner_train_id === current.id
-    );
-    if (lease?.lease_token)
-      await this.repository.releaseLock(
-        'production-environment',
-        lease.lease_token,
-        {}
-      );
-    await this.publishCandidateStatuses(
-      relevantCandidates(context),
-      'pending',
-      'Main moved; v2 will recompute and requalify this exact production subset'
-    );
-    await this.transitionTrain(current, {
-      status: 'CANCELLED',
-      failureClass: 'INTERACTION',
-      failureMessage: message,
-      recoveryMessage:
-        'Main moved before production mutation; the explicit candidate subset was safely requeued for fresh composition and qualification',
-      completedAt: Date.now()
+    const result = await this.service.preserveProductionIntentsForSafeReplan({
+      trainId: train.id,
+      reason: message,
+      actor: 'release-bus-v2'
     });
+    if (result.status === 'NOOP') return;
+    if (result.status === 'FROZEN') {
+      await this.service.setPaused(
+        'PRODUCTION',
+        true,
+        `${result.reason}; train ${train.id} must recover its original exact set`,
+        'release-bus-v2'
+      );
+      return;
+    }
+    const candidates = (
+      await Promise.all(
+        result.candidateIds.map((candidateId) =>
+          this.repository.findCandidateById(candidateId, {})
+        )
+      )
+    ).filter((candidate): candidate is ReleaseBusV2CandidateRecord =>
+      Boolean(candidate)
+    );
+    await this.publishCandidateStatuses(
+      candidates,
+      'pending',
+      'Main moved before mutation; explicit intent is preserved for a new audited replacement'
+    );
   }
 
   private async publishCandidateStatuses(

--- a/src/releaseBusV2/release-bus-v2.service.test.ts
+++ b/src/releaseBusV2/release-bus-v2.service.test.ts
@@ -1873,6 +1873,11 @@ describe('Release Bus v2 explicit production opt-in', () => {
       expect.objectContaining({
         eventType: 'PRODUCTION_REPLAN_REPLACEMENT_NOT_CLAIMED',
         payload: expect.objectContaining({
+          source_production_selection_ids: [
+            'selection-stale-base-later',
+            'selection-stale-base-original'
+          ],
+          source_train_ids: [],
           omitted_intents: expect.arrayContaining([
             expect.objectContaining({
               candidate_id: original.id,
@@ -2111,6 +2116,89 @@ describe('Release Bus v2 explicit production opt-in', () => {
     );
   });
 
+  it('re-locks an omitted intent before preserving it after a concurrent row-version change', async () => {
+    const seed = productionIntent(
+      validatedCandidate('candidate-row-race-seed', 'backend', '4', 211),
+      'WAITING_FOR_PRODUCTION_REPLAN',
+      'selection-row-race-seed',
+      10
+    );
+    const raced = productionIntent(
+      validatedCandidate('candidate-row-race-omitted', 'frontend', '5', 212),
+      'READY_FOR_CANDIDATE_EVIDENCE_PRODUCTION',
+      'selection-row-race-omitted',
+      20
+    );
+    const state = selectionRepository([seed, raced]);
+    state.candidates.set(raced.id, {
+      ...raced,
+      staging_validated_manifest_id: null
+    });
+    const originalFindCandidateById =
+      state.repository.findCandidateById.getMockImplementation()!;
+    let qualificationReadComplete = false;
+    let rowVersionBumped = false;
+    state.repository.findCandidateById.mockImplementation(
+      async (id: string) => {
+        const current = await originalFindCandidateById(id);
+        if (
+          id === raced.id &&
+          qualificationReadComplete &&
+          !rowVersionBumped &&
+          current
+        ) {
+          rowVersionBumped = true;
+          const bumped = {
+            ...current,
+            row_version: current.row_version + 1
+          };
+          state.candidates.set(id, bumped);
+          return bumped;
+        }
+        return current;
+      }
+    );
+    mockResolveRef.mockImplementation(
+      async (repository: string, ref: string) =>
+        ref === 'main'
+          ? repository === 'frontend'
+            ? '8'.repeat(40)
+            : '9'.repeat(40)
+          : [seed, raced].find((item) => item.branch_name === ref)?.head_sha
+    );
+    mockResolveRefIfExists.mockImplementation(
+      async (_repository: string, ref: string) => {
+        const selected = [seed, raced].find((item) => item.branch_name === ref);
+        if (selected?.id === raced.id) qualificationReadComplete = true;
+        return selected?.head_sha ?? null;
+      }
+    );
+    const service = new ReleaseBusV2Service(state.repository as never);
+
+    await expect(
+      service.claimLane(
+        'PRODUCTION',
+        '8'.repeat(40),
+        '9'.repeat(40),
+        'scheduler'
+      )
+    ).resolves.toEqual(
+      expect.objectContaining({ id: 'claimed-selection-train' })
+    );
+
+    expect(rowVersionBumped).toBe(true);
+    expect(state.candidates.get(raced.id)).toEqual(
+      expect.objectContaining({
+        status: 'WAITING_FOR_PRODUCTION_REPLAN',
+        production_selection_id: 'selection-row-race-omitted',
+        hold_reason: expect.stringContaining(
+          'no current staging validation evidence'
+        ),
+        row_version: raced.row_version + 2
+      })
+    );
+  });
+
   it('preserves exact source selection provenance when a train is safely replanned before mutation', async () => {
     const state = safeReplanRepository(null);
     const service = new ReleaseBusV2Service(state.repository as never);
@@ -2161,6 +2249,13 @@ describe('Release Bus v2 explicit production opt-in', () => {
         'orchestration'
       )
     );
+    state.repository.listLocks.mockResolvedValue([
+      {
+        name: 'production-environment',
+        owner_train_id: 'production-replan-source',
+        lease_token: 'production-lease'
+      }
+    ] as never);
     const beforeTrain = state.train();
     const beforeIntent = state.intent();
     const service = new ReleaseBusV2Service(state.repository as never);
@@ -2183,6 +2278,11 @@ describe('Release Bus v2 explicit production opt-in', () => {
     expect(state.intent()).toEqual(beforeIntent);
     expect(state.repository.updateOperation).not.toHaveBeenCalled();
     expect(state.appendEvent).not.toHaveBeenCalled();
+    expect(state.repository.releaseLock).not.toHaveBeenCalledWith(
+      'production-environment',
+      'production-lease',
+      expect.anything()
+    );
   });
 
   it.each([
@@ -2214,7 +2314,8 @@ describe('Release Bus v2 explicit production opt-in', () => {
   it.each([
     [
       productionOperation('ADVANCE_MAIN_BACKEND', 'SUCCEEDED', 'a'.repeat(40)),
-      'ADVANCE_MAIN_BACKEND succeeded'
+      'ADVANCE_MAIN_BACKEND succeeded',
+      true
     ],
     [
       productionOperation(
@@ -2222,16 +2323,25 @@ describe('Release Bus v2 explicit production opt-in', () => {
         'DISPATCHED',
         'deploy-run'
       ),
-      'the train entered PRODUCTION_DEPLOYING'
+      'the train entered PRODUCTION_DEPLOYING',
+      false
     ],
     [
       productionOperation('E2E_PROD', 'PENDING', null),
-      'production E2E was created'
+      'production E2E was created',
+      true
     ]
   ])(
     'freezes the original exact train after irreversible work instead of broadening it',
-    async (operation, expectedReason) => {
+    async (operation, expectedReason, releasesTerminalLock) => {
       const state = safeReplanRepository(operation);
+      state.repository.listLocks.mockResolvedValue([
+        {
+          name: 'production-environment',
+          owner_train_id: 'production-replan-source',
+          lease_token: 'production-lease'
+        }
+      ] as never);
       const before = state.intent();
       const service = new ReleaseBusV2Service(state.repository as never);
 
@@ -2258,10 +2368,27 @@ describe('Release Bus v2 explicit production opt-in', () => {
       expect(state.intent()).toEqual(before);
       expect(state.appendEvent).toHaveBeenCalledWith(
         expect.objectContaining({
-          eventType: 'PRODUCTION_REPLAN_REJECTED_AFTER_IRREVERSIBLE_MUTATION'
+          eventType: 'PRODUCTION_REPLAN_REJECTED_AFTER_IRREVERSIBLE_MUTATION',
+          payload: expect.objectContaining({
+            production_environment_lock: releasesTerminalLock
+              ? 'RELEASED_OR_ALREADY_FREE_AFTER_TERMINAL_WORK'
+              : 'RETAINED_WHILE_DISPATCHED_WORK_DRAINS'
+          })
         }),
         expect.anything()
       );
+      if (releasesTerminalLock)
+        expect(state.repository.releaseLock).toHaveBeenCalledWith(
+          'production-environment',
+          'production-lease',
+          expect.anything()
+        );
+      else
+        expect(state.repository.releaseLock).not.toHaveBeenCalledWith(
+          'production-environment',
+          'production-lease',
+          expect.anything()
+        );
     }
   );
 
@@ -2327,6 +2454,44 @@ describe('Release Bus v2 explicit production opt-in', () => {
       'scheduler-lease',
       {}
     );
+  });
+
+  it('releases the scheduler lease only after an authoritative selection rollback', async () => {
+    const state = repositoryFor(candidate('STAGING_VALIDATED'));
+    const order: string[] = [];
+    state.repository.acquireLock.mockImplementation(async () => {
+      order.push('scheduler-acquired');
+      return { lease_token: 'scheduler-lease' } as never;
+    });
+    state.repository.executeNativeQueriesInTransaction.mockImplementation(
+      async (callback: (connection: unknown) => Promise<unknown>) => {
+        order.push('transaction-started');
+        try {
+          return await callback({});
+        } catch (error) {
+          order.push('transaction-rolled-back');
+          throw error;
+        }
+      }
+    );
+    state.repository.updateCandidate.mockImplementation(async () => false);
+    state.repository.releaseLock.mockImplementation(async () => {
+      order.push('scheduler-released');
+      return true;
+    });
+    mockResolveRef.mockResolvedValue('a'.repeat(40));
+    const service = new ReleaseBusV2Service(state.repository as never);
+
+    await expect(
+      service.markReadyForProduction('candidate-id', 'a'.repeat(40), 3, 'owner')
+    ).rejects.toThrow('Candidate changed concurrently');
+
+    expect(order).toEqual([
+      'scheduler-acquired',
+      'transaction-started',
+      'transaction-rolled-back',
+      'scheduler-released'
+    ]);
   });
 
   it('rejects an omitted production dependency without exact deployed identity', async () => {

--- a/src/releaseBusV2/release-bus-v2.service.test.ts
+++ b/src/releaseBusV2/release-bus-v2.service.test.ts
@@ -1,18 +1,27 @@
 const mockResolveRef = jest.fn();
+const mockResolveRefIfExists = jest.fn();
 const mockQualification = jest.fn();
 const mockEnsureCommitStatus = jest.fn();
 
 jest.mock('@/releaseBusV2/release-bus-v2.github-app', () => ({
   releaseBusGitHubApp: {
     resolveRef: (...args: unknown[]) => mockResolveRef(...args),
+    resolveRefIfExists: (...args: unknown[]) => mockResolveRefIfExists(...args),
     getPullRequestQualification: (...args: unknown[]) =>
       mockQualification(...args),
     ensureCommitStatus: (...args: unknown[]) => mockEnsureCommitStatus(...args)
   }
 }));
 
-import { ReleaseBusV2Service } from '@/releaseBusV2/release-bus-v2.service';
-import type { ReleaseBusV2CandidateRecord } from '@/releaseBusV2/release-bus-v2.types';
+import {
+  irreversibleProductionOperationReason,
+  ReleaseBusV2Service
+} from '@/releaseBusV2/release-bus-v2.service';
+import type {
+  ReleaseBusV2CandidateRecord,
+  ReleaseBusV2OperationRecord,
+  ReleaseBusV2TrainRecord
+} from '@/releaseBusV2/release-bus-v2.types';
 
 function candidate(
   status: ReleaseBusV2CandidateRecord['status']
@@ -91,6 +100,8 @@ function repositoryFor(initial: ReleaseBusV2CandidateRecord) {
       ]),
       listDependencies: jest.fn(async () => []),
       listProductionManifestsForCandidate: jest.fn(async () => []),
+      acquireLock: jest.fn(async () => ({ lease_token: 'scheduler-lease' })),
+      releaseLock: jest.fn(async () => true),
       executeNativeQueriesInTransaction: jest.fn(
         async (callback: (connection: unknown) => Promise<unknown>) =>
           callback({})
@@ -333,6 +344,25 @@ function currentStagingRepairRepository(options?: {
   };
 }
 
+function productionIntent(
+  item: ReleaseBusV2CandidateRecord,
+  status:
+    | 'READY_FOR_CANDIDATE_EVIDENCE_PRODUCTION'
+    | 'WAITING_FOR_PRODUCTION_REPLAN',
+  selectionId: string,
+  requestedAt: number
+): ReleaseBusV2CandidateRecord {
+  return {
+    ...item,
+    status,
+    production_requested_at: requestedAt,
+    production_requested_by: `operator-${selectionId}`,
+    production_selection_id: selectionId,
+    current_train_id: null,
+    row_version: item.row_version + 1
+  };
+}
+
 function selectionRepository(
   initial: readonly ReleaseBusV2CandidateRecord[],
   dependencies: readonly {
@@ -456,6 +486,9 @@ function selectionRepository(
       Array.from(productionManifests.get(id) ?? [])
     ),
     listEvents: jest.fn(async (): Promise<unknown[]> => []),
+    listCandidateEvents: jest.fn(
+      async (..._args: unknown[]): Promise<unknown[]> => []
+    ),
     createTrain,
     executeNativeQueriesInTransaction: jest.fn(
       async (callback: (connection: unknown) => Promise<unknown>) =>
@@ -480,11 +513,17 @@ function selectionRepository(
           ...item,
           status: fields.status ?? item.status,
           production_requested_at:
-            fields.productionRequestedAt ?? item.production_requested_at,
+            fields.productionRequestedAt === undefined
+              ? item.production_requested_at
+              : fields.productionRequestedAt,
           production_requested_by:
-            fields.productionRequestedBy ?? item.production_requested_by,
+            fields.productionRequestedBy === undefined
+              ? item.production_requested_by
+              : fields.productionRequestedBy,
           production_selection_id:
-            fields.productionSelectionId ?? item.production_selection_id,
+            fields.productionSelectionId === undefined
+              ? item.production_selection_id
+              : fields.productionSelectionId,
           current_train_id:
             fields.currentTrainId === undefined
               ? item.current_train_id
@@ -1004,6 +1043,169 @@ describe('Release Bus v2 explicit grouped staging preflight retry', () => {
     );
   });
 });
+
+function productionOperation(
+  operationType: string,
+  status: ReleaseBusV2OperationRecord['status'],
+  externalId: string | null,
+  environment = 'prod'
+): ReleaseBusV2OperationRecord {
+  return {
+    id: `operation-${operationType}`,
+    idempotency_key: `operation-key-${operationType}`,
+    train_id: 'production-replan-source',
+    operation_type: operationType,
+    repository: 'backend',
+    service: operationType.startsWith('DEPLOY_') ? 'api' : null,
+    environment,
+    expected_sha: 'a'.repeat(40),
+    artifact_digest: null,
+    external_id: externalId,
+    status,
+    attempt: 1,
+    max_attempts: 3,
+    next_retry_at: null,
+    failure_class: null,
+    failure_message: null,
+    request_json: null,
+    result_json: null,
+    started_at: status === 'PENDING' ? null : 1,
+    completed_at: status === 'SUCCEEDED' ? 2 : null,
+    created_at: 1,
+    updated_at: 1,
+    row_version: 1
+  };
+}
+
+function safeReplanRepository(operation: ReleaseBusV2OperationRecord | null) {
+  let train: ReleaseBusV2TrainRecord = {
+    id: 'production-replan-source',
+    lane: 'PRODUCTION',
+    status: operation?.operation_type.startsWith('DEPLOY_')
+      ? 'PRODUCTION_DEPLOYING'
+      : 'MERGING_PRODUCTION',
+    frontend_base_sha: '1'.repeat(40),
+    backend_base_sha: '2'.repeat(40),
+    frontend_composed_sha: '3'.repeat(40),
+    backend_composed_sha: '4'.repeat(40),
+    frontend_artifact_digest: null,
+    backend_artifact_digest: '5'.repeat(64),
+    manifest_id: null,
+    parent_train_id: null,
+    qualification_identity_sha256: null,
+    qualification_train_id: null,
+    qualification_policy: 'CANDIDATE_STAGING_EVIDENCE_V1',
+    qualification_evidence_json: null,
+    failure_class: null,
+    failure_message: null,
+    recovery_message: null,
+    phase_started_at: 1,
+    completed_at: null,
+    created_at: 1,
+    updated_at: 1,
+    row_version: 1
+  };
+  let intent: ReleaseBusV2CandidateRecord = {
+    ...productionIntent(
+      validatedCandidate('candidate-replan-source', 'backend', 'a', 301),
+      'WAITING_FOR_PRODUCTION_REPLAN',
+      'selection-replan-source',
+      1
+    ),
+    status: 'PRODUCTION_BUILDING_OR_QUALIFYING',
+    current_train_id: train.id
+  };
+  const operations = operation ? [operation] : [];
+  const appendEvent = jest.fn(async () => undefined);
+  const repository = {
+    executeNativeQueriesInTransaction: jest.fn(
+      async (callback: (connection: unknown) => Promise<unknown>) =>
+        callback({})
+    ),
+    acquireLock: jest.fn(async () => ({ lease_token: 'scheduler-lease' })),
+    releaseLock: jest.fn(async () => true),
+    findTrain: jest.fn(async () => train),
+    listOperations: jest.fn(async () => operations),
+    updateOperation: jest.fn(async () => true),
+    listTrainCandidates: jest.fn(async () => [
+      {
+        candidate_id: intent.id,
+        disposition: 'INCLUDED',
+        sequence: 1
+      }
+    ]),
+    findCandidateById: jest.fn(async () => intent),
+    updateCandidate: jest.fn(
+      async (
+        _id: string,
+        rowVersion: number,
+        fields: {
+          status: ReleaseBusV2CandidateRecord['status'];
+          currentTrainId?: string | null;
+          holdReason?: string | null;
+        }
+      ) => {
+        if (rowVersion !== intent.row_version) return false;
+        intent = {
+          ...intent,
+          status: fields.status,
+          current_train_id:
+            fields.currentTrainId === undefined
+              ? intent.current_train_id
+              : fields.currentTrainId,
+          hold_reason:
+            fields.holdReason === undefined
+              ? intent.hold_reason
+              : fields.holdReason,
+          row_version: intent.row_version + 1
+        };
+        return true;
+      }
+    ),
+    updateTrain: jest.fn(
+      async (
+        _id: string,
+        rowVersion: number,
+        fields: {
+          status: ReleaseBusV2TrainRecord['status'];
+          failureClass?: ReleaseBusV2TrainRecord['failure_class'];
+          failureMessage?: string | null;
+          recoveryMessage?: string | null;
+          completedAt?: number | null;
+        }
+      ) => {
+        if (rowVersion !== train.row_version) return false;
+        train = {
+          ...train,
+          status: fields.status,
+          failure_class: fields.failureClass ?? train.failure_class,
+          failure_message:
+            fields.failureMessage === undefined
+              ? train.failure_message
+              : fields.failureMessage,
+          recovery_message:
+            fields.recoveryMessage === undefined
+              ? train.recovery_message
+              : fields.recoveryMessage,
+          completed_at:
+            fields.completedAt === undefined
+              ? train.completed_at
+              : fields.completedAt,
+          row_version: train.row_version + 1
+        };
+        return true;
+      }
+    ),
+    appendEvent,
+    listLocks: jest.fn(async () => [])
+  };
+  return {
+    repository,
+    train: () => train,
+    intent: () => intent,
+    appendEvent
+  };
+}
 
 describe('Release Bus v2 explicit production opt-in', () => {
   const previousMode = process.env.RELEASE_BUS_V2_MODE;
@@ -1525,6 +1727,524 @@ describe('Release Bus v2 explicit production opt-in', () => {
       expect.anything()
     );
     expect(state.candidates.get(b.id)).toEqual(b);
+  });
+
+  it('coalesces a later compatible explicit selection into a new pre-mutation replacement across repositories', async () => {
+    const original = productionIntent(
+      validatedCandidate('candidate-original', 'backend', 'a', 201),
+      'WAITING_FOR_PRODUCTION_REPLAN',
+      'selection-original',
+      10
+    );
+    const later = productionIntent(
+      validatedCandidate('candidate-later', 'frontend', 'b', 202),
+      'READY_FOR_CANDIDATE_EVIDENCE_PRODUCTION',
+      'selection-later',
+      20
+    );
+    const state = selectionRepository([original, later]);
+    state.repository.listCandidateEvents.mockImplementation(
+      async (candidateId: unknown) =>
+        candidateId === original.id
+          ? ([
+              {
+                train_id: 'source-train-original',
+                event_type: 'CANDIDATE_WAITING_FOR_PRODUCTION_REPLAN'
+              }
+            ] as never)
+          : []
+    );
+    mockResolveRef.mockImplementation(
+      async (repository: string, ref: string) => {
+        if (ref === 'main')
+          return repository === 'frontend' ? '8'.repeat(40) : '9'.repeat(40);
+        return [original, later].find((item) => item.branch_name === ref)
+          ?.head_sha;
+      }
+    );
+    mockResolveRefIfExists.mockImplementation(
+      async (_repository: string, ref: string) =>
+        [original, later].find((item) => item.branch_name === ref)?.head_sha ??
+        null
+    );
+    const service = new ReleaseBusV2Service(state.repository as never);
+
+    const claimed = await service.claimLane(
+      'PRODUCTION',
+      '8'.repeat(40),
+      '9'.repeat(40),
+      'scheduler'
+    );
+
+    expect(claimed?.id).toBe('claimed-selection-train');
+    expect(state.createTrain).toHaveBeenCalledWith(
+      expect.objectContaining({
+        candidateIds: expect.arrayContaining([original.id, later.id]),
+        qualificationPolicy: 'CANDIDATE_STAGING_EVIDENCE_V1',
+        qualificationEvidence: expect.arrayContaining([
+          expect.objectContaining({ candidate_id: original.id }),
+          expect.objectContaining({ candidate_id: later.id })
+        ])
+      }),
+      expect.anything()
+    );
+    const replacementSelectionId = state.candidates.get(
+      original.id
+    )?.production_selection_id;
+    expect(replacementSelectionId).toEqual(expect.any(String));
+    expect(replacementSelectionId).not.toBe('selection-original');
+    expect(replacementSelectionId).not.toBe('selection-later');
+    expect(state.candidates.get(later.id)?.production_selection_id).toBe(
+      replacementSelectionId
+    );
+    expect(state.appendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: 'PRODUCTION_REPLAN_REPLACEMENT_CLAIMED',
+        payload: expect.objectContaining({
+          replacement_production_selection_id: replacementSelectionId,
+          source_production_selection_ids: [
+            'selection-later',
+            'selection-original'
+          ],
+          source_train_ids: ['source-train-original'],
+          included_intents: expect.arrayContaining([
+            expect.objectContaining({
+              candidate_id: original.id,
+              source_production_selection_id: 'selection-original',
+              source_train_id: 'source-train-original'
+            }),
+            expect.objectContaining({
+              candidate_id: later.id,
+              source_production_selection_id: 'selection-later',
+              source_train_id: null
+            })
+          ]),
+          omitted_intents: []
+        })
+      }),
+      expect.anything()
+    );
+  });
+
+  it('fails the complete replacement closed when either current production base moved', async () => {
+    const original = productionIntent(
+      validatedCandidate('candidate-stale-base-original', 'backend', '6', 209),
+      'WAITING_FOR_PRODUCTION_REPLAN',
+      'selection-stale-base-original',
+      10
+    );
+    const later = productionIntent(
+      validatedCandidate('candidate-stale-base-later', 'frontend', '7', 210),
+      'READY_FOR_CANDIDATE_EVIDENCE_PRODUCTION',
+      'selection-stale-base-later',
+      20
+    );
+    const state = selectionRepository([original, later]);
+    mockResolveRef.mockImplementation(
+      async (repository: string, ref: string) =>
+        ref === 'main'
+          ? repository === 'frontend'
+            ? '7'.repeat(40)
+            : '9'.repeat(40)
+          : [original, later].find((item) => item.branch_name === ref)?.head_sha
+    );
+    const service = new ReleaseBusV2Service(state.repository as never);
+
+    const claimed = await service.claimLane(
+      'PRODUCTION',
+      '8'.repeat(40),
+      '9'.repeat(40),
+      'scheduler'
+    );
+
+    expect(claimed).toBeNull();
+    expect(state.createTrain).not.toHaveBeenCalled();
+    for (const candidate of [original, later])
+      expect(state.candidates.get(candidate.id)).toEqual(
+        expect.objectContaining({
+          status: 'WAITING_FOR_PRODUCTION_REPLAN',
+          production_selection_id: candidate.production_selection_id,
+          hold_reason: expect.stringContaining(
+            'Production base fence changed for frontend'
+          )
+        })
+      );
+    expect(state.appendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: 'PRODUCTION_REPLAN_REPLACEMENT_NOT_CLAIMED',
+        payload: expect.objectContaining({
+          omitted_intents: expect.arrayContaining([
+            expect.objectContaining({
+              candidate_id: original.id,
+              source_production_selection_id: original.production_selection_id,
+              reason: expect.stringContaining(
+                'Production base fence changed for frontend'
+              )
+            }),
+            expect.objectContaining({
+              candidate_id: later.id,
+              source_production_selection_id: later.production_selection_id,
+              reason: expect.stringContaining(
+                'Production base fence changed for frontend'
+              )
+            })
+          ])
+        })
+      }),
+      expect.anything()
+    );
+  });
+
+  it('keeps replacement intent explicit and dependency-closed when a prerequisite becomes ineligible', async () => {
+    const seed = productionIntent(
+      validatedCandidate('candidate-seed', 'backend', 'c', 203),
+      'WAITING_FOR_PRODUCTION_REPLAN',
+      'selection-seed',
+      10
+    );
+    const prerequisite = productionIntent(
+      validatedCandidate('candidate-prerequisite', 'backend', 'd', 204),
+      'READY_FOR_CANDIDATE_EVIDENCE_PRODUCTION',
+      'selection-dependent-set',
+      20
+    );
+    const dependent = productionIntent(
+      validatedCandidate('candidate-dependent', 'frontend', 'e', 205),
+      'READY_FOR_CANDIDATE_EVIDENCE_PRODUCTION',
+      'selection-dependent-set',
+      20
+    );
+    const state = selectionRepository(
+      [seed, prerequisite, dependent],
+      [
+        {
+          candidate_id: dependent.id,
+          prerequisite_candidate_id: prerequisite.id,
+          environment: 'PRODUCTION'
+        }
+      ]
+    );
+    state.candidates.set(prerequisite.id, {
+      ...prerequisite,
+      staging_validated_manifest_id: null
+    });
+    mockResolveRef.mockImplementation(
+      async (repository: string, ref: string) =>
+        ref === 'main'
+          ? repository === 'frontend'
+            ? '8'.repeat(40)
+            : '9'.repeat(40)
+          : [seed, prerequisite, dependent].find(
+              (item) => item.branch_name === ref
+            )?.head_sha
+    );
+    mockResolveRefIfExists.mockImplementation(
+      async (_repository: string, ref: string) =>
+        [seed, prerequisite, dependent].find((item) => item.branch_name === ref)
+          ?.head_sha ?? null
+    );
+    const service = new ReleaseBusV2Service(state.repository as never);
+
+    await service.claimLane(
+      'PRODUCTION',
+      '8'.repeat(40),
+      '9'.repeat(40),
+      'scheduler'
+    );
+
+    expect(state.createTrain).toHaveBeenCalledWith(
+      expect.objectContaining({ candidateIds: [seed.id] }),
+      expect.anything()
+    );
+    expect(state.candidates.get(prerequisite.id)).toEqual(
+      expect.objectContaining({
+        status: 'WAITING_FOR_PRODUCTION_REPLAN',
+        production_selection_id: 'selection-dependent-set',
+        hold_reason: expect.stringContaining(
+          'no current staging validation evidence'
+        )
+      })
+    );
+    expect(state.candidates.get(dependent.id)).toEqual(
+      expect.objectContaining({
+        status: 'WAITING_FOR_PRODUCTION_REPLAN',
+        production_selection_id: 'selection-dependent-set',
+        hold_reason: expect.stringContaining(
+          `dependency ${prerequisite.id} is neither eligible`
+        )
+      })
+    );
+    expect(state.appendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: 'PRODUCTION_REPLAN_REPLACEMENT_CLAIMED',
+        payload: expect.objectContaining({
+          source_production_selection_ids: ['selection-seed'],
+          omitted_intents: expect.arrayContaining([
+            expect.objectContaining({
+              candidate_id: prerequisite.id,
+              source_production_selection_id: 'selection-dependent-set',
+              reason: expect.stringContaining(
+                'no current staging validation evidence'
+              )
+            }),
+            expect.objectContaining({
+              candidate_id: dependent.id,
+              source_production_selection_id: 'selection-dependent-set',
+              reason: expect.stringContaining(
+                `dependency ${prerequisite.id} is neither eligible`
+              )
+            })
+          ])
+        })
+      }),
+      expect.anything()
+    );
+  });
+
+  it('excludes a concurrently revoked or moved intent without losing its audit reason', async () => {
+    const seed = productionIntent(
+      validatedCandidate('candidate-replan-seed', 'backend', 'f', 206),
+      'WAITING_FOR_PRODUCTION_REPLAN',
+      'selection-seed',
+      10
+    );
+    const revokedSnapshot = productionIntent(
+      validatedCandidate('candidate-revoked', 'frontend', '1', 207),
+      'READY_FOR_CANDIDATE_EVIDENCE_PRODUCTION',
+      'selection-revoked',
+      20
+    );
+    const moved = productionIntent(
+      validatedCandidate('candidate-moved', 'backend', '2', 208),
+      'READY_FOR_CANDIDATE_EVIDENCE_PRODUCTION',
+      'selection-moved',
+      30
+    );
+    const state = selectionRepository([seed, revokedSnapshot, moved]);
+    const originalListCandidates =
+      state.repository.listCandidates.getMockImplementation()!;
+    let revokedDuringReadyScan = false;
+    state.repository.listCandidates.mockImplementation(
+      async (statuses: readonly string[]) => {
+        const result = await originalListCandidates(statuses);
+        if (
+          !revokedDuringReadyScan &&
+          statuses.includes('READY_FOR_CANDIDATE_EVIDENCE_PRODUCTION')
+        ) {
+          revokedDuringReadyScan = true;
+          state.candidates.set(revokedSnapshot.id, {
+            ...revokedSnapshot,
+            status: 'STAGING_VALIDATED',
+            production_requested_at: null,
+            production_requested_by: null,
+            production_selection_id: null,
+            row_version: revokedSnapshot.row_version + 1
+          });
+        }
+        return result;
+      }
+    );
+    mockResolveRef.mockImplementation(
+      async (repository: string, ref: string) =>
+        ref === 'main'
+          ? repository === 'frontend'
+            ? '8'.repeat(40)
+            : '9'.repeat(40)
+          : [seed, revokedSnapshot, moved].find(
+              (item) => item.branch_name === ref
+            )?.head_sha
+    );
+    mockResolveRefIfExists.mockImplementation(
+      async (_repository: string, ref: string) => {
+        if (ref === moved.branch_name) return '3'.repeat(40);
+        return [seed, revokedSnapshot].find((item) => item.branch_name === ref)
+          ?.head_sha;
+      }
+    );
+    const service = new ReleaseBusV2Service(state.repository as never);
+
+    await service.claimLane(
+      'PRODUCTION',
+      '8'.repeat(40),
+      '9'.repeat(40),
+      'scheduler'
+    );
+
+    expect(state.createTrain).toHaveBeenCalledWith(
+      expect.objectContaining({ candidateIds: [seed.id] }),
+      expect.anything()
+    );
+    expect(state.candidates.get(revokedSnapshot.id)).toEqual(
+      expect.objectContaining({
+        status: 'STAGING_VALIDATED',
+        production_requested_at: null,
+        production_selection_id: null
+      })
+    );
+    expect(state.candidates.get(moved.id)).toEqual(
+      expect.objectContaining({
+        status: 'WAITING_FOR_PRODUCTION_REPLAN',
+        production_selection_id: 'selection-moved',
+        hold_reason: expect.stringContaining('branch head changed')
+      })
+    );
+    expect(state.appendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        candidateId: revokedSnapshot.id,
+        eventType: 'PRODUCTION_REPLAN_INTENT_OMITTED',
+        payload: expect.objectContaining({
+          reason:
+            'Candidate status STAGING_VALIDATED no longer carries claimable production intent'
+        })
+      }),
+      expect.anything()
+    );
+    expect(state.appendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        candidateId: moved.id,
+        eventType: 'PRODUCTION_REPLAN_INTENT_OMITTED',
+        payload: expect.objectContaining({
+          reason: expect.stringContaining('branch head changed')
+        })
+      }),
+      expect.anything()
+    );
+  });
+
+  it('preserves exact source selection provenance when a train is safely replanned before mutation', async () => {
+    const state = safeReplanRepository(null);
+    const service = new ReleaseBusV2Service(state.repository as never);
+
+    const result = await service.preserveProductionIntentsForSafeReplan({
+      trainId: 'production-replan-source',
+      reason: 'frontend main moved',
+      actor: 'reconciler'
+    });
+
+    expect(result).toEqual({
+      status: 'REPLANNED',
+      trainId: 'production-replan-source',
+      candidateIds: ['candidate-replan-source'],
+      sourceSelectionIds: ['selection-replan-source']
+    });
+    expect(state.train()).toEqual(
+      expect.objectContaining({
+        status: 'CANCELLED',
+        completed_at: expect.any(Number)
+      })
+    );
+    expect(state.intent()).toEqual(
+      expect.objectContaining({
+        status: 'WAITING_FOR_PRODUCTION_REPLAN',
+        current_train_id: null,
+        production_selection_id: 'selection-replan-source'
+      })
+    );
+    expect(state.appendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: 'PRODUCTION_TRAIN_INTENTS_PRESERVED_FOR_SAFE_REPLAN',
+        payload: expect.objectContaining({
+          source_production_selection_ids: ['selection-replan-source'],
+          candidate_ids: ['candidate-replan-source']
+        })
+      }),
+      expect.anything()
+    );
+  });
+
+  it.each([
+    [
+      productionOperation('ADVANCE_MAIN_BACKEND', 'SUCCEEDED', 'a'.repeat(40)),
+      'ADVANCE_MAIN_BACKEND succeeded'
+    ],
+    [
+      productionOperation(
+        'DEPLOY_BACKEND_PROD_api',
+        'DISPATCHED',
+        'deploy-run'
+      ),
+      'DEPLOY_BACKEND_PROD_api was dispatched'
+    ],
+    [
+      productionOperation('E2E_PROD', 'PENDING', null),
+      'production E2E was created'
+    ]
+  ])(
+    'recognizes irreversible production work and never makes it replan-eligible',
+    (operation, expectedReason) => {
+      expect(irreversibleProductionOperationReason(operation)).toBe(
+        expectedReason
+      );
+    }
+  );
+
+  it.each([
+    [
+      productionOperation('ADVANCE_MAIN_BACKEND', 'SUCCEEDED', 'a'.repeat(40)),
+      'ADVANCE_MAIN_BACKEND succeeded'
+    ],
+    [
+      productionOperation(
+        'DEPLOY_BACKEND_PROD_api',
+        'DISPATCHED',
+        'deploy-run'
+      ),
+      'the train entered PRODUCTION_DEPLOYING'
+    ],
+    [
+      productionOperation('E2E_PROD', 'PENDING', null),
+      'production E2E was created'
+    ]
+  ])(
+    'freezes the original exact train after irreversible work instead of broadening it',
+    async (operation, expectedReason) => {
+      const state = safeReplanRepository(operation);
+      const before = state.intent();
+      const service = new ReleaseBusV2Service(state.repository as never);
+
+      const result = await service.preserveProductionIntentsForSafeReplan({
+        trainId: 'production-replan-source',
+        reason: 'frontend main moved',
+        actor: 'reconciler'
+      });
+
+      expect(result).toEqual(
+        expect.objectContaining({
+          status: 'FROZEN',
+          reason: expect.stringContaining(expectedReason)
+        })
+      );
+      expect(state.train()).toEqual(
+        expect.objectContaining({
+          status: 'PAUSED',
+          recovery_message: expect.stringContaining(
+            "Resume or recover only this train's immutable membership"
+          )
+        })
+      );
+      expect(state.intent()).toEqual(before);
+      expect(state.appendEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          eventType: 'PRODUCTION_REPLAN_REJECTED_AFTER_IRREVERSIBLE_MUTATION'
+        }),
+        expect.anything()
+      );
+    }
+  );
+
+  it('fails a concurrent explicit selection closed while the scheduler transaction owns the race', async () => {
+    const state = repositoryFor(candidate('STAGING_VALIDATED'));
+    state.repository.acquireLock.mockImplementation(async () => null as never);
+    mockResolveRef.mockResolvedValue('a'.repeat(40));
+    const service = new ReleaseBusV2Service(state.repository as never);
+
+    await expect(
+      service.markReadyForProduction('candidate-id', 'a'.repeat(40), 3, 'owner')
+    ).rejects.toThrow(
+      'Production selection raced another scheduler transaction'
+    );
+    expect(state.current().production_requested_at).toBeNull();
+    expect(state.repository.updateCandidate).not.toHaveBeenCalled();
   });
 
   it('rejects an omitted production dependency without exact deployed identity', async () => {

--- a/src/releaseBusV2/release-bus-v2.service.test.ts
+++ b/src/releaseBusV2/release-bus-v2.service.test.ts
@@ -2152,6 +2152,39 @@ describe('Release Bus v2 explicit production opt-in', () => {
     );
   });
 
+  it('defers the service-level replan while dispatched composition may still be running', async () => {
+    const state = safeReplanRepository(
+      productionOperation(
+        'COMPOSE_BACKEND',
+        'RUNNING',
+        'compose-run',
+        'orchestration'
+      )
+    );
+    const beforeTrain = state.train();
+    const beforeIntent = state.intent();
+    const service = new ReleaseBusV2Service(state.repository as never);
+
+    const result = await service.preserveProductionIntentsForSafeReplan({
+      trainId: 'production-replan-source',
+      reason: 'frontend main moved',
+      actor: 'reconciler'
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        status: 'NOOP',
+        reason: expect.stringContaining(
+          'operation operation-COMPOSE_BACKEND (COMPOSE_BACKEND)'
+        )
+      })
+    );
+    expect(state.train()).toEqual(beforeTrain);
+    expect(state.intent()).toEqual(beforeIntent);
+    expect(state.repository.updateOperation).not.toHaveBeenCalled();
+    expect(state.appendEvent).not.toHaveBeenCalled();
+  });
+
   it.each([
     [
       productionOperation('ADVANCE_MAIN_BACKEND', 'SUCCEEDED', 'a'.repeat(40)),
@@ -2245,6 +2278,55 @@ describe('Release Bus v2 explicit production opt-in', () => {
     );
     expect(state.current().production_requested_at).toBeNull();
     expect(state.repository.updateCandidate).not.toHaveBeenCalled();
+  });
+
+  it('holds the scheduler lease until the authoritative selection transaction commits', async () => {
+    const state = repositoryFor(candidate('STAGING_VALIDATED'));
+    const order: string[] = [];
+    state.repository.acquireLock.mockImplementation(async () => {
+      order.push('scheduler-acquired');
+      return { lease_token: 'scheduler-lease' } as never;
+    });
+    state.repository.executeNativeQueriesInTransaction.mockImplementation(
+      async (callback: (connection: unknown) => Promise<unknown>) => {
+        order.push('transaction-started');
+        const result = await callback({});
+        order.push('transaction-committed');
+        return result;
+      }
+    );
+    state.repository.releaseLock.mockImplementation(async () => {
+      order.push('scheduler-released');
+      return true;
+    });
+    mockResolveRef.mockResolvedValue('a'.repeat(40));
+    const service = new ReleaseBusV2Service(state.repository as never);
+
+    await service.markReadyForProduction(
+      'candidate-id',
+      'a'.repeat(40),
+      3,
+      'owner'
+    );
+
+    expect(order).toEqual([
+      'scheduler-acquired',
+      'transaction-started',
+      'transaction-committed',
+      'scheduler-released'
+    ]);
+    expect(state.repository.acquireLock).toHaveBeenCalledWith(
+      'scheduler',
+      null,
+      expect.stringMatching(/^production-selection:/),
+      expect.any(Number),
+      {}
+    );
+    expect(state.repository.releaseLock).toHaveBeenCalledWith(
+      'scheduler',
+      'scheduler-lease',
+      {}
+    );
   });
 
   it('rejects an omitted production dependency without exact deployed identity', async () => {

--- a/src/releaseBusV2/release-bus-v2.service.ts
+++ b/src/releaseBusV2/release-bus-v2.service.ts
@@ -2590,6 +2590,13 @@ export class ReleaseBusV2Service {
     ctx: RequestContext
   ): Promise<ReleaseBusV2SafeProductionReplanResult> {
     const reason = `Safe production replan refused because ${irreversibleReason}; the original exact candidate set remains frozen`;
+    const runningOperationIds = operations
+      .filter(productionReplanOperationMayStillBeRunning)
+      .map(({ id }) => id);
+    const lockDisposition =
+      runningOperationIds.length > 0
+        ? 'RETAINED_WHILE_DISPATCHED_WORK_DRAINS'
+        : 'RELEASED_OR_ALREADY_FREE_AFTER_TERMINAL_WORK';
     if (
       !(await this.repository.updateTrain(
         train.id,
@@ -2598,7 +2605,7 @@ export class ReleaseBusV2Service {
           status: 'PAUSED',
           failureClass: 'INTERACTION',
           failureMessage: input.reason,
-          recoveryMessage: `${reason}. Resume or recover only this train's immutable membership`
+          recoveryMessage: `${reason}. Resume or recover only this train's immutable membership; production environment ownership is ${lockDisposition.toLowerCase().replace(/_/g, ' ')}`
         },
         ctx
       ))
@@ -2606,6 +2613,8 @@ export class ReleaseBusV2Service {
       throw new Error(
         'Release Bus v2 train changed during irreversible replan fence'
       );
+    if (runningOperationIds.length === 0)
+      await this.releaseProductionReplanEnvironmentLock(train.id, ctx);
     await this.repository.appendEvent(
       {
         trainId: train.id,
@@ -2614,7 +2623,9 @@ export class ReleaseBusV2Service {
         payload: {
           reason,
           source_train_id: train.id,
-          operation_ids: operations.map(({ id }) => id)
+          operation_ids: operations.map(({ id }) => id),
+          running_operation_ids: runningOperationIds,
+          production_environment_lock: lockDisposition
         }
       },
       ctx
@@ -2916,6 +2927,7 @@ export class ReleaseBusV2Service {
     ctx: RequestContext
   ): Promise<string | null> {
     if (candidate.status !== 'WAITING_FOR_PRODUCTION_REPLAN') return null;
+    // listCandidateEvents is explicitly newest-first by created_at and id.
     const event = (
       await this.repository.listCandidateEvents(
         candidate.id,
@@ -2931,7 +2943,15 @@ export class ReleaseBusV2Service {
     omission: ProductionReplanOmission,
     ctx: RequestContext
   ): Promise<void> {
-    const current = omission.candidate;
+    const current = await this.repository.findCandidateById(
+      omission.candidate.id,
+      ctx,
+      true
+    );
+    if (!current)
+      throw new Error(
+        `Production replan omission candidate ${omission.candidate.id} disappeared`
+      );
     if (
       current.production_requested_at !== null &&
       current.production_requested_by !== null &&
@@ -3079,7 +3099,8 @@ export class ReleaseBusV2Service {
           continue;
         const prerequisite = await this.repository.findCandidateById(
           dependency.prerequisite_candidate_id,
-          ctx
+          ctx,
+          true
         );
         if (
           prerequisite &&
@@ -3450,6 +3471,26 @@ export class ReleaseBusV2Service {
                   actor: owner,
                   payload: {
                     replacement_production_selection_id: selectionId,
+                    source_production_selection_ids: Array.from(
+                      new Set(
+                        productionReplanOmissions
+                          .map(({ sourceSelectionId }) => sourceSelectionId)
+                          .filter(
+                            (sourceSelectionId): sourceSelectionId is string =>
+                              sourceSelectionId !== null
+                          )
+                      )
+                    ).sort((left, right) => left.localeCompare(right)),
+                    source_train_ids: Array.from(
+                      new Set(
+                        productionReplanOmissions
+                          .map(({ sourceTrainId }) => sourceTrainId)
+                          .filter(
+                            (sourceTrainId): sourceTrainId is string =>
+                              sourceTrainId !== null
+                          )
+                      )
+                    ).sort((left, right) => left.localeCompare(right)),
                     omitted_intents: productionReplanOmissions.map(
                       ({
                         candidate,

--- a/src/releaseBusV2/release-bus-v2.service.ts
+++ b/src/releaseBusV2/release-bus-v2.service.ts
@@ -2605,7 +2605,7 @@ export class ReleaseBusV2Service {
           status: 'PAUSED',
           failureClass: 'INTERACTION',
           failureMessage: input.reason,
-          recoveryMessage: `${reason}. Resume or recover only this train's immutable membership; production environment ownership is ${lockDisposition.toLowerCase().replace(/_/g, ' ')}`
+          recoveryMessage: `${reason}. Resume or recover only this train's immutable membership; production environment ownership is ${lockDisposition.toLowerCase().split('_').join(' ')}`
         },
         ctx
       ))

--- a/src/releaseBusV2/release-bus-v2.service.ts
+++ b/src/releaseBusV2/release-bus-v2.service.ts
@@ -145,6 +145,15 @@ export function irreversibleProductionOperationReason(
   return null;
 }
 
+function productionReplanOperationMayStillBeRunning(
+  operation: ReleaseBusV2OperationRecord
+): boolean {
+  return (
+    ['DISPATCHED', 'RUNNING'].includes(operation.status) ||
+    (operation.status === 'PENDING' && operation.external_id !== null)
+  );
+}
+
 export class ReleaseBusV2StagingTransitionConflictError extends Error {
   public constructor(message: string) {
     super(message);
@@ -1048,212 +1057,213 @@ export class ReleaseBusV2Service {
           'Candidate branch moved after staging validation'
         );
     }
-    return this.repository.executeNativeQueriesInTransaction(
-      async (connection) => {
-        const ctx: RequestContext = { connection };
-        const scheduler = await this.repository.acquireLock(
-          'scheduler',
-          null,
-          `production-selection:${randomUUID()}`,
-          RELEASE_BUS_V2_LOCK_TTL_MS,
-          ctx
-        );
-        if (!scheduler?.lease_token)
-          throw new ReleaseBusV2ProductionSelectionError(
-            'CONFLICT',
-            'Production selection raced another scheduler transaction; refresh and retry'
+    const scheduler = await this.repository.acquireLock(
+      'scheduler',
+      null,
+      `production-selection:${randomUUID()}`,
+      RELEASE_BUS_V2_LOCK_TTL_MS,
+      {}
+    );
+    if (!scheduler?.lease_token)
+      throw new ReleaseBusV2ProductionSelectionError(
+        'CONFLICT',
+        'Production selection raced another scheduler transaction; refresh and retry'
+      );
+    try {
+      return await this.repository.executeNativeQueriesInTransaction(
+        async (connection) => {
+          const ctx: RequestContext = { connection };
+          const locked: ReleaseBusV2CandidateRecord[] = [];
+          const retrySourceByCandidateId = new Map<string, string>();
+          const orderedIds = Array.from(selectedIds).sort((left, right) =>
+            left.localeCompare(right)
           );
-        const locked: ReleaseBusV2CandidateRecord[] = [];
-        const retrySourceByCandidateId = new Map<string, string>();
-        const orderedIds = Array.from(selectedIds).sort((left, right) =>
-          left.localeCompare(right)
-        );
-        const dependencies = await this.repository.listDependencies(
-          orderedIds,
-          ctx
-        );
-        const lockIds = Array.from(
-          new Set([
-            ...orderedIds,
-            ...dependencies
-              .filter(({ environment }) => environment !== 'STAGING')
-              .map(({ prerequisite_candidate_id }) => prerequisite_candidate_id)
-          ])
-        ).sort((left, right) => left.localeCompare(right));
-        const lockedById = new Map<
-          string,
-          ReleaseBusV2CandidateRecord | null
-        >();
-        for (const candidateId of lockIds)
-          lockedById.set(
-            candidateId,
-            await this.repository.findCandidateById(candidateId, ctx, true)
-          );
-        // The exact candidate rows remain locked until the new selection is
-        // committed. A production claim must change one of those rows from a
-        // ready state while holding the scheduler lease, so no newer train can
-        // include a FAILED retry candidate between this lookup and its update.
-        for (const selectedId of orderedIds) {
-          const candidate = lockedById.get(selectedId) ?? null;
-          if (!candidate)
-            throw new ReleaseBusV2ProductionSelectionError(
-              'NOT_FOUND',
-              'Candidate not found'
-            );
-          const expected = selectionById.get(candidate.id);
-          if (
-            !expected ||
-            candidate.row_version !== expected.expectedRowVersion
-          )
-            throw new ReleaseBusV2ProductionSelectionError(
-              'CONFLICT',
-              'Candidate changed; refresh before marking production ready'
-            );
-          if (
-            !candidate.staging_validated_manifest_id ||
-            candidate.superseded_at !== null
-          )
-            throw new ReleaseBusV2ProductionSelectionError(
-              'CONFLICT',
-              'The exact candidate SHA is not staging validated'
-            );
-          const retrySource = await this.resolvePreMainProductionRetrySource(
-            candidate,
+          const dependencies = await this.repository.listDependencies(
+            orderedIds,
             ctx
           );
-          if (retrySource)
-            retrySourceByCandidateId.set(candidate.id, retrySource);
-          if (candidate.head_sha !== expected.expectedHeadSha.toLowerCase())
-            throw new ReleaseBusV2ProductionSelectionError(
-              'CONFLICT',
-              'Candidate changed after branch verification'
+          const lockIds = Array.from(
+            new Set([
+              ...orderedIds,
+              ...dependencies
+                .filter(({ environment }) => environment !== 'STAGING')
+                .map(
+                  ({ prerequisite_candidate_id }) => prerequisite_candidate_id
+                )
+            ])
+          ).sort((left, right) => left.localeCompare(right));
+          const lockedById = new Map<
+            string,
+            ReleaseBusV2CandidateRecord | null
+          >();
+          for (const candidateId of lockIds)
+            lockedById.set(
+              candidateId,
+              await this.repository.findCandidateById(candidateId, ctx, true)
             );
-          locked.push(candidate);
-        }
-        // Re-resolve while every selected candidate row is locked. The earlier
-        // resolution is a fast rejection; this is the authoritative
-        // selection-write fence.
-        const lockedHeads = await Promise.all(
-          locked.map((candidate) =>
-            releaseBusGitHubApp.resolveRef(
-              candidate.repository,
-              candidate.branch_name
+          // The exact candidate rows remain locked until the new selection is
+          // committed. A production claim must change one of those rows from a
+          // ready state while holding the scheduler lease, so no newer train can
+          // include a FAILED retry candidate between this lookup and its update.
+          for (const selectedId of orderedIds) {
+            const candidate = lockedById.get(selectedId) ?? null;
+            if (!candidate)
+              throw new ReleaseBusV2ProductionSelectionError(
+                'NOT_FOUND',
+                'Candidate not found'
+              );
+            const expected = selectionById.get(candidate.id);
+            if (
+              !expected ||
+              candidate.row_version !== expected.expectedRowVersion
             )
-          )
-        );
-        for (let index = 0; index < locked.length; index += 1) {
-          if (lockedHeads[index] !== locked[index]?.head_sha)
-            throw new ReleaseBusV2ProductionSelectionError(
-              'CONFLICT',
-              'Candidate changed after branch verification'
+              throw new ReleaseBusV2ProductionSelectionError(
+                'CONFLICT',
+                'Candidate changed; refresh before marking production ready'
+              );
+            if (
+              !candidate.staging_validated_manifest_id ||
+              candidate.superseded_at !== null
+            )
+              throw new ReleaseBusV2ProductionSelectionError(
+                'CONFLICT',
+                'The exact candidate SHA is not staging validated'
+              );
+            const retrySource = await this.resolvePreMainProductionRetrySource(
+              candidate,
+              ctx
             );
-        }
-        const evidence = await this.resolveCandidateStagingEvidence(
-          locked,
-          ctx
-        );
-        await this.assertProductionDependencyClosure(locked, ctx, lockedById);
-        const now = Date.now();
-        const selectionId = randomUUID();
-        for (const candidate of locked) {
-          if (
-            !(await this.repository.updateCandidate(
-              candidate.id,
-              candidate.row_version,
+            if (retrySource)
+              retrySourceByCandidateId.set(candidate.id, retrySource);
+            if (candidate.head_sha !== expected.expectedHeadSha.toLowerCase())
+              throw new ReleaseBusV2ProductionSelectionError(
+                'CONFLICT',
+                'Candidate changed after branch verification'
+              );
+            locked.push(candidate);
+          }
+          // Re-resolve while every selected candidate row is locked. The earlier
+          // resolution is a fast rejection; this is the authoritative
+          // selection-write fence.
+          const lockedHeads = await Promise.all(
+            locked.map((candidate) =>
+              releaseBusGitHubApp.resolveRef(
+                candidate.repository,
+                candidate.branch_name
+              )
+            )
+          );
+          for (let index = 0; index < locked.length; index += 1) {
+            if (lockedHeads[index] !== locked[index]?.head_sha)
+              throw new ReleaseBusV2ProductionSelectionError(
+                'CONFLICT',
+                'Candidate changed after branch verification'
+              );
+          }
+          const evidence = await this.resolveCandidateStagingEvidence(
+            locked,
+            ctx
+          );
+          await this.assertProductionDependencyClosure(locked, ctx, lockedById);
+          const now = Date.now();
+          const selectionId = randomUUID();
+          for (const candidate of locked) {
+            if (
+              !(await this.repository.updateCandidate(
+                candidate.id,
+                candidate.row_version,
+                {
+                  status: CANDIDATE_EVIDENCE_READY_STATUS,
+                  productionRequestedAt: now,
+                  productionRequestedBy: actor,
+                  productionSelectionId: selectionId
+                },
+                ctx
+              ))
+            )
+              throw new ReleaseBusV2ProductionSelectionError(
+                'CONFLICT',
+                'Candidate changed concurrently'
+              );
+          }
+          await this.repository.appendEvent(
+            {
+              eventType: 'PRODUCTION_SELECTION_READY',
+              actor,
+              payload: {
+                production_selection_id: selectionId,
+                qualification_policy: CANDIDATE_STAGING_EVIDENCE_POLICY,
+                candidate_ids: locked.map(({ id }) => id),
+                candidate_evidence: evidence,
+                retry_sources: locked.flatMap(({ id }) => {
+                  const failedTrainId = retrySourceByCandidateId.get(id);
+                  return failedTrainId
+                    ? [{ candidate_id: id, failed_train_id: failedTrainId }]
+                    : [];
+                })
+              }
+            },
+            ctx
+          );
+          for (const candidate of locked)
+            await this.repository.appendEvent(
               {
-                status: CANDIDATE_EVIDENCE_READY_STATUS,
-                productionRequestedAt: now,
-                productionRequestedBy: actor,
-                productionSelectionId: selectionId
+                candidateId: candidate.id,
+                eventType: 'CANDIDATE_READY_FOR_PRODUCTION',
+                actor,
+                payload: {
+                  head_sha: candidate.head_sha,
+                  production_selection_id: selectionId,
+                  qualification_policy: CANDIDATE_STAGING_EVIDENCE_POLICY,
+                  retry_source_train_id:
+                    retrySourceByCandidateId.get(candidate.id) ?? null,
+                  staging_evidence: evidence.find(
+                    ({ candidate_id }) => candidate_id === candidate.id
+                  )
+                }
               },
               ctx
-            ))
-          )
-            throw new ReleaseBusV2ProductionSelectionError(
-              'CONFLICT',
-              'Candidate changed concurrently'
             );
-        }
-        await this.repository.appendEvent(
-          {
-            eventType: 'PRODUCTION_SELECTION_READY',
-            actor,
-            payload: {
-              production_selection_id: selectionId,
-              qualification_policy: CANDIDATE_STAGING_EVIDENCE_POLICY,
-              candidate_ids: locked.map(({ id }) => id),
-              candidate_evidence: evidence,
-              retry_sources: locked.flatMap(({ id }) => {
-                const failedTrainId = retrySourceByCandidateId.get(id);
-                return failedTrainId
-                  ? [{ candidate_id: id, failed_train_id: failedTrainId }]
-                  : [];
-              })
-            }
-          },
-          ctx
-        );
-        for (const candidate of locked)
-          await this.repository.appendEvent(
-            {
-              candidateId: candidate.id,
-              eventType: 'CANDIDATE_READY_FOR_PRODUCTION',
-              actor,
-              payload: {
-                head_sha: candidate.head_sha,
-                production_selection_id: selectionId,
-                qualification_policy: CANDIDATE_STAGING_EVIDENCE_POLICY,
-                retry_source_train_id:
-                  retrySourceByCandidateId.get(candidate.id) ?? null,
-                staging_evidence: evidence.find(
-                  ({ candidate_id }) => candidate_id === candidate.id
-                )
-              }
-            },
-            ctx
-          );
-        for (const candidate of locked) {
-          const failedTrainId = retrySourceByCandidateId.get(candidate.id);
-          if (!failedTrainId) continue;
-          await this.repository.appendEvent(
-            {
-              candidateId: candidate.id,
-              eventType: 'CANDIDATE_PRE_MAIN_PRODUCTION_RETRY_READY',
-              actor,
-              payload: {
-                failed_train_id: failedTrainId,
-                head_sha: candidate.head_sha,
-                production_selection_id: selectionId,
-                qualification_policy: CANDIDATE_STAGING_EVIDENCE_POLICY,
-                staging_evidence: evidence.find(
-                  ({ candidate_id }) => candidate_id === candidate.id
-                )
-              }
-            },
-            ctx
-          );
-        }
-        const updated: ReleaseBusV2CandidateRecord[] = [];
-        for (const candidate of locked) {
-          const current = await this.repository.findCandidateById(
-            candidate.id,
-            ctx
-          );
-          if (!current)
-            throw new ReleaseBusV2ProductionSelectionError(
-              'CONFLICT',
-              'Candidate disappeared after production readiness'
+          for (const candidate of locked) {
+            const failedTrainId = retrySourceByCandidateId.get(candidate.id);
+            if (!failedTrainId) continue;
+            await this.repository.appendEvent(
+              {
+                candidateId: candidate.id,
+                eventType: 'CANDIDATE_PRE_MAIN_PRODUCTION_RETRY_READY',
+                actor,
+                payload: {
+                  failed_train_id: failedTrainId,
+                  head_sha: candidate.head_sha,
+                  production_selection_id: selectionId,
+                  qualification_policy: CANDIDATE_STAGING_EVIDENCE_POLICY,
+                  staging_evidence: evidence.find(
+                    ({ candidate_id }) => candidate_id === candidate.id
+                  )
+                }
+              },
+              ctx
             );
-          updated.push(current);
+          }
+          const updated: ReleaseBusV2CandidateRecord[] = [];
+          for (const candidate of locked) {
+            const current = await this.repository.findCandidateById(
+              candidate.id,
+              ctx
+            );
+            if (!current)
+              throw new ReleaseBusV2ProductionSelectionError(
+                'CONFLICT',
+                'Candidate disappeared after production readiness'
+              );
+            updated.push(current);
+          }
+          return updated;
         }
-        await this.repository.releaseLock(
-          'scheduler',
-          scheduler.lease_token,
-          ctx
-        );
-        return updated;
-      }
-    );
+      );
+    } finally {
+      await this.repository.releaseLock('scheduler', scheduler.lease_token, {});
+    }
   }
 
   public async resolveCandidateStagingEvidence(
@@ -2840,6 +2850,15 @@ export class ReleaseBusV2Service {
               input,
               ctx
             );
+          const runningOperation = operations.find(
+            productionReplanOperationMayStillBeRunning
+          );
+          if (runningOperation)
+            return {
+              status: 'NOOP',
+              trainId: train.id,
+              reason: `Safe production replan is waiting for operation ${runningOperation.id} (${runningOperation.operation_type}) to become terminal`
+            };
           await this.cancelPendingProductionReplanOperations(
             operations,
             input.reason,
@@ -2851,9 +2870,14 @@ export class ReleaseBusV2Service {
           );
           const sourceSelections = Array.from(
             new Set(
-              candidates.map(({ production_selection_id }) =>
-                String(production_selection_id)
-              )
+              candidates.map((candidate) => {
+                const selectionId = candidate.production_selection_id;
+                if (!selectionId)
+                  throw new Error(
+                    `Production replan candidate ${candidate.id} lost its explicit selection identity`
+                  );
+                return selectionId;
+              })
             )
           ).sort((left, right) => left.localeCompare(right));
           await this.holdProductionReplanCandidates(

--- a/src/releaseBusV2/release-bus-v2.service.ts
+++ b/src/releaseBusV2/release-bus-v2.service.ts
@@ -38,6 +38,7 @@ export const CANDIDATE_STAGING_EVIDENCE_POLICY =
   'CANDIDATE_STAGING_EVIDENCE_V1' as const;
 export const CANDIDATE_EVIDENCE_READY_STATUS =
   'READY_FOR_CANDIDATE_EVIDENCE_PRODUCTION' as const;
+const PRODUCTION_REPLAN_INTENT_SCAN_LIMIT = 500;
 
 const TERMINAL_TRAIN_STATUSES = new Set([
   'STAGING_VALIDATED',
@@ -55,11 +56,94 @@ const PRE_MAIN_PRODUCTION_OPERATION_TYPES = new Set([
   'PREPARE_ARTIFACT_BACKEND',
   'PREPARE_ARTIFACT_FRONTEND'
 ]);
+const PRODUCTION_REPLAN_READY_STATUSES = new Set<
+  ReleaseBusV2CandidateRecord['status']
+>([
+  CANDIDATE_EVIDENCE_READY_STATUS,
+  'READY_FOR_PRODUCTION',
+  'WAITING_FOR_PRODUCTION_REPLAN'
+]);
+const PRODUCTION_REPLAN_BOUND_STATUSES = new Set<
+  ReleaseBusV2CandidateRecord['status']
+>(['PRODUCTION_IN_TRAIN', 'PRODUCTION_BUILDING_OR_QUALIFYING']);
 const REQUIRED_MAINTENANCE_LOCKS = new Set([
   'scheduler',
   'staging-environment',
   'production-environment'
 ]);
+
+export type ReleaseBusV2SafeProductionReplanResult =
+  | {
+      readonly status: 'REPLANNED';
+      readonly trainId: string;
+      readonly candidateIds: readonly string[];
+      readonly sourceSelectionIds: readonly string[];
+    }
+  | {
+      readonly status: 'FROZEN';
+      readonly trainId: string;
+      readonly reason: string;
+    }
+  | {
+      readonly status: 'NOOP';
+      readonly trainId: string;
+      readonly reason: string;
+    };
+
+type ProductionReplanRequest = {
+  readonly trainId: string;
+  readonly reason: string;
+  readonly actor: string;
+};
+
+type ProductionReplanCandidateSource = {
+  readonly candidate: ReleaseBusV2CandidateRecord;
+  readonly sourceSelectionId: string;
+  readonly sourceTrainId: string | null;
+};
+
+type ProductionReplanOmission = {
+  readonly candidate: ReleaseBusV2CandidateRecord;
+  readonly sourceSelectionId: string | null;
+  readonly sourceTrainId: string | null;
+  readonly reason: string;
+};
+
+type ProductionReplanCandidateQualification =
+  | {
+      readonly eligible: true;
+      readonly source: ProductionReplanCandidateSource;
+      readonly evidence: ReleaseBusV2CandidateStagingEvidence;
+    }
+  | {
+      readonly eligible: false;
+      readonly omission: ProductionReplanOmission;
+    };
+
+export function irreversibleProductionOperationReason(
+  operation: ReleaseBusV2OperationRecord
+): string | null {
+  if (
+    operation.operation_type.startsWith('ADVANCE_MAIN_') &&
+    operation.status === 'SUCCEEDED'
+  )
+    return `${operation.operation_type} succeeded`;
+  if (
+    operation.environment === 'prod' &&
+    operation.operation_type.startsWith('DEPLOY_') &&
+    (operation.external_id !== null ||
+      ['DISPATCHED', 'RUNNING', 'RETRY_WAIT', 'SUCCEEDED'].includes(
+        operation.status
+      ))
+  )
+    return `${operation.operation_type} was dispatched`;
+  if (
+    operation.operation_type === 'E2E_PROD' &&
+    operation.status !== 'CANCELLED'
+  )
+    return 'production E2E was created';
+  return null;
+}
 
 export class ReleaseBusV2StagingTransitionConflictError extends Error {
   public constructor(message: string) {
@@ -967,6 +1051,18 @@ export class ReleaseBusV2Service {
     return this.repository.executeNativeQueriesInTransaction(
       async (connection) => {
         const ctx: RequestContext = { connection };
+        const scheduler = await this.repository.acquireLock(
+          'scheduler',
+          null,
+          `production-selection:${randomUUID()}`,
+          RELEASE_BUS_V2_LOCK_TTL_MS,
+          ctx
+        );
+        if (!scheduler?.lease_token)
+          throw new ReleaseBusV2ProductionSelectionError(
+            'CONFLICT',
+            'Production selection raced another scheduler transaction; refresh and retry'
+          );
         const locked: ReleaseBusV2CandidateRecord[] = [];
         const retrySourceByCandidateId = new Map<string, string>();
         const orderedIds = Array.from(selectedIds).sort((left, right) =>
@@ -1150,6 +1246,11 @@ export class ReleaseBusV2Service {
             );
           updated.push(current);
         }
+        await this.repository.releaseLock(
+          'scheduler',
+          scheduler.lease_token,
+          ctx
+        );
         return updated;
       }
     );
@@ -2458,6 +2559,609 @@ export class ReleaseBusV2Service {
     return this.repository.getStagingState(ctx, true);
   }
 
+  private productionReplanIrreversibleReason(
+    train: ReleaseBusV2TrainRecord,
+    operations: readonly ReleaseBusV2OperationRecord[]
+  ): string | null {
+    if (train.status === 'PRODUCTION_DEPLOYING')
+      return 'the train entered PRODUCTION_DEPLOYING';
+    return (
+      operations
+        .map(irreversibleProductionOperationReason)
+        .find((reason): reason is string => reason !== null) ?? null
+    );
+  }
+
+  private async freezeProductionReplan(
+    train: ReleaseBusV2TrainRecord,
+    operations: readonly ReleaseBusV2OperationRecord[],
+    irreversibleReason: string,
+    input: ProductionReplanRequest,
+    ctx: RequestContext
+  ): Promise<ReleaseBusV2SafeProductionReplanResult> {
+    const reason = `Safe production replan refused because ${irreversibleReason}; the original exact candidate set remains frozen`;
+    if (
+      !(await this.repository.updateTrain(
+        train.id,
+        train.row_version,
+        {
+          status: 'PAUSED',
+          failureClass: 'INTERACTION',
+          failureMessage: input.reason,
+          recoveryMessage: `${reason}. Resume or recover only this train's immutable membership`
+        },
+        ctx
+      ))
+    )
+      throw new Error(
+        'Release Bus v2 train changed during irreversible replan fence'
+      );
+    await this.repository.appendEvent(
+      {
+        trainId: train.id,
+        eventType: 'PRODUCTION_REPLAN_REJECTED_AFTER_IRREVERSIBLE_MUTATION',
+        actor: input.actor,
+        payload: {
+          reason,
+          source_train_id: train.id,
+          operation_ids: operations.map(({ id }) => id)
+        }
+      },
+      ctx
+    );
+    return {
+      status: 'FROZEN',
+      trainId: train.id,
+      reason
+    };
+  }
+
+  private async cancelPendingProductionReplanOperations(
+    operations: readonly ReleaseBusV2OperationRecord[],
+    reason: string,
+    ctx: RequestContext
+  ): Promise<void> {
+    for (const operation of operations) {
+      if (TERMINAL_OPERATION_STATUSES.has(operation.status)) continue;
+      if (
+        !(await this.repository.updateOperation(
+          operation.id,
+          operation.row_version,
+          {
+            status: 'CANCELLED',
+            failureClass: 'INTERACTION',
+            failureMessage: reason,
+            completedAt: Date.now()
+          },
+          ctx
+        ))
+      )
+        throw new Error(
+          'Release Bus v2 operation changed during safe production replan'
+        );
+    }
+  }
+
+  private async lockBoundProductionReplanCandidates(
+    train: ReleaseBusV2TrainRecord,
+    ctx: RequestContext
+  ): Promise<ReleaseBusV2CandidateRecord[]> {
+    const memberships = (
+      await this.repository.listTrainCandidates(train.id, ctx)
+    )
+      .filter(({ disposition }) => disposition === 'INCLUDED')
+      .sort(
+        (left, right) =>
+          left.sequence - right.sequence ||
+          left.candidate_id.localeCompare(right.candidate_id)
+      );
+    if (memberships.length === 0)
+      throw new Error(
+        `Production replan source train ${train.id} has no included candidates`
+      );
+    const candidates: ReleaseBusV2CandidateRecord[] = [];
+    for (const membership of memberships) {
+      const candidate = await this.repository.findCandidateById(
+        membership.candidate_id,
+        ctx,
+        true
+      );
+      if (!candidate)
+        throw new Error(
+          `Production replan lost candidate ${membership.candidate_id}`
+        );
+      if (
+        candidate.current_train_id !== train.id ||
+        !PRODUCTION_REPLAN_BOUND_STATUSES.has(candidate.status) ||
+        candidate.production_requested_at === null ||
+        candidate.production_requested_by === null ||
+        candidate.production_selection_id === null ||
+        candidate.superseded_at !== null
+      )
+        throw new Error(
+          `Candidate ${candidate.id} is not safely bound to the exact production intent being replanned`
+        );
+      candidates.push(candidate);
+    }
+    return candidates;
+  }
+
+  private async holdProductionReplanCandidates(
+    train: ReleaseBusV2TrainRecord,
+    candidates: readonly ReleaseBusV2CandidateRecord[],
+    input: ProductionReplanRequest,
+    ctx: RequestContext
+  ): Promise<void> {
+    const holdReason = `Production train ${train.id} was safely cancelled before irreversible mutation; explicit intent is preserved for a current-base replacement`;
+    for (const candidate of candidates) {
+      if (
+        !(await this.repository.updateCandidate(
+          candidate.id,
+          candidate.row_version,
+          {
+            status: 'WAITING_FOR_PRODUCTION_REPLAN',
+            currentTrainId: null,
+            holdReason
+          },
+          ctx
+        ))
+      )
+        throw new Error(
+          `Candidate ${candidate.id} changed during safe production replan`
+        );
+      await this.repository.appendEvent(
+        {
+          trainId: train.id,
+          candidateId: candidate.id,
+          eventType: 'CANDIDATE_WAITING_FOR_PRODUCTION_REPLAN',
+          actor: input.actor,
+          payload: {
+            source_train_id: train.id,
+            source_production_selection_id: candidate.production_selection_id,
+            head_sha: candidate.head_sha,
+            reason: input.reason
+          }
+        },
+        ctx
+      );
+    }
+  }
+
+  private async cancelProductionReplanSourceTrain(
+    train: ReleaseBusV2TrainRecord,
+    candidates: readonly ReleaseBusV2CandidateRecord[],
+    sourceSelections: readonly string[],
+    input: ProductionReplanRequest,
+    ctx: RequestContext
+  ): Promise<void> {
+    if (
+      !(await this.repository.updateTrain(
+        train.id,
+        train.row_version,
+        {
+          status: 'CANCELLED',
+          failureClass: 'INTERACTION',
+          failureMessage: input.reason,
+          recoveryMessage:
+            'Main moved before irreversible production mutation; every exact explicit intent is preserved for a new audited current-base replacement',
+          completedAt: Date.now()
+        },
+        ctx
+      ))
+    )
+      throw new Error(
+        'Release Bus v2 train changed during transactional production replan'
+      );
+    await this.repository.appendEvent(
+      {
+        trainId: train.id,
+        eventType: 'PRODUCTION_TRAIN_INTENTS_PRESERVED_FOR_SAFE_REPLAN',
+        actor: input.actor,
+        payload: {
+          source_train_id: train.id,
+          source_production_selection_ids: sourceSelections,
+          candidate_ids: candidates.map(({ id }) => id),
+          reason: input.reason
+        }
+      },
+      ctx
+    );
+  }
+
+  private async releaseProductionReplanEnvironmentLock(
+    trainId: string,
+    ctx: RequestContext
+  ): Promise<void> {
+    const productionLock = (await this.repository.listLocks(ctx, true)).find(
+      ({ name, owner_train_id }) =>
+        name === 'production-environment' && owner_train_id === trainId
+    );
+    if (
+      productionLock?.lease_token &&
+      !(await this.repository.releaseLock(
+        'production-environment',
+        productionLock.lease_token,
+        ctx
+      ))
+    )
+      throw new Error(
+        'Production environment ownership changed during safe replan'
+      );
+  }
+
+  public async preserveProductionIntentsForSafeReplan(
+    input: ProductionReplanRequest
+  ): Promise<ReleaseBusV2SafeProductionReplanResult> {
+    return this.repository.executeNativeQueriesInTransaction(
+      async (connection) => {
+        const ctx: RequestContext = { connection };
+        const scheduler = await this.repository.acquireLock(
+          'scheduler',
+          null,
+          `production-replan:${input.trainId}`,
+          RELEASE_BUS_V2_LOCK_TTL_MS,
+          ctx
+        );
+        if (!scheduler?.lease_token)
+          return {
+            status: 'NOOP',
+            trainId: input.trainId,
+            reason:
+              'The scheduler fence is owned by another transactional actor'
+          };
+        try {
+          const train = await this.repository.findTrain(
+            input.trainId,
+            ctx,
+            true
+          );
+          if (!train || TERMINAL_TRAIN_STATUSES.has(train.status))
+            return {
+              status: 'NOOP',
+              trainId: input.trainId,
+              reason: 'The production train is already terminal or missing'
+            };
+          if (train.lane !== 'PRODUCTION')
+            throw new Error(`Train ${input.trainId} is not a production train`);
+          const operations = await this.repository.listOperations(
+            train.id,
+            ctx,
+            true
+          );
+          const irreversibleReason = this.productionReplanIrreversibleReason(
+            train,
+            operations
+          );
+          if (irreversibleReason)
+            return this.freezeProductionReplan(
+              train,
+              operations,
+              irreversibleReason,
+              input,
+              ctx
+            );
+          await this.cancelPendingProductionReplanOperations(
+            operations,
+            input.reason,
+            ctx
+          );
+          const candidates = await this.lockBoundProductionReplanCandidates(
+            train,
+            ctx
+          );
+          const sourceSelections = Array.from(
+            new Set(
+              candidates.map(({ production_selection_id }) =>
+                String(production_selection_id)
+              )
+            )
+          ).sort((left, right) => left.localeCompare(right));
+          await this.holdProductionReplanCandidates(
+            train,
+            candidates,
+            input,
+            ctx
+          );
+          await this.cancelProductionReplanSourceTrain(
+            train,
+            candidates,
+            sourceSelections,
+            input,
+            ctx
+          );
+          await this.releaseProductionReplanEnvironmentLock(train.id, ctx);
+          return {
+            status: 'REPLANNED',
+            trainId: train.id,
+            candidateIds: candidates.map(({ id }) => id),
+            sourceSelectionIds: sourceSelections
+          };
+        } finally {
+          await this.repository.releaseLock(
+            'scheduler',
+            scheduler.lease_token,
+            ctx
+          );
+        }
+      }
+    );
+  }
+
+  private async productionReplanSourceTrainId(
+    candidate: ReleaseBusV2CandidateRecord,
+    ctx: RequestContext
+  ): Promise<string | null> {
+    if (candidate.status !== 'WAITING_FOR_PRODUCTION_REPLAN') return null;
+    const event = (
+      await this.repository.listCandidateEvents(
+        candidate.id,
+        'CANDIDATE_WAITING_FOR_PRODUCTION_REPLAN',
+        1,
+        ctx
+      )
+    )[0];
+    return event?.train_id ?? null;
+  }
+
+  private async recordProductionReplanOmission(
+    omission: ProductionReplanOmission,
+    ctx: RequestContext
+  ): Promise<void> {
+    const current = omission.candidate;
+    if (
+      current.production_requested_at !== null &&
+      current.production_requested_by !== null &&
+      current.production_selection_id !== null &&
+      current.current_train_id === null &&
+      current.superseded_at === null &&
+      PRODUCTION_REPLAN_READY_STATUSES.has(current.status)
+    ) {
+      if (
+        !(await this.repository.updateCandidate(
+          current.id,
+          current.row_version,
+          {
+            status: 'WAITING_FOR_PRODUCTION_REPLAN',
+            currentTrainId: null,
+            holdReason: omission.reason
+          },
+          ctx
+        ))
+      )
+        throw new Error(
+          `Candidate ${current.id} changed while preserving omitted production intent`
+        );
+    }
+    await this.repository.appendEvent(
+      {
+        trainId: omission.sourceTrainId,
+        candidateId: current.id,
+        eventType: 'PRODUCTION_REPLAN_INTENT_OMITTED',
+        actor: 'release-bus-v2',
+        payload: {
+          candidate_id: current.id,
+          source_train_id: omission.sourceTrainId,
+          source_production_selection_id: omission.sourceSelectionId,
+          head_sha: current.head_sha,
+          reason: omission.reason
+        }
+      },
+      ctx
+    );
+  }
+
+  private productionReplanCandidateReason(
+    candidate: ReleaseBusV2CandidateRecord,
+    sourceSelectionId: string | null
+  ): string | null {
+    if (!PRODUCTION_REPLAN_READY_STATUSES.has(candidate.status))
+      return `Candidate status ${candidate.status} no longer carries claimable production intent`;
+    if (candidate.current_train_id !== null)
+      return `Candidate is owned by train ${candidate.current_train_id}`;
+    if (
+      candidate.production_requested_at === null ||
+      candidate.production_requested_by === null ||
+      sourceSelectionId === null
+    )
+      return 'Explicit production selection was revoked or is incomplete';
+    if (candidate.superseded_at !== null)
+      return 'Exact candidate SHA was superseded';
+    return null;
+  }
+
+  private async qualifyProductionReplanCandidate(
+    candidate: ReleaseBusV2CandidateRecord,
+    ctx: RequestContext
+  ): Promise<ProductionReplanCandidateQualification> {
+    const sourceTrainId = await this.productionReplanSourceTrainId(
+      candidate,
+      ctx
+    );
+    const sourceSelectionId = candidate.production_selection_id ?? null;
+    let reason = this.productionReplanCandidateReason(
+      candidate,
+      sourceSelectionId
+    );
+    if (!reason) {
+      const currentHead = await releaseBusGitHubApp.resolveRefIfExists(
+        candidate.repository,
+        candidate.branch_name
+      );
+      if (currentHead !== candidate.head_sha)
+        reason = `Candidate branch head changed from ${candidate.head_sha} to ${currentHead ?? 'deleted'}`;
+    }
+    let evidence: ReleaseBusV2CandidateStagingEvidence | null = null;
+    if (!reason)
+      try {
+        evidence =
+          (await this.resolveCandidateStagingEvidence([candidate], ctx))[0] ??
+          null;
+        if (!evidence)
+          reason = 'Exact staging evidence resolution returned no candidate';
+      } catch (error) {
+        if (
+          !(error instanceof Error) ||
+          error.name !== 'ReleaseBusV2ProductionSelectionError'
+        )
+          throw error;
+        reason = error.message;
+      }
+    if (reason || sourceSelectionId === null || evidence === null)
+      return {
+        eligible: false,
+        omission: {
+          candidate,
+          sourceSelectionId,
+          sourceTrainId,
+          reason:
+            reason ??
+            'Explicit production selection or exact staging evidence is missing'
+        }
+      };
+    return {
+      eligible: true,
+      source: {
+        candidate,
+        sourceSelectionId,
+        sourceTrainId
+      },
+      evidence
+    };
+  }
+
+  private async omitProductionReplanDependencyGaps(
+    preliminary: readonly ProductionReplanCandidateSource[],
+    evidenceByCandidate: Map<string, ReleaseBusV2CandidateStagingEvidence>,
+    omitted: ProductionReplanOmission[],
+    ctx: RequestContext
+  ): Promise<Map<string, ProductionReplanCandidateSource>> {
+    const eligible = new Map(
+      preliminary.map((source) => [source.candidate.id, source])
+    );
+    const dependencies = await this.repository.listDependencies(
+      preliminary.map(({ candidate }) => candidate.id),
+      ctx
+    );
+    let changed = true;
+    while (changed) {
+      changed = false;
+      for (const dependency of dependencies) {
+        const source = eligible.get(dependency.candidate_id);
+        if (
+          !source ||
+          dependency.environment === 'STAGING' ||
+          eligible.has(dependency.prerequisite_candidate_id)
+        )
+          continue;
+        const prerequisite = await this.repository.findCandidateById(
+          dependency.prerequisite_candidate_id,
+          ctx
+        );
+        if (
+          prerequisite &&
+          (await this.hasExactProductionDeploymentEvidence(prerequisite, ctx))
+        )
+          continue;
+        eligible.delete(source.candidate.id);
+        evidenceByCandidate.delete(source.candidate.id);
+        omitted.push({
+          candidate: source.candidate,
+          sourceSelectionId: source.sourceSelectionId,
+          sourceTrainId: source.sourceTrainId,
+          reason: `Production dependency ${dependency.prerequisite_candidate_id} is neither eligible for this replacement nor exactly deployed`
+        });
+        changed = true;
+      }
+    }
+    return eligible;
+  }
+
+  private async qualifyProductionReplanIntents(
+    candidates: readonly ReleaseBusV2CandidateRecord[],
+    frontendBaseSha: string,
+    backendBaseSha: string,
+    ctx: RequestContext
+  ): Promise<{
+    readonly eligible: readonly ProductionReplanCandidateSource[];
+    readonly omitted: readonly ProductionReplanOmission[];
+    readonly evidence: readonly ReleaseBusV2CandidateStagingEvidence[];
+  }> {
+    const currentBases = await Promise.all(
+      (['frontend', 'backend'] as const).map(async (repository) => ({
+        repository,
+        sha: await releaseBusGitHubApp.resolveRef(repository, 'main')
+      }))
+    );
+    const expectedBase = {
+      frontend: frontendBaseSha,
+      backend: backendBaseSha
+    } as const;
+    const staleBase = currentBases.find(
+      ({ repository, sha }) =>
+        !/^[a-f0-9]{40}$/.test(sha) || sha !== expectedBase[repository]
+    );
+    if (staleBase) {
+      const omitted: ProductionReplanOmission[] = [];
+      for (const candidate of candidates)
+        omitted.push({
+          candidate,
+          sourceSelectionId: candidate.production_selection_id ?? null,
+          sourceTrainId: await this.productionReplanSourceTrainId(
+            candidate,
+            ctx
+          ),
+          reason: `Production base fence changed for ${staleBase.repository}: expected ${expectedBase[staleBase.repository]}, observed ${staleBase.sha}`
+        });
+      return {
+        eligible: [],
+        omitted,
+        evidence: []
+      };
+    }
+
+    const preliminary: ProductionReplanCandidateSource[] = [];
+    const omitted: ProductionReplanOmission[] = [];
+    const evidenceByCandidate = new Map<
+      string,
+      ReleaseBusV2CandidateStagingEvidence
+    >();
+    for (const candidate of candidates) {
+      const qualification = await this.qualifyProductionReplanCandidate(
+        candidate,
+        ctx
+      );
+      if (!qualification.eligible) {
+        omitted.push(qualification.omission);
+        continue;
+      }
+      preliminary.push(qualification.source);
+      evidenceByCandidate.set(candidate.id, qualification.evidence);
+    }
+
+    const eligible = await this.omitProductionReplanDependencyGaps(
+      preliminary,
+      evidenceByCandidate,
+      omitted,
+      ctx
+    );
+    const ordered = preliminary.filter(({ candidate }) =>
+      eligible.has(candidate.id)
+    );
+    return {
+      eligible: ordered,
+      omitted,
+      evidence: ordered
+        .map(({ candidate }) => evidenceByCandidate.get(candidate.id))
+        .filter(
+          (evidence): evidence is ReleaseBusV2CandidateStagingEvidence =>
+            evidence !== undefined
+        )
+        .sort((left, right) =>
+          left.candidate_id.localeCompare(right.candidate_id)
+        )
+    };
+  }
+
   public async claimLane(
     lane: ReleaseBusV2Lane,
     frontendBaseSha: string,
@@ -2523,37 +3227,33 @@ export class ReleaseBusV2Service {
           )
             return null;
           await this.refreshDependencyHolds(lane, ctx, betaAllowlist);
-          const readyCandidates = (
-            await this.repository.listCandidates(
-              lane === 'PRODUCTION'
-                ? [CANDIDATE_EVIDENCE_READY_STATUS, 'READY_FOR_PRODUCTION']
-                : [readyStatus(lane)],
-              RELEASE_BUS_V2_MAX_CANDIDATES,
-              ctx
-            )
-          ).filter(
+          const readyCandidateScan = await this.repository.listCandidates(
+            lane === 'PRODUCTION'
+              ? [CANDIDATE_EVIDENCE_READY_STATUS, 'READY_FOR_PRODUCTION']
+              : [readyStatus(lane)],
+            lane === 'PRODUCTION'
+              ? PRODUCTION_REPLAN_INTENT_SCAN_LIMIT
+              : RELEASE_BUS_V2_MAX_CANDIDATES,
+            ctx
+          );
+          const readyCandidates = readyCandidateScan.filter(
             (candidate) =>
               !betaLaneEnabled ||
               releaseBusV2BetaAllowsCandidate(betaAllowlist, candidate, lane)
           );
-          const heldCandidates =
+          const heldCandidateScan =
             lane === 'PRODUCTION'
-              ? (
-                  await this.repository.listCandidates(
-                    ['WAITING_FOR_PRODUCTION_REPLAN'],
-                    RELEASE_BUS_V2_MAX_CANDIDATES,
-                    ctx
-                  )
-                ).filter(
-                  (candidate) =>
-                    !betaLaneEnabled ||
-                    releaseBusV2BetaAllowsCandidate(
-                      betaAllowlist,
-                      candidate,
-                      lane
-                    )
+              ? await this.repository.listCandidates(
+                  ['WAITING_FOR_PRODUCTION_REPLAN'],
+                  PRODUCTION_REPLAN_INTENT_SCAN_LIMIT,
+                  ctx
                 )
               : [];
+          const heldCandidates = heldCandidateScan.filter(
+            (candidate) =>
+              !betaLaneEnabled ||
+              releaseBusV2BetaAllowsCandidate(betaAllowlist, candidate, lane)
+          );
           const stagingTransitionRequests =
             lane === 'STAGING' && stagingState
               ? await this.repository.listStagingTransitionRequests(ctx, true)
@@ -2574,6 +3274,13 @@ export class ReleaseBusV2Service {
           let carriedCandidates: readonly ReleaseBusV2CandidateRecord[] = [];
           let replacedCandidates: readonly ReleaseBusV2CandidateRecord[] = [];
           let removalCandidates: readonly ReleaseBusV2CandidateRecord[] = [];
+          let productionReplanSources: readonly ProductionReplanCandidateSource[] =
+            [];
+          let productionReplanOmissions: readonly ProductionReplanOmission[] =
+            [];
+          let qualificationEvidence:
+            | readonly ReleaseBusV2CandidateStagingEvidence[]
+            | undefined;
           let selectionId: string | null = null;
           if (lane === 'STAGING') {
             candidates = readyCandidates;
@@ -2657,6 +3364,87 @@ export class ReleaseBusV2Service {
                 !requestedIds.has(candidate.id)
             );
             candidates = [...carriedCandidates, ...candidates];
+          } else if (heldCandidates.length > 0) {
+            if (
+              readyCandidateScan.length ===
+                PRODUCTION_REPLAN_INTENT_SCAN_LIMIT ||
+              heldCandidateScan.length === PRODUCTION_REPLAN_INTENT_SCAN_LIMIT
+            ) {
+              await this.repository.appendEvent(
+                {
+                  eventType: 'PRODUCTION_REPLAN_INTENT_SCAN_FAILED_CLOSED',
+                  actor: owner,
+                  payload: {
+                    reason: `Production replan intent scan reached the fail-closed limit of ${PRODUCTION_REPLAN_INTENT_SCAN_LIMIT}`,
+                    ready_count: readyCandidates.length,
+                    held_count: heldCandidates.length
+                  }
+                },
+                ctx
+              );
+              return null;
+            }
+            const lockedCandidates: ReleaseBusV2CandidateRecord[] = [];
+            const queuedById = [...queued].sort((left, right) =>
+              left.id.localeCompare(right.id)
+            );
+            for (const queuedCandidate of queuedById) {
+              const locked = await this.repository.findCandidateById(
+                queuedCandidate.id,
+                ctx,
+                true
+              );
+              if (!locked)
+                throw new Error(
+                  `Production replan candidate ${queuedCandidate.id} disappeared during the scheduler fence`
+                );
+              lockedCandidates.push(locked);
+            }
+            lockedCandidates.sort(
+              (left, right) =>
+                Number(left.production_requested_at ?? left.created_at) -
+                  Number(right.production_requested_at ?? right.created_at) ||
+                left.id.localeCompare(right.id)
+            );
+            const replan = await this.qualifyProductionReplanIntents(
+              lockedCandidates,
+              frontendBaseSha,
+              backendBaseSha,
+              ctx
+            );
+            productionReplanSources = replan.eligible;
+            productionReplanOmissions = replan.omitted;
+            qualificationEvidence = replan.evidence;
+            candidates = replan.eligible.map(({ candidate }) => candidate);
+            selectionId = randomUUID();
+            for (const omission of productionReplanOmissions)
+              await this.recordProductionReplanOmission(omission, ctx);
+            if (candidates.length === 0) {
+              await this.repository.appendEvent(
+                {
+                  eventType: 'PRODUCTION_REPLAN_REPLACEMENT_NOT_CLAIMED',
+                  actor: owner,
+                  payload: {
+                    replacement_production_selection_id: selectionId,
+                    omitted_intents: productionReplanOmissions.map(
+                      ({
+                        candidate,
+                        sourceSelectionId,
+                        sourceTrainId,
+                        reason
+                      }) => ({
+                        candidate_id: candidate.id,
+                        source_production_selection_id: sourceSelectionId,
+                        source_train_id: sourceTrainId,
+                        reason
+                      })
+                    )
+                  }
+                },
+                ctx
+              );
+              return null;
+            }
           } else {
             const first = queued[0];
             selectionId = first?.production_selection_id ?? null;
@@ -2672,14 +3460,17 @@ export class ReleaseBusV2Service {
             candidates.map((candidate) => candidate.id),
             ctx
           );
-          const eligible = await this.selectDependencyClosedCandidates(
-            candidates,
-            dependencies,
-            lane,
-            ctx,
-            betaAllowlist,
-            lane !== 'STAGING'
-          );
+          const eligible =
+            lane === 'PRODUCTION' && productionReplanSources.length > 0
+              ? candidates
+              : await this.selectDependencyClosedCandidates(
+                  candidates,
+                  dependencies,
+                  lane,
+                  ctx,
+                  betaAllowlist,
+                  lane !== 'STAGING'
+                );
           if (lane === 'STAGING' && eligible.length !== candidates.length) {
             const eligibleIds = new Set(eligible.map(({ id }) => id));
             for (const candidate of readyCandidates) {
@@ -2705,7 +3496,7 @@ export class ReleaseBusV2Service {
             eligible.length !== candidates.length
           )
             return null;
-          const qualificationEvidence =
+          qualificationEvidence ??=
             lane === 'PRODUCTION'
               ? await this.resolveCandidateStagingEvidence(eligible, ctx)
               : undefined;
@@ -2827,12 +3618,84 @@ export class ReleaseBusV2Service {
                 {
                   status: claimedStatus(lane),
                   currentTrainId: train.id,
+                  productionSelectionId:
+                    productionReplanSources.length > 0
+                      ? selectionId
+                      : undefined,
                   holdReason: null
                 },
                 ctx
               ))
             )
               throw new Error(`Candidate ${candidate.id} changed during claim`);
+          }
+          if (productionReplanSources.length > 0) {
+            const sourceMapping = productionReplanSources.map(
+              ({ candidate, sourceSelectionId, sourceTrainId }) => ({
+                candidate_id: candidate.id,
+                source_production_selection_id: sourceSelectionId,
+                source_train_id: sourceTrainId
+              })
+            );
+            await this.repository.appendEvent(
+              {
+                trainId: train.id,
+                eventType: 'PRODUCTION_REPLAN_REPLACEMENT_CLAIMED',
+                actor: owner,
+                payload: {
+                  replacement_train_id: train.id,
+                  replacement_production_selection_id: selectionId,
+                  source_production_selection_ids: Array.from(
+                    new Set(
+                      productionReplanSources.map(
+                        ({ sourceSelectionId }) => sourceSelectionId
+                      )
+                    )
+                  ).sort((left, right) => left.localeCompare(right)),
+                  source_train_ids: Array.from(
+                    new Set(
+                      productionReplanSources
+                        .map(({ sourceTrainId }) => sourceTrainId)
+                        .filter(
+                          (sourceTrainId): sourceTrainId is string =>
+                            sourceTrainId !== null
+                        )
+                    )
+                  ).sort((left, right) => left.localeCompare(right)),
+                  included_intents: sourceMapping,
+                  omitted_intents: productionReplanOmissions.map(
+                    ({
+                      candidate,
+                      sourceSelectionId,
+                      sourceTrainId,
+                      reason
+                    }) => ({
+                      candidate_id: candidate.id,
+                      source_production_selection_id: sourceSelectionId,
+                      source_train_id: sourceTrainId,
+                      reason
+                    })
+                  )
+                }
+              },
+              ctx
+            );
+            for (const source of productionReplanSources)
+              await this.repository.appendEvent(
+                {
+                  trainId: train.id,
+                  candidateId: source.candidate.id,
+                  eventType: 'CANDIDATE_COALESCED_IN_PRODUCTION_REPLAN',
+                  actor: owner,
+                  payload: {
+                    replacement_train_id: train.id,
+                    replacement_production_selection_id: selectionId,
+                    source_train_id: source.sourceTrainId,
+                    source_production_selection_id: source.sourceSelectionId
+                  }
+                },
+                ctx
+              );
           }
           await this.repository.appendEvent(
             {
@@ -2881,6 +3744,30 @@ export class ReleaseBusV2Service {
                         .map(({ id }) => id)
                     : null,
                 production_selection_id: selectionId,
+                production_replan_replacement:
+                  productionReplanSources.length > 0,
+                production_replan_source_selections:
+                  productionReplanSources.map(
+                    ({ candidate, sourceSelectionId, sourceTrainId }) => ({
+                      candidate_id: candidate.id,
+                      source_production_selection_id: sourceSelectionId,
+                      source_train_id: sourceTrainId
+                    })
+                  ),
+                production_replan_omitted_intents:
+                  productionReplanOmissions.map(
+                    ({
+                      candidate,
+                      sourceSelectionId,
+                      sourceTrainId,
+                      reason
+                    }) => ({
+                      candidate_id: candidate.id,
+                      source_production_selection_id: sourceSelectionId,
+                      source_train_id: sourceTrainId,
+                      reason
+                    })
+                  ),
                 qualification_policy:
                   lane === 'PRODUCTION'
                     ? CANDIDATE_STAGING_EVIDENCE_POLICY


### PR DESCRIPTION
## Summary

- transactionally preserve exact explicit production intents when a production train is safely replanned before irreversible mutation
- claim a new audited replacement from every currently eligible explicit selection, with fresh exact-head, staging evidence, base, ownership, revocation, and dependency checks
- freeze the original immutable set after any successful main advance, production deploy dispatch, or production E2E creation
- serialize mark-ready and replan/claim races with the scheduler fence and retain exact omission reasons without inferring intent from staging

## Why

A replacement train currently preserves only the source train's original production selection identity. A later compatible explicit selection can therefore wait behind the full replacement pipeline even though it was committed before the replacement claim. This change coalesces all currently eligible explicit intents only at the safe pre-mutation replacement boundary and never broadens an active train.

## Safety and compatibility

- no migration or API contract change
- no force updates; existing non-force CAS main advancement is unchanged
- production serialization, idempotency keys, retry bounds, deploy/E2E exactly-once behavior, and manual fallback remain unchanged
- selection holds the scheduler lease across authoritative commit/rollback; replan defers nonterminal dispatched composition
- frozen trains retain the production lease only while dispatched work drains and release it after terminal work
- omitted or invalid intents are re-read under lock and stay auditable with exact source selection/train mapping and reason
- replacement scans fail closed on truncation or a moved production base, with operator recovery documented
- rollout order: `api` first, then `releaseBus`; production release-note opt-out applies because this is an internal operational change

## Verification

- `npm run build` (296 suites, 2,797 tests, TypeScript)
- focused Release Bus gate (4 suites, 148 tests)
- `npm run lint`
- `npm run format:check`
- `git diff --check`

## Coordination

Rebased onto backend main `8c96a72860daa69a669c059d5e5a54e646a37875` after #1864 merged. The staging-recovery ownership/supersession and repair behavior is retained. Registration and rollout will wait for that production deployment and every Release Bus lock/workflow to drain.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added safe production replanning when the production base changes before irreversible deployment work.
  - Preserves eligible production intents for a replacement train while keeping dependency closure and ownership intact.
  - Freezes the original train once deployment progress becomes irreversible.

- **Bug Fixes**
  - Added fail-closed handling for bounded production-intent scans and concurrent scheduling races.
  - Improved validation of production evidence, dependencies, and current production state.

- **Documentation**
  - Updated deployment lifecycle guidance, readiness constraints, and failure handling for production replans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->