### PR TITLE
Redesign Release Bus controls UI

### DIFF
--- a/.agents/skills/deploy-6529/SKILL.md
+++ b/.agents/skills/deploy-6529/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: deploy-6529
-description: Route and execute 6529 backend, frontend, or coupled staging and production releases through Simple Release Bus v2 by exact PR head SHA, or use the serialized manual fallback only while v2 reports OFF. Use for staging, deploy, promotion, release merge, pause, resume, recovery, or rollout coordination.
+description: Route and execute 6529 backend, frontend, or coupled staging and production releases through an effective Release Bus lane by exact PR head SHA, or use the serialized manual fallback while that target lane reports OFF. Use for staging, deploy, promotion, release merge, turning a lane on or off, recovery, or rollout coordination.
 ---
 
 # Deploy 6529 Backend
@@ -9,20 +9,23 @@ description: Route and execute 6529 backend, frontend, or coupled staging and pr
 
 1. Run `node ops/scripts/release-bus-status.mjs` at the start and again before
    any readiness or environment mutation. The helper uses authenticated `gh`,
-   reads the versioned v2 controls endpoint.
+   reads the versioned controls endpoint, verifies hidden safety fences, and
+   returns only the two effective automation lanes.
 2. Fail closed on an unavailable/malformed API, authentication failure, unknown
-   mode, or incomplete controls. Never infer mode from files or old output.
-3. Route by the fresh v2 result:
+   or inconsistent lane state. Never infer ownership from files, raw mode,
+   hidden controls, or old output.
+3. Route the target environment by the fresh lane result:
 
-| Mode | Staging | Production |
-| --- | --- | --- |
-| `OFF` | Serialized manual fallback | Serialized manual fallback with explicit owner authorization; staging evidence is not required |
-| `STAGING` | Register the exact candidate with v2 | Manual fallback only; production automation is disabled |
-| `PRODUCTION` | Register the exact candidate with v2 | Explicitly mark an exact `STAGING_VALIDATED` candidate ready for v2 production |
+| Target lane       | Route                                                                                                                           |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `STAGING: ON`     | Register the exact candidate with Release Bus                                                                                   |
+| `STAGING: OFF`    | Serialized manual staging after the staging drain gate                                                                          |
+| `PRODUCTION: ON`  | Explicitly mark an exact `STAGING_VALIDATED` candidate ready for Release Bus production                                         |
+| `PRODUCTION: OFF` | Serialized manual production after the production drain gate and explicit owner authorization; staging evidence is not required |
 
-When mode is active, stop if `ALL` or the target lane is paused. In `OFF`, v2
-controls are non-authoritative and do not prohibit manual staging or production
-through the documented fallback.
+Raw mode and `ALL` are internal emergency fences. They are verified by the
+helper but are not normal routing or UI controls. Do not bypass an internal
+fence. Both lanes `OFF` means full manual fallback after both drain gates.
 
 ## V2 readiness
 
@@ -38,22 +41,45 @@ through the documented fallback.
    manual deploy after v2 accepts the candidate.
 5. Wait for `STAGING_VALIDATED`. `STAGING_DEPLOYED` means E2E is still pending
    and is not production evidence.
-6. Production is a separate explicit action. Re-resolve the branch and mark
-   ready only when it still equals the exact staging-validated SHA. Staging
-   validation never schedules production automatically.
+6. Production is a separate explicit action. Re-resolve each branch, select the
+   complete dependency-closed set in one action, and mark ready only when every
+   branch still equals its exact staging-validated SHA. Staging validation never
+   schedules production automatically. Omitted candidates retain their
+   validation evidence and any separate production intent.
+   A pre-mutation production replan may create a new audited replacement from
+   all currently eligible explicit selections, including a compatible selection
+   recorded after the source train was claimed. Verify the replacement event's
+   source selection/train mapping and every omitted intent reason. It must never
+   infer candidates from staging. After any successful main advance, production
+   deploy dispatch, or production E2E, the original exact set is frozen and may
+   only resume or recover unchanged. Retain its production lease only while
+   dispatched work remains nonterminal; after terminal drain, release the lease
+   while the paused train/control continue blocking new claims.
+   If `PRODUCTION_REPLAN_INTENT_SCAN_FAILED_CLOSED` reaches its bounded cap,
+   stop claiming; after ownership drains, revoke/cancel only owner-authorized
+   stale intents or deploy a separately reviewed pagination/cap change. Never
+   edit the ledger or silently drop intent.
+   During an API-before-reconciler rolling upgrade, the selection parks at
+   `READY_FOR_CANDIDATE_EVIDENCE_PRODUCTION`; never rewrite it to the legacy
+   ready status to make an older worker claim it.
 
-V2 composes from current `main`, reuses exact green PR merge-tree evidence when
-eligible, otherwise runs one combined preflight and one immutable build, owns
-shared staging only for deploy plus manifest-bound E2E, and reuses the same
-qualified artifacts for production. It updates `main` only after exact
-qualification. It never authors or posts release notes; every production
-operation emits the autonomous bot's canonical grouping metadata and finalize
-signal unless the candidate explicitly opts out.
+For staging, v2 reuses exact green PR merge-tree evidence when eligible and
+otherwise runs one combined preflight and immutable build. For production, the
+default `CANDIDATE_STAGING_EVIDENCE_V1` policy records every selected
+candidate's staging train, manifest, and successful E2E operation/run, then
+freshly composes and builds the selected set from both current `main` bases.
+It does not mutate shared staging or create a `PRODUCTION_QUALIFICATION` child
+merely because the selected combination differs from a staging manifest. It
+updates `main` only after candidate evidence, fresh checks, immutable artifacts,
+and both base refs pass their fences. It never authors or posts release notes;
+every production operation emits the autonomous bot's canonical grouping
+metadata and finalize signal unless the candidate explicitly opts out.
 
-## Manual fallback while OFF
+## Manual fallback while the target lane is OFF
 
-1. Fetch the exact remote target head and inspect active frontend/backend
-   staging, production, and E2E workflows. Wait; never cancel another actor.
+1. Prove the target environment lock is free, no target mutation/E2E workflow
+   is active, and every already-dispatched exact operation is terminal. Fetch
+   the exact remote target head. Wait; never cancel another actor.
 2. Re-fetch immediately before pushing. If a shared ref moved, recompute from
    the new head. Never force-push.
 3. Merge the development branch into current `1a-staging`. Deploy required
@@ -65,8 +91,9 @@ signal unless the candidate explicitly opts out.
    frontend.
 5. Record exact deployed frontend/backend SHAs before E2E and freeze staging
    until E2E is terminal.
-6. In `OFF`, production requires explicit owner authorization but not prior
-   staging deployment or validation. Re-fetch `main` and preserve dependency
+6. With the production lane `OFF`, production requires explicit owner
+   authorization but not prior staging deployment or validation. Re-fetch
+   `main` and preserve dependency
    order. Pass the same merged PR number and full canonical service set to every
    backend production run; set `release_note_publish=true` only on the final
    sequential service. For an explicitly authorized internal operation that
@@ -77,22 +104,59 @@ signal unless the candidate explicitly opts out.
 
 ## Monitoring and recovery
 
+- Inspect the exact candidate ID, PR, head SHA, train, failed operation,
+  workflow, command/test, and log URL before acting.
+- Never infer that membership in a failed train makes a PR the culprit.
+- If failure evidence directly identifies that exact candidate/head or a
+  changed test, fix it, push a new head, and register that exact new SHA.
+- For grouped, `COMBINATION_FAILED`, or otherwise non-attributed staging
+  preflight failure, never push a dummy commit. Explicitly re-register the same
+  head only after its candidate is terminal and unowned; let the API fail
+  closed unless the audited grouped-failure evidence is exact.
+- Never start a parallel manual deployment or cancel another actor.
+- Report the exact failed command/test, candidate set, and log URL. Hand off
+  through durable bus/GitHub status; do not keep an interactive task polling.
 - Use train details, operations, workflow links, manifest identity, failure
   class, and recovery message in `/deploy/ui/bus`.
 - Infrastructure and retryable exact deployment failures retry the same
   idempotent operation. They do not isolate candidates.
+- An ordinary staging combined preflight failure never launches subset
+  isolation. After already-dispatched workflows drain, the failing
+  repository's NEW group fails once and independent repository candidates
+  return to the very next train.
+- Group failures do not auto-retry. Re-registering the unchanged exact head is
+  the only retry signal, and it succeeds only when fresh green PR evidence and
+  immutable registration data match one unowned audited group-failure row
+  version. Record the retry id/attempt; never require a dummy commit.
+- Active staging trains recheck every NEW exact PR head before further work.
+  A moved head stops new dispatch, drains existing workflows without
+  cancellation, supersedes the obsolete candidate, and replans unrelated NEW
+  candidates.
 - A merge conflict marks only the direct candidate `NEEDS_REBASE` and holds
   transitive dependants. Fix the branch and register its new SHA.
-- A control-plane defect pauses automation and leaves candidates unblamed. Keep
-  exact state, use the OFF/manual fallback only after an operator deliberately
-  disables v2, and resume explicitly after repair.
+- A control-plane defect turns the affected automation lane off and leaves
+  candidates unblamed. Keep exact state, wait for its drain gate, use manual
+  fallback for that environment, and turn the lane on explicitly after repair.
+- Use `node ops/scripts/release-bus-v2-fast-off.mjs --execute` only for an
+  emergency hard stop of both lanes. Its raw mode and `ALL` changes are
+  intentionally absent from normal UI and routing.
 - Failed E2E never creates staging validation. Do not mutate staging while the
   manifest owner still holds the environment lock.
-- If production `main` moved, v2 must recompose and requalify; never force the
-  recorded composition over a newer ref.
+- If either production `main` base moved, v2 must cancel/requeue and freshly
+  compose again; never force the recorded composition over a newer ref.
+- Once a production train reaches `PRODUCTION_DEPLOYING`, its exact composition
+  is already on `main`. Any exhausted deployment retry or production E2E
+  failure must pause `PRODUCTION`, fail the selected candidates closed, and
+  block later production claims. Do not resume until the recorded main SHAs
+  and runtime are reconciled exactly or an explicit rollback is complete;
+  never rewrite `main` to hide the failed release.
+- `PRODUCTION_CANDIDATE_EVIDENCE_QUALIFIED` is an auditable pre-deploy
+  composition manifest, not staging validation. Production success still
+  requires terminal production-safe read-only E2E.
 
 ## Closeout
 
 Report exact candidate SHAs/dependencies, train and operation states, deployed
-versions, manifest/E2E evidence, failures or holds, and live mode/controls. Do
+versions, manifest/E2E evidence, failures or holds, and both effective lane
+states. Do
 not expose credentials, signed URLs, raw production data, or hidden prompts.

--- a/.agents/skills/deploy-6529/agents/openai.yaml
+++ b/.agents/skills/deploy-6529/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "Deploy 6529"
-  short_description: "Route exact releases through Release Bus v2."
-  default_prompt: "Use $deploy-6529 to route, deploy, validate, and recover an exact 6529 backend or coupled release."
+  display_name: 'Deploy 6529'
+  short_description: 'Route exact releases by effective lane state.'
+  default_prompt: 'Use $deploy-6529 to route, deploy, validate, and recover an exact 6529 backend or coupled release.'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,17 +2,19 @@
 
 - Before staging, production, promotion, or release mutation, run
   `node ops/scripts/release-bus-status.mjs` and follow `deploy-6529`.
-- `OFF` uses the serialized manual fallback. `STAGING` routes staging
-  readiness through v2. `PRODUCTION` routes
-  staging through v2 and requires a separate explicit exact-SHA production
-  action after `STAGING_VALIDATED`.
-- While `OFF`, dispatch backend `Deploy a service` workflows one at a time and
-  wait for exact success before starting the next. Its shared concurrency can
-  cancel sibling service runs, including independent DAG-frontier units.
-- Stop an active v2 lane when `ALL` or that lane is paused. In `OFF`, v2
-  controls are non-authoritative and do not block manual staging or production.
-  Explicit owner production authorization is sufficient; prior staging
-  deployment or validation is not required.
+- Route only from the helper's two effective lane states. When the target lane
+  is `ON`, use v2. When it is `OFF`, use serialized manual fallback only after
+  the target environment lock is free, no mutation/E2E workflow is active, and
+  every already-dispatched exact operation is terminal. Both lanes `OFF` means
+  full manual fallback.
+- Staging `ON` accepts exact candidates. Production `ON` requires a separate
+  exact-SHA production action after `STAGING_VALIDATED`.
+- Raw mode and `ALL` are internal emergency fences, not normal routing or UI
+  controls. Never bypass them. Use `release-bus-v2-fast-off.mjs` only for an
+  emergency hard stop.
+- In manual fallback, dispatch backend `Deploy a service` workflows one at a
+  time and wait for exact success before starting the next. Shared concurrency
+  can cancel sibling service runs, including independent DAG-frontier units.
 - For coupled work, declare backend dependencies and preserve backend-before-
   frontend ordering. Within v2, only independent backend DAG frontier units run
   together.
