### PR TITLE
Fix exact empty Release Bus maintenance detach

### DIFF
--- a/ops/deployment-bus/simple-release-bus-v2.md
+++ b/ops/deployment-bus/simple-release-bus-v2.md
@@ -404,8 +404,13 @@ event records a deleted head. The reconciler can otherwise restore that exact
 row to production readiness, so deregistration must include it. Immutable
 `PRODUCTION_DEPLOYED`, `CANCELLED`, `DEREGISTERED`, and all other terminal
 `SUPERSEDED` history is excluded and preserved byte-for-byte. Execution must
-repeat that complete plan. A preparation with zero active-intent targets is an
-audited safe no-op (`candidate_count: 0`); it cannot be executed.
+repeat that complete plan. A preparation with zero active-intent targets
+remains executable (`candidate_count: 0`) solely to atomically detach the
+authoritative staging singleton before a clean-main bootstrap. The empty
+execution changes no candidate row, preserves immutable history, and still
+requires the exact controls, locks, trains, operations, workflow/ref fence,
+staging-state version, empty-inventory digest, and post-commit audit checks
+described below. Its global audit event records the zero candidate count.
 
 Execution is allowed only when `ALL` is unpaused, both independently changeable
 lanes are paused `OFF`, all three v2 locks are wholly free, all trains and

--- a/src/api-serverless/openapi.yaml
+++ b/src/api-serverless/openapi.yaml
@@ -20363,7 +20363,12 @@ components:
           pattern: ^[a-f0-9]{64}$
         expected_candidates:
           type: array
-          minItems: 1
+          description: >-
+            The exact active-intent inventory from PREPARE. An empty inventory
+            remains executable to atomically detach authoritative staging
+            ownership; every control, lock, workflow, ref, state-version, and
+            digest fence still applies.
+          minItems: 0
           maxItems: 500
           uniqueItems: true
           items:

--- a/src/api-serverless/src/deploy/deploy-release-bus-routes.test.ts
+++ b/src/api-serverless/src/deploy/deploy-release-bus-routes.test.ts
@@ -1409,7 +1409,7 @@ describe('Release Bus v2 route authorization and exact actions', () => {
     });
   });
 
