### PR TITLE
Retry transient manual deploy authorization

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -269,11 +269,27 @@ jobs:
             payload="$(jq -n               --arg repository backend               --arg environment "$INPUT_ENVIRONMENT"               --arg service "$INPUT_SERVICE"               --arg workflow_run_id "$GITHUB_RUN_ID"               --argjson workflow_run_attempt "$GITHUB_RUN_ATTEMPT"               --arg source_ref "$GITHUB_REF_NAME"               --arg source_sha "$GITHUB_SHA"               '{repository:$repository,environment:$environment,service:$service,workflow_run_id:$workflow_run_id,workflow_run_attempt:$workflow_run_attempt,source_ref:$source_ref,source_sha:$source_sha}')"
             endpoint=release-bus-v2/manual-deployment-readiness
           fi
-          http_status="$(curl --silent --show-error             --connect-timeout 10             --max-time 60             --output "$response_file"             --write-out '%{http_code}'             -H "Authorization: Bearer $RELEASE_BUS_WORKFLOW_AUTH_TOKEN"             -H 'Content-Type: application/json'             --data "$payload"             "$RELEASE_BUS_API_URL/deploy/$endpoint")"
-          if [ "$http_status" != 200 ]; then
-            echo "::error::Deployment authorization was rejected with HTTP $http_status"
+          authorization_attempt=1
+          authorization_max_attempts=6
+          while true; do
+            http_status="$(curl --silent --show-error               --connect-timeout 10               --max-time 60               --output "$response_file"               --write-out '%{http_code}'               -H "Authorization: Bearer $RELEASE_BUS_WORKFLOW_AUTH_TOKEN"               -H 'Content-Type: application/json'               --data "$payload"               "$RELEASE_BUS_API_URL/deploy/$endpoint")"
+            if [ "$http_status" = 200 ]; then
+              break
+            fi
+            if [ -z "$INPUT_OPERATION_KEY" ] && [ "$http_status" = 409 ] && [ "$authorization_attempt" -lt "$authorization_max_attempts" ]; then
+              echo "Manual deployment authorization is not ready; retrying after GitHub run-state propagation"
+              authorization_attempt=$((authorization_attempt + 1))
+              sleep 5
+              continue
+            fi
+            rejection_reason="$(jq -r '(.message // .error // empty) | tostring' "$response_file" 2>/dev/null | tr '\r\n' ' ' | cut -c1-300)"
+            if [ -n "$rejection_reason" ]; then
+              echo "::error::Deployment authorization was rejected with HTTP $http_status: $rejection_reason"
+            else
+              echo "::error::Deployment authorization was rejected with HTTP $http_status"
+            fi
             exit 1
-          fi
+          done
           if [ -n "$INPUT_OPERATION_KEY" ]; then
             jq -e               --arg train_id "$INPUT_TRAIN_ID"               --arg operation_key "$INPUT_OPERATION_KEY"               '.authorized == true and .train_id == $train_id and
                .operation_key == $operation_key'               "$response_file" > /dev/null

--- a/scripts/generate-deploy-config.mjs
+++ b/scripts/generate-deploy-config.mjs
@@ -315,19 +315,35 @@ jobs:
               '{repository:$repository,environment:$environment,service:$service,workflow_run_id:$workflow_run_id,workflow_run_attempt:$workflow_run_attempt,source_ref:$source_ref,source_sha:$source_sha}')"
             endpoint=release-bus-v2/manual-deployment-readiness
           fi
