### PR TITLE
Add surgical production TDH repair for Meme 68

### DIFF
--- a/src/backend.ts
+++ b/src/backend.ts
@@ -84,11 +84,18 @@ async function runRequestedLoopIfPresent() {
 async function start() {
   logger.info(`[CONFIG ${process.env.NODE_ENV}] [EXECUTING START SCRIPT...]`);
 
-  await dbMigrationsLoop.handler(
-    undefined as any,
-    undefined as any,
-    undefined as any
-  );
+  const requestedLoopName = getRequestedLoopName();
+  if (requestedLoopName === 'customReplayLoop') {
+    logger.info(
+      `[SKIPPING DB MIGRATIONS FOR SURGICAL LOOP] [${requestedLoopName}]`
+    );
+  } else {
+    await dbMigrationsLoop.handler(
+      undefined as any,
+      undefined as any,
+      undefined as any
+    );
+  }
 
   await runRequestedLoopIfPresent();
 

--- a/src/customReplayLoop/index.ts
+++ b/src/customReplayLoop/index.ts
@@ -1,6 +1,9 @@
 import { doInDbContext } from '../secrets';
 import { Logger } from '../logging';
 import * as sentryContext from '../sentry.context';
+import { ConsolidatedNFTOwner, NFTOwner } from '../entities/INFTOwner';
+import { Transaction } from '../entities/ITransaction';
+import { repairDuplicatedMeme68Transfer } from './repair-duplicated-meme-68-transfer';
 
 const logger = Logger.get('CUSTOM_REPLAY_LOOP');
 
@@ -9,10 +12,17 @@ export const handler = sentryContext.wrapLambdaHandler(async () => {
     async () => {
       await replay();
     },
-    { logger }
+    {
+      logger,
+      entities: [Transaction, NFTOwner, ConsolidatedNFTOwner],
+      skipRedis: true
+    }
   );
 });
 
 async function replay() {
-  logger.info(`[CUSTOM REPLAY NOT IMPLEMENTED]`);
+  const apply = process.env.CUSTOM_REPLAY_APPLY === 'true';
+  logger.info(`[CUSTOM REPLAY MODE] [${apply ? 'APPLY' : 'DRY RUN'}]`);
+  const result = await repairDuplicatedMeme68Transfer(apply);
+  logger.info(`[CUSTOM REPLAY COMPLETE] [RESULT ${result}]`);
 }

--- a/src/customReplayLoop/repair-duplicated-meme-68-transfer.test.ts
+++ b/src/customReplayLoop/repair-duplicated-meme-68-transfer.test.ts
@@ -1,0 +1,104 @@
+import {
+  classifyProdTdhRepairSnapshot,
+  ProdTdhRepairSnapshot
+} from './repair-duplicated-meme-68-transfer';
+
+type SnapshotValues = {
+  transactionCount: number;
+  recipientOwnerBalance: number;
+  recipientConsolidatedBalance: number;
+};
+
+const NEEDS_REPAIR: SnapshotValues = {
+  transactionCount: 2,
+  recipientOwnerBalance: 2,
+  recipientConsolidatedBalance: 2
+};
+
+const REPAIRED: SnapshotValues = {
+  transactionCount: 1,
+  recipientOwnerBalance: 1,
+  recipientConsolidatedBalance: 1
+};
+
+function snapshot(values: SnapshotValues): ProdTdhRepairSnapshot {
+  const tokenValue = (value: number) => [{ tokenId: 68, value }];
+  return {
+    transactions: tokenValue(values.transactionCount),
+    senderOwners: [],
+    recipientOwners: tokenValue(values.recipientOwnerBalance),
+    recipientConsolidatedOwners: tokenValue(values.recipientConsolidatedBalance)
+  };
+}
+
+describe('classifyProdTdhRepairSnapshot', () => {
+  it('recognizes the exact production state that needs repair', () => {
+    expect(classifyProdTdhRepairSnapshot(snapshot(NEEDS_REPAIR))).toBe(
+      'needs-repair'
+    );
+  });
+
+  it('recognizes an already repaired state', () => {
+    expect(classifyProdTdhRepairSnapshot(snapshot(REPAIRED))).toBe(
+      'already-repaired'
+    );
+  });
+
+  it('rejects a partial repair', () => {
+    const partial = snapshot({
+      ...NEEDS_REPAIR,
+      recipientOwnerBalance: REPAIRED.recipientOwnerBalance
+    });
+
+    expect(() => classifyProdTdhRepairSnapshot(partial)).toThrow(
+      '[RECIPIENT OWNER] Expected token 68 value 2, found 1'
+    );
+  });
+
+  it('rejects a missing target row', () => {
+    const missing = {
+      ...snapshot(NEEDS_REPAIR),
+      transactions: []
+    };
+
+    expect(() => classifyProdTdhRepairSnapshot(missing)).toThrow(
+      '[TRANSACTION] Expected 1 row, found 0'
+    );
+  });
+
+  it('rejects an unexpected duplicate target row', () => {
+    const duplicateTransaction = {
+      ...snapshot(NEEDS_REPAIR),
+      transactions: [
+        { tokenId: 68, value: 2 },
+        { tokenId: 68, value: 2 }
+      ]
+    };
+
+    expect(() => classifyProdTdhRepairSnapshot(duplicateTransaction)).toThrow(
+      '[TRANSACTION] Expected 1 row, found 2'
+    );
+  });
+
+  it('rejects an unexpected token', () => {
+    const wrongToken = {
+      ...snapshot(NEEDS_REPAIR),
+      recipientOwners: [{ tokenId: 69, value: 2 }]
+    };
+
+    expect(() => classifyProdTdhRepairSnapshot(wrongToken)).toThrow(
+      '[RECIPIENT OWNER] Expected token 68, found 69'
+    );
+  });
+
+  it('rejects unexpected positive sender ownership', () => {
+    const unexpectedSenderOwner = {
+      ...snapshot(NEEDS_REPAIR),
+      senderOwners: [{ tokenId: 68, value: 1 }]
+    };
+
+    expect(() => classifyProdTdhRepairSnapshot(unexpectedSenderOwner)).toThrow(
+      '[SENDER OWNERS] Expected no positive owner rows, found 1'
+    );
+  });
+});

--- a/src/customReplayLoop/repair-duplicated-meme-68-transfer.ts
+++ b/src/customReplayLoop/repair-duplicated-meme-68-transfer.ts
@@ -1,0 +1,306 @@
+import { EntityManager, Repository } from 'typeorm';
+import { getDataSource } from '../db';
+import { ConsolidatedNFTOwner, NFTOwner } from '../entities/INFTOwner';
+import { Transaction } from '../entities/ITransaction';
+import { Logger } from '../logging';
+
+const TRANSACTION_HASH =
+  '0xfe14ce51f9ef4313f7700f03124ca79c7422e3a8a47b0998d8e9c1328d3f93db';
+const TRANSACTION_BLOCK = 25624332;
+const MEMES_CONTRACT = '0x33fd426905f149f8376e227d0c9d3340aad17af1';
+const SENDER = '0x362ae71209f5640214ee0783b5da680505f8d562';
+const RECIPIENT = '0xed3d302285c8830c3d4b6a01dfd9bfda7e2ea26c';
+const TOKEN_ID = 68;
+const INCORRECT_BALANCE = 2;
+const CORRECT_BALANCE = 1;
+
+const logger = Logger.get('CUSTOM_REPLAY_MEME_68_TDH_REPAIR');
+
+type TokenValue = {
+  readonly tokenId: number;
+  readonly value: number;
+};
+
+type ExpectedRepairValues = {
+  readonly transactionCount: number;
+  readonly recipientOwnerBalance: number;
+  readonly recipientConsolidatedBalance: number;
+};
+
+const NEEDS_REPAIR: ExpectedRepairValues = {
+  transactionCount: INCORRECT_BALANCE,
+  recipientOwnerBalance: INCORRECT_BALANCE,
+  recipientConsolidatedBalance: INCORRECT_BALANCE
+};
+
+const REPAIRED: ExpectedRepairValues = {
+  transactionCount: CORRECT_BALANCE,
+  recipientOwnerBalance: CORRECT_BALANCE,
+  recipientConsolidatedBalance: CORRECT_BALANCE
+};
+
+export type ProdTdhRepairSnapshot = {
+  readonly transactions: TokenValue[];
+  readonly senderOwners: TokenValue[];
+  readonly recipientOwners: TokenValue[];
+  readonly recipientConsolidatedOwners: TokenValue[];
+};
+
+export type ProdTdhRepairState = 'needs-repair' | 'already-repaired';
+
+export type ProdTdhRepairResult =
+  | 'DRY_RUN_VERIFIED'
+  | 'REPAIRED'
+  | 'ALREADY_REPAIRED';
+
+function assertSingleTokenValue(
+  label: string,
+  rows: TokenValue[],
+  expectedValue: number
+): void {
+  if (rows.length !== 1) {
+    throw new Error(`[${label}] Expected 1 row, found ${rows.length}`);
+  }
+  if (rows[0].tokenId !== TOKEN_ID) {
+    throw new Error(
+      `[${label}] Expected token ${TOKEN_ID}, found ${rows[0].tokenId}`
+    );
+  }
+  if (rows[0].value !== expectedValue) {
+    throw new Error(
+      `[${label}] Expected token ${TOKEN_ID} value ${expectedValue}, found ${rows[0].value}`
+    );
+  }
+}
+
+function assertSnapshotValues(
+  snapshot: ProdTdhRepairSnapshot,
+  expected: ExpectedRepairValues
+): void {
+  if (snapshot.senderOwners.length > 0) {
+    throw new Error(
+      `[SENDER OWNERS] Expected no positive owner rows, found ${snapshot.senderOwners.length}`
+    );
+  }
+  assertSingleTokenValue(
+    'TRANSACTION',
+    snapshot.transactions,
+    expected.transactionCount
+  );
+  assertSingleTokenValue(
+    'RECIPIENT OWNER',
+    snapshot.recipientOwners,
+    expected.recipientOwnerBalance
+  );
+  assertSingleTokenValue(
+    'RECIPIENT CONSOLIDATED OWNER',
+    snapshot.recipientConsolidatedOwners,
+    expected.recipientConsolidatedBalance
+  );
+}
+
+function snapshotMatches(
+  snapshot: ProdTdhRepairSnapshot,
+  expected: ExpectedRepairValues
+): boolean {
+  try {
+    assertSnapshotValues(snapshot, expected);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function classifyProdTdhRepairSnapshot(
+  snapshot: ProdTdhRepairSnapshot
+): ProdTdhRepairState {
+  if (snapshotMatches(snapshot, REPAIRED)) {
+    return 'already-repaired';
+  }
+  if (snapshotMatches(snapshot, NEEDS_REPAIR)) {
+    return 'needs-repair';
+  }
+
+  assertSnapshotValues(snapshot, NEEDS_REPAIR);
+  throw new Error('[CUSTOM REPLAY] Unexpected repair state');
+}
+
+function toTokenValues<T>(
+  rows: T[],
+  tokenId: (row: T) => number,
+  value: (row: T) => number
+): TokenValue[] {
+  return rows.map((row) => ({
+    tokenId: Number(tokenId(row)),
+    value: Number(value(row))
+  }));
+}
+
+async function findTransactionsForUpdate(
+  manager: EntityManager
+): Promise<Transaction[]> {
+  return manager
+    .getRepository(Transaction)
+    .createQueryBuilder('tx')
+    .setLock('pessimistic_write')
+    .where('tx.transaction = :transactionHash', {
+      transactionHash: TRANSACTION_HASH
+    })
+    .andWhere('tx.block = :block', { block: TRANSACTION_BLOCK })
+    .andWhere('tx.from_address = :sender', { sender: SENDER })
+    .andWhere('tx.to_address = :recipient', { recipient: RECIPIENT })
+    .andWhere('tx.contract = :contract', { contract: MEMES_CONTRACT })
+    .andWhere('tx.token_id = :tokenId', { tokenId: TOKEN_ID })
+    .getMany();
+}
+
+async function findOwnersForUpdate(
+  repository: Repository<NFTOwner>,
+  wallet: string
+): Promise<NFTOwner[]> {
+  return repository
+    .createQueryBuilder('owner')
+    .setLock('pessimistic_write')
+    .where('owner.wallet = :wallet', { wallet })
+    .andWhere('owner.contract = :contract', { contract: MEMES_CONTRACT })
+    .andWhere('owner.token_id = :tokenId', { tokenId: TOKEN_ID })
+    .getMany();
+}
+
+async function findRecipientConsolidatedOwnersForUpdate(
+  manager: EntityManager
+): Promise<ConsolidatedNFTOwner[]> {
+  return manager
+    .getRepository(ConsolidatedNFTOwner)
+    .createQueryBuilder('owner')
+    .setLock('pessimistic_write')
+    .where('owner.consolidation_key = :consolidationKey', {
+      consolidationKey: RECIPIENT
+    })
+    .andWhere('owner.contract = :contract', { contract: MEMES_CONTRACT })
+    .andWhere('owner.token_id = :tokenId', { tokenId: TOKEN_ID })
+    .getMany();
+}
+
+async function loadSnapshot(
+  manager: EntityManager
+): Promise<ProdTdhRepairSnapshot> {
+  const ownerRepository = manager.getRepository(NFTOwner);
+  const transactions = await findTransactionsForUpdate(manager);
+  const senderOwners = await findOwnersForUpdate(ownerRepository, SENDER);
+  const recipientOwners = await findOwnersForUpdate(ownerRepository, RECIPIENT);
+  const recipientConsolidatedOwners =
+    await findRecipientConsolidatedOwnersForUpdate(manager);
+
+  return {
+    transactions: toTokenValues(
+      transactions,
+      (row) => row.token_id,
+      (row) => row.token_count
+    ),
+    senderOwners: toTokenValues(
+      senderOwners,
+      (row) => row.token_id,
+      (row) => row.balance
+    ),
+    recipientOwners: toTokenValues(
+      recipientOwners,
+      (row) => row.token_id,
+      (row) => row.balance
+    ),
+    recipientConsolidatedOwners: toTokenValues(
+      recipientConsolidatedOwners,
+      (row) => row.token_id,
+      (row) => row.balance
+    )
+  };
+}
+
+function assertOneAffected(
+  label: string,
+  affected: number | null | undefined
+): void {
+  if (affected !== 1) {
+    throw new Error(
+      `[${label}] Expected to update 1 row, updated ${affected ?? 0}`
+    );
+  }
+}
+
+async function applyRepair(manager: EntityManager): Promise<void> {
+  const transactionUpdate = await manager.getRepository(Transaction).update(
+    {
+      transaction: TRANSACTION_HASH,
+      block: TRANSACTION_BLOCK,
+      from_address: SENDER,
+      to_address: RECIPIENT,
+      contract: MEMES_CONTRACT,
+      token_id: TOKEN_ID,
+      token_count: INCORRECT_BALANCE
+    },
+    { token_count: CORRECT_BALANCE }
+  );
+  assertOneAffected('TRANSACTION', transactionUpdate.affected);
+
+  const ownerUpdate = await manager.getRepository(NFTOwner).update(
+    {
+      wallet: RECIPIENT,
+      contract: MEMES_CONTRACT,
+      token_id: TOKEN_ID,
+      balance: INCORRECT_BALANCE
+    },
+    { balance: CORRECT_BALANCE }
+  );
+  assertOneAffected('RECIPIENT OWNER', ownerUpdate.affected);
+
+  const consolidatedOwnerUpdate = await manager
+    .getRepository(ConsolidatedNFTOwner)
+    .update(
+      {
+        consolidation_key: RECIPIENT,
+        contract: MEMES_CONTRACT,
+        token_id: TOKEN_ID,
+        balance: INCORRECT_BALANCE
+      },
+      { balance: CORRECT_BALANCE }
+    );
+  assertOneAffected(
+    'RECIPIENT CONSOLIDATED OWNER',
+    consolidatedOwnerUpdate.affected
+  );
+}
+
+export async function repairDuplicatedMeme68Transfer(
+  apply = false
+): Promise<ProdTdhRepairResult> {
+  return getDataSource().transaction(async (manager) => {
+    const before = await loadSnapshot(manager);
+    const state = classifyProdTdhRepairSnapshot(before);
+
+    if (state === 'already-repaired') {
+      logger.info('[CUSTOM REPLAY] Meme 68 TDH data is already repaired');
+      return 'ALREADY_REPAIRED';
+    }
+
+    if (!apply) {
+      logger.info(
+        `[CUSTOM REPLAY] [DRY RUN VERIFIED] Would update transaction, recipient owner, and recipient consolidated owner balances from ${INCORRECT_BALANCE} to ${CORRECT_BALANCE} for token ${TOKEN_ID}`
+      );
+      return 'DRY_RUN_VERIFIED';
+    }
+
+    logger.info(
+      `[CUSTOM REPLAY] Repairing transaction ${TRANSACTION_HASH}, token ${TOKEN_ID}`
+    );
+    await applyRepair(manager);
+
+    const after = await loadSnapshot(manager);
+    const afterState = classifyProdTdhRepairSnapshot(after);
+    if (afterState !== 'already-repaired') {
+      throw new Error('[CUSTOM REPLAY] Post-repair verification failed');
+    }
+
+    logger.info('[CUSTOM REPLAY] Meme 68 TDH data repair verified');
+    return 'REPAIRED';
+  });
+}


### PR DESCRIPTION
## Issue
- Production recorded transaction `0xfe14ce51f9ef4313f7700f03124ca79c7422e3a8a47b0998d8e9c1328d3f93db` for Meme #68 with `token_count = 2`, although the ERC-1155 receipt contains one transferred edition.
- The doubled transfer left the recipient raw and consolidated owner balances at `2` instead of `1`, producing a 4 TDH oracle mismatch after the first full holding day.

## Fix
- Add a one-shot `customReplayLoop` repair that validates the complete known-bad production state and defaults to dry-run.
- Apply the three exact corrections atomically only when every target row and value matches the expected pre-repair snapshot.

## Changes
- Target the exact transaction hash, block, contract, token, sender, and recipient.
- Lock and verify the transaction row, recipient owner row, recipient consolidated-owner row, and absence of a sender owner row.
- Change only `token_count` and the two recipient balances from `2` to `1`.
- Require exactly one affected row for every update and verify the complete repaired state before commit.
- Return safely when the database is already repaired; abort on missing, duplicate, partial, or unexpected state.
- Skip Redis initialization and database migration/schema-sync execution for this surgical replay path.
- No schema, entity, API contract, dependency, deploy configuration, or architecture-shape changes.

## Validation
- Focused replay-state suite passes: 7 tests covering bad, repaired, partial, missing, duplicate, wrong-token, and unexpected-sender states.
- Repository-wide ESLint passes without errors or warnings.
- Targeted Prettier checks pass.
- The complete TypeScript project compiles with `tsc --noEmit`.
- The repository's default Jest bootstrap could not start its MySQL testcontainer because Docker is unavailable in the execution environment; the DB-independent focused suite was run with isolated Jest configuration.

## Risk
- Level: High
- Why: This is intentionally capable of mutating three production rows that feed ownership and TDH.
- Mitigation: dry-run is the default; exact preconditions, pessimistic locks, one database transaction, exact affected-row assertions, post-write verification, and idempotency prevent broad or partial writes.
- Rollback: do not apply unless the dry run reports the exact known-bad snapshot. If an update or post-write assertion fails, the transaction rolls back automatically.

## Deployment
- None. This one-shot repair is run directly from the reviewed branch; no backend service deployment is required.
- Production runbook:

  ```bash
  CUSTOM_REPLAY_APPLY=false npm run backend:local -- customReplayLoop
  CUSTOM_REPLAY_APPLY=true npm run backend:local -- customReplayLoop
  CUSTOM_REPLAY_APPLY=false npm run backend:local -- customReplayLoop
  ```

- Expected results are `DRY_RUN_VERIFIED`, then `REPAIRED`, then `ALREADY_REPAIRED`.
- Run the apply step only after reviewing the first dry-run output and explicitly authorizing the production mutation.
- After the repair, run a full `tdhLoop` calculation or allow the next scheduled calculation to rebuild derived TDH rows, then verify the production oracle against Core.

## Review Notes
- Please focus on the hard-coded target identifiers, expected before/after values, sender-row absence, and all-or-nothing transaction behavior.
- This PR repairs the current production data only. The underlying ingestion prevention remains in #1861.
