### PR TITLE
Authorize leased staging ref operations

### DIFF
--- a/src/api-serverless/src/deploy/deploy-release-bus-routes.test.ts
+++ b/src/api-serverless/src/deploy/deploy-release-bus-routes.test.ts
@@ -1146,6 +1146,33 @@ describe('Release Bus v2 route authorization and exact actions', () => {
     expect(mockManualDeploymentAuthorize).not.toHaveBeenCalled();
   });
 
+  it('accepts an exact artifact-free leased staging-ref authorization payload', async () => {
+    const body = {
+      train_id: TRAIN_ID,
+      operation_key: `rb2:${TRAIN_ID}:advance-staging:release:backend:a1`,
+      workflow_run_id: '30510086016',
+      artifact_run_id: null,
+      repository: 'backend',
+      environment: 'staging',
+      service: null,
+      expected_sha: SHA,
+      artifact_digest: null
+    };
+
+    const response = await post('/deploy/release-bus-v2/authorize', body);
+
+    expect(response.status).toBe(200);
+    expect(mockV2Authorize).toHaveBeenCalledWith({
+      ...body,
+      source_ref: null,
+      candidate_evidence_mode: null,
+      aggregate_candidate_evidence_digest: null,
+      reuse_artifact_run_id: null,
+      reuse_artifact_name: null,
+      reuse_artifact_digest: null
+    });
+  });
+
   it('accepts only a complete strict aggregate for an orchestration authorization', async () => {
     const body = {
       train_id: TRAIN_ID,

--- a/src/api-serverless/src/deploy/deploy-validation.test.ts
+++ b/src/api-serverless/src/deploy/deploy-validation.test.ts
@@ -255,6 +255,49 @@ describe('Release Bus v2 validation', () => {
     ).toBeDefined();
   });
 
+  it('allows only exact artifact-free leased staging-ref operations', () => {
+    const trainId = '8af60034-9741-4b9d-bb1c-80b483f75455';
+    const authorization = {
+      train_id: trainId,
+      operation_key: `rb2:${trainId}:advance-staging:release:backend:a1`,
+      workflow_run_id: '30510086016',
+      artifact_run_id: null,
+      repository: 'backend',
+      environment: 'staging',
+      service: null,
+      expected_sha: 'a'.repeat(40),
+      artifact_digest: null
+    };
+
+    expect(
+      ReleaseBusV2AuthorizationBodySchema.validate(authorization).error
+    ).toBeUndefined();
+    expect(
+      ReleaseBusV2AuthorizationBodySchema.validate({
+        ...authorization,
+        operation_key: `rb2:${trainId}:advance-staging:rollback:frontend:a1`,
+        repository: 'frontend'
+      }).error
+    ).toBeUndefined();
+    for (const invalid of [
+      {
+        ...authorization,
+        operation_key: `rb2:${trainId}:advance-staging:release:frontend:a1`
+      },
+      {
+        ...authorization,
+        operation_key: `rb2:${trainId}:advance-staging:release:backend:a1`,
+        environment: 'prod'
+      },
+      { ...authorization, service: 'api' },
+      { ...authorization, artifact_run_id: '30509992351' },
+      { ...authorization, artifact_digest: 'b'.repeat(64) }
+    ])
+      expect(
+        ReleaseBusV2AuthorizationBodySchema.validate(invalid).error
+      ).toBeDefined();
+  });
+
   it('accepts an exact backend PR candidate with an acyclic deploy plan', () => {
     const result = ReleaseBusV2CandidateBodySchema.validate({
       repository: 'backend',

--- a/src/api-serverless/src/deploy/deploy.validation.ts
+++ b/src/api-serverless/src/deploy/deploy.validation.ts
@@ -520,6 +520,22 @@ export const ReleaseBusV2AuthorizationBodySchema = Joi.object({
         ? value
         : helpers.error('any.invalid');
     }
+    const isExactStagingRefAdvance =
+      value.environment === 'staging' &&
+      keySegments.length === 6 &&
+      keySegments[0] === 'rb2' &&
+      keySegments[1] === value.train_id &&
+      keySegments[2] === 'advance-staging' &&
+      ['release', 'rollback'].includes(keySegments[3]) &&
+      keySegments[4] === value.repository &&
+      /^a[1-9]\d{0,8}$/.test(keySegments[5]);
+    if (isExactStagingRefAdvance) {
+      return value.service === null &&
+        value.artifact_run_id === null &&
+        value.artifact_digest === null
+        ? value
+        : helpers.error('any.invalid');
+    }
     return value.artifact_run_id !== null && value.artifact_digest !== null
       ? value
       : helpers.error('any.invalid');

--- a/src/api-serverless/src/deploy/deploy.validation.ts
+++ b/src/api-serverless/src/deploy/deploy.validation.ts
@@ -423,6 +423,48 @@ function hasEmptyReuseEvidenceIdentity(
   ].every((entry) => entry === null);
 }
 
+function hasExactManifestE2EOperationKey(
+  value: Readonly<Record<string, unknown>>
+): boolean {
+  if (
+    typeof value.operation_key !== 'string' ||
+    typeof value.train_id !== 'string' ||
+    typeof value.environment !== 'string'
+  )
+    return false;
+  const segments = value.operation_key.split(':');
+  return (
+    segments.length === 5 &&
+    segments[0] === 'rb2' &&
+    segments[1] === value.train_id &&
+    segments[2] === 'e2e' &&
+    segments[3] === value.environment &&
+    /^a[1-9]\d{0,8}$/.test(segments[4])
+  );
+}
+
+function hasExactStagingRefOperationKey(
+  value: Readonly<Record<string, unknown>>
+): boolean {
+  if (
+    value.environment !== 'staging' ||
+    typeof value.operation_key !== 'string' ||
+    typeof value.train_id !== 'string' ||
+    typeof value.repository !== 'string'
+  )
+    return false;
+  const segments = value.operation_key.split(':');
+  return (
+    segments.length === 6 &&
+    segments[0] === 'rb2' &&
+    segments[1] === value.train_id &&
+    segments[2] === 'advance-staging' &&
+    ['release', 'rollback'].includes(segments[3]) &&
+    segments[4] === value.repository &&
+    /^a[1-9]\d{0,8}$/.test(segments[5])
+  );
+}
+
 function isValidOrchestrationEvidenceAuthorization(
   value: Readonly<Record<string, unknown>>
 ): boolean {
@@ -504,15 +546,7 @@ export const ReleaseBusV2AuthorizationBodySchema = Joi.object({
       !hasEmptyReuseEvidenceIdentity(value)
     )
       return helpers.error('any.invalid');
-    const keySegments = value.operation_key.split(':');
-    const isExactManifestE2E =
-      keySegments.length === 5 &&
-      keySegments[0] === 'rb2' &&
-      keySegments[1] === value.train_id &&
-      keySegments[2] === 'e2e' &&
-      keySegments[3] === value.environment &&
-      /^a[1-9]\d{0,8}$/.test(keySegments[4]);
-    if (isExactManifestE2E) {
+    if (hasExactManifestE2EOperationKey(value)) {
       return value.repository === 'frontend' &&
         value.service === null &&
         value.artifact_run_id === null &&
@@ -520,16 +554,7 @@ export const ReleaseBusV2AuthorizationBodySchema = Joi.object({
         ? value
         : helpers.error('any.invalid');
     }
-    const isExactStagingRefAdvance =
-      value.environment === 'staging' &&
-      keySegments.length === 6 &&
-      keySegments[0] === 'rb2' &&
-      keySegments[1] === value.train_id &&
-      keySegments[2] === 'advance-staging' &&
-      ['release', 'rollback'].includes(keySegments[3]) &&
-      keySegments[4] === value.repository &&
-      /^a[1-9]\d{0,8}$/.test(keySegments[5]);
-    if (isExactStagingRefAdvance) {
+    if (hasExactStagingRefOperationKey(value)) {
       return value.service === null &&
         value.artifact_run_id === null &&
         value.artifact_digest === null


### PR DESCRIPTION
## Summary
- allow only exact artifact-free Release Bus staging-ref advance/rollback operation identities
- keep all ordinary deployment authorizations artifact-bound
- add route and schema regression coverage for backend/frontend, environment, service, artifact and repository binding

## Live failure evidence
- train `eb3735ae-1fb1-4699-8dc4-aa3a988889fa` failed closed before checkout/ref mutation
- workflow run `30510086016` received HTTP 400 at `/deploy/release-bus-v2/authorize` for exact operation `rb2:eb3735ae-1fb1-4699-8dc4-aa3a988889fa:advance-staging:release:backend:a1`
- STAGING automatically isolated OFF; backend main and `1a-staging` remained `9514d6b17e23225022df4629677209b198fef466`

## Local verification
- `npx jest src/api-serverless/src/deploy/deploy-validation.test.ts --runInBand`
- `npx jest src/api-serverless/src/deploy/deploy-release-bus-routes.test.ts --runInBand`
- focused Prettier and ESLint checks

Signed-off-by: Tarmo Kalling <tarmo.kalling@gmail.com>