@@ -141,6 +143,7 @@ npm test path/to/test.spec.ts
 ```
 
 The test configuration uses:
+
 - Jest with ts-jest preset
 - Testcontainers for MySQL integration tests
 - Global setup/teardown in `src/tests/_setup/`
@@ -179,6 +182,7 @@ validator/query tests in the same PR.
 The backend consists of independent "loop" services that run as AWS Lambda functions or cron jobs. Each loop is self-contained in `src/*Loop/` directories:
 
 **Key Loops:**
+
 - `nftsLoop` - Discovers and indexes NFTs from blockchain
 - `nftOwnersLoop` - Tracks NFT ownership changes
 - `nftHistoryLoop` - Maintains NFT ownership history
@@ -197,6 +201,7 @@ The backend consists of independent "loop" services that run as AWS Lambda funct
 - `overRatesRevocationLoop` - Handles reputation rate revocations
 
 Each loop follows the pattern:
+
 1. Entry point in `index.ts` with `handler` function
 2. Uses `doInDbContext()` to initialize database and Redis
 3. Wrapped with `sentryContext.wrapLambdaHandler()` for error tracking
@@ -207,11 +212,13 @@ Each loop follows the pattern:
 The API (`src/api-serverless/src/`) is an Express application with:
 
 **Core Files:**
+
 - `app.ts` - Main Express app configuration with routes, middleware, authentication
 - `handler.ts` - AWS Lambda handler wrapper for serverless deployment
 - `async.router.ts` - Async-aware Express router wrapper
 
 **Feature Routes (in subdirectories):**
+
 - `drops/` - Social content drops (posts/content) with voting and reactions
 - `waves/` - Community waves (voting periods/campaigns)
 - `profiles/` - User profiles, reputation, and activity logs
@@ -226,6 +233,7 @@ The API (`src/api-serverless/src/`) is an Express application with:
 - `xtdh/` - Extended TDH calculations
 
 **Architecture Patterns:**
+
 - **Routes** (`*.routes.ts`) - Define endpoints and validation
 - **API Services** (`*.api.service.ts`) - Business logic for API endpoints
 - **DB Services** (`*.db.ts` in `src/`) - Database access layer extending `LazyDbAccessCompatibleService`
@@ -234,27 +242,32 @@ The API (`src/api-serverless/src/`) is an Express application with:
 ### Database Layer
 
 **Connection Management:**
+
 - Separate read/write connection pools configured in `src/db-api.ts`
 - `read_pool` for SELECT queries, `write_pool` for INSERT/UPDATE/DELETE
 - Environment variables: `DB_HOST`, `DB_USER`, `DB_PASS`, `DB_PORT` (write) and `DB_HOST_READ`, `DB_USER_READ`, `DB_PASS_READ` (read)
 
 **Query Execution:**
+
 - `SqlExecutor` interface in `src/sql-executor.ts` provides abstraction
 - Services extend `LazyDbAccessCompatibleService` to access `this.db`
 - Use parameterized queries with named parameters: `execute(sql, { param: value })`
 - Transaction support via `executeNativeQueriesInTransaction()`
 
 **ORM:**
+
 - TypeORM for schema synchronization (entities in `src/entities/`)
 - Entities files are prefixed with `I` (e.g., `IIdentity.ts`, `IDrop.ts`) but the entity classes in them don't have this prefix. Instead they have `Entity` suffix (e.g., `IdentityEntiy`, `ProfileEntity`)
 - Schema auto-syncs on startup; migrations are only used for data migrations (and rarely for views).
 - Every time a new Entity is added it also needs to be exported in `entities.ts`.
 
 **Constants:**
+
 - All table names defined in `src/constants.ts` (e.g., `NFTS_TABLE`, `DROPS_TABLE`, `PROFILES_TABLE`)
 - Use constants instead of hardcoded strings
 
 **Important:**
+
 - Never use foreign keys in database schemas
 - Avoid fancy db level constraints (like enum validation for example)
 - Be careful with changing preexisting entity classes as there is a high chance of accidentally deleting data. This includes changing data types.
@@ -262,37 +275,44 @@ The API (`src/api-serverless/src/`) is an Express application with:
 ### Key Domain Models
 
 **NFTs:**
+
 - Primary contracts: MEMES (`0x33FD426905F149f8376e227d0C9D3340AaD17aF1`), MEME LAB, GRADIENT, NextGen
 - Tables: `nfts`, `nfts_meme_lab`, `nft_owners`, `nfts_history`
 - Extended data: `memes_extended_data`, `lab_extended_data`
 
 **Community Features:**
+
 - **Drops** - Social posts/content with voting, reactions, and metadata
 - **Waves** - Social channels with all kinds of metadata like voting periods with participation requirements and outcomes
 - **Ratings** - Reputation system with categories (CIC, REP)
 - **Identities** - User profiles with proxy support
 
 **TDH (Total Days Held):**
+
 - Scoring system based on eligible NFT ownership duration
 - Per-wallet calculations and consolidated calculations across wallet consolidations
 - Historical tracking in `tdh_history` and `tdh_global_history`
 
 **Delegations:**
+
 - Integration with delegations protocol
 - Allows delegating wallet permissions to other addresses
 
 ### Authentication & Authorization
 
 **Authorization**:
+
 - Uses a sequence of API calls and Ethereum wallet signatures to figure out who the user is. If successful, releases a JWT. (`openapi.yaml` `/auth` endpoints)
 
 **JWT Authentication:**
+
 - Passport.js with JWT strategy in `src/api-serverless/src/app.ts`
 - JWT secret from `getJwtSecret()` in `src/api-serverless/src/auth/auth.ts`
 - Routes can use `passport.authenticate('jwt')` or `passport.authenticate(['jwt', 'anonymous'])`
 - User identity in `request.user`
 
 **Rate Limiting:**
+
 - Redis-based rate limiting middleware in `src/api-serverless/src/rate-limiting/`
 - Two-tier: burst limit (requests/second) and sustained limit (requests over time window)
 - Different limits for authenticated vs unauthenticated users
@@ -302,10 +322,12 @@ The API (`src/api-serverless/src/`) is an Express application with:
 ### Environment Configuration
 
 **Environment Files:**
+
 - Use `.env.local` to set them
 - Ignore the one in `src/api-serverless/`
 
 **Environment Loading:**
+
 - `loadLocalConfig()` and `loadSecrets()`(works only in prod) in `src/env.ts`
 - `doInDbContext()` wrapper in `src/secrets.ts` handles full initialization
 
@@ -325,6 +347,7 @@ The API (`src/api-serverless/src/`) is an Express application with:
 ### Development Notes
 
 **Running Locally:**
+
 1. Set up MySQL database (or use Docker: `docker-compose up -d`)
 2. Create `.env.local` with database credentials
 3. Run migrations: `npm run migrate-local:up`
@@ -332,15 +355,18 @@ The API (`src/api-serverless/src/`) is an Express application with:
 5. Start API: `cd src/api-serverless && npm run dev`
 
 **Database Setup:**
+
 - Create database and user via docker-compose
 - TypeORM creates tables automatically
 - Migrations create views and complex structures
 
 **Video Compression:**
+
 - S3Loop requires ffmpeg installed locally
 - Only runs in `prod` mode by default
 
 **Lambda Deployment:**
+
 - Each loop folder represents a deployable Lambda
 - Serverless Framework configuration in `serverless-config/`
 - Most loops have their own serverless.yaml files in their roots. Those are used to set up lambdas (via Github Actions). All new lambdas should also use serverless.yaml and make sure they are wired in build scripts and `.github/workflows/deploy.yaml`
@@ -350,33 +376,40 @@ The API (`src/api-serverless/src/`) is an Express application with:
 ### Code Patterns
 
 **Error Handling:**
+
 - Use `ApiCompliantException` or one of its specific subclasses from `src/exceptions` for API errors
 - Sentry integration via `sentryContext.wrapLambdaHandler()`
 
 **Logging:**
+
 - `Logger.get('COMPONENT_NAME')` pattern (in classes use the pattern `private readonly logger = Logger.get(this.constructor.name);`)
 - Request-scoped logging with `loggerContext` in API
 - Each request gets unique `requestId`
 
 **Timing:**
+
 - `Time` utility in `src/time.ts` for time operations
 - `Timer` class for performance measurement
 
 **Validation:**
+
 - Joi schemas for request validation
 - `getValidatedByJoiOrThrow()` in `src/api-serverless/src/validation.ts`
 
 **Caching:**
+
 - Redis-based caching via `src/redis.ts`
 - Request-level caching via `request-cache.ts`
 - `cacheKey()` helper for consistent cache key generation
 
 **WebSockets:**
+
 - WebSocket server in `src/api-serverless/src/ws/`
 - JWT authentication for WebSocket connections
 - Notification system for real-time updates
 
 **API schemas**
+
 - API endpoints are described in `openapi.yaml` file.
 - Any time you change this file run `cd src/api-serverless && npm run restructure-openapi && npm run generate`
 - This will generate response models to `src/api-serverless/src/generated/models`, but only response models and POST/DELETE request bodies, not routes and query param models.

--- a/ops/deployment-bus/simple-release-bus-v2.md
+++ b/ops/deployment-bus/simple-release-bus-v2.md
@@ -1,7 +1,7 @@
 # Simple Release Bus v2
 
 Simple Release Bus v2 is the deployment authority for exact frontend/backend
-candidate SHAs when its live mode enables a lane.
+candidate SHAs when the target environment's effective lane is `ON`.
 
 ## Route every request from live state
 
@@ -11,18 +11,44 @@ Run:
 node ops/scripts/release-bus-status.mjs
 ```
 
-The helper reads `/deploy/release-bus-v2/controls` and fails closed if the
-versioned status is unavailable or malformed.
+The helper reads `/deploy/release-bus-v2/controls`, verifies the hidden safety
+fences, and fails closed if the versioned status is unavailable, malformed, or
+internally inconsistent. Its operator-facing result contains only:
 
-| Mode         | Staging                 | Production                                                                         |
-| ------------ | ----------------------- | ---------------------------------------------------------------------------------- |
-| `OFF`        | Serialized manual route | Serialized manual route with explicit owner authority; no staging evidence gate    |
-| `STAGING`    | V2 readiness            | Manual/disabled by default; exact operator-only production beta may be allowlisted |
-| `PRODUCTION` | V2 readiness            | Separate explicit v2 action for an exact `STAGING_VALIDATED` candidate             |
+| Effective lane | `ON`                                                                                | `OFF`                                                                                                                   |
+| -------------- | ----------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| Staging        | Register exact candidates with Release Bus                                          | Serialized manual staging after the staging drain gate                                                                  |
+| Production     | Separately select an exact `STAGING_VALIDATED` candidate for Release Bus production | Serialized manual production after the production drain gate and explicit owner authorization; no staging evidence gate |
 
-For an active mode, `ALL` and the target lane must be running. In `OFF`, v2
-controls are non-authoritative and the manual fallback remains available,
-including owner-authorized production without prior staging evidence.
+The drain gate requires the target environment lock to be free, no target
+mutation/E2E workflow to be active, and every already-dispatched exact
+operation to be terminal. Both lanes `OFF` means full manual fallback after both
+drain gates. Raw `RELEASE_BUS_V2_MODE` and `ALL` remain internal emergency
+fences; they are not normal routing or UI controls and must never be bypassed.
+
+## Dashboard read model
+
+`/deploy/ui/bus` presents Staging and Production as the two operator-facing
+lanes. Each lane shows its effective `ON`/`OFF` state, the exact frontend and
+backend SHAs currently deployed, the last successfully validated exact SHAs,
+and three train views:
+
+- the currently active train, if one has been claimed;
+- the projected next train if the queue does not change; and
+- terminal train history, loaded incrementally.
+
+The projected train is read-only planning output. It is never claim evidence and
+may change until the reconciler persists a train. Train cards split backend and
+frontend candidates and retain exact PR, SHA, status, membership, dependency,
+and backend deployment-DAG data. Locks, manifests, workflow runs, operations,
+errors, and durable events remain available inside the train's expandable
+diagnostics rather than as separate top-level dashboards.
+
+The shared Pull requests view lists every registered exact candidate and can be
+filtered by PR number or status. Public users can inspect this state without a
+GitHub token. Authentication reveals only the lane and candidate actions that
+can mutate state. The UI is a human read model; agents and scripts must continue
+to route and validate mutations from the versioned helper and API response.
 
 ## Candidate contract
 
@@ -220,7 +246,7 @@ explicitly.
 | Ordinary staging preflight    | After already-running workflows drain, fail the affected repository's NEW candidate group once, hold only dependants, and return independent repository candidates to the next train; never dispatch subset-isolation workflows                                                                      |
 | Infrastructure                | Bounded idempotent retry; no candidate isolation                                                                                                                                                                                                                                                     |
 | Retryable deployment          | Retry only the failed operation; preserve successful sibling evidence                                                                                                                                                                                                                                |
-| Control plane                 | Fail the train, requeue candidates, pause automated claiming, release an environment lock once every operation is terminal, retain manual fallback                                                                                                                                                   |
+| Control plane                 | Fail the train, preserve or requeue exact candidates, turn the affected automation lane off where safe, release its environment lock only after every operation is terminal, and permit manual fallback only after the lane drain gate                                                                 |
 | E2E                           | Keep the failed manifest unvalidated and restore/deploy/E2E the exact last validated live manifest under the same staging lock; commit no admission change until restoration validates                                                                                                               |
 | Production preflight          | Fail before shared mutation. A later explicit exact-SHA selection may retry only after the unchanged staging evidence is revalidated and the locked failed train contains only terminal compose/preflight operations; audit both selection identities and the failed source train                    |
 | Production base moved         | Before irreversible mutation, transactionally preserve explicit intent and form a new audited replacement from all currently eligible dependency-closed selections; retain every omission reason. After irreversible mutation, freeze the original exact set and pause production for exact recovery |
@@ -304,11 +330,12 @@ already committed.
 
 Deploy additive changes in this order: database migrations, API/UI, then the v2
 reconciler. Run the currently deployed status helper before the migration/API
-mutations. After the API is live, use the new helper, which requires and shows
-the authoritative `staging_state`. Do not deploy the cumulative reconciler
+mutations. After the API is live, use the new helper, which requires both
+effective lane states and the authoritative `staging_state`. Do not deploy the
+cumulative reconciler
 until the migration and API are both live. Keep `RELEASE_BUS_V2_MODE=OFF`
 throughout offline, shadow, staging beta, and production beta validation. The
-status helpers must continue to report `OFF`; manual fallback remains
+status helpers must continue to report both lanes `OFF`; manual fallback remains
 authoritative for everyone except the exact operator beta entries below.
 
 The cumulative-staging migration has an intentionally non-destructive `down`:
@@ -392,9 +419,9 @@ dispatch a workflow.
 
 For each single bounded staging test:
 
-1. Prove both helpers report `OFF`, controls are understood, no lock is owned,
-   and no frontend/backend staging deploy, staging E2E, or shared-ref mutation
-   is active. Never cancel or supersede unrelated work.
+1. Prove both helpers report both lanes `OFF`, hidden fences are understood, no
+   lock is owned, and no frontend/backend staging deploy, staging E2E, or
+   shared-ref mutation is active. Never cancel or supersede unrelated work.
 2. Install only that test's exact allowlist. Deploy the production API first
    and `releaseBus` second, both with v1/v2 modes still `OFF`; use explicit
    release-note opt-out for these internal operations.
@@ -414,7 +441,7 @@ For each single bounded staging test:
    the mixed manifest failed, requeues rather than isolates candidates, pauses
    v2 automation, and releases staging ownership.
 5. Clear the allowlist, deploy API then `releaseBus` with the empty value, and
-   prove helpers still report `OFF`, the train is terminal, all related
+   prove helpers still report both lanes `OFF`, the train is terminal, all related
    workflows are terminal, and the staging lock is free before the next case.
 
 The required staging cases are backend-only, frontend-only, coupled backend
@@ -461,22 +488,24 @@ Run the account-guarded fast path from the backend repository:
 node ops/scripts/release-bus-v2-fast-off.mjs --execute
 ```
 
-It best-effort pauses only v2, disables the reconciler schedule, clears the
+It best-effort turns both automation lanes off, disables the reconciler
+schedule, clears the
 operator beta and sets both repository variables to `OFF`, updates production
 API then reconciler with Lambda revision guards while preserving unrelated
-environment values, and verifies empty `OFF`. Manual workflows remain
-available. Every mutation is idempotent; if a
+environment values, and verifies both effective lanes `OFF`. Manual workflows
+become available only after their drain gates. Every mutation is idempotent; if a
 concurrent deploy or transient failure interrupts the command, run the same
 command again until its final verification succeeds. The GitHub OFF source and
 disabled schedule are intentionally retained after partial failure because
 they are the safe direction, not compensated back to enabled automation.
 
-1. clear the beta allowlist, pause v2 `ALL` if state is uncertain, and keep mode
-   `OFF`;
+1. clear the beta allowlist and use the internal hard stop so both effective
+   lanes report `OFF`;
 2. allow any already-dispatched exact operation to reach a safe terminal state;
 3. verify no v2 train owns staging or production;
-4. use the serialized manual fallback, dispatching backend `Deploy a service`
-   workflows one at a time because shared concurrency can cancel sibling runs;
+4. after each target drain gate, use the serialized manual fallback,
+   dispatching backend `Deploy a service` workflows one at a time because
+   shared concurrency can cancel sibling runs;
 5. preserve v2 rows and immutable manifests for diagnosis.
 
 Never cancel another actor's shared workflow or force-push a shared ref.

--- a/ops/scripts/release-bus-status.mjs
+++ b/ops/scripts/release-bus-status.mjs
@@ -6,7 +6,9 @@ const DEFAULT_API_URL = 'https://api.6529.io';
 const DEFAULT_TIMEOUT_MS = 10_000;
 const MAX_TIMEOUT_MS = 60_000;
 const REQUIRED_SCOPES = ['ALL', 'STAGING', 'PRODUCTION'];
+const REQUIRED_LANES = ['STAGING', 'PRODUCTION'];
 const VALID_MODES = new Set(['OFF', 'STAGING', 'PRODUCTION']);
+const VALID_LANE_STATUSES = new Set(['ON', 'OFF']);
 const VALID_STAGING_STATES = new Set([
   'UNINITIALIZED',
   'LIVE',
@@ -99,13 +101,26 @@ function normalizePaused(value) {
   );
 }
 
+function normalizeReason(value) {
+  if (value === null || value === undefined) return null;
+  if (typeof value === 'string') return value;
+  throw new SafeStatusError(
+    'Release Bus status API returned invalid status data.'
+  );
+}
+
+function modeAllowsLane(mode, lane) {
+  return mode === 'PRODUCTION' || (mode === 'STAGING' && lane === 'STAGING');
+}
+
 function sanitizeStatus(payload) {
   if (
     payload === null ||
     typeof payload !== 'object' ||
     Array.isArray(payload) ||
     !VALID_MODES.has(payload.mode) ||
-    !Array.isArray(payload.controls)
+    !Array.isArray(payload.controls) ||
+    !Array.isArray(payload.lanes)
   ) {
     throw new SafeStatusError(
       'Release Bus status API returned invalid status data.'
@@ -126,7 +141,60 @@ function sanitizeStatus(payload) {
         'Release Bus status API returned incomplete control information.'
       );
     }
-    controls[scope] = normalizePaused(matches[0].paused) ? 'PAUSED' : 'RUNNING';
+    controls[scope] = {
+      paused: normalizePaused(matches[0].paused),
+      reason: normalizeReason(matches[0].reason)
+    };
+  }
+
+  const lanes = {};
+  for (const lane of REQUIRED_LANES) {
+    const matches = payload.lanes.filter(
+      (item) =>
+        item !== null &&
+        typeof item === 'object' &&
+        !Array.isArray(item) &&
+        item.lane === lane
+    );
+    if (matches.length !== 1) {
+      throw new SafeStatusError(
+        'Release Bus status API returned incomplete lane information.'
+      );
+    }
+    const item = matches[0];
+    if (
+      !VALID_LANE_STATUSES.has(item.status) ||
+      typeof item.changeable !== 'boolean'
+    )
+      throw new SafeStatusError(
+        'Release Bus status API returned invalid lane information.'
+      );
+    const globalPaused = controls.ALL.paused;
+    const lanePaused = controls[lane].paused;
+    const allowed = modeAllowsLane(payload.mode, lane);
+    const expected = {
+      status: allowed && !globalPaused && !lanePaused ? 'ON' : 'OFF',
+      changeable: allowed && !globalPaused,
+      reason: !allowed
+        ? 'Internal Release Bus hard stop is active'
+        : globalPaused
+          ? (controls.ALL.reason ?? 'Internal Release Bus hard stop is active')
+          : controls[lane].reason
+    };
+    const actual = {
+      status: item.status,
+      changeable: item.changeable,
+      reason: normalizeReason(item.reason)
+    };
+    if (
+      actual.status !== expected.status ||
+      actual.changeable !== expected.changeable ||
+      actual.reason !== expected.reason
+    )
+      throw new SafeStatusError(
+        'Release Bus status API returned inconsistent lane information.'
+      );
+    lanes[lane] = actual;
   }
 
   const staging = payload.staging_state;
@@ -153,8 +221,7 @@ function sanitizeStatus(payload) {
     );
 
   return {
-    mode: payload.mode,
-    controls,
+    lanes,
     staging: {
       status: staging.status,
       current_manifest_id: staging.current_manifest_id ?? null,

--- a/ops/scripts/release-bus-status.mjs
+++ b/ops/scripts/release-bus-status.mjs
@@ -102,22 +102,173 @@ function normalizePaused(value) {
 }
 
 function normalizeReason(value) {
-  if (value === null || value === undefined) return null;
+  if (value === null) return null;
   if (typeof value === 'string') return value;
   throw new SafeStatusError(
     'Release Bus status API returned invalid status data.'
   );
 }
 
+function isRecord(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
 function modeAllowsLane(mode, lane) {
   return mode === 'PRODUCTION' || (mode === 'STAGING' && lane === 'STAGING');
 }
 
+function requireRows(rows, requiredKeys, keyName, message) {
+  if (
+    rows.length !== requiredKeys.length ||
+    rows.some((row) => !isRecord(row) || !requiredKeys.includes(row[keyName]))
+  ) {
+    throw new SafeStatusError(message);
+  }
+  const result = {};
+  for (const requiredKey of requiredKeys) {
+    const matches = rows.filter((row) => row[keyName] === requiredKey);
+    if (matches.length !== 1) throw new SafeStatusError(message);
+    result[requiredKey] = matches[0];
+  }
+  return result;
+}
+
+function sanitizeControls(rows) {
+  const rawControls = requireRows(
+    rows,
+    REQUIRED_SCOPES,
+    'scope',
+    'Release Bus status API returned incomplete control information.'
+  );
+  return Object.fromEntries(
+    REQUIRED_SCOPES.map((scope) => {
+      const control = rawControls[scope];
+      if (!Object.hasOwn(control, 'reason')) {
+        throw new SafeStatusError(
+          'Release Bus status API returned invalid status data.'
+        );
+      }
+      return [
+        scope,
+        {
+          paused: normalizePaused(control.paused),
+          reason: normalizeReason(control.reason)
+        }
+      ];
+    })
+  );
+}
+
+function expectedLaneState(mode, controls, lane) {
+  const globalPaused = controls.ALL.paused;
+  const lanePaused = controls[lane].paused;
+  const allowed = modeAllowsLane(mode, lane);
+  let reason = controls[lane].reason;
+  if (!allowed) {
+    reason = 'Internal Release Bus hard stop is active';
+  } else if (globalPaused) {
+    reason = controls.ALL.reason ?? 'Internal Release Bus hard stop is active';
+  }
+  return {
+    status: allowed && !globalPaused && !lanePaused ? 'ON' : 'OFF',
+    changeable: allowed && !globalPaused,
+    reason
+  };
+}
+
+function sanitizeLanes(rows, mode, controls) {
+  const rawLanes = requireRows(
+    rows,
+    REQUIRED_LANES,
+    'lane',
+    'Release Bus status API returned incomplete lane information.'
+  );
+  const lanes = {};
+  for (const lane of REQUIRED_LANES) {
+    const item = rawLanes[lane];
+    if (
+      !VALID_LANE_STATUSES.has(item.status) ||
+      typeof item.changeable !== 'boolean' ||
+      !Object.hasOwn(item, 'reason')
+    ) {
+      throw new SafeStatusError(
+        'Release Bus status API returned invalid lane information.'
+      );
+    }
+    const actual = {
+      status: item.status,
+      changeable: item.changeable,
+      reason: normalizeReason(item.reason)
+    };
+    const expected = expectedLaneState(mode, controls, lane);
+    if (
+      actual.status !== expected.status ||
+      actual.changeable !== expected.changeable ||
+      actual.reason !== expected.reason
+    ) {
+      throw new SafeStatusError(
+        'Release Bus status API returned inconsistent lane information.'
+      );
+    }
+    lanes[lane] = actual;
+  }
+  return lanes;
+}
+
+function normalizeOptionalString(value) {
+  if (value === null || value === undefined) return null;
+  if (typeof value === 'string') return value;
+  throw new SafeStatusError(
+    'Release Bus status API returned invalid staging identity.'
+  );
+}
+
+function normalizeOptionalSha(value) {
+  if (value === null) return null;
+  if (typeof value === 'string' && /^[a-f0-9]{40}$/.test(value)) return value;
+  throw new SafeStatusError(
+    'Release Bus status API returned invalid staging identity.'
+  );
+}
+
+function sanitizeStagingState(staging) {
+  if (
+    !isRecord(staging) ||
+    !VALID_STAGING_STATES.has(staging.status) ||
+    typeof staging.row_version !== 'number' ||
+    !Number.isInteger(staging.row_version) ||
+    staging.row_version < 1 ||
+    typeof staging.clean_main !== 'boolean'
+  ) {
+    throw new SafeStatusError(
+      'Release Bus status API returned invalid staging state.'
+    );
+  }
+  return {
+    status: staging.status,
+    current_manifest_id: normalizeOptionalString(staging.current_manifest_id),
+    last_validated_manifest_id: normalizeOptionalString(
+      staging.last_validated_manifest_id
+    ),
+    frontend_sha: normalizeOptionalSha(staging.frontend_sha),
+    backend_sha: normalizeOptionalSha(staging.backend_sha),
+    frontend_staging_ref_sha: normalizeOptionalSha(
+      staging.frontend_staging_ref_sha
+    ),
+    backend_staging_ref_sha: normalizeOptionalSha(
+      staging.backend_staging_ref_sha
+    ),
+    clean_main: staging.clean_main,
+    last_transition_train_id: normalizeOptionalString(
+      staging.last_transition_train_id
+    ),
+    row_version: staging.row_version
+  };
+}
+
 function sanitizeStatus(payload) {
   if (
-    payload === null ||
-    typeof payload !== 'object' ||
-    Array.isArray(payload) ||
+    !isRecord(payload) ||
     !VALID_MODES.has(payload.mode) ||
     !Array.isArray(payload.controls) ||
     !Array.isArray(payload.lanes)
@@ -126,114 +277,10 @@ function sanitizeStatus(payload) {
       'Release Bus status API returned invalid status data.'
     );
   }
-
-  const controls = {};
-  for (const scope of REQUIRED_SCOPES) {
-    const matches = payload.controls.filter(
-      (control) =>
-        control !== null &&
-        typeof control === 'object' &&
-        !Array.isArray(control) &&
-        control.scope === scope
-    );
-    if (matches.length !== 1) {
-      throw new SafeStatusError(
-        'Release Bus status API returned incomplete control information.'
-      );
-    }
-    controls[scope] = {
-      paused: normalizePaused(matches[0].paused),
-      reason: normalizeReason(matches[0].reason)
-    };
-  }
-
-  const lanes = {};
-  for (const lane of REQUIRED_LANES) {
-    const matches = payload.lanes.filter(
-      (item) =>
-        item !== null &&
-        typeof item === 'object' &&
-        !Array.isArray(item) &&
-        item.lane === lane
-    );
-    if (matches.length !== 1) {
-      throw new SafeStatusError(
-        'Release Bus status API returned incomplete lane information.'
-      );
-    }
-    const item = matches[0];
-    if (
-      !VALID_LANE_STATUSES.has(item.status) ||
-      typeof item.changeable !== 'boolean'
-    )
-      throw new SafeStatusError(
-        'Release Bus status API returned invalid lane information.'
-      );
-    const globalPaused = controls.ALL.paused;
-    const lanePaused = controls[lane].paused;
-    const allowed = modeAllowsLane(payload.mode, lane);
-    const expected = {
-      status: allowed && !globalPaused && !lanePaused ? 'ON' : 'OFF',
-      changeable: allowed && !globalPaused,
-      reason: !allowed
-        ? 'Internal Release Bus hard stop is active'
-        : globalPaused
-          ? (controls.ALL.reason ?? 'Internal Release Bus hard stop is active')
-          : controls[lane].reason
-    };
-    const actual = {
-      status: item.status,
-      changeable: item.changeable,
-      reason: normalizeReason(item.reason)
-    };
-    if (
-      actual.status !== expected.status ||
-      actual.changeable !== expected.changeable ||
-      actual.reason !== expected.reason
-    )
-      throw new SafeStatusError(
-        'Release Bus status API returned inconsistent lane information.'
-      );
-    lanes[lane] = actual;
-  }
-
-  const staging = payload.staging_state;
-  if (
-    !staging ||
-    typeof staging !== 'object' ||
-    !VALID_STAGING_STATES.has(staging.status) ||
-    !Number.isInteger(Number(staging.row_version)) ||
-    Number(staging.row_version) < 1
-  )
-    throw new SafeStatusError(
-      'Release Bus status API returned invalid staging state.'
-    );
-  const optionalSha = (value) =>
-    value === null || /^[a-f0-9]{40}$/.test(String(value));
-  if (
-    !optionalSha(staging.frontend_sha) ||
-    !optionalSha(staging.backend_sha) ||
-    !optionalSha(staging.frontend_staging_ref_sha) ||
-    !optionalSha(staging.backend_staging_ref_sha)
-  )
-    throw new SafeStatusError(
-      'Release Bus status API returned invalid staging identity.'
-    );
-
+  const controls = sanitizeControls(payload.controls);
   return {
-    lanes,
-    staging: {
-      status: staging.status,
-      current_manifest_id: staging.current_manifest_id ?? null,
-      last_validated_manifest_id: staging.last_validated_manifest_id ?? null,
-      frontend_sha: staging.frontend_sha,
-      backend_sha: staging.backend_sha,
-      frontend_staging_ref_sha: staging.frontend_staging_ref_sha,
-      backend_staging_ref_sha: staging.backend_staging_ref_sha,
-      clean_main: normalizePaused(staging.clean_main),
-      last_transition_train_id: staging.last_transition_train_id ?? null,
-      row_version: Number(staging.row_version)
-    }
+    lanes: sanitizeLanes(payload.lanes, payload.mode, controls),
+    staging: sanitizeStagingState(payload.staging_state)
   };
 }
 

--- a/ops/scripts/release-bus-status.test.ts
+++ b/ops/scripts/release-bus-status.test.ts
@@ -37,7 +37,11 @@ type TestServer = {
 
 function laneStates(
   mode: 'OFF' | 'STAGING' | 'PRODUCTION',
-  controls = VALID_CONTROLS
+  controls: readonly {
+    readonly scope: string;
+    readonly paused: boolean | number;
+    readonly reason: string | null;
+  }[] = VALID_CONTROLS
 ) {
   const byScope = Object.fromEntries(
     controls.map((control) => [control.scope, control])
@@ -54,7 +58,7 @@ function laneStates(
       reason: !allowed
         ? 'Internal Release Bus hard stop is active'
         : globalPaused
-          ? byScope.ALL?.reason
+          ? (byScope.ALL?.reason ?? 'Internal Release Bus hard stop is active')
           : byScope[lane]?.reason
     };
   });
@@ -223,7 +227,11 @@ describe('release-bus-status helper', () => {
     async (pausedScope, expectedStaging, expectedProduction) => {
       const controls = VALID_CONTROLS.map((control) => ({
         ...control,
-        paused: control.scope === pausedScope
+        paused: control.scope === pausedScope,
+        reason:
+          pausedScope === 'ALL' && control.scope === 'ALL'
+            ? null
+            : control.reason
       }));
       const result = await runWithResponse({
         mode: 'PRODUCTION',
@@ -237,6 +245,20 @@ describe('release-bus-status helper', () => {
         STAGING: { status: expectedStaging },
         PRODUCTION: { status: expectedProduction }
       });
+      if (pausedScope === 'ALL') {
+        expect(JSON.parse(result.stdout).lanes).toEqual({
+          STAGING: {
+            status: 'OFF',
+            changeable: false,
+            reason: 'Internal Release Bus hard stop is active'
+          },
+          PRODUCTION: {
+            status: 'OFF',
+            changeable: false,
+            reason: 'Internal Release Bus hard stop is active'
+          }
+        });
+      }
     }
   );
 
@@ -268,6 +290,47 @@ describe('release-bus-status helper', () => {
       expect(result.code).not.toBe(0);
       expect(result.stderr).toContain('incomplete lane information');
     }
+  });
+
+  it('fails when an unknown third effective lane is present', async () => {
+    const result = await runWithResponse({
+      mode: 'PRODUCTION',
+      controls: VALID_CONTROLS,
+      lanes: [
+        ...laneStates('PRODUCTION'),
+        {
+          lane: 'ALL',
+          status: 'OFF',
+          changeable: false,
+          reason: null
+        }
+      ],
+      staging_state: VALID_STAGING_STATE
+    });
+
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toContain('incomplete lane information');
+  });
+
+  it('fails when an effective lane omits its reason', async () => {
+    const lanes = laneStates('PRODUCTION').map((lane) =>
+      lane.lane === 'STAGING'
+        ? {
+            lane: lane.lane,
+            status: lane.status,
+            changeable: lane.changeable
+          }
+        : lane
+    );
+    const result = await runWithResponse({
+      mode: 'PRODUCTION',
+      controls: VALID_CONTROLS,
+      lanes,
+      staging_state: VALID_STAGING_STATE
+    });
+
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toContain('invalid lane information');
   });
 
   it('fails when an effective lane has an invalid state', async () => {
@@ -473,4 +536,26 @@ describe('release-bus-status helper', () => {
     expect(result.code).not.toBe(0);
     expect(result.stderr).toContain('invalid staging state');
   });
+
+  test.each([
+    ['row_version', true, 'invalid staging state'],
+    ['clean_main', null, 'invalid staging state'],
+    ['frontend_sha', 123, 'invalid staging identity'],
+    ['current_manifest_id', 123, 'invalid staging identity'],
+    ['last_validated_manifest_id', {}, 'invalid staging identity'],
+    ['last_transition_train_id', false, 'invalid staging identity']
+  ])(
+    'fails closed when staging %s has malformed value %p',
+    async (field, value, message) => {
+      const result = await runWithResponse({
+        mode: 'PRODUCTION',
+        controls: VALID_CONTROLS,
+        lanes: laneStates('PRODUCTION'),
+        staging_state: { ...VALID_STAGING_STATE, [field]: value }
+      });
+
+      expect(result.code).not.toBe(0);
+      expect(result.stderr).toContain(message);
+    }
+  );
 });

--- a/ops/scripts/release-bus-status.test.ts
+++ b/ops/scripts/release-bus-status.test.ts
@@ -7,9 +7,9 @@ import path from 'node:path';
 const HELPER_PATH = path.resolve(__dirname, 'release-bus-status.mjs');
 const TOKEN = 'test-token-that-must-never-be-printed';
 const VALID_CONTROLS = [
-  { scope: 'ALL', paused: 0 },
-  { scope: 'STAGING', paused: false },
-  { scope: 'PRODUCTION', paused: 0 }
+  { scope: 'ALL', paused: 0, reason: 'Global recovery complete' },
+  { scope: 'STAGING', paused: false, reason: 'Staging enabled' },
+  { scope: 'PRODUCTION', paused: 0, reason: 'Production enabled' }
 ];
 const VALID_STAGING_STATE = {
   status: 'LIVE',
@@ -34,6 +34,31 @@ type TestServer = {
   readonly url: string;
   readonly server: Server;
 };
+
+function laneStates(
+  mode: 'OFF' | 'STAGING' | 'PRODUCTION',
+  controls = VALID_CONTROLS
+) {
+  const byScope = Object.fromEntries(
+    controls.map((control) => [control.scope, control])
+  );
+  return ['STAGING', 'PRODUCTION'].map((lane) => {
+    const allowed =
+      mode === 'PRODUCTION' || (mode === 'STAGING' && lane === 'STAGING');
+    const globalPaused = Boolean(byScope.ALL?.paused);
+    const lanePaused = Boolean(byScope[lane]?.paused);
+    return {
+      lane,
+      status: allowed && !globalPaused && !lanePaused ? 'ON' : 'OFF',
+      changeable: allowed && !globalPaused,
+      reason: !allowed
+        ? 'Internal Release Bus hard stop is active'
+        : globalPaused
+          ? byScope.ALL?.reason
+          : byScope[lane]?.reason
+    };
+  });
+}
 
 let tempRoot: string;
 let mockBin: string;
@@ -151,12 +176,13 @@ async function runWithResponse(
 }
 
 describe('release-bus-status helper', () => {
-  test.each(['OFF', 'STAGING', 'PRODUCTION'])(
+  test.each(['OFF', 'STAGING', 'PRODUCTION'] as const)(
     'prints sanitized status for %s mode',
     async (mode) => {
       const result = await runWithResponse({
         mode,
         controls: VALID_CONTROLS,
+        lanes: laneStates(mode),
         staging_state: VALID_STAGING_STATE
       });
 
@@ -164,11 +190,13 @@ describe('release-bus-status helper', () => {
       expect(result.stderr).toBe('');
       expect(result.authorization).toBe(`Bearer ${TOKEN}`);
       expect(JSON.parse(result.stdout)).toEqual({
-        mode,
-        controls: {
-          ALL: 'RUNNING',
-          STAGING: 'RUNNING',
-          PRODUCTION: 'RUNNING'
+        lanes: {
+          STAGING: expect.objectContaining({
+            status: mode === 'OFF' ? 'OFF' : 'ON'
+          }),
+          PRODUCTION: expect.objectContaining({
+            status: mode === 'PRODUCTION' ? 'ON' : 'OFF'
+          })
         },
         staging: {
           status: 'LIVE',
@@ -186,22 +214,75 @@ describe('release-bus-status helper', () => {
     }
   );
 
-  test.each(['ALL', 'STAGING', 'PRODUCTION'])(
-    'reports a paused %s control',
-    async (pausedScope) => {
+  test.each([
+    ['ALL', 'OFF', 'OFF'],
+    ['STAGING', 'OFF', 'ON'],
+    ['PRODUCTION', 'ON', 'OFF']
+  ] as const)(
+    'derives the two effective lanes when hidden %s is paused',
+    async (pausedScope, expectedStaging, expectedProduction) => {
+      const controls = VALID_CONTROLS.map((control) => ({
+        ...control,
+        paused: control.scope === pausedScope
+      }));
       const result = await runWithResponse({
-        mode: 'STAGING',
-        controls: VALID_CONTROLS.map((control) => ({
-          ...control,
-          paused: control.scope === pausedScope
-        })),
+        mode: 'PRODUCTION',
+        controls,
+        lanes: laneStates('PRODUCTION', controls),
         staging_state: VALID_STAGING_STATE
       });
 
       expect(result.code).toBe(0);
-      expect(JSON.parse(result.stdout).controls[pausedScope]).toBe('PAUSED');
+      expect(JSON.parse(result.stdout).lanes).toMatchObject({
+        STAGING: { status: expectedStaging },
+        PRODUCTION: { status: expectedProduction }
+      });
     }
   );
+
+  it('fails when derived lane state disagrees with hidden safety controls', async () => {
+    const result = await runWithResponse({
+      mode: 'PRODUCTION',
+      controls: VALID_CONTROLS,
+      lanes: laneStates('OFF'),
+      staging_state: VALID_STAGING_STATE
+    });
+
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toContain('inconsistent lane information');
+  });
+
+  it('fails when a required effective lane is missing or duplicated', async () => {
+    const lanes = laneStates('PRODUCTION');
+    for (const invalidLanes of [
+      lanes.filter(({ lane }) => lane !== 'PRODUCTION'),
+      [...lanes, lanes[0]]
+    ]) {
+      const result = await runWithResponse({
+        mode: 'PRODUCTION',
+        controls: VALID_CONTROLS,
+        lanes: invalidLanes,
+        staging_state: VALID_STAGING_STATE
+      });
+
+      expect(result.code).not.toBe(0);
+      expect(result.stderr).toContain('incomplete lane information');
+    }
+  });
+
+  it('fails when an effective lane has an invalid state', async () => {
+    const result = await runWithResponse({
+      mode: 'PRODUCTION',
+      controls: VALID_CONTROLS,
+      lanes: laneStates('PRODUCTION').map((lane) =>
+        lane.lane === 'STAGING' ? { ...lane, changeable: 'yes' } : lane
+      ),
+      staging_state: VALID_STAGING_STATE
+    });
+
+    expect(result.code).not.toBe(0);
+    expect(result.stderr).toContain('invalid lane information');
+  });
 
   it('fails closed when the v2 status endpoint is missing', async () => {
     const paths: string[] = [];
@@ -326,7 +407,8 @@ describe('release-bus-status helper', () => {
   it('fails on an unknown mode', async () => {
     const result = await runWithResponse({
       mode: TOKEN,
-      controls: VALID_CONTROLS
+      controls: VALID_CONTROLS,
+      lanes: []
     });
 
     expect(result.code).not.toBe(0);
@@ -334,7 +416,11 @@ describe('release-bus-status helper', () => {
   });
 
   test.each([null, 1, {}])('fails on non-string mode %j', async (mode) => {
-    const result = await runWithResponse({ mode, controls: VALID_CONTROLS });
+    const result = await runWithResponse({
+      mode,
+      controls: VALID_CONTROLS,
+      lanes: []
+    });
 
     expect(result.code).not.toBe(0);
     expect(result.stderr).toContain('invalid status data');
@@ -345,7 +431,8 @@ describe('release-bus-status helper', () => {
       mode: 'OFF',
       controls: VALID_CONTROLS.filter(
         (control) => control.scope !== 'PRODUCTION'
-      )
+      ),
+      lanes: []
     });
 
     expect(result.code).not.toBe(0);
@@ -355,7 +442,8 @@ describe('release-bus-status helper', () => {
   it('fails when a required control is duplicated', async () => {
     const result = await runWithResponse({
       mode: 'OFF',
-      controls: [...VALID_CONTROLS, VALID_CONTROLS[0]]
+      controls: [...VALID_CONTROLS, VALID_CONTROLS[0]],
+      lanes: []
     });
 
     expect(result.code).not.toBe(0);
@@ -367,7 +455,8 @@ describe('release-bus-status helper', () => {
       mode: 'OFF',
       controls: VALID_CONTROLS.map((control) =>
         control.scope === 'ALL' ? { ...control, paused: 'false' } : control
-      )
+      ),
+      lanes: []
     });
 
     expect(result.code).not.toBe(0);
@@ -377,7 +466,8 @@ describe('release-bus-status helper', () => {
   it('fails closed when authoritative staging state is missing', async () => {
     const result = await runWithResponse({
       mode: 'OFF',
-      controls: VALID_CONTROLS
+      controls: VALID_CONTROLS,
+      lanes: laneStates('OFF')
     });
 
     expect(result.code).not.toBe(0);

--- a/ops/skills/deploy-6529/SKILL.md
+++ b/ops/skills/deploy-6529/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: deploy-6529
-description: Route and execute 6529 backend, frontend, or coupled staging and production releases through Simple Release Bus v2 by exact PR head SHA, or use the serialized manual fallback only while v2 reports OFF. Use for staging, deploy, promotion, release merge, pause, resume, recovery, or rollout coordination.
+description: Route and execute 6529 backend, frontend, or coupled staging and production releases through an effective Release Bus lane by exact PR head SHA, or use the serialized manual fallback while that target lane reports OFF. Use for staging, deploy, promotion, release merge, turning a lane on or off, recovery, or rollout coordination.
 ---
 
 # Deploy 6529 Backend
@@ -9,20 +9,23 @@ description: Route and execute 6529 backend, frontend, or coupled staging and pr
 
 1. Run `node ops/scripts/release-bus-status.mjs` at the start and again before
    any readiness or environment mutation. The helper uses authenticated `gh`,
-   reads the versioned v2 controls endpoint.
+   reads the versioned controls endpoint, verifies hidden safety fences, and
+   returns only the two effective automation lanes.
 2. Fail closed on an unavailable/malformed API, authentication failure, unknown
-   mode, or incomplete controls. Never infer mode from files or old output.
-3. Route by the fresh v2 result:
+   or inconsistent lane state. Never infer ownership from files, raw mode,
+   hidden controls, or old output.
+3. Route the target environment by the fresh lane result:
 
-| Mode         | Staging                              | Production                                                                                     |
-| ------------ | ------------------------------------ | ---------------------------------------------------------------------------------------------- |
-| `OFF`        | Serialized manual fallback           | Serialized manual fallback with explicit owner authorization; staging evidence is not required |
-| `STAGING`    | Register the exact candidate with v2 | Manual fallback only; production automation is disabled                                        |
-| `PRODUCTION` | Register the exact candidate with v2 | Explicitly mark an exact `STAGING_VALIDATED` candidate ready for v2 production                 |
+| Target lane       | Route                                                                                                                           |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `STAGING: ON`     | Register the exact candidate with Release Bus                                                                                   |
+| `STAGING: OFF`    | Serialized manual staging after the staging drain gate                                                                          |
+| `PRODUCTION: ON`  | Explicitly mark an exact `STAGING_VALIDATED` candidate ready for Release Bus production                                         |
+| `PRODUCTION: OFF` | Serialized manual production after the production drain gate and explicit owner authorization; staging evidence is not required |
 
-When mode is active, stop if `ALL` or the target lane is paused. In `OFF`, v2
-controls are non-authoritative and do not prohibit manual staging or production
-through the documented fallback.
+Raw mode and `ALL` are internal emergency fences. They are verified by the
+helper but are not normal routing or UI controls. Do not bypass an internal
+fence. Both lanes `OFF` means full manual fallback after both drain gates.
 
 ## V2 readiness
 
@@ -72,10 +75,11 @@ and both base refs pass their fences. It never authors or posts release notes;
 every production operation emits the autonomous bot's canonical grouping
 metadata and finalize signal unless the candidate explicitly opts out.
 
-## Manual fallback while OFF
+## Manual fallback while the target lane is OFF
 
-1. Fetch the exact remote target head and inspect active frontend/backend
-   staging, production, and E2E workflows. Wait; never cancel another actor.
+1. Prove the target environment lock is free, no target mutation/E2E workflow
+   is active, and every already-dispatched exact operation is terminal. Fetch
+   the exact remote target head. Wait; never cancel another actor.
 2. Re-fetch immediately before pushing. If a shared ref moved, recompute from
    the new head. Never force-push.
 3. Merge the development branch into current `1a-staging`. Deploy required
@@ -87,8 +91,9 @@ metadata and finalize signal unless the candidate explicitly opts out.
    frontend.
 5. Record exact deployed frontend/backend SHAs before E2E and freeze staging
    until E2E is terminal.
-6. In `OFF`, production requires explicit owner authorization but not prior
-   staging deployment or validation. Re-fetch `main` and preserve dependency
+6. With the production lane `OFF`, production requires explicit owner
+   authorization but not prior staging deployment or validation. Re-fetch
+   `main` and preserve dependency
    order. Pass the same merged PR number and full canonical service set to every
    backend production run; set `release_note_publish=true` only on the final
    sequential service. For an explicitly authorized internal operation that
@@ -129,9 +134,12 @@ metadata and finalize signal unless the candidate explicitly opts out.
   candidates.
 - A merge conflict marks only the direct candidate `NEEDS_REBASE` and holds
   transitive dependants. Fix the branch and register its new SHA.
-- A control-plane defect pauses automation and leaves candidates unblamed. Keep
-  exact state, use the OFF/manual fallback only after an operator deliberately
-  disables v2, and resume explicitly after repair.
+- A control-plane defect turns the affected automation lane off and leaves
+  candidates unblamed. Keep exact state, wait for its drain gate, use manual
+  fallback for that environment, and turn the lane on explicitly after repair.
+- Use `node ops/scripts/release-bus-v2-fast-off.mjs --execute` only for an
+  emergency hard stop of both lanes. Its raw mode and `ALL` changes are
+  intentionally absent from normal UI and routing.
 - Failed E2E never creates staging validation. Do not mutate staging while the
   manifest owner still holds the environment lock.
 - If either production `main` base moved, v2 must cancel/requeue and freshly
@@ -149,5 +157,6 @@ metadata and finalize signal unless the candidate explicitly opts out.
 ## Closeout
 
 Report exact candidate SHAs/dependencies, train and operation states, deployed
-versions, manifest/E2E evidence, failures or holds, and live mode/controls. Do
+versions, manifest/E2E evidence, failures or holds, and both effective lane
+states. Do
 not expose credentials, signed URLs, raw production data, or hidden prompts.

--- a/ops/skills/deploy-6529/agents/openai.yaml
+++ b/ops/skills/deploy-6529/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "Deploy 6529"
-  short_description: "Route exact releases through Release Bus v2."
-  default_prompt: "Use $deploy-6529 to route, deploy, validate, and recover an exact 6529 backend or coupled release."
+  display_name: 'Deploy 6529'
+  short_description: 'Route exact releases by effective lane state.'
+  default_prompt: 'Use $deploy-6529 to route, deploy, validate, and recover an exact 6529 backend or coupled release.'

--- a/src/api-serverless/openapi.yaml
+++ b/src/api-serverless/openapi.yaml
@@ -7885,7 +7885,7 @@ paths:
     get:
       tags:
         - Release Bus v2
-      summary: Read runtime mode, pause controls, and environment locks
+      summary: Read effective automation lanes and environment state
       operationId: getReleaseBusV2Controls
       security: []
       responses:
@@ -7899,7 +7899,7 @@ paths:
     post:
       tags:
         - Release Bus v2
-      summary: Pause a Release Bus v2 control scope
+      summary: Turn off a Release Bus automation lane
       operationId: pauseReleaseBusV2
       security:
         - bearerAuth: []
@@ -7920,7 +7920,7 @@ paths:
     post:
       tags:
         - Release Bus v2
-      summary: Resume a Release Bus v2 control scope
+      summary: Turn on a Release Bus automation lane
       operationId: resumeReleaseBusV2
       security:
         - bearerAuth: []
@@ -24333,6 +24333,7 @@ components:
       type: object
       required:
         - controls
+        - lanes
         - locks
         - mode
         - staging_state
@@ -24341,6 +24342,12 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/ReleaseBusV2Control"
+        lanes:
+          type: array
+          minItems: 2
+          maxItems: 2
+          items:
+            $ref: "#/components/schemas/ReleaseBusV2LaneState"
         locks:
           type: array
           items:
@@ -24353,12 +24360,19 @@ components:
       type: object
       required:
         - controls
+        - lanes
         - mode
       properties:
         controls:
           type: array
           items:
             $ref: "#/components/schemas/ReleaseBusV2Control"
+        lanes:
+          type: array
+          minItems: 2
+          maxItems: 2
+          items:
+            $ref: "#/components/schemas/ReleaseBusV2LaneState"
         mode:
           $ref: "#/components/schemas/ReleaseBusV2Mode"
     ReleaseBusV2Dependency:
@@ -24435,6 +24449,29 @@ components:
     ReleaseBusV2Event:
       type: object
       additionalProperties: true
+    ReleaseBusV2LaneState:
+      type: object
+      required:
+        - lane
+        - status
+        - changeable
+        - reason
+      properties:
+        lane:
+          type: string
+          enum:
+            - STAGING
+            - PRODUCTION
+        status:
+          type: string
+          enum:
+            - "ON"
+            - "OFF"
+        changeable:
+          type: boolean
+        reason:
+          type: string
+          nullable: true
     ReleaseBusV2Lock:
       type: object
       additionalProperties: true

--- a/src/api-serverless/openapi.yaml
+++ b/src/api-serverless/openapi.yaml
@@ -24653,6 +24653,8 @@ components:
         - id
         - status
         - clean_main
+        - last_validated_frontend_sha
+        - last_validated_backend_sha
         - updated_at
         - row_version
       properties:
@@ -24680,6 +24682,14 @@ components:
           pattern: ^[a-f0-9]{40}$
           nullable: true
         backend_sha:
+          type: string
+          pattern: ^[a-f0-9]{40}$
+          nullable: true
+        last_validated_frontend_sha:
+          type: string
+          pattern: ^[a-f0-9]{40}$
+          nullable: true
+        last_validated_backend_sha:
           type: string
           pattern: ^[a-f0-9]{40}$
           nullable: true

--- a/src/api-serverless/src/deploy/deploy-bus-ui.renderer.test.ts
+++ b/src/api-serverless/src/deploy/deploy-bus-ui.renderer.test.ts
@@ -4,72 +4,128 @@ import {
 } from '@/api/deploy/deploy-bus-ui.renderer';
 
 describe('deploy-bus-ui.renderer', () => {
-  it('renders separate staging and explicit production queues', () => {
+  it('renders compact authentication and exactly two environment blocks', () => {
     const html = renderDeployBusUI();
-
-    expect(html).toContain('Register exact green PR for staging');
-    expect(html).toContain('id="staging-candidates"');
-    expect(html).toContain('id="production-candidates"');
-    expect(html).toContain('successful staging E2E evidence');
-    expect(html).toContain('STAGING_DEPLOYED is distinct');
-    expect(html).toContain('retry the unchanged SHA only after it is terminal');
-    expect(html).toContain('never push a dummy commit');
-    expect(html).toContain('Mark selected for production');
-    expect(html).toContain('Operator controls');
-    expect(html).toContain('Pause all');
-    expect(html).toContain('Active staging and production work');
-    expect(html).toContain('Legacy exact-manifest qualification records');
-    expect(html).toContain('id="active-trains"');
-    expect(html).toContain('Exact manifests');
-    expect(html).toContain('Runtime and environment ownership');
-    expect(html).toContain('dashboard below is public');
-    expect(html).toContain('Connect as operator (optional)');
-    expect(html).toContain('id="dashboard" class="stack"');
-    expect(html).toContain('id="dashboard-status"');
-  });
-
-  it('resolves a branch head before submitting and escapes server values', () => {
     const app = renderDeployBusUiApp();
 
-    expect(app).toContain("request('/deploy/ui/branch-head?");
-    expect(app).toContain("request('/deploy/release-bus-v2/candidates'");
-    expect(app).toContain('data-retry-same-head');
-    expect(app).toContain('Explicit same-head retry accepted');
-    expect(app).toContain('deploy_plan:parseJson(item.deploy_plan_json)');
-    expect(app).toContain('candidate_id:dependency.prerequisite_candidate_id');
-    expect(app).toContain('replace(/[&<>"\']/g');
-    expect(app).toContain('expected_head_sha:');
-    expect(app).toContain('pr_number:');
-    expect(app).toContain('/release-bus-v2/production-selections');
-    expect(app).toContain('data-select-production');
-    expect(app).toContain('revoke-production-readiness');
-    expect(app).toContain("data.mode==='OFF'");
-    expect(app).toContain('item.reason');
-    expect(app).toContain('function renderRuntime');
-    expect(app).toContain('function renderTrainDetail');
-    expect(app).toContain('Exact candidate set');
-    expect(app).toContain('membership.disposition');
-    expect(app).toContain('function renderOperation');
-    expect(app).toContain('function renderManifests');
-    expect(app).toContain("request('/deploy/release-bus-v2/trains/'");
-    expect(app).toContain('Candidate isolation is not applied');
-    expect(app).toContain('awaiting structured terminal reconciliation');
-    expect(app).toContain("item.status==='STAGING_DEPLOYED'");
-    expect(app).toContain("item.status==='STAGING_VALIDATED'");
-    expect(app).toContain('Production remains explicit');
-    expect(app).toContain('failure_message');
-    expect(app).toContain('artifact_digest');
-    expect(app).toContain('current-live manifest');
-    expect(app).toContain('Authoritative shared staging');
-    expect(app).toContain('CURRENT STAGING PRESENCE UNKNOWN');
+    expect(html).toContain('<h1>Release Bus</h1>');
+    expect(html).not.toContain('Release Bus v2');
+    expect(html).not.toContain('Candidate-level staging evidence');
+    expect(html).not.toContain('<h2>GitHub authentication</h2>');
+    expect(html).toContain('id="show-auth"');
+    expect(html).toContain('>Authenticate</button>');
+    expect(html).toContain('id="auth-connected"');
+    expect(html).toContain('>Forget Token</button>');
+    expect(html).toContain('aria-label="Advanced deployment console"');
+    expect(html).toContain('id="staging-environment"');
+    expect(html).toContain('id="production-environment"');
+    expect(html).toContain('id="staging-heading"');
+    expect(html).toContain('id="production-heading"');
+    expect(app).toContain("'Authenticated as '+login");
+    expect(app).toContain("byId('auth-form').classList.add('hidden')");
+    expect(app).toContain("byId('show-auth').onclick=showAuthenticationForm");
+  });
+
+  it('replaces the legacy dashboard sections with lane-focused train views', () => {
+    const html = renderDeployBusUI();
+
+    expect(html.match(/<h3>Current train<\/h3>/g)).toHaveLength(2);
+    expect(html.match(/<h3>Next train if nothing changes<\/h3>/g)).toHaveLength(
+      2
+    );
+    expect(html.match(/<h3>Previous trains<\/h3>/g)).toHaveLength(2);
+    expect(html).toContain('id="staging-heads"');
+    expect(html).toContain('id="production-heads"');
+    expect(html).not.toContain('<h2>Staging queue</h2>');
+    expect(html).not.toContain('<h2>Production queue</h2>');
+    expect(html).not.toContain('Active staging and production work');
+    expect(html).not.toContain('<h2>Recent trains</h2>');
+    expect(html).not.toContain('<h2>Exact manifests</h2>');
+    expect(html).not.toContain('Runtime and environment ownership');
+    expect(html).not.toContain('Operator controls');
+    expect(html).not.toContain('data-scope="ALL"');
+    expect(html).not.toContain('id="refresh"');
+    expect(html).not.toContain('id="reconcile"');
+  });
+
+  it('renders a filtered, incrementally paginated common PR view', () => {
+    const html = renderDeployBusUI();
+    const app = renderDeployBusUiApp();
+
+    expect(html).toContain('<h2 id="pull-requests-heading">Pull requests</h2>');
+    expect(html).toContain('id="pr-filter"');
+    expect(html).toContain('id="status-filter"');
+    expect(html).toContain('id="pull-requests"');
+    expect(html).toContain('id="load-more-prs"');
+    expect(html).toContain('>Load 10 more</button>');
+    expect(html).toContain('<summary>Register another PR</summary>');
+    expect(app).toContain('state.prVisible+=10');
+    expect(app).toContain('state.previousVisible[lane]+=5');
+    expect(app).toContain("Showing '+visible.length+' of '+filtered.length");
+    expect(app).toContain("byId('pr-filter').oninput");
+    expect(app).toContain("byId('status-filter').onchange");
+  });
+
+  it('shows exact train timing, repository groups, PR links, DAGs and diagnostics', () => {
+    const app = renderDeployBusUiApp();
+
+    expect(app).toContain("Started '+esc(dateTime(train.created_at))");
+    expect(app).toContain(
+      "Status since '+esc(dateTime(train.phase_started_at||train.updated_at))"
+    );
+    expect(app).toContain('repositoryGroups(candidates,data,false)');
+    expect(app).toContain("['backend','frontend'].map");
+    expect(app).toContain("'https://github.com/6529-Collections/6529seize-'");
+    expect(app).toContain('<strong>DAG:</strong>');
+    expect(app).toContain('candidate_role');
+    expect(app).toContain('disposition');
+    expect(app).toContain(
+      '<details class="diagnostics"><summary>Diagnostics and immutable evidence</summary>'
+    );
+    expect(app).toContain('Open workflow');
+    expect(app).toContain('Durable events');
+    expect(app).toContain('This mutable projection is not claim evidence');
+    expect(app).toContain("candidate.status==='WAITING_FOR_PRODUCTION_REPLAN'");
+    expect(app).toContain('if(replanning)');
+  });
+
+  it('derives deployed and validated heads and keeps mutations authenticated', () => {
+    const app = renderDeployBusUiApp();
+
+    expect(app).toContain("headPair('Currently deployed'");
+    expect(app).toContain("headPair('Last successfully validated'");
+    expect(app).toContain('staging.last_validated_manifest_id');
+    expect(app).toContain('latestProductionManifest()');
+    expect(app).toContain('data-lane-control');
     expect(app).toContain(
       "if(state.token)result.Authorization='Bearer '+state.token"
     );
-    expect(app).toContain('var actions=state.operator?');
-    expect(app).toContain('setOperator(false);refresh().catch(function(error)');
-    expect(app).toContain('Public read-only access remains available');
-    expect(app).not.toContain("byId('authenticated')");
-    expect(app).toContain("if(register)register.disabled=data.mode==='OFF'");
-    expect(app).toContain("if(reconcile)reconcile.disabled=data.mode==='OFF'");
+    expect(app).toContain("request('/deploy/release-bus-v2/candidates'");
+    expect(app).toContain('/release-bus-v2/production-selections');
+    expect(app).toContain('data-select-production');
+    expect(app).toContain('revoke-production-readiness');
+    expect(app).toContain("request('/deploy/ui/branch-head?");
+    expect(app).not.toContain('Mode ');
+    expect(app).not.toContain('state.mode');
+  });
+
+  it('uses semantic controls, live regions and locale-aware timestamps', () => {
+    const html = renderDeployBusUI();
+    const app = renderDeployBusUiApp();
+
+    expect(html).toContain('aria-busy="true"');
+    expect(html).toContain('role="status" aria-live="polite"');
+    expect(html).toContain('<details class="registration operator hidden">');
+    expect(html).toContain('<label for="pr-filter">PR number</label>');
+    expect(html).toContain('<label for="status-filter">Status</label>');
+    expect(html).toContain(
+      '.pr-title .badge{max-width:100%;white-space:normal;overflow-wrap:anywhere}'
+    );
+    expect(app).toContain('new Intl.DateTimeFormat');
+    expect(app).not.toContain('aria-pressed');
+    expect(app).toContain('setInterval(function(){refresh()');
+    expect(app).toContain(
+      "byId('dashboard').setAttribute('aria-busy','false')"
+    );
   });
 });

--- a/src/api-serverless/src/deploy/deploy-bus-ui.renderer.test.ts
+++ b/src/api-serverless/src/deploy/deploy-bus-ui.renderer.test.ts
@@ -83,10 +83,15 @@ describe('deploy-bus-ui.renderer', () => {
       '<details class="diagnostics"><summary>Diagnostics and immutable evidence</summary>'
     );
     expect(app).toContain('Open workflow');
+    expect(app).toContain('function safeHttpsUrl(value)');
+    expect(app).toContain('safeHttpsUrl(workflow&&workflow.html_url)||runUrl');
     expect(app).toContain('Durable events');
     expect(app).toContain('This mutable projection is not claim evidence');
     expect(app).toContain("candidate.status==='WAITING_FOR_PRODUCTION_REPLAN'");
     expect(app).toContain('if(replanning)');
+    expect(app).toContain('(!activeId||candidate.current_train_id!==activeId)');
+    expect(app).toContain('Production selection provenance is unavailable');
+    expect(app).toContain('queued=ordered.slice(0,1)');
   });
 
   it('derives deployed and validated heads and keeps mutations authenticated', () => {
@@ -95,6 +100,11 @@ describe('deploy-bus-ui.renderer', () => {
     expect(app).toContain("headPair('Currently deployed'");
     expect(app).toContain("headPair('Last successfully validated'");
     expect(app).toContain('staging.last_validated_manifest_id');
+    expect(app).toContain('staging.last_validated_frontend_sha');
+    expect(app).toContain('staging.last_validated_backend_sha');
+    expect(app).toContain(
+      "headPair('Last successfully validated (production E2E)'"
+    );
     expect(app).toContain('latestProductionManifest()');
     expect(app).toContain('data-lane-control');
     expect(app).toContain(
@@ -123,9 +133,23 @@ describe('deploy-bus-ui.renderer', () => {
     );
     expect(app).toContain('new Intl.DateTimeFormat');
     expect(app).not.toContain('aria-pressed');
-    expect(app).toContain('setInterval(function(){refresh()');
+    expect(app).toContain(
+      "state.lanes[lane]||{status:'OFF',changeable:false,reason:'Lane state is unavailable'}"
+    );
+    expect(app).toContain('disabled title="Internal emergency stop is active"');
+    expect(app).toContain('function interactionActive()');
+    expect(app).toContain("document.querySelector('details[open]')");
+    expect(app).toContain('if(!interactionActive())refresh()');
     expect(app).toContain(
       "byId('dashboard').setAttribute('aria-busy','false')"
+    );
+    expect(app).toContain('new AbortController()');
+    expect(app).toContain('controller.abort()},20000');
+    expect(app).toContain('delete state.trainDetails[id];throw error');
+    expect(app).toContain('await trainDetailSlot(current.id)');
+    expect(app).toContain('return result.detail?trainCard');
+    expect(app).toContain(
+      "if(state.token){connect()}else{showDisconnected('',false);refresh()"
     );
   });
 });

--- a/src/api-serverless/src/deploy/deploy-bus-ui.renderer.ts
+++ b/src/api-serverless/src/deploy/deploy-bus-ui.renderer.ts
@@ -224,7 +224,7 @@ export function renderDeployBusUI(): string {
 }
 
 export function renderDeployBusUiApp(): string {
-  return `'use strict';
+  return String.raw`'use strict';
 (function(){
   var key='deploy-ui-token';
   var terminal=['STAGING_VALIDATED','STAGING_ROLLBACK_FAILED','PRODUCTION_DEPLOYED','FAILED','CANCELLED'];
@@ -239,6 +239,7 @@ export function renderDeployBusUiApp(): string {
     trains:[],
     manifests:[],
     trainDetails:{},
+    queueWarnings:{STAGING:'',PRODUCTION:''},
     previousVisible:{STAGING:1,PRODUCTION:1},
     prVisible:10,
     refreshing:false
@@ -249,10 +250,13 @@ export function renderDeployBusUiApp(): string {
   function status(node,message,error){if(!node)return;node.textContent=message||'';node.className='status '+(error?'error':'success-text')}
   function headers(){var result={'Content-Type':'application/json'};if(state.token)result.Authorization='Bearer '+state.token;return result}
   async function request(url,options){
-    var response=await fetch(url,Object.assign({},options||{},{headers:Object.assign({},headers(),options&&options.headers||{})}));
-    var payload=await response.json().catch(function(){return{}});
-    if(!response.ok)throw new Error(payload.error||payload.message||('Request failed ('+response.status+')'));
-    return payload
+    var controller=new AbortController(),timer=setTimeout(function(){controller.abort()},20000);
+    try{
+      var response=await fetch(url,Object.assign({},options||{},{signal:controller.signal,headers:Object.assign({},headers(),options&&options.headers||{})}));
+      var payload=await response.json().catch(function(){return{}});
+      if(!response.ok)throw new Error(payload.error||payload.message||('Request failed ('+response.status+')'));
+      return payload
+    }finally{clearTimeout(timer)}
   }
   function setOperator(connected){
     state.operator=connected;
@@ -272,7 +276,8 @@ export function renderDeployBusUiApp(): string {
   function laneLabel(lane){return laneKey(lane)==='STAGING'?'Staging':'Production'}
   function repositoryLabel(repository){return repository==='backend'?'Backend':'Frontend'}
   function prUrl(item){return 'https://github.com/6529-Collections/6529seize-'+encodeURIComponent(item.repository)+'/pull/'+encodeURIComponent(item.pr_number)}
-  function runUrl(repository,id){return repository&&/^\\d+$/.test(String(id||''))?'https://github.com/6529-Collections/6529seize-'+encodeURIComponent(repository)+'/actions/runs/'+encodeURIComponent(id):''}
+  function runUrl(repository,id){return repository&&/^\d+$/.test(String(id||''))?'https://github.com/6529-Collections/6529seize-'+encodeURIComponent(repository)+'/actions/runs/'+encodeURIComponent(id):''}
+  function safeHttpsUrl(value){try{var parsed=new URL(String(value||''));return parsed.protocol==='https:'?parsed.href:''}catch(_error){return ''}}
   function badge(value,extra){return '<span class="badge '+esc(extra||'')+'">'+esc(value)+'</span>'}
   function empty(message){return '<div class="empty">'+esc(message)+'</div>'}
   function statusTone(value){
@@ -339,7 +344,7 @@ export function renderDeployBusUiApp(): string {
     }).join('')
   }
   function operationCard(item){
-    var workflow=item.workflow_run,workflowUrl=workflow&&workflow.html_url||runUrl(item.repository,item.external_id);
+    var workflow=item.workflow_run,workflowUrl=safeHttpsUrl(workflow&&workflow.html_url)||runUrl(item.repository,item.external_id);
     return '<article class="operation">'+
       '<div class="row"><strong>'+esc(item.operation_type)+(item.service?' · '+esc(item.service):'')+'</strong>'+badge(item.status,statusTone(item.status))+'</div>'+
       '<div class="muted small">'+esc(item.repository||'control')+' / '+esc(item.environment||'orchestration')+' · attempt '+esc(item.attempt)+'/'+esc(item.max_attempts)+'</div>'+
@@ -392,8 +397,14 @@ export function renderDeployBusUiApp(): string {
       '</article>'
   }
   async function trainDetail(id){
-    if(!state.trainDetails[id])state.trainDetails[id]=request('/deploy/release-bus-v2/trains/'+encodeURIComponent(id));
+    if(!state.trainDetails[id])state.trainDetails[id]=request('/deploy/release-bus-v2/trains/'+encodeURIComponent(id)).catch(function(error){delete state.trainDetails[id];throw error});
     return state.trainDetails[id]
+  }
+  async function trainDetailSlot(id){
+    try{return{detail:await trainDetail(id),error:null}}catch(error){return{detail:null,error:error}}
+  }
+  function trainDetailError(label,error){
+    return '<article class="train-card"><h4>'+esc(label)+'</h4><p class="error">Train details are temporarily unavailable: '+esc(error&&error.message||'Request failed')+'</p></article>'
   }
   function laneTrains(lane){
     return state.trains.filter(function(train){return train.lane===lane}).sort(function(left,right){return Number(right.created_at)-Number(left.created_at)})
@@ -404,15 +415,23 @@ export function renderDeployBusUiApp(): string {
   function queuedCandidates(lane){
     var statuses=lane==='STAGING'?['READY_FOR_STAGING','WAITING_FOR_DEPENDENCY']:['READY_FOR_PRODUCTION','READY_FOR_CANDIDATE_EVIDENCE_PRODUCTION','WAITING_FOR_PRODUCTION_REPLAN'];
     var active=activeTrain(lane),activeId=active&&active.id;
-    var queued=state.candidates.filter(function(candidate){return statuses.includes(candidate.status)&&candidate.current_train_id!==activeId});
+    var queued=state.candidates.filter(function(candidate){return statuses.includes(candidate.status)&&(!activeId||candidate.current_train_id!==activeId)});
+    state.queueWarnings[lane]='';
     if(lane==='PRODUCTION'&&queued.length){
       var ordered=queued.slice().sort(function(left,right){return Number(left.production_requested_at||left.created_at)-Number(right.production_requested_at||right.created_at)});
       var replanning=ordered.some(function(candidate){return candidate.status==='WAITING_FOR_PRODUCTION_REPLAN'});
+      var missingSelection=ordered.some(function(candidate){return !candidate.production_selection_id});
       if(replanning){
-        queued=ordered
+        queued=ordered;
+        if(missingSelection)state.queueWarnings.PRODUCTION='At least one explicit intent has no selection provenance. The scheduler will fail closed or omit it after exact revalidation.'
       }else{
         var selection=ordered[0].production_selection_id||null;
-        queued=ordered.filter(function(candidate){return (candidate.production_selection_id||null)===selection})
+        if(selection){
+          queued=ordered.filter(function(candidate){return candidate.production_selection_id===selection})
+        }else{
+          queued=ordered.slice(0,1);
+          state.queueWarnings.PRODUCTION='Production selection provenance is unavailable. Only the earliest intent is shown and the claimed set cannot be projected safely.'
+        }
       }
     }
     if(lane==='STAGING'&&queued.length){
@@ -426,7 +445,8 @@ export function renderDeployBusUiApp(): string {
     }
     return queued
   }
-  function queueBlocker(candidates){
+  function queueBlocker(lane,candidates){
+    if(state.queueWarnings[lane])return state.queueWarnings[lane];
     var held=candidates.find(function(candidate){return candidate.status==='WAITING_FOR_DEPENDENCY'});
     return held?'At least one queued PR is waiting for a dependency. The final claimed set may be smaller or may wait.':''
   }
@@ -448,13 +468,13 @@ export function renderDeployBusUiApp(): string {
       validated=manifestById(staging.last_validated_manifest_id);
       byId('staging-heads').innerHTML=
         headPair('Currently deployed',current&&current.frontend_sha||staging.frontend_sha,current&&current.backend_sha||staging.backend_sha,staging.current_manifest_id)+
-        headPair('Last successfully validated',validated&&validated.frontend_sha,validated&&validated.backend_sha,staging.last_validated_manifest_id)
+        headPair('Last successfully validated',validated&&validated.frontend_sha||staging.last_validated_frontend_sha,validated&&validated.backend_sha||staging.last_validated_backend_sha,staging.last_validated_manifest_id)
     }else{
       current=latestProductionManifest();
       validated=current;
       byId('production-heads').innerHTML=
         headPair('Currently deployed',current&&current.frontend_sha,current&&current.backend_sha,current&&current.id)+
-        headPair('Last successfully validated',validated&&validated.frontend_sha,validated&&validated.backend_sha,validated&&validated.id)
+        headPair('Last successfully validated (production E2E)',validated&&validated.frontend_sha,validated&&validated.backend_sha,validated&&validated.id)
     }
   }
   function laneHeader(lane){
@@ -481,13 +501,16 @@ export function renderDeployBusUiApp(): string {
     renderHeads(lane);
     var current=activeTrain(lane),currentNode=byId(lane.toLowerCase()+'-current'),nextNode=byId(lane.toLowerCase()+'-next'),previousNode=byId(lane.toLowerCase()+'-previous');
     currentNode.innerHTML='<h3>Current train</h3>'+(current?empty('Loading current train details…'):empty('No active '+laneLabel(lane).toLowerCase()+' train.'));
-    if(current)currentNode.innerHTML='<h3>Current train</h3>'+trainCard(await trainDetail(current.id),{label:'Current '+laneLabel(lane).toLowerCase()+' train'});
+    if(current){
+      var currentResult=await trainDetailSlot(current.id),currentLabel='Current '+laneLabel(lane).toLowerCase()+' train';
+      currentNode.innerHTML='<h3>Current train</h3>'+(currentResult.detail?trainCard(currentResult.detail,{label:currentLabel}):trainDetailError(currentLabel,currentResult.error))
+    }
     var queued=queuedCandidates(lane);
-    nextNode.innerHTML='<h3>Next train if nothing changes</h3>'+(queued.length?projectedTrainCard(lane,queued,queueBlocker(queued)):empty('Nothing is currently queued for the next '+laneLabel(lane).toLowerCase()+' train.'));
+    nextNode.innerHTML='<h3>Next train if nothing changes</h3>'+(queued.length?projectedTrainCard(lane,queued,queueBlocker(lane,queued)):empty('Nothing is currently queued for the next '+laneLabel(lane).toLowerCase()+' train.'));
     var previous=laneTrains(lane).filter(function(train){return terminal.includes(train.status)});
     var visible=previous.slice(0,state.previousVisible[lane]);
-    var details=await Promise.all(visible.map(function(train){return trainDetail(train.id)}));
-    previousNode.innerHTML='<h3>Previous trains</h3>'+(details.length?'<div class="train-list">'+details.map(function(detail,index){return trainCard(detail,{label:'Previous train '+(index+1)})}).join('')+'</div>':empty('No previous '+laneLabel(lane).toLowerCase()+' trains recorded.'))+(previous.length>visible.length?'<div class="actions"><button class="compact" data-load-trains="'+esc(lane)+'">Load 5 more</button></div>':'');
+    var details=await Promise.all(visible.map(function(train){return trainDetailSlot(train.id)}));
+    previousNode.innerHTML='<h3>Previous trains</h3>'+(details.length?'<div class="train-list">'+details.map(function(result,index){var label='Previous train '+(index+1);return result.detail?trainCard(result.detail,{label:label}):trainDetailError(label,result.error)}).join('')+'</div>':empty('No previous '+laneLabel(lane).toLowerCase()+' trains recorded.'))+(previous.length>visible.length?'<div class="actions"><button class="compact" data-load-trains="'+esc(lane)+'">Load 5 more</button></div>':'');
     var loadButton=previousNode.querySelector('[data-load-trains]');
     if(loadButton)loadButton.onclick=function(){state.previousVisible[lane]+=5;renderLane(lane).catch(function(error){status(byId('dashboard-status'),error.message,true)})};
     bindLaneControls()
@@ -516,7 +539,7 @@ export function renderDeployBusUiApp(): string {
     select.value=selected
   }
   function parseDependencies(){
-    return byId('dependencies').value.split(/\\n/).map(function(value){return value.trim()}).filter(Boolean).map(function(line){
+    return byId('dependencies').value.split(/\n/).map(function(value){return value.trim()}).filter(Boolean).map(function(line){
       var parts=line.split(':');
       if(parts.length!==2)throw new Error('Dependency must be candidate-uuid:ENVIRONMENT');
       return{candidate_id:parts[0],environment:parts[1].toUpperCase()}
@@ -524,10 +547,10 @@ export function renderDeployBusUiApp(): string {
   }
   function parsePlan(){
     if(byId('repository').value!=='backend')return null;
-    var units=byId('units').value.split(/\\n|,/).map(function(value){return value.trim()}).filter(Boolean);
+    var units=byId('units').value.split(/\n|,/).map(function(value){return value.trim()}).filter(Boolean);
     if(!units.length)throw new Error('At least one backend deploy unit is required');
-    var edges=byId('edges').value.split(/\\n/).map(function(value){return value.trim()}).filter(Boolean).map(function(line){
-      var values=line.split(/\\s*->\\s*/);
+    var edges=byId('edges').value.split(/\n/).map(function(value){return value.trim()}).filter(Boolean).map(function(line){
+      var values=line.split(/\s*->\s*/);
       if(values.length!==2)throw new Error('DAG edge must use A -> B');
       return values
     });