-          http_status="$(curl --silent --show-error \
-            --connect-timeout 10 \
-            --max-time 60 \
-            --output "$response_file" \
-            --write-out '%{http_code}' \
-            -H "Authorization: Bearer $RELEASE_BUS_WORKFLOW_AUTH_TOKEN" \
-            -H 'Content-Type: application/json' \
-            --data "$payload" \
-            "$RELEASE_BUS_API_URL/deploy/$endpoint")"
-          if [ "$http_status" != 200 ]; then
-            echo "::error::Deployment authorization was rejected with HTTP $http_status"
+          authorization_attempt=1
+          authorization_max_attempts=6
+          while true; do
+            http_status="$(curl --silent --show-error \
+              --connect-timeout 10 \
+              --max-time 60 \
+              --output "$response_file" \
+              --write-out '%{http_code}' \
+              -H "Authorization: Bearer $RELEASE_BUS_WORKFLOW_AUTH_TOKEN" \
+              -H 'Content-Type: application/json' \
+              --data "$payload" \
+              "$RELEASE_BUS_API_URL/deploy/$endpoint")"
+            if [ "$http_status" = 200 ]; then
+              break
+            fi
+            if [ -z "$INPUT_OPERATION_KEY" ] && [ "$http_status" = 409 ] && [ "$authorization_attempt" -lt "$authorization_max_attempts" ]; then
+              echo "Manual deployment authorization is not ready; retrying after GitHub run-state propagation"
+              authorization_attempt=$((authorization_attempt + 1))
+              sleep 5
+              continue
+            fi
+            rejection_reason="$(jq -r '(.message // .error // empty) | tostring' "$response_file" 2>/dev/null | tr '\\r\\n' ' ' | cut -c1-300)"
+            if [ -n "$rejection_reason" ]; then
+              echo "::error::Deployment authorization was rejected with HTTP $http_status: $rejection_reason"
+            else
+              echo "::error::Deployment authorization was rejected with HTTP $http_status"
+            fi
             exit 1
-          fi
+          done
           if [ -n "$INPUT_OPERATION_KEY" ]; then
             jq -e \
               --arg train_id "$INPUT_TRAIN_ID" \

--- a/src/releaseBusV2/release-bus-v2-performance-workflow.test.ts
+++ b/src/releaseBusV2/release-bus-v2-performance-workflow.test.ts
@@ -153,6 +153,12 @@ describe('Release Bus v2 backend critical-path contract', () => {
     expect(guard).toContain('--arg source_sha "$GITHUB_SHA"');
     expect(guard).toContain('.ready == true and .mode == "manual"');
     expect(guard).toContain('.authorized == true and .train_id == $train_id');
+    expect(guard).toContain('authorization_max_attempts=6');
+    expect(guard).toContain(
+      '[ -z "$INPUT_OPERATION_KEY" ] && [ "$http_status" = 409 ]'
+    );
+    expect(guard).toContain('sleep 5');
+    expect(guard).toContain('rejection_reason=');
     expect(guard).not.toContain('head -c 4000');
     expect(steps[verifySource]?.if).toBeUndefined();
     expect(steps[verifySource]?.run).toContain(
@@ -285,6 +291,95 @@ printf '200'
         },
         url: 'https://release-bus.invalid/deploy/release-bus-v2/authorize'
       });
