### PR TITLE
Fix Release Bus dispatch reservation consistency

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -605,6 +605,13 @@ backend DAG frontiers run concurrently; only shared environment mutation plus
 E2E ownership is serialized. Operation keys, workflow titles, workflow
 authorization, SHA/artifact checks, row versions, and callback identity make
 retries and duplicate reconciliation idempotent.
+Operation reads normally use the read pool. When reconciliation has just
+CAS-written a dispatch reservation and must decide whether it may call GitHub,
+it rereads that immutable operation from the writer pool. An explicit
+transaction connection already identifies the writer and takes precedence over
+pool selection. Only an authoritative `DISPATCHED` reservation permits the
+external dispatch; missing or concurrently advanced state fails closed without
+dispatching.
 
 For cumulative staging, each affected repository's immutable release commit
 has the recorded `1a-staging` head as its first parent and the composed

--- a/src/releaseBusV2/release-bus-v2.operations.test.ts
+++ b/src/releaseBusV2/release-bus-v2.operations.test.ts
@@ -220,6 +220,46 @@ describe('Release Bus v2 exact operation callbacks', () => {
     expect(state.repository.appendEvent).toHaveBeenCalledTimes(1);
   });
 
+  it('returns the writer-reserved dispatch when the read replica is stale', async () => {
+    const staleReplica = operation({
+      external_id: null,
+      status: 'PENDING',
+      idempotency_key: 'rb2:train-id:e2e:staging',
+      operation_type: 'E2E_STAGING',
+      repository: 'frontend',
+      environment: 'staging'
+    });
+    const state = repositoryFor(staleReplica);
+    state.repository.findOperation.mockImplementation(
+      async (_key: string, _ctx: unknown, forceWrite = false) =>
+        forceWrite ? state.current() : staleReplica
+    );
+    mockFindWorkflowRun.mockResolvedValue(null);
+    const service = new ReleaseBusV2Operations(state.repository as never);
+
+    const reconciled = await service.reconcileWorkflow({
+      idempotencyKey: staleReplica.idempotency_key,
+      trainId: staleReplica.train_id,
+      operationType: staleReplica.operation_type,
+      repository: 'frontend',
+      workflow: 'staging-e2e.yml',
+      ref: '1a-staging',
+      environment: 'staging',
+      service: null,
+      expectedSha: staleReplica.expected_sha!,
+      artifactDigest: null,
+      inputs: {}
+    });
+
+    expect(reconciled.status).toBe('DISPATCHED');
+    expect(state.repository.findOperation).toHaveBeenCalledWith(
+      staleReplica.idempotency_key,
+      {},
+      true
+    );
+    expect(mockDispatchWorkflow).toHaveBeenCalledTimes(1);
+  });
+
   it('continues an old-producer preflight with its immutable stored request after the reconciler upgrade', async () => {
     const oldInputs = {
       release_train_id: 'train-id',

--- a/src/releaseBusV2/release-bus-v2.operations.test.ts
+++ b/src/releaseBusV2/release-bus-v2.operations.test.ts
@@ -260,6 +260,83 @@ describe('Release Bus v2 exact operation callbacks', () => {
     expect(mockDispatchWorkflow).toHaveBeenCalledTimes(1);
   });
 
+  it.each([
+    'PENDING',
+    'RUNNING',
+    'RETRY_WAIT',
+    'SUCCEEDED',
+    'FAILED',
+    'CANCELLED'
+  ] as const)(
+    'does not dispatch when the writer has advanced the reservation to %s',
+    async (writerStatus) => {
+      const staleReplica = operation({
+        external_id: null,
+        status: 'PENDING'
+      });
+      const state = repositoryFor(staleReplica);
+      state.repository.findOperation.mockImplementation(
+        async (_key: string, _ctx: unknown, forceWrite = false) =>
+          forceWrite
+            ? operation({
+                ...state.current(),
+                status: writerStatus,
+                row_version: state.current().row_version + 1
+              })
+            : staleReplica
+      );
+      mockFindWorkflowRun.mockResolvedValue(null);
+      const service = new ReleaseBusV2Operations(state.repository as never);
+
+      const reconciled = await service.reconcileWorkflow({
+        idempotencyKey: staleReplica.idempotency_key,
+        trainId: staleReplica.train_id,
+        operationType: staleReplica.operation_type,
+        repository: 'frontend',
+        workflow: 'staging-e2e.yml',
+        ref: '1a-staging',
+        environment: 'staging',
+        service: null,
+        expectedSha: staleReplica.expected_sha!,
+        artifactDigest: null,
+        inputs: {}
+      });
+
+      expect(reconciled.status).toBe(writerStatus);
+      expect(mockDispatchWorkflow).not.toHaveBeenCalled();
+    }
+  );
+
+  it('fails closed when the writer cannot see the dispatch reservation', async () => {
+    const pending = operation({ external_id: null, status: 'PENDING' });
+    const state = repositoryFor(pending);
+    state.repository.findOperation.mockImplementation(
+      async (_key: string, _ctx: unknown, forceWrite = false) =>
+        forceWrite ? null : pending
+    );
+    mockFindWorkflowRun.mockResolvedValue(null);
+    const service = new ReleaseBusV2Operations(state.repository as never);
+
+    await expect(
+      service.reconcileWorkflow({
+        idempotencyKey: pending.idempotency_key,
+        trainId: pending.train_id,
+        operationType: pending.operation_type,
+        repository: 'frontend',
+        workflow: 'staging-e2e.yml',
+        ref: '1a-staging',
+        environment: 'staging',
+        service: null,
+        expectedSha: pending.expected_sha!,
+        artifactDigest: null,
+        inputs: {}
+      })
+    ).rejects.toThrow(
+      'Release Bus v2 dispatch reservation was not visible on the writer'
+    );
+    expect(mockDispatchWorkflow).not.toHaveBeenCalled();
+  });
+
   it('continues an old-producer preflight with its immutable stored request after the reconciler upgrade', async () => {
     const oldInputs = {
       release_train_id: 'train-id',

--- a/src/releaseBusV2/release-bus-v2.operations.test.ts
+++ b/src/releaseBusV2/release-bus-v2.operations.test.ts
@@ -117,7 +117,13 @@ function repositoryFor(initial: ReleaseBusV2OperationRecord) {
   return {
     repository: {
       appendEvent: jest.fn(async () => undefined),
-      findOperation: jest.fn(async () => current),
+      findOperation: jest.fn(
+        async (
+          _key: string,
+          _ctx: unknown,
+          _forceWrite = false
+        ): Promise<ReleaseBusV2OperationRecord | null> => current
+      ),
       getOrCreateOperation: jest.fn(async () => current),
       updateOperation
     },

--- a/src/releaseBusV2/release-bus-v2.operations.ts
+++ b/src/releaseBusV2/release-bus-v2.operations.ts
@@ -826,9 +826,17 @@ export class ReleaseBusV2Operations {
         // reconcilers race on this optimistic update, so only one winner can
         // dispatch while the workflow is not yet discoverable.
         await this.update(operation, { status: 'DISPATCHED', result: null });
-        operation =
-          (await this.repository.findOperation(spec.idempotencyKey, {}, true)) ??
-          operation;
+        const reserved = await this.repository.findOperation(
+          spec.idempotencyKey,
+          {},
+          true
+        );
+        if (!reserved)
+          throw new Error(
+            'Release Bus v2 dispatch reservation was not visible on the writer'
+          );
+        if (reserved.status !== 'DISPATCHED') return reserved;
+        operation = reserved;
         await releaseBusGitHubApp.dispatchWorkflow(
           spec.repository,
           operationRequest.workflow,

--- a/src/releaseBusV2/release-bus-v2.operations.ts
+++ b/src/releaseBusV2/release-bus-v2.operations.ts
@@ -827,11 +827,7 @@ export class ReleaseBusV2Operations {
         // dispatch while the workflow is not yet discoverable.
         await this.update(operation, { status: 'DISPATCHED', result: null });
         operation =
-          (await this.repository.findOperation(
-            spec.idempotencyKey,
-            {},
-            true
-          )) ??
+          (await this.repository.findOperation(spec.idempotencyKey, {}, true)) ??
           operation;
         await releaseBusGitHubApp.dispatchWorkflow(
           spec.repository,

--- a/src/releaseBusV2/release-bus-v2.operations.ts
+++ b/src/releaseBusV2/release-bus-v2.operations.ts
@@ -827,7 +827,11 @@ export class ReleaseBusV2Operations {
         // dispatch while the workflow is not yet discoverable.
         await this.update(operation, { status: 'DISPATCHED', result: null });
         operation =
-          (await this.repository.findOperation(spec.idempotencyKey, {})) ??
+          (await this.repository.findOperation(
+            spec.idempotencyKey,
+            {},
+            true
+          )) ??
           operation;
         await releaseBusGitHubApp.dispatchWorkflow(
           spec.repository,

--- a/src/releaseBusV2/release-bus-v2.repository.ts
+++ b/src/releaseBusV2/release-bus-v2.repository.ts
@@ -43,11 +43,9 @@ import type {
 } from '@/releaseBusV2/release-bus-v2.types';
 
 function dbOptions(ctx: RequestContext, forceWrite = false) {
-  return ctx.connection
-    ? { wrappedConnection: ctx.connection }
-    : forceWrite
-      ? { forcePool: DbPoolName.WRITE }
-      : undefined;
+  if (ctx.connection) return { wrappedConnection: ctx.connection };
+  if (forceWrite) return { forcePool: DbPoolName.WRITE };
+  return undefined;
 }
 
 function json(value: unknown): string | null {

--- a/src/releaseBusV2/release-bus-v2.repository.ts
+++ b/src/releaseBusV2/release-bus-v2.repository.ts
@@ -42,8 +42,12 @@ import type {
   ReleaseBusV2TrainStatus
 } from '@/releaseBusV2/release-bus-v2.types';
 
-function dbOptions(ctx: RequestContext) {
-  return ctx.connection ? { wrappedConnection: ctx.connection } : undefined;
+function dbOptions(ctx: RequestContext, forceWrite = false) {
+  return ctx.connection
+    ? { wrappedConnection: ctx.connection }
+    : forceWrite
+      ? { forcePool: DbPoolName.WRITE }
+      : undefined;
 }
 
 function json(value: unknown): string | null {
@@ -1338,12 +1342,13 @@ export class ReleaseBusV2Repository extends LazyDbAccessCompatibleService {
 
   public async findOperation(
     idempotencyKey: string,
-    ctx: RequestContext
+    ctx: RequestContext,
+    forceWrite = false
   ): Promise<ReleaseBusV2OperationRecord | null> {
     return this.db.oneOrNull<ReleaseBusV2OperationRecord>(
       `select * from ${RELEASE_BUS_V2_OPERATIONS_TABLE} where idempotency_key = :idempotencyKey`,
       { idempotencyKey },
-      dbOptions(ctx)
+      dbOptions(ctx, forceWrite)
     );
   }
 


### PR DESCRIPTION
## Summary

- read the just-written workflow dispatch reservation from the writer pool
- dispatch only while the authoritative reservation remains `DISPATCHED`
- fail closed when the writer row is missing or has advanced concurrently
- document the writer-read contract and transaction precedence

## Root cause

The exact baseline-adoption manifest froze and the operation CAS-reserved `DISPATCHED`, but the immediate post-write lookup used the lagging read replica. It returned stale `PENDING` after GitHub had accepted the sole E2E dispatch, so baseline adoption failed closed with “not yet durably reserved” even though the exact run existed.

## Validation

CI-first per the owner recovery directive. `git diff --check` passed locally; the directly affected Jest/static/format gates are delegated to exact-head GitHub CI. No broad local suite was run.

## Deployment / recovery order

After merge and fresh Release Bus OFF/changeable/drain gates: deploy production `api`; normally merge exact backend `main` into existing `1a-staging`; deploy staging `releaseBus`, then staging `api`; prepare a fresh bounded adoption intent only after exact runtime/ref/candidate revalidation. Production remains OFF.

## Live safety

This PR does not retry, deploy, change refs, adopt staging state, or change either lane. The already-dispatched exact E2E remains untouched.