-  it('returns an explicit successful zero-target preparation as a non-executable no-op', async () => {
+  it('returns an explicit successful zero-target exact preparation', async () => {
     mockCandidateDeregistrationPrepare.mockResolvedValue({
       phase: 'PREPARE',
       plan_sha256: '1'.repeat(64),
@@ -1457,6 +1457,71 @@ describe('Release Bus v2 route authorization and exact actions', () => {
       requested_by: 'developer'
     });
     expect(mockCandidateDeregistrationExecute).not.toHaveBeenCalled();
+  });
+
+  it('executes a complete strict zero-target control/lock/state/ref CAS plan', async () => {
+    const expected = {
+      expected_plan_sha256: '1'.repeat(64),
+      expected_inventory_sha256: '2'.repeat(64),
+      expected_candidates: [],
+      expected_controls: [
+        { scope: 'ALL', paused: false, row_version: 1 },
+        { scope: 'PRODUCTION', paused: true, row_version: 2 },
+        { scope: 'STAGING', paused: true, row_version: 3 }
+      ],
+      expected_locks: [
+        { name: 'production-environment', row_version: 1 },
+        { name: 'scheduler', row_version: 2 },
+        { name: 'staging-environment', row_version: 3 }
+      ],
+      expected_staging_state_row_version: 9,
+      expected_staging_refs: {
+        frontend: SHA,
+        backend: 'b'.repeat(40)
+      }
+    };
+    mockCandidateDeregistrationExecute.mockResolvedValue({
+      phase: 'EXECUTE',
+      plan_sha256: expected.expected_plan_sha256,
+      inventory_sha256: expected.expected_inventory_sha256,
+      candidate_count: 0,
+      candidates: [],
+      controls: expected.expected_controls,
+      locks: expected.expected_locks,
+      staging_state_row_version: expected.expected_staging_state_row_version,
+      staging_refs: expected.expected_staging_refs,
+      mode: 'PRODUCTION',
+      executed: true,
+      deregistration_id: RESET_ID,
+      physical_staging_presence: 'UNKNOWN_DETACHED'
+    });
+
+    const response = await post(
+      '/deploy/release-bus-v2/maintenance/deregister-all-candidates',
+      {
+        phase: 'EXECUTE',
+        reason: 'Detach the exact empty candidate inventory',
+        ...expected
+      }
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockCandidateDeregistrationExecute).toHaveBeenCalledWith(
+      {
+        reason: 'Detach the exact empty candidate inventory',
+        ...expected
+      },
+      'developer'
+    );
+    expect(response.body).toMatchObject({
+      phase: 'EXECUTE',
+      candidate_count: 0,
+      candidates: [],
+      executed: true,
+      deregistration_id: RESET_ID,
+      physical_staging_presence: 'UNKNOWN_DETACHED',
+      requested_by: 'developer'
+    });
   });
 
   it('executes only a complete strict candidate/control/lock/state/ref CAS plan', async () => {

--- a/src/api-serverless/src/deploy/deploy-validation.test.ts
+++ b/src/api-serverless/src/deploy/deploy-validation.test.ts
@@ -99,6 +99,14 @@ describe('Release Bus v2 validation', () => {
         ...exact
       }).error
     ).toBeUndefined();
+    expect(
+      ReleaseBusV2CandidateDeregistrationBodySchema.validate({
+        phase: 'EXECUTE',
+        reason: 'Detach the exact empty candidate inventory',
+        ...exact,
+        expected_candidates: []
+      }).error
+    ).toBeUndefined();
     for (const invalid of [
       {
         phase: 'EXECUTE',

--- a/src/api-serverless/src/deploy/deploy-validation.test.ts
+++ b/src/api-serverless/src/deploy/deploy-validation.test.ts
@@ -121,6 +121,18 @@ describe('Release Bus v2 validation', () => {
         phase: 'EXECUTE',
         reason: 'Retire the audited candidate inventory',
         ...exact,
+        expected_candidates: [null]
+      },
+      {
+        phase: 'EXECUTE',
+        reason: 'Retire the audited candidate inventory',
+        ...exact,
+        expected_candidates: [{}]
+      },
+      {
+        phase: 'EXECUTE',
+        reason: 'Retire the audited candidate inventory',
+        ...exact,
         expected_controls: exact.expected_controls.slice(1)
       },
       {

--- a/src/api-serverless/src/deploy/deploy.validation.ts
+++ b/src/api-serverless/src/deploy/deploy.validation.ts
@@ -240,8 +240,8 @@ export const ReleaseBusV2CandidateDeregistrationBodySchema = Joi.object({
       otherwise: Joi.forbidden()
     }),
   expected_candidates: Joi.array()
-    .items(ReleaseBusV2CandidateDeregistrationCandidateVersionSchema)
-    .min(1)
+    .items(ReleaseBusV2CandidateDeregistrationCandidateVersionSchema.optional())
+    .min(0)
     .max(500)
     .unique('id')
     .when('phase', {

--- a/src/api-serverless/src/deploy/deploy.validation.ts
+++ b/src/api-serverless/src/deploy/deploy.validation.ts
@@ -200,7 +200,7 @@ const ReleaseBusV2CandidateDeregistrationCandidateVersionSchema = Joi.object({
     .guid({ version: ['uuidv4'] })
     .required(),
   row_version: Joi.number().integer().positive().strict().required()
-}).required();
+});
 
 const ReleaseBusV2CandidateDeregistrationControlVersionSchema = Joi.object({
   scope: Joi.string()
@@ -240,7 +240,7 @@ export const ReleaseBusV2CandidateDeregistrationBodySchema = Joi.object({
       otherwise: Joi.forbidden()
     }),
   expected_candidates: Joi.array()
-    .items(ReleaseBusV2CandidateDeregistrationCandidateVersionSchema.optional())
+    .items(ReleaseBusV2CandidateDeregistrationCandidateVersionSchema)
     .min(0)
     .max(500)
     .unique('id')

--- a/src/api-serverless/src/generated/models/ApiReleaseBusV2CandidateDeregistrationExecuteRequest.ts
+++ b/src/api-serverless/src/generated/models/ApiReleaseBusV2CandidateDeregistrationExecuteRequest.ts
@@ -21,6 +21,9 @@ export class ApiReleaseBusV2CandidateDeregistrationExecuteRequest {
     'reason': string;
     'expected_plan_sha256': string;
     'expected_inventory_sha256': string;
+    /**
+    * The exact active-intent inventory from PREPARE. An empty inventory remains executable to atomically detach authoritative staging ownership; every control, lock, workflow, ref, state-version, and digest fence still applies.
+    */
     'expected_candidates': Set<ApiReleaseBusV2CandidateDeregistrationCandidateVersion>;
     'expected_controls': Set<ApiReleaseBusV2CandidateDeregistrationControlVersion>;
     'expected_locks': Set<ApiReleaseBusV2CandidateDeregistrationLockVersion>;

--- a/src/releaseBusV2/release-bus-v2-candidate-deregistration-contract.test.ts
+++ b/src/releaseBusV2/release-bus-v2-candidate-deregistration-contract.test.ts
@@ -166,7 +166,7 @@ describe('Release Bus v2 logical deregistration generated contract', () => {
       /ApiReleaseBusV2CandidateDeregistrationUncommittedError:\n\s+type: object/
     );
     expect(schemas).toMatch(
-      /expected_candidates:\n\s+type: array\n\s+minItems: 1/
+      /expected_candidates:\n\s+type: array[\s\S]*?\n\s+minItems: 0/
     );
     expect(schemas).toMatch(
       /candidate_count:\n\s+type: integer\n\s+minimum: 0/

--- a/src/releaseBusV2/release-bus-v2-repository.test.ts
+++ b/src/releaseBusV2/release-bus-v2-repository.test.ts
@@ -608,6 +608,102 @@ describe('ReleaseBusV2Repository', () => {
     );
   });
 
+  it('atomically detaches CLEAN_MAIN with an exact empty inventory and no candidate mutation', async () => {
+    const db = new RecordingSqlExecutor();
+    const repository = new ReleaseBusV2Repository(() => db);
+    const controls = controlRows();
+    const stagingState = {
+      ...state(),
+      status: 'CLEAN_MAIN' as const,
+      current_manifest_id: null,
+      clean_main: true,
+      last_transition_train_id: null
+    };
+    const { locks, leases } = acquiredLocks();
+    jest
+      .spyOn(repository, 'executeNativeQueriesInTransaction')
+      .mockImplementation(async (callback) =>
+        callback({ connection: {} } as never)
+      );
+    jest.spyOn(repository, 'listControls').mockResolvedValue(controls);
+    jest.spyOn(repository, 'listLocks').mockResolvedValue(locks);
+    jest.spyOn(repository, 'listActiveTrains').mockResolvedValue([]);
+    jest
+      .spyOn(repository, 'listNonterminalOperationsForLanes')
+      .mockResolvedValue([]);
+    jest.spyOn(repository, 'getStagingState').mockResolvedValue(stagingState);
+    const listCandidateDeregistrationScope = jest
+      .spyOn(repository, 'listCandidateDeregistrationScope')
+      .mockResolvedValue([]);
+    const updateCandidate = jest.spyOn(repository, 'updateCandidate');
+    const updateStagingState = jest
+      .spyOn(repository, 'updateStagingState')
+      .mockResolvedValue(true);
+    const appendEvent = jest
+      .spyOn(repository, 'appendEvent')
+      .mockResolvedValue(undefined);
+    const emptyInventorySha256 = releaseBusV2CandidateInventoryDigest([]);
+
+    await expect(
+      repository.commitAllCandidateDeregistration({
+        deregistrationId: 'empty-deregistration-id',
+        actor: 'operator',
+        reason: 'Detach the exact empty candidate inventory',
+        expectedControls: controls.map(({ scope, paused, row_version }) => ({
+          scope,
+          paused: Boolean(paused),
+          row_version
+        })),
+        maintenanceLeases: leases,
+        expectedStagingStateRowVersion: stagingState.row_version,
+        expectedCandidates: [],
+        expectedInventorySha256: emptyInventorySha256,
+        observedFrontendStagingSha: 'a'.repeat(40),
+        observedBackendStagingSha: 'b'.repeat(40)
+      })
+    ).resolves.toEqual({ candidateCount: 0 });
+
+    expect(listCandidateDeregistrationScope).toHaveBeenCalledWith(
+      expect.objectContaining({ connection: expect.anything() }),
+      true
+    );
+    expect(updateCandidate).not.toHaveBeenCalled();
+    expect(updateStagingState).toHaveBeenCalledWith(
+      stagingState.row_version,
+      {
+        status: 'DETACHED_MANUAL_OWNERSHIP',
+        currentManifestId: null,
+        lastValidatedManifestId: stagingState.last_validated_manifest_id,
+        frontendSha: null,
+        backendSha: null,
+        frontendStagingRefSha: null,
+        backendStagingRefSha: null,
+        cleanMain: false,
+        lastTransitionTrainId: null
+      },
+      expect.objectContaining({ connection: expect.anything() })
+    );
+    expect(appendEvent).toHaveBeenCalledTimes(1);
+    expect(appendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: 'CANDIDATE_INVENTORY_LOGICALLY_DEREGISTERED',
+        actor: 'operator',
+        payload: expect.objectContaining({
+          deregistration_id: 'empty-deregistration-id',
+          candidate_count: 0,
+          inventory_sha256: emptyInventorySha256,
+          previous_staging_state: expect.objectContaining({
+            status: 'CLEAN_MAIN',
+            row_version: stagingState.row_version,
+            clean_main: true
+          }),
+          immutable_history_preserved: true
+        })
+      }),
+      expect.objectContaining({ connection: expect.anything() })
+    );
+  });
+
   it('aborts the transaction before any candidate mutation when the inventory CAS is stale', async () => {
     const db = new RecordingSqlExecutor();
     const repository = new ReleaseBusV2Repository(() => db);

--- a/src/releaseBusV2/release-bus-v2.candidate-deregistration.test.ts
+++ b/src/releaseBusV2/release-bus-v2.candidate-deregistration.test.ts
@@ -332,11 +332,22 @@ describe('ReleaseBusV2CandidateDeregistrationService', () => {
     );
   });
 
-  it('returns an explicit zero-target preparation as a safe non-executable no-op', async () => {
-    const { service, repository } = harness();
+  it('commits an exact zero-target plan to detach authoritative staging state', async () => {
+    const { service, repository, leases, state } = harness();
     repository.listCandidateDeregistrationTargets.mockResolvedValue([]);
+    repository.commitAllCandidateDeregistration.mockResolvedValue({
+      candidateCount: 0
+    });
+    Object.assign(state, {
+      status: 'CLEAN_MAIN',
+      current_manifest_id: null,
+      clean_main: true,
+      last_transition_train_id: null
+    });
 
-    const plan = await service.prepare('Confirm no active candidate intent');
+    const plan = await service.prepare(
+      'Retire the audited candidate inventory'
+    );
 
     expect(plan).toMatchObject({
       phase: 'PREPARE',
@@ -346,11 +357,29 @@ describe('ReleaseBusV2CandidateDeregistrationService', () => {
     });
     await expect(
       service.execute(executeInput(plan), 'operator')
-    ).rejects.toMatchObject({
-      code: 'CONFLICT'
+    ).resolves.toMatchObject({
+      phase: 'EXECUTE',
+      candidate_count: 0,
+      candidates: [],
+      executed: true,
+      physical_staging_presence: 'UNKNOWN_DETACHED'
     });
-    expect(repository.acquireExactFreeMaintenanceLocks).not.toHaveBeenCalled();
-    expect(repository.commitAllCandidateDeregistration).not.toHaveBeenCalled();
+    expect(repository.acquireExactFreeMaintenanceLocks).toHaveBeenCalledWith(
+      plan.locks,
+      expect.stringMatching(/^deregister:operator:/),
+      expect.any(Number)
+    );
+    expect(repository.commitAllCandidateDeregistration).toHaveBeenCalledWith(
+      expect.objectContaining({
+        expectedCandidates: [],
+        expectedInventorySha256: plan.inventory_sha256,
+        expectedStagingStateRowVersion: plan.staging_state_row_version,
+        maintenanceLeases: leases
+      })
+    );
+    expect(repository.releaseExactMaintenanceLocks).toHaveBeenCalledWith(
+      leases
+    );
   });
 
   it.each([

--- a/src/releaseBusV2/release-bus-v2.candidate-deregistration.ts
+++ b/src/releaseBusV2/release-bus-v2.candidate-deregistration.ts
@@ -303,11 +303,6 @@ export class ReleaseBusV2CandidateDeregistrationService {
       const before = await this.readReadySnapshot();
       const plan = this.plan(reason, before);
       this.assertExpectedPlan(plan, input);
-      if (plan.candidate_count === 0)
-        throw new ReleaseBusV2CandidateDeregistrationError(
-          'CONFLICT',
-          'Candidate deregistration preparation is a safe no-op because no active candidate intent exists'
-        );
       return this.executePreparedPlan(plan, input, actor, reason);
     });
   }

--- a/src/releaseBusV2/release-bus-v2.repository.integration.test.ts
+++ b/src/releaseBusV2/release-bus-v2.repository.integration.test.ts
@@ -1503,6 +1503,163 @@ describeWithSeed(
       }
     });
 
+    it('gap-fences an active candidate insert while committing an exact empty inventory', async () => {
+      let leases: ReleaseBusV2MaintenanceLease[] = [];
+      try {
+        await repository.setControl(
+          'STAGING',
+          true,
+          'empty inventory integration maintenance',
+          'integration',
+          {}
+        );
+        await repository.setControl(
+          'PRODUCTION',
+          true,
+          'empty inventory integration maintenance',
+          'integration',
+          {}
+        );
+        const controls = (await repository.listControls({})).map(
+          ({ scope, paused, row_version }) => ({
+            scope,
+            paused: paused === true || paused === 1,
+            row_version
+          })
+        );
+        const exactFreeLocks = (await repository.listLocks({})).map(
+          ({ name, row_version }) => ({ name, row_version })
+        );
+        const candidates = await repository.listCandidateDeregistrationTargets(
+          {}
+        );
+        expect(candidates).toEqual([]);
+        const stagingState = await repository.getStagingState({});
+        leases = await repository.acquireExactFreeMaintenanceLocks(
+          exactFreeLocks,
+          'integration-empty-deregistration',
+          60_000
+        );
+        const originalListCandidateDeregistrationTargets =
+          repository.listCandidateDeregistrationTargets.bind(repository);
+        let releaseInventoryFence = () => {};
+        let inventoryFenceObserved!: () => void;
+        const inventoryFenceHeld = new Promise<void>((resolve) => {
+          inventoryFenceObserved = resolve;
+        });
+        const continueCommit = new Promise<void>((resolve) => {
+          releaseInventoryFence = resolve;
+        });
+        let trappedInventoryFence = false;
+        const inventorySpy = jest
+          .spyOn(repository, 'listCandidateDeregistrationTargets')
+          .mockImplementation(async (ctx, forUpdate) => {
+            const rows = await originalListCandidateDeregistrationTargets(
+              ctx,
+              forUpdate
+            );
+            if (forUpdate && !trappedInventoryFence) {
+              trappedInventoryFence = true;
+              inventoryFenceObserved();
+              await continueCommit;
+            }
+            return rows;
+          });
+        const emptyInventorySha256 =
+          releaseBusV2CandidateInventoryDigest(candidates);
+        const commitPromise = repository.commitAllCandidateDeregistration({
+          deregistrationId: 'integration-empty-deregistration',
+          actor: 'integration',
+          reason: 'Prove atomic empty logical deregistration',
+          expectedControls: controls,
+          maintenanceLeases: leases,
+          expectedStagingStateRowVersion: stagingState.row_version,
+          expectedCandidates: [],
+          expectedInventorySha256: emptyInventorySha256,
+          observedFrontendStagingSha: SHA_A,
+          observedBackendStagingSha: SHA_B
+        });
+        let concurrentInsertCompleted = false;
+        let concurrentInsert:
+          | Awaited<ReturnType<typeof repository.createCandidate>>
+          | undefined;
+        let concurrentInsertPromise:
+          | ReturnType<typeof repository.createCandidate>
+          | undefined;
+        try {
+          await inventoryFenceHeld;
+          concurrentInsertPromise = new ReleaseBusV2Repository()
+            .createCandidate(
+              {
+                repository: 'backend',
+                prNumber: 2003,
+                branchName: 'feature/concurrent-empty-active-intent',
+                headSha: SHA_C,
+                requestedBy: 'integration',
+                deployPlan: null,
+                prEvidence: null
+              },
+              {}
+            )
+            .then((created) => {
+              concurrentInsertCompleted = true;
+              return created;
+            });
+          await new Promise((resolve) => setTimeout(resolve, 150));
+          expect(concurrentInsertCompleted).toBe(false);
+          releaseInventoryFence();
+          await expect(commitPromise).resolves.toEqual({ candidateCount: 0 });
+          concurrentInsert = await concurrentInsertPromise;
+        } finally {
+          releaseInventoryFence();
+          await Promise.allSettled(
+            concurrentInsertPromise
+              ? [commitPromise, concurrentInsertPromise]
+              : [commitPromise]
+          );
+          inventorySpy.mockRestore();
+        }
+
+        await expect(repository.getStagingState({})).resolves.toMatchObject({
+          status: 'DETACHED_MANUAL_OWNERSHIP',
+          current_manifest_id: null,
+          last_validated_manifest_id: stagingState.last_validated_manifest_id,
+          frontend_sha: null,
+          backend_sha: null,
+          clean_main: false
+        });
+        await expect(
+          repository.findCandidateById(concurrentInsert?.id ?? '', {})
+        ).resolves.toMatchObject({
+          id: concurrentInsert?.id,
+          status: 'READY_FOR_STAGING'
+        });
+      } finally {
+        try {
+          if (leases.length > 0)
+            await repository.releaseExactMaintenanceLocks(leases);
+        } finally {
+          try {
+            await repository.setControl(
+              'STAGING',
+              false,
+              'empty inventory integration cleanup',
+              'integration',
+              {}
+            );
+          } finally {
+            await repository.setControl(
+              'PRODUCTION',
+              false,
+              'empty inventory integration cleanup',
+              'integration',
+              {}
+            );
+          }
+        }
+      }
+    });
+
     it('finds staging validation only for exact SHAs and artifact digests', async () => {
       const manifest = await repository.createManifest(
         {


### PR DESCRIPTION
## Summary
- allow an exact zero-candidate deregistration plan to execute under the existing controls, locks, workflow/ref, state-version, inventory-digest, and post-commit fences
- atomically detach authoritative staging ownership without changing candidate rows, while preserving immutable history and emitting a global zero-count audit event
- align Joi, OpenAPI/generated contract, durable operating docs, route/service/repository coverage, and prove the empty status-index scan gap-fences a concurrent active insert

## Safety
- both lanes remain OFF; this PR performs no live-state mutation
- non-empty behavior and every stale/moved CAS rejection remain unchanged
- the only deployment unit is `api`; release notes are opted out for this internal control-plane fix

## Verification
- `npm run check:changed` (181 related tests + typecheck/lint/format)
- focused unit/route/contract suites (151 tests)
- repository integration suite (22 tests)
- `src/api-serverless npm run generate:openapi`
- `src/api-serverless npm run build`
- `git diff --check`

## Deploy plan
```json
{"units":["api"],"edges":[],"publish_release_notes":false}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Zero-target Release Bus maintenance plans can now be explicitly executed.
  * Empty candidate inventories can detach authoritative staging ownership while preserving history and leaving candidate records unchanged.
  * Empty candidate lists are now accepted in execution requests.

* **Bug Fixes**
  * Added safeguards to prevent concurrent candidate additions from being included in an empty deregistration operation.

* **Tests**
  * Expanded coverage for zero-target preparation, execution, validation, and atomic staging detachment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->