### PR TITLE
Fix cumulative carry-forward evidence validation

### DIFF
--- a/src/releaseBusV2/release-bus-v2.acceptance.test.ts
+++ b/src/releaseBusV2/release-bus-v2.acceptance.test.ts
@@ -37,6 +37,7 @@ jest.mock('@/releaseBusV2/release-bus-v2.github-app', () => ({
 
 import {
   backendGraph,
+  candidateEvidenceCandidates,
   candidateEvidenceSelection,
   preparedArtifactDeployBinding,
   ReleaseBusV2Reconciler
@@ -261,6 +262,55 @@ describe('whole-repository candidate evidence modes', () => {
         null
       )
     ).toThrow('no complete exact PR CI policy evidence');
+  });
+
+  it('requires fresh evidence only from NEW candidates in a cumulative staging train', () => {
+    const fresh = candidate('fresh', 'frontend', null);
+    const carried = {
+      ...candidate('carried', 'frontend', null),
+      pr_evidence_json: null,
+      status: 'PRODUCTION_DEPLOYED' as const,
+      current_train_id: null
+    };
+    const cumulative = train('train-1', {
+      lane: 'STAGING',
+      staging_policy: 'CUMULATIVE_ADMITTED_SET_V1',
+      staging_baseline_manifest_id: 'baseline-manifest'
+    });
+    const selected = candidateEvidenceCandidates(
+      {
+        train: cumulative,
+        memberships: [
+          {
+            id: 'membership-fresh',
+            train_id: cumulative.id,
+            candidate_id: fresh.id,
+            sequence: 1,
+            disposition: 'INCLUDED',
+            candidate_role: 'NEW',
+            created_at: 1
+          },
+          {
+            id: 'membership-carried',
+            train_id: cumulative.id,
+            candidate_id: carried.id,
+            sequence: 2,
+            disposition: 'INCLUDED',
+            candidate_role: 'CARRY_FORWARD',
+            created_at: 1
+          }
+        ],
+        candidates: [fresh, carried],
+        dependencies: []
+      },
+      'frontend'
+    );
+
+    expect(selected).toEqual([fresh]);
+    expect(candidateEvidenceSelection(selected, null)).toMatchObject({
+      mode: 'strict-aggregate',
+      aggregateDigest: expect.stringMatching(/^[a-f0-9]{64}$/)
+    });
   });
 });
 

--- a/src/releaseBusV2/release-bus-v2.acceptance.test.ts
+++ b/src/releaseBusV2/release-bus-v2.acceptance.test.ts
@@ -264,10 +264,17 @@ describe('whole-repository candidate evidence modes', () => {
     ).toThrow('no complete exact PR CI policy evidence');
   });
 
