### PR TITLE
Prepare bounded Release Bus activation proof

### DIFF
--- a/ops/deployment-bus/beta-fixtures/backend-only-1.md
+++ b/ops/deployment-bus/beta-fixtures/backend-only-1.md
@@ -1,9 +1,12 @@
 # Release Bus v2 backend-only beta fixture 1
 
 This file intentionally changes no runtime behavior. It gives the bounded
-operator-only staging acceptance test one exact green merge-tree while its
-deploy plan selects only the backend `api` unit.
+operator-only activation proof one exact green merge-tree while its explicit
+deploy plan selects only the backend `releaseBus` unit. The proof exercises
+non-force staging-ref advancement, an environment-bound artifact, manifest-
+bound staging E2E, and a fresh production composition without redeploying an
+unchanged frontend.
 
 - Test ID: `backend-only-1`
-- Candidate ID: `6549ea1d-5914-488b-b6f4-3e88cc7a222b`
-- Global Release Bus v2 mode: `OFF`
+- Prior historical candidate ID: `6549ea1d-5914-488b-b6f4-3e88cc7a222b`
+- Activation cycle: `post-staging-ref-parity`

--- a/ops/deployment-bus/beta-fixtures/backend-only-1.md
+++ b/ops/deployment-bus/beta-fixtures/backend-only-1.md
@@ -2,7 +2,7 @@
 
 This file intentionally changes no runtime behavior. It gives the bounded
 operator-only activation proof one exact green merge-tree while its explicit
-deploy plan selects only the backend `releaseBus` unit. The proof exercises
+deploy plan selects only the backend `api` unit. The proof exercises
 non-force staging-ref advancement, an environment-bound artifact, manifest-
 bound staging E2E, and a fresh production composition without redeploying an
 unchanged frontend.


### PR DESCRIPTION
## Summary

- refresh the existing operator-only backend fixture for the post-parity activation cycle
- select only the `api` deploy unit in the eventual explicit candidate plan
- keep the proof runtime-neutral while exercising staging-ref CAS, environment-bound artifacts, manifest-bound staging E2E, and fresh production composition

## Validation

- Prettier check passed
- `git diff --check` passed
- repository-wide reference audit confirms the Markdown fixture is not parsed for deploy-plan fields; the explicit registration request is authoritative

## Deployment plan

This PR is the operator-owned bounded proof candidate. Register only after the compatibility runtime is exact. Backend units: `api`; DAG edges: none; release notes: explicit opt-out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated beta deployment fixture guidance to clarify operator-only activation, backend-only deployment selection, staging validation, and production composition behavior.
  * Refined metadata and test identifiers while removing outdated release-mode information.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->