### PR TITLE
Fix baseline adoption E2E workflow identity

### DIFF
--- a/src/releaseBusV2/release-bus-v2.baseline-adoption.test.ts
+++ b/src/releaseBusV2/release-bus-v2.baseline-adoption.test.ts
@@ -484,9 +484,9 @@ function frontendE2EIdentity() {
     event: 'workflow_run',
     headBranch: 'main',
     headSha: FRONTEND_SHA,
-    name: 'Staging E2E',
+    name: 'Staging E2E [automatic]',
     path: '.github/workflows/staging-e2e.yml',
-    displayTitle: 'Staging E2E',
+    displayTitle: 'Staging E2E [automatic]',
     status: 'in_progress'
   };
 }
@@ -723,6 +723,48 @@ describe('ReleaseBusV2BaselineAdoptionService', () => {
     expect(context.repository.trains).toHaveLength(0);
     expect(context.repository.operations).toHaveLength(0);
     expect(context.operations.reconcileWorkflow).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    'Staging E2E [automatic]',
+    `Staging E2E [rb2:${INTENT_ID}:baseline-adoption-e2e:staging:a1:a1]`
+  ])('accepts the real trusted GitHub run.name %s', async (name) => {
+    const context = harness();
+    Object.assign(context.identities[FRONTEND_E2E_RUN_ID], {
+      name,
+      displayTitle: name
+    });
+    await prepare(context);
+    await expect(
+      context.service.decideAutomaticE2E(automaticInput())
+    ).resolves.toMatchObject({
+      decision: 'DEFERRED',
+      adoption_id: INTENT_ID,
+      manifest_ready: false
+    });
+  });
+
+  it.each([
+    'Staging E2E',
+    'Staging E2E [Automatic]',
+    'Staging E2E [automatic]-lookalike',
+    'Staging E2E [release-bus:train:e2e:a1]',
+    'Staging E2E [rb2:train:e2e:a0]',
+    `Staging E2E [rb2:${'x'.repeat(176)}:a1]`
+  ])('rejects the lookalike or untrusted GitHub run.name %s', async (name) => {
+    const context = harness();
+    Object.assign(context.identities[FRONTEND_E2E_RUN_ID], {
+      name,
+      displayTitle: name
+    });
+    await prepare(context);
+    await expect(
+      context.service.decideAutomaticE2E(automaticInput())
+    ).rejects.toBeInstanceOf(ReleaseBusV2BaselineAdoptionError);
+    expect(context.repository.trains).toHaveLength(0);
+    expect(context.repository.manifests).toHaveLength(0);
+    expect(context.repository.operations).toHaveLength(0);
+    expect(context.repository.state.row_version).toBe(23);
   });
 
   it.each(['frontend', 'backend'] as const)(

--- a/src/releaseBusV2/release-bus-v2.baseline-adoption.ts
+++ b/src/releaseBusV2/release-bus-v2.baseline-adoption.ts
@@ -53,6 +53,8 @@ const UUID_V4_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 const RUN_ID_PATTERN = /^[1-9]\d{0,19}$/;
 const UNIT_PATTERN = /^[A-Za-z0-9_-]{1,100}$/;
+const RELEASE_BUS_OPERATION_ATTEMPT_PATTERN =
+  /^rb2:[A-Za-z0-9:._-]+:a[1-9]\d{0,8}$/;
 
 export type ReleaseBusV2BaselineAdoptionCandidate = {
   readonly candidate_id: string;
@@ -687,7 +689,7 @@ function assertFrontendWorkflowIdentities(
     e2e.conclusion !== null ||
     e2e.event !== 'workflow_run' ||
     e2e.path !== '.github/workflows/staging-e2e.yml' ||
-    e2e.name !== 'Staging E2E' ||
+    !isTrustedStagingE2EWorkflowName(e2e.name) ||
     deploy.status !== 'completed' ||
     deploy.conclusion !== 'success' ||
     !['push', 'workflow_dispatch'].includes(deploy.event) ||
@@ -700,6 +702,16 @@ function assertFrontendWorkflowIdentities(
       'CONFLICT',
       'Automatic E2E does not bind the exact successful staging deployment'
     );
+}
+
+function isTrustedStagingE2EWorkflowName(value: string): boolean {
+  const match = /^Staging E2E \[([A-Za-z0-9:._-]+)\]$/.exec(value);
+  const identity = match?.[1] ?? '';
+  return (
+    identity === 'automatic' ||
+    (identity.length <= 180 &&
+      RELEASE_BUS_OPERATION_ATTEMPT_PATTERN.test(identity))
+  );
 }
 
 function assertBackendWorkflowIdentity(


### PR DESCRIPTION
## Issue

- GitHub reports the existing staging E2E workflow's custom run name as `Staging E2E [automatic]`, while the baseline-adoption backend predicate required the obsolete static name `Staging E2E`.
- That deterministic contract mismatch failed the exact automatic adoption decision closed with HTTP 409 before any expensive E2E or authoritative-state mutation.

## Fix

- Accept only the real trusted staging E2E run-name contract: the exact automatic name or a bounded Release Bus manifest-operation attempt name.
- Preserve the existing workflow path, event, repository lookup, exact run ID, deployment ref/SHA, status, and conclusion checks.

## Changes

- Model the real GitHub `run.name` and `display_title` values in baseline-adoption tests.
- Add acceptance coverage for automatic and manifest-bound names.
- Add rejection coverage for static, case-shifted, suffixed, non-Release-Bus, invalid-attempt, and overlong lookalike names.
- No schema, API shape, architecture, frontend, or user-facing documentation change.

## Validation

- `npm test -- --runInBand src/releaseBusV2/release-bus-v2.baseline-adoption.test.ts` — 37 tests passed.
- File-scoped Prettier check — passed.
- File-scoped ESLint with zero warnings — passed.
- `tsc --noEmit --pretty false -p tsconfig.json` — passed after installing both root and API workspace dependencies.
- `git diff --check` — passed.
- Broader local regression intentionally starts after publication so GitHub CI and review can run in parallel, per the recovery directive.

## Risk

- Level: Medium.
- Why: the change is two-field control-plane identity matching, but it gates a staging baseline-adoption workflow.
- Rollback: revert this commit and redeploy the production API. The operation remains fail-closed, and failed intents cannot partially adopt state.

## Review Notes

- Focus on the exact run-name grammar and its rejection boundary.
- Required deployment unit: production `api` only, serialized under the OFF-lane manual fallback with the internal operational release-note opt-out.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recognition of staging E2E workflow names, including automatically generated names and valid release attempt identifiers.
  - Added stricter validation to reject untrusted or lookalike workflow names.
  - Invalid workflow identities now leave release trains, manifests, operations, and repository state unchanged.
  - Trusted staging E2E runs are correctly deferred for further processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->