-  it('requires fresh evidence only from NEW candidates in a cumulative staging train', () => {
-    const fresh = candidate('fresh', 'frontend', null);
-    const carried = {
-      ...candidate('carried', 'frontend', null),
+  it('requires fresh evidence only from NEW frontend and backend candidates in cumulative staging', () => {
+    const freshFrontend = candidate('fresh-frontend', 'frontend', null);
+    const freshBackend = candidate('fresh-backend', 'backend', null);
+    const carriedFrontend = {
+      ...candidate('carried-frontend', 'frontend', null),
+      pr_evidence_json: null,
+      status: 'PRODUCTION_DEPLOYED' as const,
+      current_train_id: null
+    };
+    const carriedBackend = {
+      ...candidate('carried-backend', 'backend', null),
       pr_evidence_json: null,
       status: 'PRODUCTION_DEPLOYED' as const,
       current_train_id: null
@@ -277,40 +284,88 @@ describe('whole-repository candidate evidence modes', () => {
       staging_policy: 'CUMULATIVE_ADMITTED_SET_V1',
       staging_baseline_manifest_id: 'baseline-manifest'
     });
-    const selected = candidateEvidenceCandidates(
-      {
-        train: cumulative,
-        memberships: [
-          {
-            id: 'membership-fresh',
-            train_id: cumulative.id,
-            candidate_id: fresh.id,
-            sequence: 1,
-            disposition: 'INCLUDED',
-            candidate_role: 'NEW',
-            created_at: 1
-          },
-          {
-            id: 'membership-carried',
-            train_id: cumulative.id,
-            candidate_id: carried.id,
-            sequence: 2,
-            disposition: 'INCLUDED',
-            candidate_role: 'CARRY_FORWARD',
-            created_at: 1
-          }
-        ],
-        candidates: [fresh, carried],
-        dependencies: []
-      },
-      'frontend'
-    );
+    const context = {
+      train: cumulative,
+      memberships: [
+        {
+          id: 'membership-fresh-frontend',
+          train_id: cumulative.id,
+          candidate_id: freshFrontend.id,
+          sequence: 1,
+          disposition: 'INCLUDED' as const,
+          candidate_role: 'NEW' as const,
+          created_at: 1
+        },
+        {
+          id: 'membership-fresh-backend',
+          train_id: cumulative.id,
+          candidate_id: freshBackend.id,
+          sequence: 2,
+          disposition: 'INCLUDED' as const,
+          candidate_role: 'NEW' as const,
+          created_at: 1
+        },
+        {
+          id: 'membership-carried-frontend',
+          train_id: cumulative.id,
+          candidate_id: carriedFrontend.id,
+          sequence: 3,
+          disposition: 'INCLUDED' as const,
+          candidate_role: 'CARRY_FORWARD' as const,
+          created_at: 1
+        },
+        {
+          id: 'membership-carried-backend',
+          train_id: cumulative.id,
+          candidate_id: carriedBackend.id,
+          sequence: 4,
+          disposition: 'INCLUDED' as const,
+          candidate_role: 'CARRY_FORWARD' as const,
+          created_at: 1
+        }
+      ],
+      candidates: [
+        freshFrontend,
+        freshBackend,
+        carriedFrontend,
+        carriedBackend
+      ],
+      dependencies: []
+    };
 
-    expect(selected).toEqual([fresh]);
-    expect(candidateEvidenceSelection(selected, null)).toMatchObject({
-      mode: 'strict-aggregate',
-      aggregateDigest: expect.stringMatching(/^[a-f0-9]{64}$/)
-    });
+    for (const [repository, fresh] of [
+      ['frontend', freshFrontend],
+      ['backend', freshBackend]
+    ] as const) {
+      const selected = candidateEvidenceCandidates(context, repository);
+      expect(selected).toEqual([fresh]);
+      expect(candidateEvidenceSelection(selected, null)).toMatchObject({
+        mode: 'strict-aggregate',
+        aggregateDigest: expect.stringMatching(/^[a-f0-9]{64}$/)
+      });
+    }
+
+    const productionContext = {
+      ...context,
+      train: {
+        ...cumulative,
+        lane: 'PRODUCTION' as const
+      },
+      memberships: context.memberships.map((membership) => ({
+        ...membership,
+        train_id: cumulative.id
+      }))
+    };
+    expect(candidateEvidenceCandidates(productionContext, 'frontend')).toEqual([
+      freshFrontend,
+      carriedFrontend
+    ]);
+    expect(() =>
+      candidateEvidenceSelection(
+        candidateEvidenceCandidates(productionContext, 'frontend'),
+        null
+      )
+    ).toThrow('frontend#20 has no complete exact PR CI policy evidence');
   });
 });
 

--- a/src/releaseBusV2/release-bus-v2.reconciler.ts
+++ b/src/releaseBusV2/release-bus-v2.reconciler.ts
@@ -1457,6 +1457,20 @@ export function candidateStatusMutationCandidates(
     : relevantCandidates(context);
 }
 
+export function candidateEvidenceCandidates(
+  context: TrainContext,
+  repository?: ReleaseBusV2Repository
+): ReleaseBusV2CandidateRecord[] {
+  const candidates =
+    context.train.lane === 'STAGING' &&
+    context.train.staging_policy === 'CUMULATIVE_ADMITTED_SET_V1'
+      ? stagingStatusCandidates(context)
+      : relevantCandidates(context);
+  return repository
+    ? candidates.filter((candidate) => candidate.repository === repository)
+    : candidates;
+}
+
 export function stagingDeploymentCandidates(
   context: TrainContext,
   repository?: ReleaseBusV2Repository
@@ -2295,7 +2309,10 @@ export class ReleaseBusV2Reconciler {
       >
     > = [];
     for (const repository of ['frontend', 'backend'] as const) {
-      const repositoryCandidates = relevantCandidates(context, repository);
+      const repositoryCandidates = candidateEvidenceCandidates(
+        context,
+        repository
+      );
       if (repositoryCandidates.length === 0) continue;
       try {
         candidateEvidenceSelection(repositoryCandidates, null);
@@ -2459,6 +2476,10 @@ export class ReleaseBusV2Reconciler {
   ): Promise<PreparedRepository> {
     const train = context.train;
     const candidates = relevantCandidates(context, repository);
+    const evidenceCandidates = candidateEvidenceCandidates(
+      context,
+      repository
+    );
     const deployCandidates = stagingDeploymentCandidates(context, repository);
     const releaseParentSha = cumulativeStagingReleaseParent(
       context,
@@ -2493,7 +2514,7 @@ export class ReleaseBusV2Reconciler {
         : null;
     const releaseFastCandidate = releaseParentSha ? null : fastCandidate;
     const evidenceSelection = candidateEvidenceSelectionForPreparation(
-      candidates,
+      evidenceCandidates,
       releaseFastCandidate?.id ?? null
     );
     let initialComposedSha: string | null | undefined = null;

--- a/src/releaseBusV2/release-bus-v2.reconciler.ts
+++ b/src/releaseBusV2/release-bus-v2.reconciler.ts
@@ -359,8 +359,8 @@ export function canUseSingleCandidateFastPath(
   const evidence = prEvidence(candidate);
   return Boolean(
     evidence &&
-    evidence.base_sha === baseSha &&
-    /^[a-f0-9]{40}$/.test(evidence.merge_sha)
+      evidence.base_sha === baseSha &&
+      /^[a-f0-9]{40}$/.test(evidence.merge_sha)
   );
 }
 
@@ -387,19 +387,19 @@ function hasExactEvidenceAudit(
 } {
   return Boolean(
     evidence &&
-    /^[a-f0-9]{40}$/.test(evidence.base_sha) &&
-    /^[a-f0-9]{40}$/.test(evidence.merge_sha) &&
-    /^[1-9][0-9]{0,19}$/.test(evidence.checks_run_id) &&
-    Number.isSafeInteger(evidence.checks_completed_at) &&
-    evidence.checks_completed_at > 0 &&
-    evidence?.workflow_path &&
-    /^[a-f0-9]{40}$/.test(evidence.base_workflow_blob_sha ?? '') &&
-    /^[a-f0-9]{40}$/.test(evidence.merge_workflow_blob_sha ?? '') &&
-    /^[a-f0-9]{64}$/.test(evidence.base_gate_policy_digest ?? '') &&
-    /^[a-f0-9]{64}$/.test(evidence.merge_gate_policy_digest ?? '') &&
-    ['evidence-manifest-v1', 'legacy-exact-workflow-v0'].includes(
-      evidence.trust_mode ?? ''
-    )
+      /^[a-f0-9]{40}$/.test(evidence.base_sha) &&
+      /^[a-f0-9]{40}$/.test(evidence.merge_sha) &&
+      /^[1-9][0-9]{0,19}$/.test(evidence.checks_run_id) &&
+      Number.isSafeInteger(evidence.checks_completed_at) &&
+      evidence.checks_completed_at > 0 &&
+      evidence?.workflow_path &&
+      /^[a-f0-9]{40}$/.test(evidence.base_workflow_blob_sha ?? '') &&
+      /^[a-f0-9]{40}$/.test(evidence.merge_workflow_blob_sha ?? '') &&
+      /^[a-f0-9]{64}$/.test(evidence.base_gate_policy_digest ?? '') &&
+      /^[a-f0-9]{64}$/.test(evidence.merge_gate_policy_digest ?? '') &&
+      ['evidence-manifest-v1', 'legacy-exact-workflow-v0'].includes(
+        evidence.trust_mode ?? ''
+      )
   );
 }
 
@@ -2476,10 +2476,7 @@ export class ReleaseBusV2Reconciler {
   ): Promise<PreparedRepository> {
     const train = context.train;
     const candidates = relevantCandidates(context, repository);
-    const evidenceCandidates = candidateEvidenceCandidates(
-      context,
-      repository
-    );
+    const evidenceCandidates = candidateEvidenceCandidates(context, repository);
     const deployCandidates = stagingDeploymentCandidates(context, repository);
     const releaseParentSha = cumulativeStagingReleaseParent(
       context,

--- a/src/releaseBusV2/release-bus-v2.reconciler.ts
+++ b/src/releaseBusV2/release-bus-v2.reconciler.ts
@@ -359,8 +359,8 @@ export function canUseSingleCandidateFastPath(
   const evidence = prEvidence(candidate);
   return Boolean(
     evidence &&
-      evidence.base_sha === baseSha &&
-      /^[a-f0-9]{40}$/.test(evidence.merge_sha)
+    evidence.base_sha === baseSha &&
+    /^[a-f0-9]{40}$/.test(evidence.merge_sha)
   );
 }
 
@@ -387,19 +387,19 @@ function hasExactEvidenceAudit(
 } {
   return Boolean(
     evidence &&
-      /^[a-f0-9]{40}$/.test(evidence.base_sha) &&
-      /^[a-f0-9]{40}$/.test(evidence.merge_sha) &&
-      /^[1-9][0-9]{0,19}$/.test(evidence.checks_run_id) &&
-      Number.isSafeInteger(evidence.checks_completed_at) &&
-      evidence.checks_completed_at > 0 &&
-      evidence?.workflow_path &&
-      /^[a-f0-9]{40}$/.test(evidence.base_workflow_blob_sha ?? '') &&
-      /^[a-f0-9]{40}$/.test(evidence.merge_workflow_blob_sha ?? '') &&
-      /^[a-f0-9]{64}$/.test(evidence.base_gate_policy_digest ?? '') &&
-      /^[a-f0-9]{64}$/.test(evidence.merge_gate_policy_digest ?? '') &&
-      ['evidence-manifest-v1', 'legacy-exact-workflow-v0'].includes(
-        evidence.trust_mode ?? ''
-      )
+    /^[a-f0-9]{40}$/.test(evidence.base_sha) &&
+    /^[a-f0-9]{40}$/.test(evidence.merge_sha) &&
+    /^[1-9][0-9]{0,19}$/.test(evidence.checks_run_id) &&
+    Number.isSafeInteger(evidence.checks_completed_at) &&
+    evidence.checks_completed_at > 0 &&
+    evidence?.workflow_path &&
+    /^[a-f0-9]{40}$/.test(evidence.base_workflow_blob_sha ?? '') &&
+    /^[a-f0-9]{40}$/.test(evidence.merge_workflow_blob_sha ?? '') &&
+    /^[a-f0-9]{64}$/.test(evidence.base_gate_policy_digest ?? '') &&
+    /^[a-f0-9]{64}$/.test(evidence.merge_gate_policy_digest ?? '') &&
+    ['evidence-manifest-v1', 'legacy-exact-workflow-v0'].includes(
+      evidence.trust_mode ?? ''
+    )
   );
 }
 


### PR DESCRIPTION
## Issue
The first real frontend-only cumulative staging train failed before dispatch because Release Bus required the newest exact PR CI policy evidence from every baseline-adopted carry-forward candidate. Legacy carried frontend PR #3498 predates that evidence contract, so the bus incorrectly failed new PR #3533.

## Fix
For cumulative staging trains, require fresh PR CI evidence only from NEW candidates. Continue composing the complete carried candidate set from the validated baseline release parent, while binding artifact preparation to the NEW candidate evidence. The selector is repository-generic and applies identically to frontend and backend candidates. Non-cumulative staging and production validation remain unchanged.

## Validation
- Added focused regression coverage with legacy carried frontend and backend candidates plus fresh frontend and backend candidates.
- Proved cumulative staging selects only the fresh candidate per repository.
- Proved production still selects fresh plus carried candidates and rejects missing evidence.
- `git diff --check` passed.
- Targeted Jest could not start in the fresh worktree because dependencies are not installed; exact-head CI is the authoritative execution gate.

## Deployment impact and order
This source is bundled into the production API and the production-only `releaseBus` Serverless service.

1. Deploy backend service `api` to production, updating Lambda `seizeAPI` (the manual reconcile/control route imports the reconciler).
2. Deploy backend service `releaseBus` to production, updating Lambda `releaseBusV2Reconciler`; the same Serverless service deployment also refreshes `releaseBusCleaner`, although cleaner behavior is not changed.

No staging `releaseBus` deployment exists. After production control-plane deployment, merge the exact backend main into `1a-staging` without losing staging-only history and deploy staging `api` so API/runtime SHA guards remain exact. Keep both automation lanes OFF during rollout; turn only STAGING back ON after drains, parity, and status checks pass. PRODUCTION remains OFF.

## Safety
No shared ref, runtime, manifest, candidate inventory, or deployment is changed by this patch. STAGING is OFF during rollout and PRODUCTION remains OFF.