### PR TITLE
Fix baseline evidence writer consistency

### DIFF
--- a/src/releaseBusV2/release-bus-v2.baseline-adoption.test.ts
+++ b/src/releaseBusV2/release-bus-v2.baseline-adoption.test.ts
@@ -834,6 +834,38 @@ describe('ReleaseBusV2BaselineAdoptionService', () => {
     expect(conflict.repository.trains).toHaveLength(0);
   });
 
+  it('verifies newly inserted immutable evidence through the writer when the replica is stale', async () => {
+    const context = harness();
+    await prepare(context);
+    context.repository.findEvent.mockImplementation(
+      async (id: string, ctx?: { connection?: unknown }) =>
+        ctx?.connection
+          ? context.repository.events.find((item) => item.id === id)
+          : undefined
+    );
+
+    await expect(
+      context.service.decideAutomaticE2E(automaticInput())
+    ).resolves.toMatchObject({
+      decision: 'DEFERRED',
+      manifest_ready: false
+    });
+    expect(
+      context.repository.events.filter(({ event_type }) =>
+        [
+          'EXACT_STAGING_BASELINE_FRONTEND_DEPLOYMENT_VERIFIED',
+          'EXACT_STAGING_BASELINE_AUTOMATIC_E2E_DEFERRED'
+        ].includes(event_type)
+      )
+    ).toHaveLength(2);
+    expect(
+      context.repository.events.some(
+        ({ event_type }) =>
+          event_type === 'EXACT_STAGING_BASELINE_ADOPTION_FAILED'
+      )
+    ).toBe(false);
+  });
+
   it('fails ambiguous and malformed intent lookup closed without partial adoption', async () => {
     const context = harness();
     const other = harness();

--- a/src/releaseBusV2/release-bus-v2.baseline-adoption.ts
+++ b/src/releaseBusV2/release-bus-v2.baseline-adoption.ts
@@ -1348,20 +1348,25 @@ export class ReleaseBusV2BaselineAdoptionService {
     actor: string,
     payload: unknown
   ): Promise<void> {
-    await this.repository.appendEvent(
-      { eventId: id, eventType, actor, payload },
-      {}
+    await this.repository.executeNativeQueriesInTransaction(
+      async (connection) => {
+        const ctx = { connection };
+        await this.repository.appendEvent(
+          { eventId: id, eventType, actor, payload },
+          ctx
+        );
+        const event = await this.repository.findEvent(id, ctx, true);
+        if (
+          !event ||
+          event.event_type !== eventType ||
+          !isDeepStrictEqual(parseStoredJson(event.payload_json), payload)
+        )
+          throw new ReleaseBusV2BaselineAdoptionError(
+            'CONFLICT',
+            'A different callback already owns this immutable evidence identity'
+          );
+      }
     );
-    const event = await this.repository.findEvent(id, {});
-    if (
-      !event ||
-      event.event_type !== eventType ||
-      !isDeepStrictEqual(parseStoredJson(event.payload_json), payload)
-    )
-      throw new ReleaseBusV2BaselineAdoptionError(
-        'CONFLICT',
-        'A different callback already owns this immutable evidence identity'
-      );
   }
 
   private async evidenceForIntent(intent: PreparedIntent): Promise<{


### PR DESCRIPTION
## What changed

- verify each immutable baseline-adoption evidence insert through the same writer transaction/connection
- lock and compare an existing deterministic evidence row on idempotent retry
- add a regression test that models a stale read replica immediately after a successful writer insert

## Root cause

`recordExactEvent()` inserted evidence through the writer pool and immediately verified it with an unscoped `SELECT`, which routed to the read-replica pool. Replica lag could make the just-inserted row appear missing and falsely fail the intent as a conflicting callback.

## Impact

The exact evidence callback is now read-your-writes consistent without weakening immutable callback identity checks. No schema, API, lane, ref, deployment, or adoption-state behavior is otherwise changed.

## Validation

Per owner direction, no local tests or other local verification were run before publication. Exact-head GitHub CI and automated review are the validation path.