### PR TITLE
Bound baseline adoption runtime convergence checks

### DIFF
--- a/src/releaseBusV2/release-bus-v2.baseline-adoption.test.ts
+++ b/src/releaseBusV2/release-bus-v2.baseline-adoption.test.ts
@@ -560,6 +560,7 @@ function harness(options?: {
     readRuntimeShas: jest.fn(async () => runtimes),
     readFrontendRuntimeSha: jest.fn(async () => runtimes.frontend),
     readBackendRuntimeSha: jest.fn(async () => runtimes.backend),
+    waitForBackendRuntimeRetry: jest.fn(async () => undefined),
     hasActiveStagingWorkflow: jest.fn(async () => false),
     refContainsCommit: jest.fn(async () => true),
     getWorkflowRunIdentity: jest.fn(
@@ -1006,13 +1007,6 @@ describe('ReleaseBusV2BaselineAdoptionService', () => {
         return context.service.recordBackendDeployment(backendInput());
       }
     ],
-    [
-      'backend runtime',
-      (context: Harness) => {
-        context.runtimes.backend = 'f'.repeat(40);
-        return context.service.recordBackendDeployment(backendInput());
-      }
-    ]
   ])(
     'fails moved %s evidence closed with no partial adoption',
     async (_label, act) => {
@@ -1027,6 +1021,46 @@ describe('ReleaseBusV2BaselineAdoptionService', () => {
       expect(context.repository.state.row_version).toBe(23);
     }
   );
+
+  it('accepts a transient old backend runtime once the exact deployment converges', async () => {
+    const context = harness();
+    context.deps.readBackendRuntimeSha
+      .mockResolvedValueOnce('f'.repeat(40))
+      .mockResolvedValueOnce(BACKEND_SHA);
+    await prepare(context);
+
+    await expect(
+      context.service.recordBackendDeployment(backendInput())
+    ).resolves.toMatchObject({ outcome: 'RECORDED' });
+    expect(context.deps.readBackendRuntimeSha).toHaveBeenCalledTimes(2);
+    expect(context.deps.waitForBackendRuntimeRetry).toHaveBeenCalledWith(1_000);
+    expect(
+      context.repository.events.some(
+        ({ event_type }) =>
+          event_type === 'EXACT_STAGING_BASELINE_ADOPTION_FAILED'
+      )
+    ).toBe(false);
+  });
+
+  it('fails a persistently mismatched backend runtime closed', async () => {
+    const context = harness();
+    context.runtimes.backend = 'f'.repeat(40);
+    await prepare(context);
+
+    await expect(
+      context.service.recordBackendDeployment(backendInput())
+    ).rejects.toBeInstanceOf(ReleaseBusV2BaselineAdoptionError);
+    expect(context.deps.readBackendRuntimeSha).toHaveBeenCalledTimes(4);
+    expect(context.deps.waitForBackendRuntimeRetry.mock.calls).toEqual([
+      [1_000],
+      [2_000],
+      [4_000]
+    ]);
+    expect(context.repository.trains).toHaveLength(0);
+    expect(context.repository.manifests).toHaveLength(0);
+    expect(context.repository.operations).toHaveLength(0);
+    expect(context.repository.state.row_version).toBe(23);
+  });
 
   it.each([
     [

--- a/src/releaseBusV2/release-bus-v2.baseline-adoption.ts
+++ b/src/releaseBusV2/release-bus-v2.baseline-adoption.ts
@@ -46,6 +46,7 @@ const INTENT_EVENT_TYPES = [
 const INTENT_MIN_TTL_MS = 5 * 60 * 1000;
 const INTENT_MAX_TTL_MS = 2 * 60 * 60 * 1000;
 const ADOPTION_STAGING_LOCK_TTL_MS = 2 * 60 * 60 * 1000;
+const BACKEND_RUNTIME_RETRY_DELAYS_MS = [1_000, 2_000, 4_000] as const;
 const MAX_CANDIDATES = 500;
 const SHA_PATTERN = /^[a-f0-9]{40}$/;
 const SHA256_PATTERN = /^[a-f0-9]{64}$/;
@@ -231,6 +232,7 @@ type BaselineAdoptionDependencies = {
   readonly readRuntimeShas: () => Promise<RuntimeShas>;
   readonly readFrontendRuntimeSha: () => Promise<string>;
   readonly readBackendRuntimeSha: () => Promise<string>;
+  readonly waitForBackendRuntimeRetry: (delayMs: number) => Promise<void>;
   readonly hasActiveStagingWorkflow: (
     ignoredRunIds?: readonly string[]
   ) => Promise<boolean>;
@@ -389,6 +391,8 @@ const dependencies: BaselineAdoptionDependencies = {
   },
   readFrontendRuntimeSha: defaultFrontendRuntimeSha,
   readBackendRuntimeSha: defaultBackendRuntimeSha,
+  waitForBackendRuntimeRetry: (delayMs) =>
+    new Promise((resolve) => setTimeout(resolve, delayMs)),
   hasActiveStagingWorkflow: async (ignoredRunIds) => {
     const active = await Promise.all([
       releaseBusGitHubApp.hasActiveStagingMutationOrE2ERun(
@@ -1089,16 +1093,10 @@ export class ReleaseBusV2BaselineAdoptionService {
           );
         const runtimeSha =
           input.service === 'api'
-            ? await this.deps.readBackendRuntimeSha()
+            ? await this.readConvergedBackendRuntimeSha(
+                intent.expected_backend_runtime_sha
+              )
             : null;
-        if (
-          runtimeSha !== null &&
-          runtimeSha !== intent.expected_backend_runtime_sha
-        )
-          throw new ReleaseBusV2BaselineAdoptionError(
-            'CONFLICT',
-            'Backend API runtime moved from the pending adoption intent'
-          );
         const evidence: BackendEvidence = {
           contract: 'release-bus-v2-baseline-backend-evidence-v1',
           intent_id: intent.intent_id,
@@ -1179,6 +1177,23 @@ export class ReleaseBusV2BaselineAdoptionService {
         );
       }
     });
+  }
+
+  private async readConvergedBackendRuntimeSha(
+    expectedSha: string
+  ): Promise<string> {
+    let runtimeSha = await this.deps.readBackendRuntimeSha();
+    for (const delayMs of BACKEND_RUNTIME_RETRY_DELAYS_MS) {
+      if (runtimeSha === expectedSha) return runtimeSha;
+      await this.deps.waitForBackendRuntimeRetry(delayMs);
+      runtimeSha = await this.deps.readBackendRuntimeSha();
+    }
+    if (runtimeSha !== expectedSha)
+      throw new ReleaseBusV2BaselineAdoptionError(
+        'CONFLICT',
+        'Backend API runtime moved from the pending adoption intent'
+      );
+    return runtimeSha;
   }
 
   private async readPreparationSnapshot(intent: PreparedIntent): Promise<{


### PR DESCRIPTION
## What changed

- retry only valid-but-mismatched staging API runtime SHAs during baseline-adoption backend evidence recording
- bound convergence to the initial sample plus 1s, 2s, and 4s backoffs
- preserve immediate failure for malformed or unavailable runtime evidence
- add focused regression coverage for transient old-SHA to expected-SHA convergence and persistent mismatch failure

## Root cause

A successful exact staging API deployment can return before every Lambda/API path serves the new `/health` commit. The baseline-adoption callback permanently failed on its first valid old-SHA sample, even though the exact expected runtime became visible seconds later.

## Safety

The change accepts evidence only when the exact expected SHA becomes visible within the bounded window. Persistent mismatch still fails closed, and the existing manifest-freeze snapshot and CAS fences continue to revalidate refs, runtimes, state, controls, locks, workflows, and candidates.

## Validation

Per the owner CI-first recovery directive, no local tests, typecheck, lint, format, or broad validation were run before publication. GitHub CI and automated review are the first executable validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backend runtime reconciliation by retrying transient SHA mismatches.
  * Accepts deployments once the backend runtime converges to the expected version.
  * Fails safely after repeated mismatches, preventing incomplete deployment artifacts or operations from being created.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->