+    } finally {
+      rmSync(fixture, { recursive: true, force: true });
+    }
+  });
+
+  it('retries transient manual authorization conflicts without retrying Release Bus operations', () => {
+    const parsed = YAML.parse(deploy) as {
+      jobs: Record<string, { steps: Array<{ name?: string; run?: string }> }>;
+    };
+    const guard = parsed.jobs['build-and-deploy'].steps.find(
+      ({ name }) => name === 'Authorize exact deployment operation'
+    )?.run;
+    expect(guard).toBeTruthy();
+    const fixture = mkdtempSync(path.join(tmpdir(), 'deploy-guard-retry-'));
+    const fakeCurl = path.join(fixture, 'curl');
+    const fakeSleep = path.join(fixture, 'sleep');
+    const callCount = path.join(fixture, 'call-count.txt');
+    const response = path.join(fixture, 'response.json');
+    writeFileSync(
+      fakeCurl,
+      `#!/bin/sh
+output=
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --output) output="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+count="$(cat "$CALL_COUNT" 2>/dev/null || printf 0)"
+count=$((count + 1))
+printf '%s' "$count" > "$CALL_COUNT"
+if [ "$count" -lt 3 ]; then
+  printf '{"message":"Manual deployment workflow identity does not match this run"}' > "$output"
+  printf '409'
+else
+  cp "$CAPTURE_RESPONSE" "$output"
+  printf '200'
+fi
+`
+    );
+    writeFileSync(fakeSleep, '#!/bin/sh\nexit 0\n');
+    chmodSync(fakeCurl, 0o755);
+    chmodSync(fakeSleep, 0o755);
+    writeFileSync(
+      response,
+      `${JSON.stringify({
+        ready: true,
+        mode: 'manual',
+        lane: 'STAGING',
+        repository: 'backend',
+        environment: 'staging',
+        service: 'api',
+        workflow_run_id: '12345',
+        workflow_run_attempt: 2,
+        source_ref: '1a-staging',
+        source_sha: 'a'.repeat(40)
+      })}\n`
+    );
+    const execute = (operationKey: string) =>
+      execFileSync('bash', ['-c', guard ?? 'exit 1'], {
+        cwd: root,
+        env: {
+          ...process.env,
+          CALL_COUNT: callCount,
+          CAPTURE_RESPONSE: response,
+          GITHUB_REF_NAME: '1a-staging',
+          GITHUB_RUN_ATTEMPT: '2',
+          GITHUB_RUN_ID: '12345',
+          GITHUB_SHA: 'a'.repeat(40),
+          INPUT_ARTIFACT_DIGEST: 'b'.repeat(64),
+          INPUT_ARTIFACT_RUN_ID: '54321',
+          INPUT_ENVIRONMENT: 'staging',
+          INPUT_EXPECTED_SHA: 'a'.repeat(40),
+          INPUT_OPERATION_KEY: operationKey,
+          INPUT_SERVICE: 'api',
+          INPUT_TRAIN_ID: 'train-id',
+          PATH: `${fixture}:${process.env.PATH ?? ''}`,
+          RELEASE_BUS_API_URL: 'https://release-bus.invalid',
+          RELEASE_BUS_WORKFLOW_AUTH_TOKEN: 'test-token'
+        },
+        stdio: 'pipe'
+      });
+    try {
+      expect(() => execute('')).not.toThrow();
+      expect(readFileSync(callCount, 'utf8')).toBe('3');
+
+      writeFileSync(callCount, '0');
+      expect(() => execute('rb2:train-id:deploy:api:a1')).toThrow();
+      expect(readFileSync(callCount, 'utf8')).toBe('1');
     } finally {
       rmSync(fixture, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Issue

Manual backend deploys can receive an immediate HTTP 409 because GitHub may not yet expose a just-started workflow run as `in_progress` when the authorization gate checks it. The workflow also discarded the API's rejection reason, making these failures opaque.

## Fix

Retry only manual HTTP 409 authorization responses during a bounded 25-second propagation window. Every attempt re-runs the complete server-side readiness gate; Release Bus operations remain fail-fast.

## Changes

- Added up to six authorization attempts, five seconds apart, for manual 409 responses only.
- Surface a sanitized, bounded API rejection reason on terminal failure.
- Added a workflow contract regression covering manual retries and Release Bus no-retry behavior.
- Regenerated the deploy workflow.
- No API, schema, migration, or architecture changes.

## Validation

- Focused manual authorization retry regression passed locally.
- Generated workflow and diff checks passed.
- CI will run the full Linux validation suite.

## Risk

- **Level:** Low
- Retry scope is limited to manual 409 responses; every safety gate is re-evaluated and all other failures remain fail-closed.
- **Rollback:** Revert this PR.

## Deployment

None. The workflow change takes effect after merge.

## Review Notes

Please focus on retry scoping and fail-closed behavior.