### PR TITLE
fix(release-bus): canonicalize adoption E2E operation key

### DIFF
--- a/src/releaseBusV2/release-bus-v2.baseline-adoption.test.ts
+++ b/src/releaseBusV2/release-bus-v2.baseline-adoption.test.ts
@@ -728,7 +728,7 @@ describe('ReleaseBusV2BaselineAdoptionService', () => {
 
   it.each([
     'Staging E2E [automatic]',
-    `Staging E2E [rb2:${INTENT_ID}:baseline-adoption-e2e:staging:a1:a1]`
+    `Staging E2E [rb2:${INTENT_ID}:baseline-adoption-e2e:staging:a1]`
   ])('accepts the real trusted GitHub run.name %s', async (name) => {
     const context = harness();
     Object.assign(context.identities[FRONTEND_E2E_RUN_ID], {
@@ -751,6 +751,7 @@ describe('ReleaseBusV2BaselineAdoptionService', () => {
     'Staging E2E [automatic]-lookalike',
     'Staging E2E [release-bus:train:e2e:a1]',
     'Staging E2E [rb2:train:e2e:a0]',
+    `Staging E2E [rb2:${INTENT_ID}:baseline-adoption-e2e:staging:a1:a1]`,
     `Staging E2E [rb2:${'x'.repeat(176)}:a1]`
   ])('rejects the lookalike or untrusted GitHub run.name %s', async (name) => {
     const context = harness();
@@ -785,6 +786,7 @@ describe('ReleaseBusV2BaselineAdoptionService', () => {
       expect(context.repository.state.row_version).toBe(23);
       expect(context.repository.operations[0]).toMatchObject({
         operation_type: 'E2E_STAGING',
+        idempotency_key: `rb2:${INTENT_ID}:baseline-adoption-e2e:staging`,
         expected_sha: FRONTEND_SHA,
         max_attempts: 1,
         status: 'DISPATCHED',
@@ -792,6 +794,7 @@ describe('ReleaseBusV2BaselineAdoptionService', () => {
       });
       expect(context.operations.reconcileWorkflow).toHaveBeenCalledWith(
         expect.objectContaining({
+          idempotencyKey: `rb2:${INTENT_ID}:baseline-adoption-e2e:staging`,
           workflow: 'staging-e2e.yml',
           ref: '1a-staging',
           artifactDigest: context.repository.manifests[0].identity_sha256,

--- a/src/releaseBusV2/release-bus-v2.baseline-adoption.test.ts
+++ b/src/releaseBusV2/release-bus-v2.baseline-adoption.test.ts
@@ -1009,7 +1009,7 @@ describe('ReleaseBusV2BaselineAdoptionService', () => {
         context.refs.backend = 'f'.repeat(40);
         return context.service.recordBackendDeployment(backendInput());
       }
-    ],
+    ]
   ])(
     'fails moved %s evidence closed with no partial adoption',
     async (_label, act) => {

--- a/src/releaseBusV2/release-bus-v2.baseline-adoption.test.ts
+++ b/src/releaseBusV2/release-bus-v2.baseline-adoption.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import {
   ReleaseBusV2BaselineAdoptionError,
   ReleaseBusV2BaselineAdoptionService,
@@ -18,6 +19,23 @@ const FRONTEND_DEPLOY_RUN_ID = '92000';
 const BACKEND_DEPLOY_RUN_ID = '93000';
 const OTHER_BACKEND_DEPLOY_RUN_ID = '93001';
 const BOUND_E2E_RUN_ID = '94000';
+
+function canonicalJson(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalJson);
+  if (value && typeof value === 'object')
+    return Object.fromEntries(
+      Object.entries(value)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, entry]) => [key, canonicalJson(entry)])
+    );
+  return value;
+}
+
+function sha256(value: unknown): string {
+  return createHash('sha256')
+    .update(JSON.stringify(canonicalJson(value)))
+    .digest('hex');
+}
 
 function controls() {
   return [
@@ -767,6 +785,37 @@ describe('ReleaseBusV2BaselineAdoptionService', () => {
     expect(context.repository.manifests).toHaveLength(0);
     expect(context.repository.operations).toHaveLength(0);
     expect(context.repository.state.row_version).toBe(23);
+  });
+
+  it('reconciles a frozen legacy once-suffixed operation without dispatching another E2E', async () => {
+    const context = harness();
+    await prepare(context);
+    await freeze(context);
+    const prepared = context.repository.events.find(
+      ({ id }) => id === INTENT_ID
+    ).payload_json;
+    const { intent_identity_sha256: _oldIdentity, ...core } = prepared;
+    core.operation_key = `rb2:${INTENT_ID}:baseline-adoption-e2e:staging:a1`;
+    Object.assign(prepared, {
+      ...core,
+      intent_identity_sha256: sha256(core)
+    });
+    Object.assign(context.repository.operations[0], {
+      idempotency_key: core.operation_key,
+      status: 'FAILED',
+      failure_message: 'Legacy double-suffixed workflow failed'
+    });
+
+    await expect(
+      context.service.recordBackendDeployment(backendInput())
+    ).rejects.toBeInstanceOf(ReleaseBusV2BaselineAdoptionError);
+    expect(context.operations.reconcileWorkflow).toHaveBeenCalledWith(
+      expect.objectContaining({ idempotencyKey: core.operation_key })
+    );
+    expect(context.dispatchCount()).toBe(1);
+    expect(context.repository.operations).toHaveLength(1);
+    expect(context.repository.trains[0].status).toBe('FAILED');
+    expect(context.repository.locks[2].lease_token).toBeNull();
   });
 
   it.each(['frontend', 'backend'] as const)(

--- a/src/releaseBusV2/release-bus-v2.baseline-adoption.ts
+++ b/src/releaseBusV2/release-bus-v2.baseline-adoption.ts
@@ -95,7 +95,10 @@ export type ReleaseBusV2BaselineAdoptionResult = {
   readonly operation_id: string | null;
   readonly workflow_run_id: string | null;
   readonly status:
-    'WAITING_FOR_DEPLOYMENTS' | 'E2E_RUNNING' | 'STAGING_VALIDATED' | 'FAILED';
+    | 'WAITING_FOR_DEPLOYMENTS'
+    | 'E2E_RUNNING'
+    | 'STAGING_VALIDATED'
+    | 'FAILED';
   readonly reused: boolean;
 };
 

--- a/src/releaseBusV2/release-bus-v2.baseline-adoption.ts
+++ b/src/releaseBusV2/release-bus-v2.baseline-adoption.ts
@@ -315,7 +315,7 @@ function exactSha(value: unknown, description: string): string {
 }
 
 function operationKey(intentId: string): string {
-  return `rb2:${intentId}:baseline-adoption-e2e:staging:a1`;
+  return `rb2:${intentId}:baseline-adoption-e2e:staging`;
 }
 
 function failureEventId(intentId: string): string {

--- a/src/releaseBusV2/release-bus-v2.baseline-adoption.ts
+++ b/src/releaseBusV2/release-bus-v2.baseline-adoption.ts
@@ -95,10 +95,7 @@ export type ReleaseBusV2BaselineAdoptionResult = {
   readonly operation_id: string | null;
   readonly workflow_run_id: string | null;
   readonly status:
-    | 'WAITING_FOR_DEPLOYMENTS'
-    | 'E2E_RUNNING'
-    | 'STAGING_VALIDATED'
-    | 'FAILED';
+    'WAITING_FOR_DEPLOYMENTS' | 'E2E_RUNNING' | 'STAGING_VALIDATED' | 'FAILED';
   readonly reused: boolean;
 };
 
@@ -316,6 +313,10 @@ function exactSha(value: unknown, description: string): string {
 
 function operationKey(intentId: string): string {
   return `rb2:${intentId}:baseline-adoption-e2e:staging`;
+}
+
+function legacyOperationKey(intentId: string): string {
+  return `${operationKey(intentId)}:a1`;
 }
 
 function failureEventId(intentId: string): string {
@@ -672,7 +673,10 @@ function exactPreparedIntent(
       !payload ||
       payload.contract !== 'release-bus-v2-baseline-adoption-intent-v1' ||
       !UUID_V4_PATTERN.test(payload.intent_id) ||
-      payload.operation_key !== operationKey(payload.intent_id) ||
+      ![
+        operationKey(payload.intent_id),
+        legacyOperationKey(payload.intent_id)
+      ].includes(payload.operation_key) ||
       !SHA256_PATTERN.test(payload.intent_identity_sha256)
     )
       return null;
@@ -1728,7 +1732,7 @@ export class ReleaseBusV2BaselineAdoptionService {
         const updated = await this.repository.findTrain(train.id, ctx, true);
         if (!updated)
           throw new Error('Frozen baseline-adoption train is unavailable');
-        const spec = this.workflowSpec(updated, manifest);
+        const spec = this.workflowSpec(updated, manifest, intent.operation_key);
         await this.repository.getOrCreateOperation(
           {
             idempotencyKey: spec.idempotencyKey,
@@ -1774,7 +1778,8 @@ export class ReleaseBusV2BaselineAdoptionService {
 
   private workflowSpec(
     train: ReleaseBusV2TrainRecord,
-    manifest: ReleaseBusV2ManifestRecord
+    manifest: ReleaseBusV2ManifestRecord,
+    idempotencyKey: string
   ): ReleaseBusV2WorkflowSpec {
     const frontendSha = train.frontend_composed_sha;
     const backendSha = train.backend_composed_sha;
@@ -1784,11 +1789,14 @@ export class ReleaseBusV2BaselineAdoptionService {
       !backendSha ||
       !SHA_PATTERN.test(frontendSha) ||
       !SHA_PATTERN.test(backendSha) ||
-      !SHA256_PATTERN.test(manifest.identity_sha256)
+      !SHA256_PATTERN.test(manifest.identity_sha256) ||
+      ![operationKey(train.id), legacyOperationKey(train.id)].includes(
+        idempotencyKey
+      )
     )
       throw new Error('Baseline-adoption E2E identity is incomplete');
     return {
-      idempotencyKey: operationKey(train.id),
+      idempotencyKey,
       trainId: train.id,
       operationType: 'E2E_STAGING',
       repository: 'frontend',
@@ -1819,10 +1827,11 @@ export class ReleaseBusV2BaselineAdoptionService {
   private isExactBoundOperation(
     train: ReleaseBusV2TrainRecord,
     manifest: ReleaseBusV2ManifestRecord,
-    operation: ReleaseBusV2OperationRecord
+    operation: ReleaseBusV2OperationRecord,
+    idempotencyKey: string
   ): boolean {
     try {
-      const spec = this.workflowSpec(train, manifest);
+      const spec = this.workflowSpec(train, manifest, idempotencyKey);
       const request = parseStoredJson<unknown>(operation.request_json);
       return (
         operation.idempotency_key === spec.idempotencyKey &&
@@ -1861,7 +1870,7 @@ export class ReleaseBusV2BaselineAdoptionService {
         'Frozen baseline-adoption manifest is unavailable'
       );
     const reconciled = await this.operations.reconcileWorkflow(
-      this.workflowSpec(train, manifest)
+      this.workflowSpec(train, manifest, intent.operation_key)
     );
     if (['FAILED', 'CANCELLED'].includes(reconciled.status)) {
       await this.failIntent(
@@ -1961,7 +1970,14 @@ export class ReleaseBusV2BaselineAdoptionService {
     const body = this.exactManifestBody(intent, train, manifest);
     if (!body)
       throw new Error('Immutable baseline-adoption manifest is malformed');
-    if (!this.isExactBoundOperation(train, manifest, operation))
+    if (
+      !this.isExactBoundOperation(
+        train,
+        manifest,
+        operation,
+        intent.operation_key
+      )
+    )
       throw new Error('Manifest-bound E2E operation identity is malformed');
     const [refs, runtimes, controls, otherActive, nonterminal, activeWorkflow] =
       await Promise.all([
@@ -2034,7 +2050,12 @@ export class ReleaseBusV2BaselineAdoptionService {
         const exactE2e = lockedOperations.filter(
           (item) =>
             item.id === operation.id &&
-            this.isExactBoundOperation(lockedTrain ?? train, manifest, item) &&
+            this.isExactBoundOperation(
+              lockedTrain ?? train,
+              manifest,
+              item,
+              intent.operation_key
+            ) &&
             item.status === 'SUCCEEDED' &&
             item.external_id === operation.external_id &&
             item.artifact_digest === manifest.identity_sha256

--- a/src/releaseBusV2/release-bus-v2.baseline-adoption.ts
+++ b/src/releaseBusV2/release-bus-v2.baseline-adoption.ts
@@ -54,6 +54,7 @@ const UUID_V4_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 const RUN_ID_PATTERN = /^[1-9]\d{0,19}$/;
 const UNIT_PATTERN = /^[A-Za-z0-9_-]{1,100}$/;
+const OPERATION_ATTEMPT_SUFFIX_PATTERN = /^a[1-9]\d{0,8}$/;
 const RELEASE_BUS_OPERATION_ATTEMPT_PATTERN =
   /^rb2:[A-Za-z0-9:._-]+:a[1-9]\d{0,8}$/;
 
@@ -718,10 +719,12 @@ function assertFrontendWorkflowIdentities(
 function isTrustedStagingE2EWorkflowName(value: string): boolean {
   const match = /^Staging E2E \[([A-Za-z0-9:._-]+)\]$/.exec(value);
   const identity = match?.[1] ?? '';
+  const segments = identity.split(':');
   return (
     identity === 'automatic' ||
     (identity.length <= 180 &&
-      RELEASE_BUS_OPERATION_ATTEMPT_PATTERN.test(identity))
+      RELEASE_BUS_OPERATION_ATTEMPT_PATTERN.test(identity) &&
+      !OPERATION_ATTEMPT_SUFFIX_PATTERN.test(segments.at(-2) ?? ''))
   );
 }
 


### PR DESCRIPTION
## Summary
- persist new baseline-adoption E2E operations as suffix-free durable identities
- let the generic workflow dispatcher append the sole attempt suffix
- preserve bounded read/reconcile compatibility for the one known frozen legacy once-suffixed intent so its existing failed run is terminalized without redispatch
- cover canonical single-suffix acceptance, double-suffix rejection, and legacy failed-operation recovery

## Root cause
The baseline producer persisted `...:staging:a1`, while the generic dispatcher owns attempt suffixing and emitted `...:staging:a1:a1`. Authorization correctly rejected that malformed identity before expensive tests ran. The durable key and trusted run name intentionally differ: the durable key omits an attempt suffix; the generic dispatcher adds `:a1` to the GitHub run identity.

## Existing in-flight operation
The known frozen legacy intent is immutable. This patch accepts its exactly once-suffixed signed prepared event only for lookup, then reconciles its existing double-suffixed failed GitHub run under that original durable key. It does not create another operation or dispatch. All new intents use the suffix-free durable key.

## Validation
GitHub exact-head CI and automated review are the validation authority per the owner's CI-first recovery directive. A local focused Jest launch was unavailable because this fresh worktree has no installed `ts-jest`; no dependency install or broad local suite was put on the critical path. Prettier passed for both changed files.

Signed-off-by: GelatoGenesis <1407802+GelatoGenesis@users.noreply.github.com>