@@ -626,8 +649,11 @@ export function renderDeployBusUiApp(): string {
     }catch(error){status(byId('register-status'),error.message,true)}
   };
   setOperator(false);
-  refresh().catch(function(error){status(byId('dashboard-status'),error.message,true)});
-  if(state.token)connect();else showDisconnected('',false);
-  setInterval(function(){refresh().catch(function(error){status(byId('dashboard-status'),error.message,true)})},30000)
+  if(state.token){connect()}else{showDisconnected('',false);refresh().catch(function(error){status(byId('dashboard-status'),error.message,true)})}
+  function interactionActive(){
+    var active=document.activeElement;
+    return Boolean(document.querySelector('details[open]'))||Boolean(active&&['INPUT','SELECT','TEXTAREA'].includes(active.tagName))
+  }
+  setInterval(function(){if(!interactionActive())refresh().catch(function(error){status(byId('dashboard-status'),error.message,true)})},30000)
 })();`;
 }

--- a/src/api-serverless/src/deploy/deploy-bus-ui.renderer.ts
+++ b/src/api-serverless/src/deploy/deploy-bus-ui.renderer.ts
@@ -1,63 +1,633 @@
 export function renderDeployBusUI(): string {
   return `<!doctype html>
-<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
-<title>6529 Release Bus v2</title><meta name="theme-color" content="#050505">
-<style>
-*{box-sizing:border-box}body{margin:0;background:#080808;color:#f4f4f5;font:15px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;padding:16px}main{max-width:1240px;margin:auto;display:grid;gap:16px}header,.panel{border:1px solid #2d2d30;background:#111113;border-radius:16px;padding:20px}h1,h2,h3{margin:0 0 8px}h1{font-size:25px}h2{font-size:18px}h3{font-size:15px}.muted{color:#a1a1aa}.grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px}.three{grid-template-columns:repeat(3,minmax(0,1fr))}.field{display:grid;gap:6px}.wide{grid-column:1/-1}label{font-weight:650}input,select,textarea,button{font:inherit;border-radius:10px}input,select,textarea{width:100%;border:1px solid #3f3f46;background:#09090b;color:#fafafa;padding:10px 12px}input[type=checkbox]{width:auto}textarea{min-height:76px;resize:vertical}:focus-visible{outline:3px solid #60a5fa;outline-offset:2px}.actions,.row{display:flex;gap:8px;flex-wrap:wrap}.actions{margin-top:12px}.row{justify-content:space-between;align-items:flex-start}button,a.button{border:1px solid #4b5563;background:#27272a;color:white;padding:8px 12px;text-decoration:none;cursor:pointer}button.primary{background:#2563eb;border-color:#3b82f6}button.danger{background:#7f1d1d;border-color:#ef4444}button:disabled{opacity:.5;cursor:not-allowed}.status{min-height:24px;margin-top:10px}.error{color:#fca5a5}.success{color:#86efac}.warning{color:#fde68a}.cards,.stack{display:grid;gap:10px}.card{border:1px solid #303036;background:#0b0b0d;border-radius:12px;padding:12px}.incident{border-color:#7f1d1d;background:#1c0b0b}.badge{border:1px solid #52525b;border-radius:999px;padding:2px 8px;font-size:12px;white-space:nowrap}.sha{font-family:ui-monospace,monospace;overflow-wrap:anywhere}.metrics{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:8px;margin:10px 0}.metric{border:1px solid #27272a;border-radius:8px;padding:8px}.metric strong{display:block}.list{margin:6px 0;padding-left:20px}.hidden{display:none!important}@media(max-width:760px){.grid,.three,.metrics{grid-template-columns:1fr}.wide{grid-column:auto}.row{display:grid}}
-</style></head><body><main>
-<header><div class="row"><div><h1>Release Bus v2</h1><p class="muted">Public read-only candidate state, staging evidence, immutable manifests, and serialized environment ownership.</p></div><a class="button" href="/deploy/ui">Manual console (OFF only)</a></div></header>
-<section class="panel"><h2>Connect as operator (optional)</h2><p class="muted">The dashboard below is public and loads without authentication. Connect a GitHub token only to request mutation actions; the server verifies authorization for every action.</p><div class="field"><label for="token">GitHub token</label><textarea id="token" autocomplete="off" spellcheck="false" placeholder="Token with repository write access"></textarea></div><div class="actions"><button id="connect" class="primary">Connect as operator</button><button id="forget">Forget token</button></div><div id="auth-status" class="status" role="status" aria-live="polite"></div></section>
-<div id="dashboard" class="stack">
-<section class="panel"><div class="row"><div><h2>Runtime and environment ownership</h2><p class="muted">OFF blocks all reconciliation. Pauses retain exact state. Locks serialize only shared mutation and E2E.</p></div><div class="actions"><button id="reconcile" class="operator hidden">Reconcile now</button><button id="refresh">Refresh</button></div></div><div id="dashboard-status" class="status" role="status" aria-live="polite"></div><div id="runtime" class="cards"></div></section>
-<section class="panel operator hidden"><h2>Register exact green PR for staging</h2><form id="register-form"><div class="grid three">
-<div class="field"><label for="repository">Repository</label><select id="repository"><option value="frontend">Frontend</option><option value="backend">Backend</option></select></div>
-<div class="field"><label for="pr-number">PR number</label><input id="pr-number" type="number" min="1" required></div>
-<div class="field"><label for="branch">Branch</label><input id="branch" required pattern="[A-Za-z0-9._/-]+"></div>
-<div class="field wide"><label for="sha">Exact head SHA</label><input id="sha" required pattern="[a-fA-F0-9]{40}" maxlength="40" class="sha"></div>
-<div id="backend-plan" class="wide hidden"><div class="grid"><div class="field"><label for="units">Backend deploy units</label><textarea id="units" placeholder="dbMigrationsLoop&#10;api"></textarea></div><div class="field"><label for="edges">Unit DAG edges</label><textarea id="edges" placeholder="dbMigrationsLoop -> api"></textarea></div></div></div>
-<div class="field wide"><label for="dependencies">Candidate dependencies</label><textarea id="dependencies" placeholder="candidate-uuid:BOTH"></textarea><span class="muted">One candidate UUID plus STAGING, PRODUCTION, or BOTH per line.</span></div>
-</div><div class="actions"><button id="resolve" type="button">Resolve current SHA</button><button id="register" class="primary" type="submit">Register for staging</button></div><div id="register-status" class="status" role="status" aria-live="polite"></div></form></section>
-<section class="panel"><div class="row"><div><h2>Staging queue</h2><p class="muted">STAGING_DEPLOYED is distinct from STAGING_VALIDATED. Production selection remains an explicit authenticated operator action.</p><p class="muted">For a directly attributed failure, fix the branch and register its new exact SHA. For an audited grouped repository-preflight failure, retry the unchanged SHA only after it is terminal and unowned; never push a dummy commit.</p></div><button id="mark-selection" class="primary operator hidden">Mark selected for production</button></div><div id="production-selection-status" class="status" role="status" aria-live="polite"></div><div id="staging-candidates" class="cards"></div></section>
-<section class="panel"><h2>Production queue</h2><p class="muted">Every selected unchanged SHA carries its own successful staging E2E evidence. Production is freshly composed against current main; no combined staging qualification is implied.</p><div id="production-candidates" class="cards"></div></section>
-<section class="panel"><h2>Active staging and production work</h2><p class="muted">Legacy exact-manifest qualification records remain visible for trains claimed under the previous immutable policy.</p><div id="active-trains" class="stack"></div></section>
-<section class="panel"><h2>Recent trains</h2><div id="trains" class="cards"></div><div id="train-detail" class="stack"></div></section>
-<section class="panel"><h2>Exact manifests</h2><div id="manifests" class="cards"></div></section>
-<section class="panel operator hidden"><h2>Operator controls</h2><div class="field"><label for="control-reason">Audited reason</label><input id="control-reason" maxlength="1000"></div><div class="actions"><button data-control="pause" data-scope="ALL" class="danger">Pause all</button><button data-control="pause" data-scope="STAGING">Pause staging</button><button data-control="pause" data-scope="PRODUCTION">Pause production</button><button data-control="resume" data-scope="ALL">Resume all</button><button data-control="resume" data-scope="STAGING">Resume staging</button><button data-control="resume" data-scope="PRODUCTION">Resume production</button></div><div id="control-status" class="status" role="status" aria-live="polite"></div></section>
-</div></main><script src="/deploy/ui/bus/app.js" defer></script></body></html>`;
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>6529 Release Bus</title>
+  <meta name="theme-color" content="#050505">
+  <style>
+    *{box-sizing:border-box}
+    body{margin:0;background:#080808;color:#f4f4f5;font:15px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;padding:16px}
+    main{max-width:1240px;margin:auto;display:grid;gap:16px}
+    header,.panel{border:1px solid #2d2d30;background:#111113;border-radius:16px;padding:20px}
+    h1,h2,h3,h4,h5{margin:0}
+    h1{font-size:25px}
+    h2{font-size:21px}
+    h3{font-size:16px}
+    h4{font-size:14px}
+    h5{font-size:13px}
+    p{margin:6px 0}
+    .header-title,.auth-summary,.auth-connected,.auth-form,.row,.actions,.lane-title,.filter-row{display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+    .header-title{justify-content:flex-start}
+    .auth-summary{margin-top:6px}
+    .auth-form{margin-top:10px}
+    .auth-form input{width:min(420px,100%)}
+    .row{justify-content:space-between;align-items:flex-start}
+    .lane-title{gap:10px}
+    .environment-stack,.stack,.cards,.train-list,.repository-groups{display:grid;gap:12px}
+    .environment-panel{display:grid;gap:18px}
+    .environment-header{border-bottom:1px solid #27272a;padding-bottom:14px}
+    .heads{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:12px}
+    .head-card,.train-slot,.repository-group,.card{border:1px solid #303036;background:#0b0b0d;border-radius:12px;padding:14px}
+    .head-card{display:grid;gap:8px}
+    .head-pair{display:grid;grid-template-columns:96px minmax(0,1fr);gap:8px;align-items:start}
+    .train-slot{display:grid;gap:10px}
+    .train-slot>h3{padding-bottom:4px}
+    .train-card{border:1px solid #3f3f46;background:#101012;border-radius:12px;padding:14px;display:grid;gap:14px}
+    .train-meta{display:flex;gap:18px;flex-wrap:wrap;color:#a1a1aa;font-size:13px}
+    .repository-groups{grid-template-columns:repeat(2,minmax(0,1fr))}
+    .repository-group{min-width:0}
+    .repository-group>h5{margin-bottom:8px}
+    .pr-list{display:grid;gap:8px}
+    .pr-card{border:1px solid #27272a;background:#09090b;border-radius:10px;padding:11px;display:grid;gap:7px;min-width:0}
+    .pr-title{display:flex;gap:8px;align-items:flex-start;justify-content:space-between}
+    .pr-title>div{min-width:0}
+    .pr-title a{color:#93c5fd;text-decoration:none;font-weight:700}
+    .pr-title a:hover{text-decoration:underline}
+    .sha{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;overflow-wrap:anywhere}
+    .short-sha{font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
+    .muted{color:#a1a1aa}
+    .small{font-size:13px}
+    .compact{padding:5px 9px!important;font-size:13px!important}
+    .badge{display:inline-flex;align-items:center;border:1px solid #52525b;border-radius:999px;padding:2px 8px;font-size:12px;white-space:nowrap}
+    .badge.on,.badge.success{border-color:#166534;color:#86efac;background:#052e16}
+    .badge.off,.badge.failed{border-color:#7f1d1d;color:#fca5a5;background:#450a0a}
+    .badge.warning{border-color:#854d0e;color:#fde68a;background:#422006}
+    .badge.frontend{border-color:#1d4ed8;color:#bfdbfe;background:#172554}
+    .badge.backend{border-color:#6d28d9;color:#ddd6fe;background:#2e1065}
+    .field{display:grid;gap:6px}
+    .wide{grid-column:1/-1}
+    label{font-weight:650}
+    input,select,textarea,button{font:inherit;border-radius:10px}
+    input,select,textarea{width:100%;border:1px solid #3f3f46;background:#09090b;color:#fafafa;padding:10px 12px}
+    input[type=checkbox]{width:auto}
+    textarea{min-height:76px;resize:vertical}
+    button,a.button{border:1px solid #4b5563;background:#27272a;color:white;padding:8px 12px;text-decoration:none;cursor:pointer}
+    button.primary{background:#2563eb;border-color:#3b82f6}
+    button.danger{background:#7f1d1d;border-color:#ef4444}
+    button:disabled{opacity:.5;cursor:not-allowed}
+    button:hover:not(:disabled),a.button:hover{border-color:#71717a;background:#3f3f46}
+    :focus-visible{outline:3px solid #60a5fa;outline-offset:2px}
+    .icon-button{display:inline-grid;place-items:center;width:28px;height:28px;border:0;background:transparent;color:#a1a1aa;font-size:15px;line-height:1;text-decoration:none;border-radius:7px}
+    .icon-button:hover{color:#f4f4f5;background:#27272a}
+    .actions{margin-top:8px}
+    .status{min-height:24px;margin-top:8px}
+    .auth-form+.status:empty{display:none}
+    .error{color:#fca5a5}
+    .success-text{color:#86efac}
+    .warning-text{color:#fde68a}
+    .empty{border:1px dashed #3f3f46;border-radius:10px;padding:16px;color:#a1a1aa}
+    .metrics{display:grid;grid-template-columns:repeat(4,minmax(0,1fr));gap:8px}
+    .metric{border:1px solid #27272a;border-radius:8px;padding:8px;min-width:0}
+    .metric strong{display:block;margin-top:2px;overflow-wrap:anywhere}
+    .list{margin:6px 0;padding-left:20px}
+    .filters{display:grid;grid-template-columns:minmax(180px,1fr) minmax(220px,1fr);gap:12px;margin:12px 0}
+    .filter-row{justify-content:space-between;margin-top:12px}
+    details.diagnostics{border-top:1px solid #27272a;padding-top:10px}
+    details.diagnostics>summary,details.registration>summary{cursor:pointer;font-weight:700;list-style-position:outside}
+    .diagnostic-body{display:grid;gap:10px;margin-top:10px}
+    .operation{border-left:3px solid #3f3f46;padding-left:10px}
+    .registration{border:1px solid #303036;border-radius:12px;padding:12px;margin-top:12px}
+    .registration-form{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:12px;margin-top:12px}
+    .hidden{display:none!important}
+    .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
+    @media(max-width:820px){
+      .heads,.repository-groups,.filters,.registration-form,.metrics{grid-template-columns:1fr}
+      .head-pair{grid-template-columns:1fr}
+      .row{display:grid}
+      .pr-title{display:grid}
+      .pr-title .badge{max-width:100%;white-space:normal;overflow-wrap:anywhere}
+      header,.panel{padding:16px}
+    }
+  </style>
+</head>
+<body>
+<main>
+  <header>
+    <div class="header-title">
+      <h1>Release Bus</h1>
+      <a class="icon-button" href="/deploy/ui" aria-label="Advanced deployment console" title="Advanced deployment console">&#9881;</a>
+    </div>
+    <div class="auth-summary">
+      <div id="auth-connected" class="auth-connected hidden">
+        <span id="auth-identity" class="muted"></span>
+        <button id="forget" class="compact">Forget Token</button>
+      </div>
+      <button id="show-auth" class="compact">Authenticate</button>
+    </div>
+    <div id="auth-form" class="auth-form hidden">
+      <input id="token" type="password" autocomplete="off" spellcheck="false" aria-label="GitHub token" placeholder="Paste GitHub token">
+      <button id="connect" class="primary compact">Connect</button>
+    </div>
+    <div id="auth-status" class="status" role="status" aria-live="polite"></div>
+  </header>
+
+  <div id="dashboard" class="environment-stack" aria-busy="true">
+    <section id="staging-environment" class="panel environment-panel" aria-labelledby="staging-heading">
+      <div class="environment-header">
+        <div id="staging-header"><h2 id="staging-heading">Staging</h2></div>
+        <div id="staging-control-status" class="status operator hidden" role="status" aria-live="polite"></div>
+      </div>
+      <div id="staging-heads" class="heads"></div>
+      <div id="staging-current" class="train-slot"><h3>Current train</h3><div class="empty">Loading current staging train…</div></div>
+      <div id="staging-next" class="train-slot"><h3>Next train if nothing changes</h3><div class="empty">Calculating the current queue…</div></div>
+      <div id="staging-previous" class="train-slot"><h3>Previous trains</h3><div class="empty">Loading train history…</div></div>
+    </section>
+
+    <section id="production-environment" class="panel environment-panel" aria-labelledby="production-heading">
+      <div class="environment-header">
+        <div id="production-header"><h2 id="production-heading">Production</h2></div>
+        <div id="production-control-status" class="status operator hidden" role="status" aria-live="polite"></div>
+      </div>
+      <div id="production-heads" class="heads"></div>
+      <div id="production-current" class="train-slot"><h3>Current train</h3><div class="empty">Loading current production train…</div></div>
+      <div id="production-next" class="train-slot"><h3>Next train if nothing changes</h3><div class="empty">Calculating the current queue…</div></div>
+      <div id="production-previous" class="train-slot"><h3>Previous trains</h3><div class="empty">Loading train history…</div></div>
+    </section>
+
+    <section class="panel" aria-labelledby="pull-requests-heading">
+      <div class="row">
+        <div>
+          <h2 id="pull-requests-heading">Pull requests</h2>
+          <p class="muted">Every registered exact SHA, across both lanes and repositories.</p>
+        </div>
+        <button id="mark-selection" class="primary compact operator hidden">Mark selected for production</button>
+      </div>
+      <div class="filters">
+        <div class="field">
+          <label for="pr-filter">PR number</label>
+          <input id="pr-filter" type="number" min="1" inputmode="numeric" placeholder="All PR numbers">
+        </div>
+        <div class="field">
+          <label for="status-filter">Status</label>
+          <select id="status-filter"><option value="">All statuses</option></select>
+        </div>
+      </div>
+      <div id="production-selection-status" class="status" role="status" aria-live="polite"></div>
+      <div id="pull-requests" class="cards"></div>
+      <div class="filter-row">
+        <span id="pull-request-count" class="muted small"></span>
+        <button id="load-more-prs" class="compact">Load 10 more</button>
+      </div>
+
+      <details class="registration operator hidden">
+        <summary>Register another PR</summary>
+        <form id="register-form" class="registration-form">
+          <div class="field">
+            <label for="repository">Repository</label>
+            <select id="repository"><option value="frontend">Frontend</option><option value="backend">Backend</option></select>
+          </div>
+          <div class="field">
+            <label for="pr-number">PR number</label>
+            <input id="pr-number" type="number" min="1" required>
+          </div>
+          <div class="field">
+            <label for="branch">Branch</label>
+            <input id="branch" required pattern="[A-Za-z0-9._/-]+">
+          </div>
+          <div class="field wide">
+            <label for="sha">Exact head SHA</label>
+            <input id="sha" required pattern="[a-fA-F0-9]{40}" maxlength="40" class="sha">
+          </div>
+          <div id="backend-plan" class="wide hidden">
+            <div class="heads">
+              <div class="field">
+                <label for="units">Backend deploy units</label>
+                <textarea id="units" placeholder="dbMigrationsLoop&#10;api"></textarea>
+              </div>
+              <div class="field">
+                <label for="edges">Unit DAG edges</label>
+                <textarea id="edges" placeholder="dbMigrationsLoop -> api"></textarea>
+              </div>
+            </div>
+          </div>
+          <div class="field wide">
+            <label for="dependencies">Candidate dependencies</label>
+            <textarea id="dependencies" placeholder="candidate-uuid:BOTH"></textarea>
+            <span class="muted small">One candidate UUID plus STAGING, PRODUCTION, or BOTH per line.</span>
+          </div>
+          <div class="actions wide">
+            <button id="resolve" type="button">Resolve current SHA</button>
+            <button id="register" class="primary" type="submit">Register for staging</button>
+          </div>
+          <div id="register-status" class="status wide" role="status" aria-live="polite"></div>
+        </form>
+      </details>
+    </section>
+  </div>
+  <div id="dashboard-status" class="sr-only" role="status" aria-live="polite"></div>
+</main>
+<script src="/deploy/ui/bus/app.js" defer></script>
+</body>
+</html>`;
 }
 
 export function renderDeployBusUiApp(): string {
-  return `'use strict';(function(){
-var key='deploy-ui-token';var state={token:localStorage.getItem(key)||'',operator:false,mode:'OFF',stagingState:null};
-var terminal=['STAGING_VALIDATED','STAGING_ROLLBACK_FAILED','PRODUCTION_DEPLOYED','FAILED','CANCELLED'];
-var byId=function(id){return document.getElementById(id)};
-function esc(value){return String(value==null?'':value).replace(/[&<>"']/g,function(c){return{'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]})}
-function status(node,message,error){node.textContent=message||'';node.className='status '+(error?'error':'success')}
-function headers(){var result={'Content-Type':'application/json'};if(state.token)result.Authorization='Bearer '+state.token;return result}
-async function request(url,options){var response=await fetch(url,Object.assign({},options||{},{headers:Object.assign({},headers(),options&&options.headers||{})}));var payload=await response.json().catch(function(){return{}});if(!response.ok)throw new Error(payload.error||payload.message||('Request failed ('+response.status+')'));return payload}
-function setOperator(connected){state.operator=connected;Array.prototype.forEach.call(document.querySelectorAll('.operator'),function(node){node.classList.toggle('hidden',!connected)})}
-function time(value){return Number(value)?new Date(Number(value)).toLocaleString():'Not recorded'}
-function duration(start,end){var ms=Math.max(0,(Number(end)||Date.now())-(Number(start)||Date.now())),s=Math.floor(ms/1000),m=Math.floor(s/60),h=Math.floor(m/60);return h?h+'h '+m%60+'m':m?m+'m '+s%60+'s':s+'s'}
-function runLink(repository,id){return repository&&/^\\d+$/.test(String(id||''))?'<a class="button" target="_blank" rel="noreferrer" href="https://github.com/6529-Collections/6529seize-'+esc(repository)+'/actions/runs/'+esc(id)+'">Workflow '+esc(id)+'</a>':''}
-function parseJson(value){if(!value)return null;if(typeof value==='object')return value;try{return JSON.parse(value)}catch(_){return null}}
-function parseDependencies(){return byId('dependencies').value.split(/\\n/).map(function(v){return v.trim()}).filter(Boolean).map(function(line){var parts=line.split(':');if(parts.length!==2)throw new Error('Dependency must be candidate-uuid:ENVIRONMENT');return{candidate_id:parts[0],environment:parts[1].toUpperCase()}})}
-function parsePlan(){if(byId('repository').value!=='backend')return null;var units=byId('units').value.split(/\\n|,/).map(function(v){return v.trim()}).filter(Boolean);if(!units.length)throw new Error('At least one backend deploy unit is required');var edges=byId('edges').value.split(/\\n/).map(function(v){return v.trim()}).filter(Boolean).map(function(line){var values=line.split(/\\s*->\\s*/);if(values.length!==2)throw new Error('DAG edge must use A -> B');return values});return{units:units,edges:edges}}
-function candidateCard(item){var canMark=item.status==='STAGING_VALIDATED'&&state.mode==='PRODUCTION';var canRetry=item.status==='FAILED'&&!item.current_train_id;var canRevoke=['READY_FOR_PRODUCTION','READY_FOR_CANDIDATE_EVIDENCE_PRODUCTION','WAITING_FOR_PRODUCTION_REPLAN'].includes(item.status);var canCancel=['READY_FOR_STAGING','READY_FOR_PRODUCTION','READY_FOR_CANDIDATE_EVIDENCE_PRODUCTION','WAITING_FOR_PRODUCTION_REPLAN','NEEDS_REBASE','WAITING_FOR_DEPENDENCY'].includes(item.status);var actions=state.operator?((canMark?'<label><input type="checkbox" data-select-production="'+esc(item.id)+'" data-sha="'+esc(item.head_sha)+'" data-version="'+esc(item.row_version)+'"> Select exact candidate for production</label>':'')+(canRetry?'<button data-retry-same-head="'+esc(item.id)+'">Retry audited grouped failure at same SHA</button>':'')+(canRevoke?'<button data-revoke="'+esc(item.id)+'" data-version="'+esc(item.row_version)+'">Revoke readiness</button>':'')+(canCancel?'<button data-cancel="'+esc(item.id)+'" data-version="'+esc(item.row_version)+'" class="danger">Cancel</button>':'')):'';var dependencies=(item.dependencies||[]).map(function(dependency){return '<a class="button" href="#candidate-'+esc(dependency.prerequisite_candidate_id)+'">Requires '+esc(dependency.prerequisite_candidate_id)+' · '+esc(dependency.environment)+'</a>'}).join('');var known=state.stagingState&&['LIVE','CLEAN_MAIN'].includes(state.stagingState.status),present=known&&item.staging_live_state==='LIVE'&&item.staging_live_manifest_id===state.stagingState.current_manifest_id,liveLabel=known?(present?'LIVE in current staging':'NOT LIVE in current staging'):'CURRENT STAGING PRESENCE UNKNOWN',live='<span class="badge">'+esc(liveLabel)+'</span>';return '<article id="candidate-'+esc(item.id)+'" class="card"><div class="row"><div><strong>'+esc(item.repository)+' PR #'+esc(item.pr_number)+' · '+esc(item.branch_name)+'</strong><div class="sha">'+esc(item.head_sha)+'</div><div class="muted">Candidate '+esc(item.id)+'</div><div class="muted">'+esc(item.hold_reason||'No hold')+'</div><div class="muted">Historical staging evidence '+esc(item.staging_validated_manifest_id||'none')+' · current-live manifest '+esc(item.staging_live_manifest_id||'none')+'</div><div class="muted">Updated '+esc(time(item.updated_at))+'</div></div><div><span class="badge">'+esc(item.status)+'</span> '+live+'</div></div>'+(dependencies?'<div class="actions">'+dependencies+'</div>':'')+(actions?'<div class="actions">'+actions+'</div>':'')+'</article>'}
-function bindCandidateActions(items){var candidates={};(items||[]).forEach(function(item){candidates[item.id]=item});Array.prototype.forEach.call(document.querySelectorAll('[data-retry-same-head]'),function(button){button.onclick=async function(){var item=candidates[button.dataset.retrySameHead];if(!item){status(byId('register-status'),'Candidate is no longer visible; refresh before retrying.',true);return}var body={repository:item.repository,pr_number:Number(item.pr_number),branch_name:item.branch_name,expected_head_sha:item.head_sha,deploy_plan:parseJson(item.deploy_plan_json),dependencies:(item.dependencies||[]).map(function(dependency){return{candidate_id:dependency.prerequisite_candidate_id,environment:dependency.environment}})};try{var data=await request('/deploy/release-bus-v2/candidates',{method:'POST',body:JSON.stringify(body)});status(byId('register-status'),'Explicit same-head retry accepted for '+data.candidate.head_sha+'.',false);await refresh()}catch(error){status(byId('register-status'),error.message,true)}}});Array.prototype.forEach.call(document.querySelectorAll('[data-revoke]'),function(button){button.onclick=async function(){await candidateAction('/deploy/release-bus-v2/candidates/'+encodeURIComponent(button.dataset.revoke)+'/revoke-production-readiness',{expected_row_version:Number(button.dataset.version)})}});Array.prototype.forEach.call(document.querySelectorAll('[data-cancel]'),function(button){button.onclick=async function(){await candidateAction('/deploy/release-bus-v2/candidates/'+encodeURIComponent(button.dataset.cancel)+'/cancel',{expected_row_version:Number(button.dataset.version)})}})}
-async function candidateAction(url,body){try{await request(url,{method:'POST',body:JSON.stringify(body)});await refresh()}catch(error){status(byId('register-status'),error.message,true)}}
-function renderCandidates(items){var production=['READY_FOR_PRODUCTION','READY_FOR_CANDIDATE_EVIDENCE_PRODUCTION','WAITING_FOR_PRODUCTION_REPLAN','PRODUCTION_IN_TRAIN','PRODUCTION_BUILDING_OR_QUALIFYING','PRODUCTION_DEPLOYING','PRODUCTION_DEPLOYED'];var prod=items.filter(function(item){return production.includes(item.status)}),staging=items.filter(function(item){return !production.includes(item.status)});byId('staging-candidates').innerHTML=staging.length?staging.map(candidateCard).join(''):'<p class="muted">No staging candidates.</p>';byId('production-candidates').innerHTML=prod.length?prod.map(candidateCard).join(''):'<p class="muted">No explicit production candidates.</p>';bindCandidateActions(items)}
-function renderOperation(item){var result=parseJson(item.result_json),summary=result&&result.summary||{},live=item.workflow_run;var failure=item.failure_class||item.failure_message?'<p class="error"><strong>'+esc(item.failure_class||'FAILURE')+':</strong> '+esc(item.failure_message||'See workflow result')+'</p>':'';var retry=item.status==='RETRY_WAIT'?'<p class="warning">Infrastructure retry '+esc(item.attempt)+'/'+esc(item.max_attempts)+' scheduled '+esc(time(item.next_retry_at))+'. Candidate isolation is not applied.</p>':'';var amber=['PENDING','DISPATCHED','RUNNING'].includes(item.status)?'<p class="warning">'+esc(item.status==='PENDING'?'Awaiting idempotent dispatch':item.status==='DISPATCHED'?'Dispatched; discovering exact workflow run':'Workflow is active or awaiting structured terminal reconciliation')+'</p>':'';var jobs=live?(live.jobs||[]).map(function(job){var active=(job.steps||[]).filter(function(step){return step.status==='in_progress'||step.conclusion==='failure'}).map(function(step){return step.name+' · '+(step.conclusion||step.status)}).join(', ');return '<li><strong>'+esc(job.name)+'</strong> · '+esc(job.conclusion||job.status)+(active?' · '+esc(active):'')+'</li>'}).join(''):'';var observation=item.workflow_observation_error?'<p class="warning">'+esc(item.workflow_observation_error)+'</p>':jobs?'<ul class="list">'+jobs+'</ul>':'';return '<article class="card"><div class="row"><div><strong>'+esc(item.operation_type)+(item.service?' · '+esc(item.service):'')+'</strong><div class="muted">'+esc(item.repository||'control')+' / '+esc(item.environment||'orchestration')+' · attempt '+esc(item.attempt)+'/'+esc(item.max_attempts)+'</div></div><span class="badge">'+esc(item.status)+'</span></div><div class="metrics"><div class="metric"><span class="muted">Elapsed</span><strong>'+esc(duration(item.started_at||item.created_at,item.completed_at))+'</strong></div><div class="metric"><span class="muted">Started</span><strong>'+esc(time(item.started_at||item.created_at))+'</strong></div><div class="metric"><span class="muted">Expected SHA</span><strong class="sha">'+esc(item.expected_sha||'n/a')+'</strong></div><div class="metric"><span class="muted">Artifact</span><strong class="sha">'+esc(item.artifact_digest||summary.artifact_digest||'pending')+'</strong></div></div>'+amber+retry+failure+observation+'<div class="actions">'+runLink(item.repository,item.external_id)+'</div></article>'}
-function renderTrainDetail(data){var train=data.train,evidence=parseJson(train.qualification_evidence_json)||[],memberships=data.memberships||[],candidates=(data.candidates||[]).map(function(candidate){var membership=memberships.find(function(item){return item.candidate_id===candidate.id});return '<li><strong>'+esc(candidate.repository)+' PR #'+esc(candidate.pr_number)+'</strong> · candidate '+esc(candidate.id)+' · <span class="sha">'+esc(candidate.head_sha)+'</span> · '+esc(membership&&membership.disposition||'membership unknown')+'</li>'}).join('');return '<article class="card"><div class="row"><div><h3>'+esc(train.lane)+' · '+esc(train.status)+'</h3><div class="sha">'+esc(train.id)+'</div></div><span class="badge">'+esc(duration(train.created_at,train.completed_at))+'</span></div><div class="metrics"><div class="metric"><span class="muted">Phase elapsed</span><strong>'+esc(duration(train.phase_started_at))+'</strong></div><div class="metric"><span class="muted">Frontend SHA</span><strong class="sha">'+esc(train.frontend_composed_sha||train.frontend_base_sha||'n/a')+'</strong></div><div class="metric"><span class="muted">Backend SHA</span><strong class="sha">'+esc(train.backend_composed_sha||train.backend_base_sha||'n/a')+'</strong></div><div class="metric"><span class="muted">Manifest</span><strong>'+esc(train.manifest_id||'pending')+'</strong></div></div><p><strong>Qualification policy:</strong> '+esc(train.qualification_policy||'legacy claimed policy')+' · '+esc(evidence.length)+' candidate evidence record(s)</p>'+(train.failure_message?'<p class="error"><strong>'+esc(train.failure_class)+':</strong> '+esc(train.failure_message)+'</p>':'')+'<p class="muted">'+esc(train.recovery_message||'Exact state is reconciling idempotently.')+'</p></article><article class="card"><h3>Exact candidate set</h3><ul class="list">'+(candidates||'<li>No candidate memberships recorded.</li>')+'</ul></article>'+(data.operations||[]).map(renderOperation).join('')+'<article class="card"><h3>Durable events</h3><ul class="list">'+(data.events||[]).map(function(event){return '<li>'+esc(time(event.created_at))+' · '+esc(event.event_type)+'</li>'}).join('')+'</ul></article>'}
-function renderTrains(items,details){var active=items.filter(function(item){return !terminal.includes(item.status)});byId('active-trains').innerHTML=active.length?active.map(function(item){return details[item.id]?renderTrainDetail(details[item.id]):'<p class="muted">Loading '+esc(item.id)+'</p>'}).join(''):'<p class="muted">No active train owns staging or production.</p>';byId('trains').innerHTML=items.length?items.map(function(item){return '<article class="card"><div class="row"><div><strong>'+esc(item.lane)+' train</strong><div class="sha">'+esc(item.id)+'</div><div class="muted">Created '+esc(time(item.created_at))+' · '+esc(duration(item.created_at,item.completed_at))+'</div></div><div><span class="badge">'+esc(item.status)+'</span> <button data-train="'+esc(item.id)+'">Details</button></div></div></article>'}).join(''):'<p class="muted">No trains recorded.</p>';Array.prototype.forEach.call(document.querySelectorAll('[data-train]'),function(button){button.onclick=async function(){try{byId('train-detail').innerHTML=renderTrainDetail(await request('/deploy/release-bus-v2/trains/'+encodeURIComponent(button.dataset.train)))}catch(error){byId('train-detail').innerHTML='<p class="error">'+esc(error.message)+'</p>'}}})}
-function renderManifests(items){byId('manifests').innerHTML=items.length?items.map(function(item){var body=parseJson(item.manifest_json)||{},exact=item.status==='STAGING_DEPLOYED'?'<p class="warning">Deployed, but E2E validation is not complete.</p>':item.status==='STAGING_VALIDATED'?'<p class="success">This exact release set passed staging E2E. Production remains explicit.</p>':item.status==='PRODUCTION_CANDIDATE_EVIDENCE_QUALIFIED'?'<p class="success">Fresh production composition qualified from '+esc((body.candidate_staging_evidence||[]).length)+' exact candidate staging evidence record(s); staging was not mutated.</p>':'';return '<article class="card"><div class="row"><div><strong>'+esc(item.lane)+' manifest</strong><div class="sha">'+esc(item.id)+' · '+esc(item.identity_sha256)+'</div></div><span class="badge">'+esc(item.status)+'</span></div>'+exact+'<p class="muted">Policy '+esc(body.qualification_policy||'staging/legacy')+'</p><div class="metrics"><div class="metric"><span class="muted">Frontend</span><strong class="sha">'+esc(item.frontend_sha||'n/a')+'</strong></div><div class="metric"><span class="muted">Backend</span><strong class="sha">'+esc(item.backend_sha||'n/a')+'</strong></div><div class="metric"><span class="muted">Deployed</span><strong>'+esc(time(item.deployed_at))+'</strong></div><div class="metric"><span class="muted">Validated</span><strong>'+esc(time(item.validated_at))+'</strong></div></div>'+runLink('frontend',item.e2e_run_id)+'</article>'}).join(''):'<p class="muted">No exact manifests yet.</p>'}
-function renderRuntime(data){state.mode=data.mode;state.stagingState=data.staging_state||null;var maintenance=data.mode==='OFF'?'<article class="card warning"><strong>Maintenance/manual fallback active.</strong> V2 cannot claim or advance work while OFF. Serialize shared refs and deployments using the linked fallback console.</article>':'';var staging=state.stagingState||{},stagingCard='<article class="card"><div class="row"><strong>Authoritative shared staging</strong><span class="badge">'+esc(staging.status||'UNKNOWN')+'</span></div><div class="sha">Manifest '+esc(staging.current_manifest_id||'none')+'</div><div class="muted">Frontend '+esc(staging.frontend_staging_ref_sha||'unknown')+' · Backend '+esc(staging.backend_staging_ref_sha||'unknown')+' · state v'+esc(staging.row_version||'?')+'</div></article>';var controls=(data.controls||[]).map(function(item){return '<article class="card"><div class="row"><strong>'+esc(item.scope)+'</strong><span class="badge">'+(item.paused?'PAUSED':'RUNNING')+'</span></div><div class="muted">'+esc(item.reason||'No pause reason')+'</div></article>'}).join('');var locks=(data.locks||[]).map(function(item){var owned=item.owner_train_id&&Number(item.expires_at)>Date.now();return '<article class="card"><div class="row"><strong>'+esc(item.name)+'</strong><span class="badge">'+(owned?'OWNED':'FREE')+'</span></div><div class="sha">'+esc(item.owner_train_id||'No owner')+'</div><div class="muted">Lease expiry '+esc(time(item.expires_at))+'</div></article>'}).join('');byId('runtime').innerHTML=maintenance+'<p><span class="badge">Mode '+esc(data.mode)+'</span></p>'+stagingCard+controls+locks;var register=byId('register'),reconcile=byId('reconcile');if(register)register.disabled=data.mode==='OFF';if(reconcile)reconcile.disabled=data.mode==='OFF'}
-async function refresh(){var all=await Promise.all([request('/deploy/release-bus-v2/candidates?limit=100'),request('/deploy/release-bus-v2/trains'),request('/deploy/release-bus-v2/manifests'),request('/deploy/release-bus-v2/controls')]);var details={};await Promise.all((all[1].trains||[]).filter(function(item){return !terminal.includes(item.status)}).map(async function(item){details[item.id]=await request('/deploy/release-bus-v2/trains/'+encodeURIComponent(item.id))}));renderRuntime(all[3]);renderCandidates(all[0].candidates||[]);renderTrains(all[1].trains||[],details);renderManifests(all[2].manifests||[]);status(byId('dashboard-status'),'Read-only state updated.',false)}
-async function connect(){state.token=(byId('token').value||state.token).trim();if(!state.token){status(byId('auth-status'),'Paste a token first.',true);return}try{var session=await request('/deploy/ui/session');localStorage.setItem(key,state.token);byId('token').value='';setOperator(true);status(byId('auth-status'),'Connected as '+session.login+'. Mutation authorization is checked per action.',false);await refresh()}catch(error){localStorage.removeItem(key);state.token='';setOperator(false);status(byId('auth-status'),error.message,true)}}
-byId('connect').onclick=connect;byId('forget').onclick=function(){localStorage.removeItem(key);state.token='';setOperator(false);status(byId('auth-status'),'Operator token removed. Public read-only access remains available.',false);refresh().catch(function(error){status(byId('dashboard-status'),error.message,true)})};byId('refresh').onclick=function(){refresh().catch(function(error){status(byId('dashboard-status'),error.message,true)})};byId('reconcile').onclick=async function(){try{await request('/deploy/release-bus-v2/reconcile',{method:'POST',body:'{}'});await refresh()}catch(error){status(byId('register-status'),error.message,true)}};byId('repository').onchange=function(){byId('backend-plan').classList.toggle('hidden',byId('repository').value!=='backend')};
-byId('mark-selection').onclick=async function(){var selected=Array.prototype.map.call(document.querySelectorAll('[data-select-production]:checked'),function(input){return{candidate_id:input.dataset.selectProduction,expected_head_sha:input.dataset.sha,expected_row_version:Number(input.dataset.version)}});if(!selected.length){status(byId('production-selection-status'),'Select at least one staging-validated candidate.',true);return}try{var result=await request('/deploy/release-bus-v2/production-selections',{method:'POST',body:JSON.stringify({candidates:selected})});status(byId('production-selection-status'),'Production selection '+result.production_selection_id+' recorded with candidate staging evidence.',false);await refresh()}catch(error){status(byId('production-selection-status'),error.message,true)}};
-byId('resolve').onclick=async function(){try{var repository=byId('repository').value,branch=byId('branch').value.trim();if(!branch)throw new Error('Enter a branch first');var data=await request('/deploy/ui/branch-head?repository='+encodeURIComponent(repository)+'&branch='+encodeURIComponent(branch));byId('sha').value=data.head_sha;status(byId('register-status'),'Resolved '+data.head_sha,false)}catch(error){status(byId('register-status'),error.message,true)}};
-byId('register-form').onsubmit=async function(event){event.preventDefault();try{var body={repository:byId('repository').value,pr_number:Number(byId('pr-number').value),branch_name:byId('branch').value.trim(),expected_head_sha:byId('sha').value.trim().toLowerCase(),deploy_plan:parsePlan(),dependencies:parseDependencies()};var data=await request('/deploy/release-bus-v2/candidates',{method:'POST',body:JSON.stringify(body)});status(byId('register-status'),'Queued exact '+data.candidate.head_sha+' for staging.',false);await refresh()}catch(error){status(byId('register-status'),error.message,true)}};
-Array.prototype.forEach.call(document.querySelectorAll('[data-control]'),function(button){button.onclick=async function(){try{var reason=byId('control-reason').value.trim();if(reason.length<3)throw new Error('Enter an audited reason');await request('/deploy/release-bus-v2/'+button.dataset.control,{method:'POST',body:JSON.stringify({scope:button.dataset.scope,reason:reason})});status(byId('control-status'),'Control updated.',false);await refresh()}catch(error){status(byId('control-status'),error.message,true)}}});
-setOperator(false);refresh().catch(function(error){status(byId('dashboard-status'),error.message,true)});if(state.token){connect()}else{status(byId('auth-status'),'Viewing public read-only state. Connect only when operator actions are needed.',false)}
+  return `'use strict';
+(function(){
+  var key='deploy-ui-token';
+  var terminal=['STAGING_VALIDATED','STAGING_ROLLBACK_FAILED','PRODUCTION_DEPLOYED','FAILED','CANCELLED'];
+  var candidateStatuses=['READY_FOR_STAGING','STAGING_IN_TRAIN','STAGING_BUILDING','STAGING_DEPLOYING','STAGING_DEPLOYED','STAGING_VALIDATING','STAGING_VALIDATED','READY_FOR_PRODUCTION','READY_FOR_CANDIDATE_EVIDENCE_PRODUCTION','WAITING_FOR_PRODUCTION_REPLAN','PRODUCTION_IN_TRAIN','PRODUCTION_BUILDING_OR_QUALIFYING','PRODUCTION_DEPLOYING','PRODUCTION_DEPLOYED','NEEDS_REBASE','WAITING_FOR_DEPENDENCY','SUPERSEDED','FAILED','CANCELLED'];
+  var state={
+    token:localStorage.getItem(key)||'',
+    operator:false,
+    lanes:{},
+    controls:null,
+    candidates:[],
+    candidateById:{},
+    trains:[],
+    manifests:[],
+    trainDetails:{},
+    previousVisible:{STAGING:1,PRODUCTION:1},
+    prVisible:10,
+    refreshing:false
+  };
+  var byId=function(id){return document.getElementById(id)};
+  function esc(value){return String(value==null?'':value).replace(/[&<>"']/g,function(character){return{'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[character]})}
+  function parseJson(value){if(!value)return null;if(typeof value==='object')return value;try{return JSON.parse(value)}catch(_error){return null}}
+  function status(node,message,error){if(!node)return;node.textContent=message||'';node.className='status '+(error?'error':'success-text')}
+  function headers(){var result={'Content-Type':'application/json'};if(state.token)result.Authorization='Bearer '+state.token;return result}
+  async function request(url,options){
+    var response=await fetch(url,Object.assign({},options||{},{headers:Object.assign({},headers(),options&&options.headers||{})}));
+    var payload=await response.json().catch(function(){return{}});
+    if(!response.ok)throw new Error(payload.error||payload.message||('Request failed ('+response.status+')'));
+    return payload
+  }
+  function setOperator(connected){
+    state.operator=connected;
+    Array.prototype.forEach.call(document.querySelectorAll('.operator'),function(node){node.classList.toggle('hidden',!connected)})
+  }
+  function dateTime(value){
+    if(!Number(value))return 'Not recorded';
+    return new Intl.DateTimeFormat(undefined,{dateStyle:'medium',timeStyle:'medium'}).format(new Date(Number(value)))
+  }
+  function duration(start,end){
+    var startValue=Number(start),endValue=Number(end)||Date.now();
+    if(!startValue)return 'Not recorded';
+    var seconds=Math.floor(Math.max(0,endValue-startValue)/1000),minutes=Math.floor(seconds/60),hours=Math.floor(minutes/60);
+    return hours?hours+'h '+minutes%60+'m':minutes?minutes+'m '+seconds%60+'s':seconds+'s'
+  }
+  function laneKey(lane){return lane==='STAGING'?'STAGING':'PRODUCTION'}
+  function laneLabel(lane){return laneKey(lane)==='STAGING'?'Staging':'Production'}
+  function repositoryLabel(repository){return repository==='backend'?'Backend':'Frontend'}
+  function prUrl(item){return 'https://github.com/6529-Collections/6529seize-'+encodeURIComponent(item.repository)+'/pull/'+encodeURIComponent(item.pr_number)}
+  function runUrl(repository,id){return repository&&/^\\d+$/.test(String(id||''))?'https://github.com/6529-Collections/6529seize-'+encodeURIComponent(repository)+'/actions/runs/'+encodeURIComponent(id):''}
+  function badge(value,extra){return '<span class="badge '+esc(extra||'')+'">'+esc(value)+'</span>'}
+  function empty(message){return '<div class="empty">'+esc(message)+'</div>'}
+  function statusTone(value){
+    if(['STAGING_VALIDATED','PRODUCTION_DEPLOYED','SUCCEEDED','ON','LIVE'].includes(value))return 'success';
+    if(['FAILED','CANCELLED','STAGING_ROLLBACK_FAILED','OFF'].includes(value))return 'failed';
+    if(['READY_FOR_STAGING','READY_FOR_PRODUCTION','READY_FOR_CANDIDATE_EVIDENCE_PRODUCTION','WAITING_FOR_DEPENDENCY','WAITING_FOR_PRODUCTION_REPLAN','PAUSED'].includes(value))return 'warning';
+    return ''
+  }
+  function candidateMembership(data,candidateId){
+    return (data&&data.memberships||[]).find(function(item){return item.candidate_id===candidateId})||null
+  }
+  function dependencyLabel(dependency){
+    var prerequisite=state.candidateById[dependency.prerequisite_candidate_id];
+    return prerequisite?repositoryLabel(prerequisite.repository)+' PR #'+prerequisite.pr_number:dependency.prerequisite_candidate_id
+  }
+  function dagMarkup(item,dependencies){
+    var plan=parseJson(item.deploy_plan_json)||{},units=Array.isArray(plan.units)?plan.units:[],edges=Array.isArray(plan.edges)?plan.edges:[];
+    var candidateDependencies=(dependencies||item.dependencies||[]).map(function(dependency){return '<li>'+esc(dependencyLabel(dependency))+' · '+esc(dependency.environment)+'</li>'}).join('');
+    var graph=edges.map(function(edge){return Array.isArray(edge)?esc(edge.join(' → ')):esc(edge)}).join(', ');
+    var parts=[];
+    if(units.length)parts.push('<div><strong>Deploy units:</strong> '+esc(units.join(', '))+'</div>');
+    if(graph)parts.push('<div><strong>DAG:</strong> '+graph+'</div>');
+    if(candidateDependencies)parts.push('<div><strong>Depends on:</strong><ul class="list">'+candidateDependencies+'</ul></div>');
+    return parts.length?'<div class="small muted">'+parts.join('')+'</div>':''
+  }
+  function candidateActions(item){
+    if(!state.operator)return '';
+    var productionOn=state.lanes.PRODUCTION&&state.lanes.PRODUCTION.status==='ON';
+    var canMark=item.status==='STAGING_VALIDATED'&&productionOn;
+    var canRevoke=['READY_FOR_PRODUCTION','READY_FOR_CANDIDATE_EVIDENCE_PRODUCTION','WAITING_FOR_PRODUCTION_REPLAN'].includes(item.status);
+    var canCancel=['READY_FOR_STAGING','READY_FOR_PRODUCTION','READY_FOR_CANDIDATE_EVIDENCE_PRODUCTION','WAITING_FOR_PRODUCTION_REPLAN','NEEDS_REBASE','WAITING_FOR_DEPENDENCY'].includes(item.status);
+    return '<div class="actions">'+
+      (canMark?'<label class="small"><input type="checkbox" data-select-production="'+esc(item.id)+'" data-sha="'+esc(item.head_sha)+'" data-version="'+esc(item.row_version)+'"> Select for production</label>':'')+
+      (canRevoke?'<button class="compact" data-revoke="'+esc(item.id)+'" data-version="'+esc(item.row_version)+'">Revoke readiness</button>':'')+
+      (canCancel?'<button class="danger compact" data-cancel="'+esc(item.id)+'" data-version="'+esc(item.row_version)+'">Cancel</button>':'')+
+      '</div>'
+  }
+  function candidateCard(item,options){
+    var membership=options&&options.membership;
+    var dependencies=options&&options.dependencies||item.dependencies||[];
+    var role=membership?(badge(membership.candidate_role||'MEMBER','')+' '+badge(membership.disposition||'INCLUDED','')):'';
+    var updatedLabel=options&&options.projected?'Queued '+dateTime(item.updated_at):'Updated '+dateTime(item.updated_at);
+    return '<article class="pr-card">'+
+      '<div class="pr-title"><div><span class="badge '+esc(item.repository)+'">'+esc(repositoryLabel(item.repository))+'</span> <a target="_blank" rel="noreferrer" href="'+esc(prUrl(item))+'">PR #'+esc(item.pr_number)+'</a></div><div>'+badge(item.status,statusTone(item.status))+' '+role+'</div></div>'+
+      '<div class="sha">'+esc(item.head_sha)+'</div>'+
+      '<div class="muted small">'+esc(updatedLabel)+(item.hold_reason?' · '+esc(item.hold_reason):'')+'</div>'+
+      dagMarkup(item,dependencies)+
+      (options&&options.actions===false?'':candidateActions(item))+
+      '</article>'
+  }
+  function repositoryGroups(candidates,data,projected){
+    return ['backend','frontend'].map(function(repository){
+      var items=candidates.filter(function(item){return item.repository===repository});
+      return '<section class="repository-group" aria-label="'+esc(repositoryLabel(repository))+' pull requests">'+
+        '<h5>'+esc(repositoryLabel(repository))+' PRs '+badge(items.length,repository)+'</h5>'+
+        '<div class="pr-list">'+(items.length?items.map(function(item){
+          return candidateCard(item,{
+            membership:candidateMembership(data,item.id),
+            dependencies:(data&&data.dependencies||[]).filter(function(dependency){return dependency.candidate_id===item.id}),
+            projected:Boolean(projected),
+            actions:false
+          })
+        }).join(''):empty('No '+repository+' PRs in this train.'))+'</div></section>'
+    }).join('')
+  }
+  function operationCard(item){
+    var workflow=item.workflow_run,workflowUrl=workflow&&workflow.html_url||runUrl(item.repository,item.external_id);
+    return '<article class="operation">'+
+      '<div class="row"><strong>'+esc(item.operation_type)+(item.service?' · '+esc(item.service):'')+'</strong>'+badge(item.status,statusTone(item.status))+'</div>'+
+      '<div class="muted small">'+esc(item.repository||'control')+' / '+esc(item.environment||'orchestration')+' · attempt '+esc(item.attempt)+'/'+esc(item.max_attempts)+'</div>'+
+      '<div class="small">Started '+esc(dateTime(item.started_at||item.created_at))+' · elapsed '+esc(duration(item.started_at||item.created_at,item.completed_at))+'</div>'+
+      (item.expected_sha?'<div class="sha small">Expected '+esc(item.expected_sha)+'</div>':'')+
+      (item.failure_message?'<p class="error"><strong>'+esc(item.failure_class||'Failure')+':</strong> '+esc(item.failure_message)+'</p>':'')+
+      (item.workflow_observation_error?'<p class="warning-text">'+esc(item.workflow_observation_error)+'</p>':'')+
+      (workflowUrl?'<div class="actions"><a class="button compact" target="_blank" rel="noreferrer" href="'+esc(workflowUrl)+'">Open workflow</a></div>':'')+
+      '</article>'
+  }
+  function diagnostics(data){
+    var train=data.train,events=data.events||[],operations=data.operations||[];
+    var locks=(state.controls&&state.controls.locks||[]).filter(function(lock){return lock.owner_train_id===train.id});
+    var manifests=state.manifests.filter(function(manifest){return manifest.train_id===train.id});
+    return '<details class="diagnostics"><summary>Diagnostics and immutable evidence</summary><div class="diagnostic-body">'+
+      '<div class="metrics">'+
+        '<div class="metric"><span class="muted">Train ID</span><strong class="sha">'+esc(train.id)+'</strong></div>'+
+        '<div class="metric"><span class="muted">Manifest</span><strong class="sha">'+esc(train.manifest_id||'Not created')+'</strong></div>'+
+        '<div class="metric"><span class="muted">Frontend artifact</span><strong class="sha">'+esc(train.frontend_artifact_digest||'Not created')+'</strong></div>'+
+        '<div class="metric"><span class="muted">Backend artifact</span><strong class="sha">'+esc(train.backend_artifact_digest||'Not created')+'</strong></div>'+
+      '</div>'+
+      (train.failure_message?'<p class="error"><strong>'+esc(train.failure_class||'Failure')+':</strong> '+esc(train.failure_message)+'</p>':'')+
+      (train.recovery_message?'<p class="muted">'+esc(train.recovery_message)+'</p>':'')+
+      '<section><h4>Environment ownership</h4>'+(locks.length?'<ul class="list">'+locks.map(function(lock){return '<li>'+esc(lock.name)+' · lease expires '+esc(dateTime(lock.expires_at))+'</li>'}).join('')+'</ul>':empty('This train does not currently hold an environment lock.'))+'</section>'+
+      '<section><h4>Manifests and E2E evidence</h4>'+(manifests.length?'<div class="stack">'+manifests.map(function(manifest){var e2eUrl=runUrl('frontend',manifest.e2e_run_id);return '<article class="operation"><div class="row"><span class="sha">'+esc(manifest.id)+'</span>'+badge(manifest.status,statusTone(manifest.status))+'</div><div class="muted small">Deployed '+esc(dateTime(manifest.deployed_at))+' · validated '+esc(dateTime(manifest.validated_at))+'</div>'+(e2eUrl?'<div class="actions"><a class="button compact" target="_blank" rel="noreferrer" href="'+esc(e2eUrl)+'">Open E2E workflow</a></div>':'')+'</article>'}).join('')+'</div>':empty('No immutable manifest has been recorded for this train.'))+'</section>'+
+      '<section><h4>Operations</h4><div class="stack">'+(operations.length?operations.map(operationCard).join(''):empty('No operations recorded for this train.'))+'</div></section>'+
+      '<section><h4>Durable events</h4>'+(events.length?'<ul class="list">'+events.map(function(event){return '<li>'+esc(dateTime(event.created_at))+' · '+esc(event.event_type)+'</li>'}).join('')+'</ul>':empty('No durable events recorded.'))+'</section>'+
+      '</div></details>'
+  }
+  function trainCard(data,options){
+    var train=data.train,candidates=(data.candidates||[]).filter(Boolean);
+    var label=options&&options.label||laneLabel(train.lane)+' train';
+    return '<article class="train-card">'+
+      '<div class="row"><div><h4>'+esc(label)+'</h4><div class="train-meta"><span>Started '+esc(dateTime(train.created_at))+'</span><span>Status since '+esc(dateTime(train.phase_started_at||train.updated_at))+'</span>'+(train.completed_at?'<span>Completed '+esc(dateTime(train.completed_at))+'</span>':'')+'</div></div>'+badge(train.status,statusTone(train.status))+'</div>'+
+      '<div class="metrics">'+
+        '<div class="metric"><span class="muted">Frontend release SHA</span><strong class="sha">'+esc(train.frontend_composed_sha||train.frontend_base_sha||'Not available')+'</strong></div>'+
+        '<div class="metric"><span class="muted">Backend release SHA</span><strong class="sha">'+esc(train.backend_composed_sha||train.backend_base_sha||'Not available')+'</strong></div>'+
+        '<div class="metric"><span class="muted">Elapsed</span><strong>'+esc(duration(train.created_at,train.completed_at))+'</strong></div>'+
+        '<div class="metric"><span class="muted">PRs</span><strong>'+esc(candidates.length)+'</strong></div>'+
+      '</div>'+
+      '<div class="repository-groups">'+repositoryGroups(candidates,data,false)+'</div>'+
+      diagnostics(data)+
+      '</article>'
+  }
+  function projectedTrainCard(lane,candidates,blocked){
+    return '<article class="train-card">'+
+      '<div class="row"><div><h4>Projected '+esc(laneLabel(lane).toLowerCase())+' train</h4><p class="muted small">Calculated from the current exact queue. This mutable projection is not claim evidence; the scheduler revalidates the exact set. No train has been claimed and no state was changed.</p></div>'+badge(blocked?'BLOCKED':'READY',blocked?'warning':'success')+'</div>'+
+      (blocked?'<p class="warning-text">'+esc(blocked)+'</p>':'')+
+      '<div class="repository-groups">'+repositoryGroups(candidates,null,true)+'</div>'+
+      '</article>'
+  }
+  async function trainDetail(id){
+    if(!state.trainDetails[id])state.trainDetails[id]=request('/deploy/release-bus-v2/trains/'+encodeURIComponent(id));
+    return state.trainDetails[id]
+  }
+  function laneTrains(lane){
+    return state.trains.filter(function(train){return train.lane===lane}).sort(function(left,right){return Number(right.created_at)-Number(left.created_at)})
+  }
+  function activeTrain(lane){
+    return laneTrains(lane).find(function(train){return !terminal.includes(train.status)})||null
+  }
+  function queuedCandidates(lane){
+    var statuses=lane==='STAGING'?['READY_FOR_STAGING','WAITING_FOR_DEPENDENCY']:['READY_FOR_PRODUCTION','READY_FOR_CANDIDATE_EVIDENCE_PRODUCTION','WAITING_FOR_PRODUCTION_REPLAN'];
+    var active=activeTrain(lane),activeId=active&&active.id;
+    var queued=state.candidates.filter(function(candidate){return statuses.includes(candidate.status)&&candidate.current_train_id!==activeId});
+    if(lane==='PRODUCTION'&&queued.length){
+      var ordered=queued.slice().sort(function(left,right){return Number(left.production_requested_at||left.created_at)-Number(right.production_requested_at||right.created_at)});
+      var replanning=ordered.some(function(candidate){return candidate.status==='WAITING_FOR_PRODUCTION_REPLAN'});
+      if(replanning){
+        queued=ordered
+      }else{
+        var selection=ordered[0].production_selection_id||null;
+        queued=ordered.filter(function(candidate){return (candidate.production_selection_id||null)===selection})
+      }
+    }
+    if(lane==='STAGING'&&queued.length){
+      var proposedByPr={};
+      queued.forEach(function(candidate){proposedByPr[candidate.repository+':'+candidate.pr_number]=candidate});
+      state.candidates.filter(function(candidate){return candidate.staging_live_state==='LIVE'}).forEach(function(candidate){
+        var identity=candidate.repository+':'+candidate.pr_number;
+        if(!proposedByPr[identity])proposedByPr[identity]=candidate
+      });
+      queued=Object.keys(proposedByPr).map(function(identity){return proposedByPr[identity]})
+    }
+    return queued
+  }
+  function queueBlocker(candidates){
+    var held=candidates.find(function(candidate){return candidate.status==='WAITING_FOR_DEPENDENCY'});
+    return held?'At least one queued PR is waiting for a dependency. The final claimed set may be smaller or may wait.':''
+  }
+  function manifestById(id){return state.manifests.find(function(manifest){return manifest.id===id})||null}
+  function latestProductionManifest(){
+    return state.manifests.filter(function(manifest){return manifest.lane==='PRODUCTION'&&manifest.status==='PRODUCTION_DEPLOYED'}).sort(function(left,right){return Number(right.created_at)-Number(left.created_at)})[0]||null
+  }
+  function headPair(label,frontendSha,backendSha,manifestId){
+    return '<article class="head-card"><h3>'+esc(label)+'</h3>'+
+      '<div class="head-pair"><span class="muted">Frontend</span><span class="sha">'+esc(frontendSha||'Not recorded')+'</span></div>'+
+      '<div class="head-pair"><span class="muted">Backend</span><span class="sha">'+esc(backendSha||'Not recorded')+'</span></div>'+
+      (manifestId?'<div class="muted small">Manifest <span class="sha">'+esc(manifestId)+'</span></div>':'')+
+      '</article>'
+  }
+  function renderHeads(lane){
+    var staging=state.controls&&state.controls.staging_state||{},current,validated;
+    if(lane==='STAGING'){
+      current=manifestById(staging.current_manifest_id);
+      validated=manifestById(staging.last_validated_manifest_id);
+      byId('staging-heads').innerHTML=
+        headPair('Currently deployed',current&&current.frontend_sha||staging.frontend_sha,current&&current.backend_sha||staging.backend_sha,staging.current_manifest_id)+
+        headPair('Last successfully validated',validated&&validated.frontend_sha,validated&&validated.backend_sha,staging.last_validated_manifest_id)
+    }else{
+      current=latestProductionManifest();
+      validated=current;
+      byId('production-heads').innerHTML=
+        headPair('Currently deployed',current&&current.frontend_sha,current&&current.backend_sha,current&&current.id)+
+        headPair('Last successfully validated',validated&&validated.frontend_sha,validated&&validated.backend_sha,validated&&validated.id)
+    }
+  }
+  function laneHeader(lane){
+    var item=state.lanes[lane]||{status:'OFF',changeable:false,reason:'Lane state is unavailable'},turningOff=item.status==='ON';
+    var action=state.operator?'<div class="field"><label for="'+lane.toLowerCase()+'-reason">Reason for lane change</label><div class="actions"><input id="'+lane.toLowerCase()+'-reason" maxlength="1000" placeholder="Required before changing the lane"><button class="'+(turningOff?'danger ':'')+'compact" data-lane-control="'+(turningOff?'pause':'resume')+'" data-scope="'+esc(lane)+'" '+(item.changeable?'':'disabled title="Internal emergency stop is active"')+'>'+(turningOff?'Turn off':'Turn on')+'</button></div></div>':'';
+    return '<div class="row"><div><div class="lane-title"><h2 id="'+lane.toLowerCase()+'-heading">'+esc(laneLabel(lane))+'</h2>'+badge(item.status,item.status==='ON'?'on':'off')+'</div><p class="muted">Latest state change reason: '+esc(item.reason||'None recorded')+'</p></div>'+action+'</div>'
+  }
+  function bindLaneControls(){
+    Array.prototype.forEach.call(document.querySelectorAll('[data-lane-control]'),function(button){
+      button.onclick=async function(){
+        var lane=button.dataset.scope,input=byId(lane.toLowerCase()+'-reason'),message=byId(lane.toLowerCase()+'-control-status');
+        try{
+          var reason=input.value.trim();
+          if(reason.length<3)throw new Error('Enter a reason for the lane change.');
+          await request('/deploy/release-bus-v2/'+button.dataset.laneControl,{method:'POST',body:JSON.stringify({scope:lane,reason:reason})});
+          status(message,laneLabel(lane)+' automation updated.',false);
+          await refresh()
+        }catch(error){status(message,error.message,true)}
+      }
+    })
+  }
+  async function renderLane(lane){
+    byId(lane.toLowerCase()+'-header').innerHTML=laneHeader(lane);
+    renderHeads(lane);
+    var current=activeTrain(lane),currentNode=byId(lane.toLowerCase()+'-current'),nextNode=byId(lane.toLowerCase()+'-next'),previousNode=byId(lane.toLowerCase()+'-previous');
+    currentNode.innerHTML='<h3>Current train</h3>'+(current?empty('Loading current train details…'):empty('No active '+laneLabel(lane).toLowerCase()+' train.'));
+    if(current)currentNode.innerHTML='<h3>Current train</h3>'+trainCard(await trainDetail(current.id),{label:'Current '+laneLabel(lane).toLowerCase()+' train'});
+    var queued=queuedCandidates(lane);
+    nextNode.innerHTML='<h3>Next train if nothing changes</h3>'+(queued.length?projectedTrainCard(lane,queued,queueBlocker(queued)):empty('Nothing is currently queued for the next '+laneLabel(lane).toLowerCase()+' train.'));
+    var previous=laneTrains(lane).filter(function(train){return terminal.includes(train.status)});
+    var visible=previous.slice(0,state.previousVisible[lane]);
+    var details=await Promise.all(visible.map(function(train){return trainDetail(train.id)}));
+    previousNode.innerHTML='<h3>Previous trains</h3>'+(details.length?'<div class="train-list">'+details.map(function(detail,index){return trainCard(detail,{label:'Previous train '+(index+1)})}).join('')+'</div>':empty('No previous '+laneLabel(lane).toLowerCase()+' trains recorded.'))+(previous.length>visible.length?'<div class="actions"><button class="compact" data-load-trains="'+esc(lane)+'">Load 5 more</button></div>':'');
+    var loadButton=previousNode.querySelector('[data-load-trains]');
+    if(loadButton)loadButton.onclick=function(){state.previousVisible[lane]+=5;renderLane(lane).catch(function(error){status(byId('dashboard-status'),error.message,true)})};
+    bindLaneControls()
+  }
+  function filteredCandidates(){
+    var number=Number(byId('pr-filter').value)||null,statusValue=byId('status-filter').value;
+    return state.candidates.filter(function(candidate){return(!number||candidate.pr_number===number)&&(!statusValue||candidate.status===statusValue)}).sort(function(left,right){return Number(right.updated_at)-Number(left.updated_at)})
+  }
+  function bindCandidateActions(){
+    Array.prototype.forEach.call(document.querySelectorAll('[data-revoke]'),function(button){button.onclick=function(){candidateAction('/deploy/release-bus-v2/candidates/'+encodeURIComponent(button.dataset.revoke)+'/revoke-production-readiness',{expected_row_version:Number(button.dataset.version)})}});
+    Array.prototype.forEach.call(document.querySelectorAll('[data-cancel]'),function(button){button.onclick=function(){candidateAction('/deploy/release-bus-v2/candidates/'+encodeURIComponent(button.dataset.cancel)+'/cancel',{expected_row_version:Number(button.dataset.version)})}})
+  }
+  async function candidateAction(url,body){
+    try{await request(url,{method:'POST',body:JSON.stringify(body)});await refresh()}catch(error){status(byId('production-selection-status'),error.message,true)}
+  }
+  function renderPullRequests(){
+    var filtered=filteredCandidates(),visible=filtered.slice(0,state.prVisible);
+    byId('pull-requests').innerHTML=visible.length?visible.map(function(item){return candidateCard(item,{actions:true})}).join(''):empty('No registered PRs match these filters.');
+    byId('pull-request-count').textContent='Showing '+visible.length+' of '+filtered.length+' matching PRs';
+    byId('load-more-prs').classList.toggle('hidden',visible.length>=filtered.length);
+    bindCandidateActions()
+  }
+  function populateStatusFilter(){
+    var select=byId('status-filter'),selected=select.value;
+    select.innerHTML='<option value="">All statuses</option>'+candidateStatuses.map(function(value){return '<option value="'+esc(value)+'">'+esc(value)+'</option>'}).join('');
+    select.value=selected
+  }
+  function parseDependencies(){
+    return byId('dependencies').value.split(/\\n/).map(function(value){return value.trim()}).filter(Boolean).map(function(line){
+      var parts=line.split(':');
+      if(parts.length!==2)throw new Error('Dependency must be candidate-uuid:ENVIRONMENT');
+      return{candidate_id:parts[0],environment:parts[1].toUpperCase()}
+    })
+  }
+  function parsePlan(){
+    if(byId('repository').value!=='backend')return null;
+    var units=byId('units').value.split(/\\n|,/).map(function(value){return value.trim()}).filter(Boolean);
+    if(!units.length)throw new Error('At least one backend deploy unit is required');
+    var edges=byId('edges').value.split(/\\n/).map(function(value){return value.trim()}).filter(Boolean).map(function(line){
+      var values=line.split(/\\s*->\\s*/);
+      if(values.length!==2)throw new Error('DAG edge must use A -> B');
+      return values
+    });
+    return{units:units,edges:edges}
+  }
+  async function refresh(){
+    if(state.refreshing)return;
+    state.refreshing=true;
+    byId('dashboard').setAttribute('aria-busy','true');
+    try{
+      var all=await Promise.all([
+        request('/deploy/release-bus-v2/candidates?limit=500'),
+        request('/deploy/release-bus-v2/trains'),
+        request('/deploy/release-bus-v2/manifests'),
+        request('/deploy/release-bus-v2/controls')
+      ]);
+      state.candidates=all[0].candidates||[];
+      state.candidateById=Object.fromEntries(state.candidates.map(function(candidate){return[candidate.id,candidate]}));
+      state.trains=all[1].trains||[];
+      state.manifests=all[2].manifests||[];
+      state.controls=all[3];
+      state.trainDetails={};
+      state.lanes={};
+      (all[3].lanes||[]).forEach(function(lane){state.lanes[lane.lane]=lane});
+      populateStatusFilter();
+      await Promise.all([renderLane('STAGING'),renderLane('PRODUCTION')]);
+      renderPullRequests();
+      var stagingOn=state.lanes.STAGING&&state.lanes.STAGING.status==='ON',register=byId('register');
+      if(register)register.disabled=!stagingOn;
+      status(byId('dashboard-status'),'Release Bus state updated '+dateTime(Date.now())+'.',false)
+    }finally{
+      state.refreshing=false;
+      byId('dashboard').setAttribute('aria-busy','false')
+    }
+  }
+  function showAuthenticationForm(){byId('auth-form').classList.remove('hidden');byId('show-auth').classList.add('hidden');byId('token').focus()}
+  function showDisconnected(message,error){byId('auth-connected').classList.add('hidden');byId('show-auth').classList.remove('hidden');setOperator(false);status(byId('auth-status'),message||'',error)}
+  function showConnected(login){byId('auth-identity').textContent='Authenticated as '+login;byId('auth-connected').classList.remove('hidden');byId('show-auth').classList.add('hidden');byId('auth-form').classList.add('hidden');setOperator(true);status(byId('auth-status'),'',false)}
+  async function connect(){
+    state.token=(byId('token').value||state.token).trim();
+    if(!state.token){showAuthenticationForm();status(byId('auth-status'),'Paste a token first.',true);return}
+    try{
+      var session=await request('/deploy/ui/session');
+      localStorage.setItem(key,state.token);
+      byId('token').value='';
+      showConnected(session.login);
+      await refresh()
+    }catch(error){
+      localStorage.removeItem(key);
+      state.token='';
+      showDisconnected(error.message,true);
+      showAuthenticationForm()
+    }
+  }
+  byId('show-auth').onclick=showAuthenticationForm;
+  byId('connect').onclick=connect;
+  byId('forget').onclick=function(){
+    localStorage.removeItem(key);
+    state.token='';
+    byId('token').value='';
+    byId('auth-form').classList.add('hidden');
+    showDisconnected('',false);
+    refresh().catch(function(error){status(byId('dashboard-status'),error.message,true)})
+  };
+  byId('pr-filter').oninput=function(){state.prVisible=10;renderPullRequests()};
+  byId('status-filter').onchange=function(){state.prVisible=10;renderPullRequests()};
+  byId('load-more-prs').onclick=function(){state.prVisible+=10;renderPullRequests()};
+  byId('repository').onchange=function(){byId('backend-plan').classList.toggle('hidden',byId('repository').value!=='backend')};
+  byId('mark-selection').onclick=async function(){
+    var selected=Array.prototype.map.call(document.querySelectorAll('[data-select-production]:checked'),function(input){return{candidate_id:input.dataset.selectProduction,expected_head_sha:input.dataset.sha,expected_row_version:Number(input.dataset.version)}});
+    if(!selected.length){status(byId('production-selection-status'),'Select at least one staging-validated PR.',true);return}
+    try{
+      var result=await request('/deploy/release-bus-v2/production-selections',{method:'POST',body:JSON.stringify({candidates:selected})});
+      status(byId('production-selection-status'),'Production selection '+result.production_selection_id+' recorded.',false);
+      await refresh()
+    }catch(error){status(byId('production-selection-status'),error.message,true)}
+  };
+  byId('resolve').onclick=async function(){
+    try{
+      var repository=byId('repository').value,branch=byId('branch').value.trim();
+      if(!branch)throw new Error('Enter a branch first.');
+      var data=await request('/deploy/ui/branch-head?repository='+encodeURIComponent(repository)+'&branch='+encodeURIComponent(branch));
+      byId('sha').value=data.head_sha;
+      status(byId('register-status'),'Resolved '+data.head_sha,false)
+    }catch(error){status(byId('register-status'),error.message,true)}
+  };
+  byId('register-form').onsubmit=async function(event){
+    event.preventDefault();
+    try{
+      var body={repository:byId('repository').value,pr_number:Number(byId('pr-number').value),branch_name:byId('branch').value.trim(),expected_head_sha:byId('sha').value.trim().toLowerCase(),deploy_plan:parsePlan(),dependencies:parseDependencies()};
+      var data=await request('/deploy/release-bus-v2/candidates',{method:'POST',body:JSON.stringify(body)});
+      status(byId('register-status'),'Queued exact '+data.candidate.head_sha+' for staging.',false);
+      event.target.reset();
+      byId('backend-plan').classList.add('hidden');
+      await refresh()
+    }catch(error){status(byId('register-status'),error.message,true)}
+  };
+  setOperator(false);
+  refresh().catch(function(error){status(byId('dashboard-status'),error.message,true)});
+  if(state.token)connect();else showDisconnected('',false);
+  setInterval(function(){refresh().catch(function(error){status(byId('dashboard-status'),error.message,true)})},30000)
 })();`;
 }

--- a/src/api-serverless/src/deploy/deploy-release-bus-routes.test.ts
+++ b/src/api-serverless/src/deploy/deploy-release-bus-routes.test.ts
@@ -564,6 +564,20 @@ describe('Release Bus v2 route authorization and exact actions', () => {
             row_version: 1
           })
         );
+        expect(response.body.lanes).toEqual([
+          {
+            lane: 'STAGING',
+            status: 'ON',
+            changeable: true,
+            reason: null
+          },
+          {
+            lane: 'PRODUCTION',
+            status: 'ON',
+            changeable: true,
+            reason: null
+          }
+        ]);
       }
       expect(mockGetViewer).not.toHaveBeenCalled();
       expectNoReleaseMutation();

--- a/src/api-serverless/src/deploy/deploy-release-bus-routes.test.ts
+++ b/src/api-serverless/src/deploy/deploy-release-bus-routes.test.ts
@@ -11,6 +11,7 @@ const mockV2ListDependencies = jest.fn();
 const mockV2AppendEvent = jest.fn();
 const mockV2ListTrains = jest.fn();
 const mockV2FindTrain = jest.fn();
+const mockV2FindManifest = jest.fn();
 const mockV2ListManifests = jest.fn();
 const mockV2ListTrainCandidates = jest.fn();
 const mockV2ListOperations = jest.fn();
@@ -93,6 +94,7 @@ jest.mock('@/releaseBusV2/release-bus-v2.repository', () => ({
     appendEvent: (...args: unknown[]) => mockV2AppendEvent(...args),
     listTrains: (...args: unknown[]) => mockV2ListTrains(...args),
     findTrain: (...args: unknown[]) => mockV2FindTrain(...args),
+    findManifest: (...args: unknown[]) => mockV2FindManifest(...args),
     listManifests: (...args: unknown[]) => mockV2ListManifests(...args),
     listTrainCandidates: (...args: unknown[]) =>
       mockV2ListTrainCandidates(...args),
@@ -434,15 +436,22 @@ describe('Release Bus v2 route authorization and exact actions', () => {
     mockV2ListCandidates.mockResolvedValue([v2Candidate]);
     mockV2ListTrains.mockResolvedValue([]);
     mockV2ListManifests.mockResolvedValue([]);
+    mockV2FindManifest.mockResolvedValue({
+      id: RESET_ID,
+      frontend_sha: SHA,
+      backend_sha: 'b'.repeat(40)
+    });
     mockV2ListControls.mockResolvedValue([
-      { scope: 'ALL', paused: false },
-      { scope: 'STAGING', paused: false },
-      { scope: 'PRODUCTION', paused: false }
+      { scope: 'ALL', paused: false, reason: null },
+      { scope: 'STAGING', paused: false, reason: null },
+      { scope: 'PRODUCTION', paused: false, reason: null }
     ]);
     mockV2ListLocks.mockResolvedValue([]);
     mockV2GetStagingState.mockResolvedValue({
+      id: 'current',
       status: 'CLEAN_MAIN',
       current_manifest_id: null,
+      last_validated_manifest_id: RESET_ID,
       frontend_sha: SHA,
       backend_sha: 'b'.repeat(40),
       frontend_staging_ref_sha: SHA,
@@ -561,9 +570,12 @@ describe('Release Bus v2 route authorization and exact actions', () => {
         expect(response.body.staging_state).toEqual(
           expect.objectContaining({
             status: 'CLEAN_MAIN',
+            last_validated_frontend_sha: SHA,
+            last_validated_backend_sha: 'b'.repeat(40),
             row_version: 1
           })
         );
+        expect(mockV2FindManifest).toHaveBeenCalledWith(RESET_ID, {});
         expect(response.body.lanes).toEqual([
           {
             lane: 'STAGING',

--- a/src/api-serverless/src/deploy/deploy.routes.ts
+++ b/src/api-serverless/src/deploy/deploy.routes.ts
@@ -39,6 +39,7 @@ import { setNoStoreHeaders } from '@/api/response-headers';
 import { getValidatedByJoiOrThrow } from '@/api/validation';
 import { releaseBusGitHubApp } from '@/releaseBusV2/release-bus-v2.github-app';
 import {
+  deriveReleaseBusV2LaneStates,
   getReleaseBusV2BetaAllowlist,
   getReleaseBusV2Mode,
   RELEASE_BUS_OPERATOR_TEAM,
@@ -763,12 +764,15 @@ deployRoutes.get('/release-bus-v2/manifests', async (_req, res) => {
 });
 
 deployRoutes.get('/release-bus-v2/controls', async (_req, res) => {
+  const controls = await releaseBusV2Repository.listControls({});
+  const mode = getReleaseBusV2Mode();
   setNoStoreHeaders(res);
   return res.json({
-    controls: await releaseBusV2Repository.listControls({}),
+    controls,
+    lanes: deriveReleaseBusV2LaneStates(mode, controls),
     locks: await releaseBusV2Repository.listLocks({}),
     staging_state: await releaseBusV2Repository.getStagingState({}),
-    mode: getReleaseBusV2Mode()
+    mode
   });
 });
 
@@ -780,9 +784,12 @@ async function updateBusV2Control(req: Request, paused: boolean) {
     reason: string;
   }>(req.body, ReleaseBusV2ControlBodySchema);
   await releaseBusV2Service.setPaused(body.scope, paused, body.reason, actor);
+  const controls = await releaseBusV2Repository.listControls({});
+  const mode = getReleaseBusV2Mode();
   return {
-    controls: await releaseBusV2Repository.listControls({}),
-    mode: getReleaseBusV2Mode()
+    controls,
+    lanes: deriveReleaseBusV2LaneStates(mode, controls),
+    mode
   };
 }
 

--- a/src/api-serverless/src/deploy/deploy.routes.ts
+++ b/src/api-serverless/src/deploy/deploy.routes.ts
@@ -763,6 +763,27 @@ deployRoutes.get('/release-bus-v2/manifests', async (_req, res) => {
   });
 });
 
+async function getReleaseBusV2StagingStateView() {
+  const state = await releaseBusV2Repository.getStagingState({});
+  const lastValidatedManifest = state.last_validated_manifest_id
+    ? await releaseBusV2Repository.findManifest(
+        state.last_validated_manifest_id,
+        {}
+      )
+    : null;
+  const currentIsLastValidated =
+    state.current_manifest_id === state.last_validated_manifest_id;
+  return {
+    ...state,
+    last_validated_frontend_sha:
+      lastValidatedManifest?.frontend_sha ??
+      (currentIsLastValidated ? state.frontend_sha : null),
+    last_validated_backend_sha:
+      lastValidatedManifest?.backend_sha ??
+      (currentIsLastValidated ? state.backend_sha : null)
+  };
+}
+
 deployRoutes.get('/release-bus-v2/controls', async (_req, res) => {
   const controls = await releaseBusV2Repository.listControls({});
   const mode = getReleaseBusV2Mode();
@@ -771,7 +792,7 @@ deployRoutes.get('/release-bus-v2/controls', async (_req, res) => {
     controls,
     lanes: deriveReleaseBusV2LaneStates(mode, controls),
     locks: await releaseBusV2Repository.listLocks({}),
-    staging_state: await releaseBusV2Repository.getStagingState({}),
+    staging_state: await getReleaseBusV2StagingStateView(),
     mode
   });
 });

--- a/src/api-serverless/src/generated/models/ObjectSerializer.ts
+++ b/src/api-serverless/src/generated/models/ObjectSerializer.ts
@@ -1167,7 +1167,7 @@ import { ReleaseBusV2ProductionSelectionItem } from '../models/ReleaseBusV2Produ
 import { ReleaseBusV2ProductionSelectionRequest } from '../models/ReleaseBusV2ProductionSelectionRequest';
 import { ReleaseBusV2ProductionSelectionResponse , ReleaseBusV2ProductionSelectionResponseQualificationPolicyEnum     } from '../models/ReleaseBusV2ProductionSelectionResponse';
 import { ReleaseBusV2RegisterRequest , ReleaseBusV2RegisterRequestRepositoryEnum        } from '../models/ReleaseBusV2RegisterRequest';
-import { ReleaseBusV2StagingState, ReleaseBusV2StagingStateIdEnum  , ReleaseBusV2StagingStateStatusEnum             } from '../models/ReleaseBusV2StagingState';
+import { ReleaseBusV2StagingState, ReleaseBusV2StagingStateIdEnum  , ReleaseBusV2StagingStateStatusEnum               } from '../models/ReleaseBusV2StagingState';
 import { ReleaseBusV2StagingTransitionRequest  , ReleaseBusV2StagingTransitionRequestTransitionEnum    } from '../models/ReleaseBusV2StagingTransitionRequest';
 import { ReleaseBusV2Train , ReleaseBusV2TrainLaneEnum  , ReleaseBusV2TrainStatusEnum          , ReleaseBusV2TrainStagingPolicyEnum    , ReleaseBusV2TrainQualificationPolicyEnum             } from '../models/ReleaseBusV2Train';
 import { ReleaseBusV2TrainDetailResponse } from '../models/ReleaseBusV2TrainDetailResponse';

--- a/src/api-serverless/src/generated/models/ObjectSerializer.ts
+++ b/src/api-serverless/src/generated/models/ObjectSerializer.ts
@@ -561,6 +561,7 @@ export * from '../models/ReleaseBusV2ControlsResponse';
 export * from '../models/ReleaseBusV2Dependency';
 export * from '../models/ReleaseBusV2DependencyRequest';
 export * from '../models/ReleaseBusV2DeployPlan';
+export * from '../models/ReleaseBusV2LaneState';
 export * from '../models/ReleaseBusV2Manifest';
 export * from '../models/ReleaseBusV2ManifestListResponse';
 export * from '../models/ReleaseBusV2Mode';
@@ -1153,11 +1154,12 @@ import { ReleaseBusV2CandidateListResponse   } from '../models/ReleaseBusV2Candi
 import { ReleaseBusV2CandidateResponse   } from '../models/ReleaseBusV2CandidateResponse';
 import { ReleaseBusV2CandidateStatus } from '../models/ReleaseBusV2CandidateStatus';
 import { ReleaseBusV2ControlRequest, ReleaseBusV2ControlRequestScopeEnum    } from '../models/ReleaseBusV2ControlRequest';
-import { ReleaseBusV2ControlUpdateResponse   } from '../models/ReleaseBusV2ControlUpdateResponse';
-import { ReleaseBusV2ControlsResponse     } from '../models/ReleaseBusV2ControlsResponse';
+import { ReleaseBusV2ControlUpdateResponse    } from '../models/ReleaseBusV2ControlUpdateResponse';
+import { ReleaseBusV2ControlsResponse      } from '../models/ReleaseBusV2ControlsResponse';
 import { ReleaseBusV2Dependency   , ReleaseBusV2DependencyEnvironmentEnum    } from '../models/ReleaseBusV2Dependency';
 import { ReleaseBusV2DependencyRequest , ReleaseBusV2DependencyRequestEnvironmentEnum   } from '../models/ReleaseBusV2DependencyRequest';
 import { ReleaseBusV2DeployPlan } from '../models/ReleaseBusV2DeployPlan';
+import { ReleaseBusV2LaneState, ReleaseBusV2LaneStateLaneEnum  , ReleaseBusV2LaneStateStatusEnum     } from '../models/ReleaseBusV2LaneState';
 import { ReleaseBusV2Manifest  , ReleaseBusV2ManifestLaneEnum   , ReleaseBusV2ManifestStatusEnum             } from '../models/ReleaseBusV2Manifest';
 import { ReleaseBusV2ManifestListResponse } from '../models/ReleaseBusV2ManifestListResponse';
 import { ReleaseBusV2Mode } from '../models/ReleaseBusV2Mode';
@@ -1333,6 +1335,8 @@ let enumsMap: Set<string> = new Set<string>([
     "ReleaseBusV2ControlRequestScopeEnum",
     "ReleaseBusV2DependencyEnvironmentEnum",
     "ReleaseBusV2DependencyRequestEnvironmentEnum",
+    "ReleaseBusV2LaneStateLaneEnum",
+    "ReleaseBusV2LaneStateStatusEnum",
     "ReleaseBusV2ManifestLaneEnum",
     "ReleaseBusV2ManifestStatusEnum",
     "ReleaseBusV2Mode",
@@ -1846,6 +1850,7 @@ let typeMap: {[index: string]: any} = {
     "ReleaseBusV2Dependency": ReleaseBusV2Dependency,
     "ReleaseBusV2DependencyRequest": ReleaseBusV2DependencyRequest,
     "ReleaseBusV2DeployPlan": ReleaseBusV2DeployPlan,
+    "ReleaseBusV2LaneState": ReleaseBusV2LaneState,
     "ReleaseBusV2Manifest": ReleaseBusV2Manifest,
     "ReleaseBusV2ManifestListResponse": ReleaseBusV2ManifestListResponse,
     "ReleaseBusV2ProductionSelectionItem": ReleaseBusV2ProductionSelectionItem,

--- a/src/api-serverless/src/generated/models/ReleaseBusV2ControlsResponse.ts
+++ b/src/api-serverless/src/generated/models/ReleaseBusV2ControlsResponse.ts
@@ -10,12 +10,14 @@
  * Do not edit the class manually.
  */
 
+import { ReleaseBusV2LaneState } from '../models/ReleaseBusV2LaneState';
 import { ReleaseBusV2Mode } from '../models/ReleaseBusV2Mode';
 import { ReleaseBusV2StagingState } from '../models/ReleaseBusV2StagingState';
 import { HttpFile } from '../http/http';
 
 export class ReleaseBusV2ControlsResponse {
     'controls': Array<{ [key: string]: any; }>;
+    'lanes': Array<ReleaseBusV2LaneState>;
     'locks': Array<{ [key: string]: any; }>;
     'mode': ReleaseBusV2Mode;
     'staging_state': ReleaseBusV2StagingState;
@@ -29,6 +31,12 @@ export class ReleaseBusV2ControlsResponse {
             "name": "controls",
             "baseName": "controls",
             "type": "Array<{ [key: string]: any; }>",
+            "format": ""
+        },
+        {
+            "name": "lanes",
+            "baseName": "lanes",
+            "type": "Array<ReleaseBusV2LaneState>",
             "format": ""
         },
         {

--- a/src/api-serverless/src/generated/models/ReleaseBusV2LaneState.ts
+++ b/src/api-serverless/src/generated/models/ReleaseBusV2LaneState.ts
@@ -10,14 +10,13 @@
  * Do not edit the class manually.
  */
 
-import { ReleaseBusV2LaneState } from '../models/ReleaseBusV2LaneState';
-import { ReleaseBusV2Mode } from '../models/ReleaseBusV2Mode';
 import { HttpFile } from '../http/http';
 
-export class ReleaseBusV2ControlUpdateResponse {
-    'controls': Array<{ [key: string]: any; }>;
-    'lanes': Array<ReleaseBusV2LaneState>;
-    'mode': ReleaseBusV2Mode;
+export class ReleaseBusV2LaneState {
+    'lane': ReleaseBusV2LaneStateLaneEnum;
+    'status': ReleaseBusV2LaneStateStatusEnum;
+    'changeable': boolean;
+    'reason': string | null;
 
     static readonly discriminator: string | undefined = undefined;
 
@@ -25,30 +24,44 @@ export class ReleaseBusV2ControlUpdateResponse {
 
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
         {
-            "name": "controls",
-            "baseName": "controls",
-            "type": "Array<{ [key: string]: any; }>",
+            "name": "lane",
+            "baseName": "lane",
+            "type": "ReleaseBusV2LaneStateLaneEnum",
             "format": ""
         },
         {
-            "name": "lanes",
-            "baseName": "lanes",
-            "type": "Array<ReleaseBusV2LaneState>",
+            "name": "status",
+            "baseName": "status",
+            "type": "ReleaseBusV2LaneStateStatusEnum",
             "format": ""
         },
         {
-            "name": "mode",
-            "baseName": "mode",
-            "type": "ReleaseBusV2Mode",
+            "name": "changeable",
+            "baseName": "changeable",
+            "type": "boolean",
+            "format": ""
+        },
+        {
+            "name": "reason",
+            "baseName": "reason",
+            "type": "string",
             "format": ""
         }    ];
 
     static getAttributeTypeMap() {
-        return ReleaseBusV2ControlUpdateResponse.attributeTypeMap;
+        return ReleaseBusV2LaneState.attributeTypeMap;
     }
 
     public constructor() {
     }
 }
 
+export enum ReleaseBusV2LaneStateLaneEnum {
+    Staging = 'STAGING',
+    Production = 'PRODUCTION'
+}
+export enum ReleaseBusV2LaneStateStatusEnum {
+    On = 'ON',
+    Off = 'OFF'
+}
 

--- a/src/api-serverless/src/generated/models/ReleaseBusV2StagingState.ts
+++ b/src/api-serverless/src/generated/models/ReleaseBusV2StagingState.ts
@@ -19,6 +19,8 @@ export class ReleaseBusV2StagingState {
     'last_validated_manifest_id'?: string | null;
     'frontend_sha'?: string | null;
     'backend_sha'?: string | null;
+    'last_validated_frontend_sha': string | null;
+    'last_validated_backend_sha': string | null;
     'frontend_staging_ref_sha'?: string | null;
     'backend_staging_ref_sha'?: string | null;
     'clean_main': boolean;
@@ -64,6 +66,18 @@ export class ReleaseBusV2StagingState {
         {
             "name": "backend_sha",
             "baseName": "backend_sha",
+            "type": "string",
+            "format": ""
+        },
+        {
+            "name": "last_validated_frontend_sha",
+            "baseName": "last_validated_frontend_sha",
+            "type": "string",
+            "format": ""
+        },
+        {
+            "name": "last_validated_backend_sha",
+            "baseName": "last_validated_backend_sha",
             "type": "string",
             "format": ""
         },

--- a/src/releaseBusV2/release-bus-v2.config.test.ts
+++ b/src/releaseBusV2/release-bus-v2.config.test.ts
@@ -1,4 +1,5 @@
 import {
+  deriveReleaseBusV2LaneStates,
   getReleaseBusV2BetaAllowlist,
   getReleaseBusV2Mode,
   releaseBusV2BetaAllowsCandidate,
@@ -216,5 +217,142 @@ describe('Release Bus v2 operator-only OFF beta configuration', () => {
       ReleaseBusV2BetaConfigurationError
     );
     expect(getReleaseBusV2Mode()).toBe('OFF');
+  });
+});
+
+describe('deriveReleaseBusV2LaneStates', () => {
+  const runningControls = [
+    {
+      scope: 'ALL' as const,
+      paused: false,
+      reason: 'Global recovery complete'
+    },
+    {
+      scope: 'STAGING' as const,
+      paused: false,
+      reason: 'Staging enabled'
+    },
+    {
+      scope: 'PRODUCTION' as const,
+      paused: false,
+      reason: 'Production enabled'
+    }
+  ];
+
+  it('exposes only the two effective automation lanes', () => {
+    expect(deriveReleaseBusV2LaneStates('PRODUCTION', runningControls)).toEqual(
+      [
+        {
+          lane: 'STAGING',
+          status: 'ON',
+          changeable: true,
+          reason: 'Staging enabled'
+        },
+        {
+          lane: 'PRODUCTION',
+          status: 'ON',
+          changeable: true,
+          reason: 'Production enabled'
+        }
+      ]
+    );
+  });
+
+  it('derives an individual lane off state from its control', () => {
+    expect(
+      deriveReleaseBusV2LaneStates('PRODUCTION', [
+        ...runningControls.filter(({ scope }) => scope !== 'PRODUCTION'),
+        {
+          scope: 'PRODUCTION',
+          paused: true,
+          reason: 'Production maintenance'
+        }
+      ])
+    ).toEqual([
+      {
+        lane: 'STAGING',
+        status: 'ON',
+        changeable: true,
+        reason: 'Staging enabled'
+      },
+      {
+        lane: 'PRODUCTION',
+        status: 'OFF',
+        changeable: true,
+        reason: 'Production maintenance'
+      }
+    ]);
+  });
+
+  it('derives both lanes off from the internal emergency fence', () => {
+    expect(
+      deriveReleaseBusV2LaneStates('PRODUCTION', [
+        {
+          scope: 'ALL',
+          paused: true,
+          reason: 'Emergency hard stop'
+        },
+        ...runningControls.filter(({ scope }) => scope !== 'ALL')
+      ])
+    ).toEqual([
+      {
+        lane: 'STAGING',
+        status: 'OFF',
+        changeable: false,
+        reason: 'Emergency hard stop'
+      },
+      {
+        lane: 'PRODUCTION',
+        status: 'OFF',
+        changeable: false,
+        reason: 'Emergency hard stop'
+      }
+    ]);
+  });
+
+  it('keeps the internal capability ceiling fail-closed', () => {
+    expect(deriveReleaseBusV2LaneStates('STAGING', runningControls)).toEqual([
+      {
+        lane: 'STAGING',
+        status: 'ON',
+        changeable: true,
+        reason: 'Staging enabled'
+      },
+      {
+        lane: 'PRODUCTION',
+        status: 'OFF',
+        changeable: false,
+        reason: 'Internal Release Bus hard stop is active'
+      }
+    ]);
+    expect(deriveReleaseBusV2LaneStates('OFF', runningControls)).toEqual([
+      {
+        lane: 'STAGING',
+        status: 'OFF',
+        changeable: false,
+        reason: 'Internal Release Bus hard stop is active'
+      },
+      {
+        lane: 'PRODUCTION',
+        status: 'OFF',
+        changeable: false,
+        reason: 'Internal Release Bus hard stop is active'
+      }
+    ]);
+  });
+
+  it('fails closed when an internal control is missing or duplicated', () => {
+    expect(() =>
+      deriveReleaseBusV2LaneStates(
+        'PRODUCTION',
+        runningControls.filter(({ scope }) => scope !== 'ALL')
+      )
+    ).toThrow('ALL control is unavailable');
+    expect(() =>
+      deriveReleaseBusV2LaneStates('PRODUCTION', [
+        ...runningControls,
+        runningControls[0]
+      ])
+    ).toThrow('ALL control is unavailable');
   });
 });

--- a/src/releaseBusV2/release-bus-v2.config.test.ts
+++ b/src/releaseBusV2/release-bus-v2.config.test.ts
@@ -355,4 +355,38 @@ describe('deriveReleaseBusV2LaneStates', () => {
       ])
     ).toThrow('ALL control is unavailable');
   });
+
+  it.each([
+    ['ALL', 'paused', '1', 'ALL'],
+    ['STAGING', 'reason', undefined, 'STAGING'],
+    ['PRODUCTION', 'reason', false, 'PRODUCTION']
+  ])(
+    'fails closed when %s has malformed %s data',
+    (scope, field, malformedValue, expectedScope) => {
+      const controls = runningControls.map((control) =>
+        control.scope === scope
+          ? { ...control, [field]: malformedValue }
+          : control
+      );
+      expect(() =>
+        deriveReleaseBusV2LaneStates(
+          'PRODUCTION',
+          controls as unknown as typeof runningControls
+        )
+      ).toThrow(`Release Bus v2 ${expectedScope} control is invalid`);
+    }
+  );
+
+  it('fails closed when an unknown extra control is present', () => {
+    expect(() =>
+      deriveReleaseBusV2LaneStates('PRODUCTION', [
+        ...runningControls,
+        {
+          scope: 'UNKNOWN' as 'ALL',
+          paused: false,
+          reason: null
+        }
+      ])
+    ).toThrow('ALL control is unavailable');
+  });
 });

--- a/src/releaseBusV2/release-bus-v2.config.ts
+++ b/src/releaseBusV2/release-bus-v2.config.ts
@@ -1,10 +1,14 @@
 import type {
+  ReleaseBusV2AutomationLane,
   ReleaseBusV2CandidateRecord,
+  ReleaseBusV2ControlScope,
   ReleaseBusV2Lane,
+  ReleaseBusV2LaneState,
   ReleaseBusV2Mode,
   ReleaseBusV2RegisterInput,
   ReleaseBusV2Repository
 } from '@/releaseBusV2/release-bus-v2.types';
+import { RELEASE_BUS_V2_AUTOMATION_LANES } from '@/releaseBusV2/release-bus-v2.types';
 
 export const RELEASE_BUS_OPERATOR_TEAM =
   process.env.RELEASE_BUS_OPERATOR_TEAM ?? 'release-bus-operators';
@@ -270,6 +274,55 @@ export function releaseBusV2AllowsLane(
   lane: 'STAGING' | 'PRODUCTION'
 ): boolean {
   return mode === 'PRODUCTION' || (mode === 'STAGING' && lane === 'STAGING');
+}
+
+type ReleaseBusV2ControlState = {
+  readonly scope: ReleaseBusV2ControlScope;
+  readonly paused: boolean | number;
+  readonly reason?: string | null;
+};
+
+function requireControl(
+  controls: readonly ReleaseBusV2ControlState[],
+  scope: ReleaseBusV2ControlScope
+): ReleaseBusV2ControlState {
+  const matches = controls.filter((control) => control.scope === scope);
+  if (matches.length !== 1)
+    throw new Error(`Release Bus v2 ${scope} control is unavailable`);
+  return matches[0];
+}
+
+function deriveReleaseBusV2LaneState(
+  mode: ReleaseBusV2Mode,
+  controls: readonly ReleaseBusV2ControlState[],
+  lane: ReleaseBusV2AutomationLane
+): ReleaseBusV2LaneState {
+  const globalControl = requireControl(controls, 'ALL');
+  const laneControl = requireControl(controls, lane);
+  const modeAllowsLane = releaseBusV2AllowsLane(mode, lane);
+  const globalPaused = Boolean(globalControl.paused);
+  const lanePaused = Boolean(laneControl.paused);
+  const enabled = modeAllowsLane && !globalPaused && !lanePaused;
+  const reason = !modeAllowsLane
+    ? 'Internal Release Bus hard stop is active'
+    : globalPaused
+      ? (globalControl.reason ?? 'Internal Release Bus hard stop is active')
+      : (laneControl.reason ?? null);
+  return {
+    lane,
+    status: enabled ? 'ON' : 'OFF',
+    changeable: modeAllowsLane && !globalPaused,
+    reason
+  };
+}
+
+export function deriveReleaseBusV2LaneStates(
+  mode: ReleaseBusV2Mode,
+  controls: readonly ReleaseBusV2ControlState[]
+): readonly ReleaseBusV2LaneState[] {
+  return RELEASE_BUS_V2_AUTOMATION_LANES.map((lane) =>
+    deriveReleaseBusV2LaneState(mode, controls, lane)
+  );
 }
 
 export const RELEASE_BUS_V2_LOCK_TTL_MS = 5 * 60 * 1000;

--- a/src/releaseBusV2/release-bus-v2.config.ts
+++ b/src/releaseBusV2/release-bus-v2.config.ts
@@ -8,7 +8,10 @@ import type {
   ReleaseBusV2RegisterInput,
   ReleaseBusV2Repository
 } from '@/releaseBusV2/release-bus-v2.types';
-import { RELEASE_BUS_V2_AUTOMATION_LANES } from '@/releaseBusV2/release-bus-v2.types';
+import {
+  RELEASE_BUS_V2_AUTOMATION_LANES,
+  RELEASE_BUS_V2_CONTROL_SCOPES
+} from '@/releaseBusV2/release-bus-v2.types';
 
 export const RELEASE_BUS_OPERATOR_TEAM =
   process.env.RELEASE_BUS_OPERATOR_TEAM ?? 'release-bus-operators';
@@ -277,19 +280,41 @@ export function releaseBusV2AllowsLane(
 }
 
 type ReleaseBusV2ControlState = {
+  readonly scope: unknown;
+  readonly paused: unknown;
+  readonly reason?: unknown;
+};
+
+type ValidatedReleaseBusV2ControlState = {
   readonly scope: ReleaseBusV2ControlScope;
-  readonly paused: boolean | number;
-  readonly reason?: string | null;
+  readonly paused: boolean;
+  readonly reason: string | null;
 };
 
 function requireControl(
   controls: readonly ReleaseBusV2ControlState[],
   scope: ReleaseBusV2ControlScope
-): ReleaseBusV2ControlState {
-  const matches = controls.filter((control) => control.scope === scope);
-  if (matches.length !== 1)
+): ValidatedReleaseBusV2ControlState {
+  if (controls.length !== RELEASE_BUS_V2_CONTROL_SCOPES.length) {
     throw new Error(`Release Bus v2 ${scope} control is unavailable`);
-  return matches[0];
+  }
+  const matches = controls.filter((control) => control.scope === scope);
+  if (matches.length !== 1) {
+    throw new Error(`Release Bus v2 ${scope} control is unavailable`);
+  }
+  const match = matches[0];
+  let paused: boolean;
+  if (match.paused === true || match.paused === 1) {
+    paused = true;
+  } else if (match.paused === false || match.paused === 0) {
+    paused = false;
+  } else {
+    throw new Error(`Release Bus v2 ${scope} control is invalid`);
+  }
+  if (match.reason !== null && typeof match.reason !== 'string') {
+    throw new Error(`Release Bus v2 ${scope} control is invalid`);
+  }
+  return { scope, paused, reason: match.reason };
 }
 
 function deriveReleaseBusV2LaneState(
@@ -300,14 +325,15 @@ function deriveReleaseBusV2LaneState(
   const globalControl = requireControl(controls, 'ALL');
   const laneControl = requireControl(controls, lane);
   const modeAllowsLane = releaseBusV2AllowsLane(mode, lane);
-  const globalPaused = Boolean(globalControl.paused);
-  const lanePaused = Boolean(laneControl.paused);
+  const globalPaused = globalControl.paused;
+  const lanePaused = laneControl.paused;
   const enabled = modeAllowsLane && !globalPaused && !lanePaused;
-  const reason = !modeAllowsLane
-    ? 'Internal Release Bus hard stop is active'
-    : globalPaused
-      ? (globalControl.reason ?? 'Internal Release Bus hard stop is active')
-      : (laneControl.reason ?? null);
+  let reason = laneControl.reason;
+  if (!modeAllowsLane) {
+    reason = 'Internal Release Bus hard stop is active';
+  } else if (globalPaused) {
+    reason = globalControl.reason ?? 'Internal Release Bus hard stop is active';
+  }
   return {
     lane,
     status: enabled ? 'ON' : 'OFF',

--- a/src/releaseBusV2/release-bus-v2.types.ts
+++ b/src/releaseBusV2/release-bus-v2.types.ts
@@ -20,6 +20,20 @@ export const RELEASE_BUS_V2_CONTROL_SCOPES = [
 export type ReleaseBusV2ControlScope =
   (typeof RELEASE_BUS_V2_CONTROL_SCOPES)[number];
 
+export const RELEASE_BUS_V2_AUTOMATION_LANES = [
+  'STAGING',
+  'PRODUCTION'
+] as const;
+export type ReleaseBusV2AutomationLane =
+  (typeof RELEASE_BUS_V2_AUTOMATION_LANES)[number];
+
+export type ReleaseBusV2LaneState = {
+  readonly lane: ReleaseBusV2AutomationLane;
+  readonly status: 'ON' | 'OFF';
+  readonly changeable: boolean;
+  readonly reason: string | null;
+};
+
 export type ReleaseBusV2DependencyEnvironment =
   | 'STAGING'
   | 'PRODUCTION'


### PR DESCRIPTION
## Summary

- expose authenticated-source Release Bus state for anonymous reads while keeping every mutation authorization-protected
- derive and return only the two effective developer-facing Staging/Production lanes, with raw mode and `ALL` retained as hidden emergency fences
- replace the legacy dashboard with separate lane blocks, deployed/validated SHAs, current/projected/history trains, exact PR/dependency/DAG detail, expandable diagnostics, shared filters/pagination, and contextual authenticated actions
- synchronize the authoritative and `.agents` deploy skill copies, helper contract, OpenAPI/generated models, and operator docs, including PR #1866 production-replan coalescing semantics
- harden malformed status/control handling, dashboard request recovery, train-detail isolation, URL safety, and authenticated startup ordering in response to review

## Verification

- `npm run build` — 296 suites / 2,829 tests and TypeScript passed
- focused Release Bus/helper/UI/routes/config suite — 4 suites / 143 tests passed
- API OpenAPI regeneration parity and API bundle build passed with no generated drift
- backend lint, targeted format checks, and `git diff --check` passed
- real local browser QA passed for anonymous read-only rendering, lane heads/trains/PR views, filtering, focus styling, no legacy/ALL controls, no horizontal overflow, and no console errors; authenticated and responsive fixture coverage remains green
- exact review head: `a745ffb71a68ad4b2745256618dc93fd2bef8818`
- exact-head 6529bot follow-up: no new findings; Sonar: zero new issues; all CodeRabbit threads addressed and resolved

## Rollout / coordination

- based on exact deployed backend main `413711ecd5147ba7f83ed3080b0cf3eda1edebac` from PR #1866
- the PR #1866 worktree, branch, PR, and rollout were not modified or interrupted
- no database migration; deploy API/UI before `releaseBus` so the older/newer runtime combination remains additive-compatible
- frontend companion is documentation/helper/skill-only and does not require a frontend runtime deployment
