### PR TITLE
Fix Release Bus writer consistency after mutations

### DIFF
--- a/src/releaseBusV2/release-bus-v2.baseline-adoption.test.ts
+++ b/src/releaseBusV2/release-bus-v2.baseline-adoption.test.ts
@@ -933,7 +933,7 @@ describe('ReleaseBusV2BaselineAdoptionService', () => {
     context.repository.findTrain.mockImplementation(
       async (
         id: string,
-        _ctx: unknown,
+        _ctx?: unknown,
         forUpdate = false,
         forceWrite = false
       ) =>
@@ -942,7 +942,7 @@ describe('ReleaseBusV2BaselineAdoptionService', () => {
           : undefined
     );
     context.repository.findManifest.mockImplementation(
-      async (id: string, _ctx: unknown, forceWrite = false) =>
+      async (id: string, _ctx?: unknown, forceWrite = false) =>
         forceWrite
           ? context.repository.manifests.find((item) => item.id === id)
           : undefined

--- a/src/releaseBusV2/release-bus-v2.baseline-adoption.test.ts
+++ b/src/releaseBusV2/release-bus-v2.baseline-adoption.test.ts
@@ -887,12 +887,18 @@ describe('ReleaseBusV2BaselineAdoptionService', () => {
     expect(conflict.repository.trains).toHaveLength(0);
   });
 
-  it('verifies newly inserted immutable evidence through the writer when the replica is stale', async () => {
+  it('freezes from newly inserted immutable evidence through the writer when the replica is stale', async () => {
     const context = harness();
     await prepare(context);
+    await context.service.recordBackendDeployment(backendInput());
     context.repository.findEvent.mockImplementation(
-      async (id: string, ctx?: { connection?: unknown }) =>
-        ctx?.connection
+      async (
+        id: string,
+        ctx?: { connection?: unknown },
+        _forUpdate = false,
+        forceWrite = false
+      ) =>
+        ctx?.connection || forceWrite
           ? context.repository.events.find((item) => item.id === id)
           : undefined
     );
@@ -901,7 +907,7 @@ describe('ReleaseBusV2BaselineAdoptionService', () => {
       context.service.decideAutomaticE2E(automaticInput())
     ).resolves.toMatchObject({
       decision: 'DEFERRED',
-      manifest_ready: false
+      manifest_ready: true
     });
     expect(
       context.repository.events.filter(({ event_type }) =>
@@ -917,6 +923,49 @@ describe('ReleaseBusV2BaselineAdoptionService', () => {
           event_type === 'EXACT_STAGING_BASELINE_ADOPTION_FAILED'
       )
     ).toBe(false);
+    expect(context.dispatchCount()).toBe(1);
+  });
+
+  it('dispatches from the writer when the frozen train and manifest are not yet visible on a replica', async () => {
+    const context = harness();
+    await prepare(context);
+    await context.service.recordBackendDeployment(backendInput());
+    context.repository.findTrain.mockImplementation(
+      async (
+        id: string,
+        _ctx: unknown,
+        forUpdate = false,
+        forceWrite = false
+      ) =>
+        forUpdate || forceWrite
+          ? context.repository.trains.find((item) => item.id === id)
+          : undefined
+    );
+    context.repository.findManifest.mockImplementation(
+      async (id: string, _ctx: unknown, forceWrite = false) =>
+        forceWrite
+          ? context.repository.manifests.find((item) => item.id === id)
+          : undefined
+    );
+
+    await expect(
+      context.service.decideAutomaticE2E(automaticInput())
+    ).resolves.toMatchObject({
+      decision: 'DEFERRED',
+      manifest_ready: true
+    });
+    expect(context.repository.findTrain).toHaveBeenCalledWith(
+      INTENT_ID,
+      {},
+      false,
+      true
+    );
+    expect(context.repository.findManifest).toHaveBeenCalledWith(
+      context.repository.manifests[0].id,
+      {},
+      true
+    );
+    expect(context.dispatchCount()).toBe(1);
   });
 
   it('fails ambiguous and malformed intent lookup closed without partial adoption', async () => {

--- a/src/releaseBusV2/release-bus-v2.baseline-adoption.ts
+++ b/src/releaseBusV2/release-bus-v2.baseline-adoption.ts
@@ -618,11 +618,11 @@ function controlsAreSafe(
 function lockIsWhollyFree(lock: ReleaseBusV2LockRecord | undefined): boolean {
   return Boolean(
     lock &&
-      lock.owner_train_id === null &&
-      lock.lease_owner === null &&
-      lock.lease_token === null &&
-      lock.heartbeat_at === null &&
-      lock.expires_at === null
+    lock.owner_train_id === null &&
+    lock.lease_owner === null &&
+    lock.lease_token === null &&
+    lock.heartbeat_at === null &&
+    lock.expires_at === null
   );
 }
 

--- a/src/releaseBusV2/release-bus-v2.baseline-adoption.ts
+++ b/src/releaseBusV2/release-bus-v2.baseline-adoption.ts
@@ -768,7 +768,12 @@ export class ReleaseBusV2BaselineAdoptionService {
   ): Promise<ReleaseBusV2BaselineAdoptionResult> {
     return this.failClosed(async () => {
       const existingById = UUID_V4_PATTERN.test(rawInput.idempotency_key)
-        ? await this.repository.findEvent(rawInput.idempotency_key, {})
+        ? await this.repository.findEvent(
+            rawInput.idempotency_key,
+            {},
+            false,
+            true
+          )
         : null;
       const input = normalizedInput(
         rawInput,
@@ -809,11 +814,15 @@ export class ReleaseBusV2BaselineAdoptionService {
           exact.expires_at <= this.deps.now() &&
           !(await this.repository.findEvent(
             frozenEventId(exact.intent_id),
-            {}
+            {},
+            false,
+            true
           )) &&
           !(await this.repository.findEvent(
             failureEventId(exact.intent_id),
-            {}
+            {},
+            false,
+            true
           ))
         )
           await this.failIntent(
@@ -1144,14 +1153,24 @@ export class ReleaseBusV2BaselineAdoptionService {
 
   public async handleE2EProgress(trainId: string): Promise<void> {
     return this.failClosed(async () => {
-      const train = await this.repository.findTrain(trainId, {});
+      const train = await this.repository.findTrain(
+        trainId,
+        {},
+        false,
+        true
+      );
       if (!train || train.staging_policy !== ADOPTION_POLICY) return;
       if (['STAGING_VALIDATED', 'FAILED', 'CANCELLED'].includes(train.status))
         return;
       const manifest = train.manifest_id
-        ? await this.repository.findManifest(train.manifest_id, {})
+        ? await this.repository.findManifest(train.manifest_id, {}, true)
         : null;
-      const operations = await this.repository.listOperations(train.id, {});
+      const operations = await this.repository.listOperations(
+        train.id,
+        {},
+        false,
+        true
+      );
       const e2e = operations.filter(
         ({ operation_type }) => operation_type === 'E2E_STAGING'
       );
@@ -1307,7 +1326,8 @@ export class ReleaseBusV2BaselineAdoptionService {
       2000,
       {},
       false,
-      this.deps.now() - INTENT_MAX_TTL_MS
+      this.deps.now() - INTENT_MAX_TTL_MS,
+      true
     );
     if (events.length >= 2000)
       throw new ReleaseBusV2BaselineAdoptionError(
@@ -1348,7 +1368,7 @@ export class ReleaseBusV2BaselineAdoptionService {
   private async preparedIntent(
     intentId: string
   ): Promise<PreparedIntent | null> {
-    const event = await this.repository.findEvent(intentId, {});
+    const event = await this.repository.findEvent(intentId, {}, false, true);
     return event ? exactPreparedIntent(event) : null;
   }
 
@@ -1400,8 +1420,18 @@ export class ReleaseBusV2BaselineAdoptionService {
     readonly backend: readonly BackendEvidence[];
   }> {
     const [frontendEvent, deferredEvent] = await Promise.all([
-      this.repository.findEvent(frontendEvidenceEventId(intent.intent_id), {}),
-      this.repository.findEvent(deferredEventId(intent.intent_id), {})
+      this.repository.findEvent(
+        frontendEvidenceEventId(intent.intent_id),
+        {},
+        false,
+        true
+      ),
+      this.repository.findEvent(
+        deferredEventId(intent.intent_id),
+        {},
+        false,
+        true
+      )
     ]);
     const frontend = frontendEvent
       ? parseStoredJson<FrontendEvidence>(frontendEvent.payload_json)
@@ -1449,7 +1479,9 @@ export class ReleaseBusV2BaselineAdoptionService {
     for (const unit of intent.required_backend_units) {
       const event = await this.repository.findEvent(
         backendEvidenceEventId(intent.intent_id, unit.service),
-        {}
+        {},
+        false,
+        true
       );
       if (!event) continue;
       const payload = parseStoredJson<BackendEvidence>(event.payload_json);
@@ -1483,7 +1515,9 @@ export class ReleaseBusV2BaselineAdoptionService {
     this.assertUnexpired(intent);
     const existingFrozen = await this.repository.findEvent(
       frozenEventId(intent.intent_id),
-      {}
+      {},
+      false,
+      true
     );
     if (existingFrozen) {
       await this.ensureBoundE2EDispatched(intent);
@@ -1508,7 +1542,9 @@ export class ReleaseBusV2BaselineAdoptionService {
     } catch (error) {
       const raced = await this.repository.findEvent(
         frozenEventId(intent.intent_id),
-        {}
+        {},
+        false,
+        true
       );
       if (!raced) throw error;
     }
@@ -1866,9 +1902,14 @@ export class ReleaseBusV2BaselineAdoptionService {
   private async ensureBoundE2EDispatched(
     intent: PreparedIntent
   ): Promise<void> {
-    const train = await this.repository.findTrain(intent.intent_id, {});
+    const train = await this.repository.findTrain(
+      intent.intent_id,
+      {},
+      false,
+      true
+    );
     const manifest = train?.manifest_id
-      ? await this.repository.findManifest(train.manifest_id, {})
+      ? await this.repository.findManifest(train.manifest_id, {}, true)
       : null;
     if (!train || !manifest)
       throw new ReleaseBusV2BaselineAdoptionError(
@@ -2241,7 +2282,7 @@ export class ReleaseBusV2BaselineAdoptionService {
   }
 
   private async releaseOwnedStagingLock(trainId: string): Promise<void> {
-    const lock = (await this.repository.listLocks({})).find(
+    const lock = (await this.repository.listLocks({}, false, true)).find(
       ({ name }) => name === 'staging-environment'
     );
     if (lock?.owner_train_id === trainId && lock.lease_token)
@@ -2258,14 +2299,21 @@ export class ReleaseBusV2BaselineAdoptionService {
   ): Promise<ReleaseBusV2BaselineAdoptionResult> {
     const failed = await this.repository.findEvent(
       failureEventId(intent.intent_id),
-      {}
+      {},
+      false,
+      true
     );
-    const train = await this.repository.findTrain(intent.intent_id, {});
+    const train = await this.repository.findTrain(
+      intent.intent_id,
+      {},
+      false,
+      true
+    );
     const manifest = train?.manifest_id
-      ? await this.repository.findManifest(train.manifest_id, {})
+      ? await this.repository.findManifest(train.manifest_id, {}, true)
       : null;
     const operation = train
-      ? await this.repository.findOperation(intent.operation_key, {})
+      ? await this.repository.findOperation(intent.operation_key, {}, true)
       : null;
     return {
       adoption_id: intent.intent_id,

--- a/src/releaseBusV2/release-bus-v2.baseline-adoption.ts
+++ b/src/releaseBusV2/release-bus-v2.baseline-adoption.ts
@@ -618,11 +618,11 @@ function controlsAreSafe(
 function lockIsWhollyFree(lock: ReleaseBusV2LockRecord | undefined): boolean {
   return Boolean(
     lock &&
-    lock.owner_train_id === null &&
-    lock.lease_owner === null &&
-    lock.lease_token === null &&
-    lock.heartbeat_at === null &&
-    lock.expires_at === null
+      lock.owner_train_id === null &&
+      lock.lease_owner === null &&
+      lock.lease_token === null &&
+      lock.heartbeat_at === null &&
+      lock.expires_at === null
   );
 }
 
@@ -1153,12 +1153,7 @@ export class ReleaseBusV2BaselineAdoptionService {
 
   public async handleE2EProgress(trainId: string): Promise<void> {
     return this.failClosed(async () => {
-      const train = await this.repository.findTrain(
-        trainId,
-        {},
-        false,
-        true
-      );
+      const train = await this.repository.findTrain(trainId, {}, false, true);
       if (!train || train.staging_policy !== ADOPTION_POLICY) return;
       if (['STAGING_VALIDATED', 'FAILED', 'CANCELLED'].includes(train.status))
         return;

--- a/src/releaseBusV2/release-bus-v2.operations.ts
+++ b/src/releaseBusV2/release-bus-v2.operations.ts
@@ -659,7 +659,8 @@ export class ReleaseBusV2Operations {
       ) {
         const current = await this.repository.findOperation(
           spec.idempotencyKey,
-          {}
+          {},
+          true
         );
         if (current) return current;
       }
@@ -672,7 +673,8 @@ export class ReleaseBusV2Operations {
   ): Promise<ReleaseBusV2OperationRecord> {
     const existing = await this.repository.findOperation(
       spec.idempotencyKey,
-      {}
+      {},
+      true
     );
     const existingRequest = existing
       ? exactStoredWorkflowRequest(existing.request_json)
@@ -739,7 +741,11 @@ export class ReleaseBusV2Operations {
             operation.failure_message ?? 'Infrastructure retry budget exhausted'
         });
         return (
-          (await this.repository.findOperation(spec.idempotencyKey, {})) ??
+          (await this.repository.findOperation(
+            spec.idempotencyKey,
+            {},
+            true
+          )) ??
           operation
         );
       }
@@ -754,7 +760,11 @@ export class ReleaseBusV2Operations {
         completedAt: null
       });
       operation =
-        (await this.repository.findOperation(spec.idempotencyKey, {})) ??
+        (await this.repository.findOperation(
+          spec.idempotencyKey,
+          {},
+          true
+        )) ??
         operation;
     }
 
@@ -789,7 +799,11 @@ export class ReleaseBusV2Operations {
         {}
       );
       return (
-        (await this.repository.findOperation(spec.idempotencyKey, {})) ??
+        (await this.repository.findOperation(
+          spec.idempotencyKey,
+          {},
+          true
+        )) ??
         operation
       );
     }
@@ -817,7 +831,11 @@ export class ReleaseBusV2Operations {
         // attempt key, so an eventually indexed run wins over a duplicate.
         await this.update(operation, { status: 'PENDING', result: null });
         return (
-          (await this.repository.findOperation(spec.idempotencyKey, {})) ??
+          (await this.repository.findOperation(
+            spec.idempotencyKey,
+            {},
+            true
+          )) ??
           operation
         );
       }
@@ -881,13 +899,17 @@ export class ReleaseBusV2Operations {
         result: transportRetryState(operation.result_json) ? null : undefined
       });
       operation =
-        (await this.repository.findOperation(spec.idempotencyKey, {})) ??
+        (await this.repository.findOperation(
+          spec.idempotencyKey,
+          {},
+          true
+        )) ??
         operation;
     }
     if (run.status !== 'completed') return operation;
 
     const latest =
-      (await this.repository.findOperation(spec.idempotencyKey, {})) ??
+      (await this.repository.findOperation(spec.idempotencyKey, {}, true)) ??
       operation;
     if (['SUCCEEDED', 'FAILED', 'RETRY_WAIT'].includes(latest.status))
       return latest;
@@ -908,7 +930,8 @@ export class ReleaseBusV2Operations {
       completedAt: retry ? null : Date.now()
     });
     return (
-      (await this.repository.findOperation(spec.idempotencyKey, {})) ?? latest
+      (await this.repository.findOperation(spec.idempotencyKey, {}, true)) ??
+      latest
     );
   }
 
@@ -918,7 +941,11 @@ export class ReleaseBusV2Operations {
     const { idempotencyKey, attempt } = parseAttemptOperationKey(
       input.operation_key
     );
-    const operation = await this.repository.findOperation(idempotencyKey, {});
+    const operation = await this.repository.findOperation(
+      idempotencyKey,
+      {},
+      true
+    );
     if (
       !operation ||
       operation.train_id !== input.train_id ||
@@ -1023,7 +1050,11 @@ export class ReleaseBusV2Operations {
     const { idempotencyKey, attempt } = parseAttemptOperationKey(
       input.operation_key
     );
-    const operation = await this.repository.findOperation(idempotencyKey, {});
+    const operation = await this.repository.findOperation(
+      idempotencyKey,
+      {},
+      true
+    );
     if (
       !operation ||
       operation.train_id !== input.train_id ||
@@ -1135,7 +1166,11 @@ export class ReleaseBusV2Operations {
       completedAt: exhausted ? Date.now() : null
     });
     return (
-      (await this.repository.findOperation(operation.idempotency_key, {})) ??
+      (await this.repository.findOperation(
+        operation.idempotency_key,
+        {},
+        true
+      )) ??
       operation
     );
   }

--- a/src/releaseBusV2/release-bus-v2.operations.ts
+++ b/src/releaseBusV2/release-bus-v2.operations.ts
@@ -745,8 +745,7 @@ export class ReleaseBusV2Operations {
             spec.idempotencyKey,
             {},
             true
-          )) ??
-          operation
+          )) ?? operation
         );
       }
       await this.update(operation, {
@@ -760,11 +759,7 @@ export class ReleaseBusV2Operations {
         completedAt: null
       });
       operation =
-        (await this.repository.findOperation(
-          spec.idempotencyKey,
-          {},
-          true
-        )) ??
+        (await this.repository.findOperation(spec.idempotencyKey, {}, true)) ??
         operation;
     }
 
@@ -799,11 +794,7 @@ export class ReleaseBusV2Operations {
         {}
       );
       return (
-        (await this.repository.findOperation(
-          spec.idempotencyKey,
-          {},
-          true
-        )) ??
+        (await this.repository.findOperation(spec.idempotencyKey, {}, true)) ??
         operation
       );
     }
@@ -835,8 +826,7 @@ export class ReleaseBusV2Operations {
             spec.idempotencyKey,
             {},
             true
-          )) ??
-          operation
+          )) ?? operation
         );
       }
       if (!run && operation.status === 'PENDING') {
@@ -899,11 +889,7 @@ export class ReleaseBusV2Operations {
         result: transportRetryState(operation.result_json) ? null : undefined
       });
       operation =
-        (await this.repository.findOperation(
-          spec.idempotencyKey,
-          {},
-          true
-        )) ??
+        (await this.repository.findOperation(spec.idempotencyKey, {}, true)) ??
         operation;
     }
     if (run.status !== 'completed') return operation;
@@ -1170,8 +1156,7 @@ export class ReleaseBusV2Operations {
         operation.idempotency_key,
         {},
         true
-      )) ??
-      operation
+      )) ?? operation
     );
   }
 }

--- a/src/releaseBusV2/release-bus-v2.reconciler.test.ts
+++ b/src/releaseBusV2/release-bus-v2.reconciler.test.ts
@@ -58,6 +58,45 @@ function candidate(
 }
 
 describe('Release Bus v2 deterministic orchestration', () => {
+  it('loads train membership and dependency edges from the writer', async () => {
+    const train = {
+      id: 'train-writer-context'
+    } as ReleaseBusV2TrainRecord;
+    const selected = candidate('candidate-writer-context', 'a'.repeat(40));
+    const memberships = [
+      {
+        train_id: train.id,
+        candidate_id: selected.id,
+        sequence: 1,
+        disposition: 'INCLUDED'
+      }
+    ];
+    const listTrainCandidates = jest.fn(async () => memberships);
+    const findCandidateById = jest.fn(async () => selected);
+    const listDependencies = jest.fn(async () => []);
+    const reconciler = new ReleaseBusV2Reconciler(
+      {
+        listTrainCandidates,
+        findCandidateById,
+        listDependencies
+      } as never,
+      {} as never
+    ) as unknown as {
+      loadContext(train: ReleaseBusV2TrainRecord): Promise<unknown>;
+    };
+
+    await reconciler.loadContext(train);
+
+    expect(listTrainCandidates).toHaveBeenCalledWith(train.id, {}, true);
+    expect(findCandidateById).toHaveBeenCalledWith(
+      selected.id,
+      {},
+      false,
+      true
+    );
+    expect(listDependencies).toHaveBeenCalledWith([selected.id], {}, true);
+  });
+
   it('fails closed when a rollback baseline candidate identity cannot be resolved', async () => {
     const stagingTrain: ReleaseBusV2TrainRecord = {
       id: 'train-unresolvable-baseline',

--- a/src/releaseBusV2/release-bus-v2.reconciler.ts
+++ b/src/releaseBusV2/release-bus-v2.reconciler.ts
@@ -359,8 +359,8 @@ export function canUseSingleCandidateFastPath(
   const evidence = prEvidence(candidate);
   return Boolean(
     evidence &&
-    evidence.base_sha === baseSha &&
-    /^[a-f0-9]{40}$/.test(evidence.merge_sha)
+      evidence.base_sha === baseSha &&
+      /^[a-f0-9]{40}$/.test(evidence.merge_sha)
   );
 }
 
@@ -387,19 +387,19 @@ function hasExactEvidenceAudit(
 } {
   return Boolean(
     evidence &&
-    /^[a-f0-9]{40}$/.test(evidence.base_sha) &&
-    /^[a-f0-9]{40}$/.test(evidence.merge_sha) &&
-    /^[1-9][0-9]{0,19}$/.test(evidence.checks_run_id) &&
-    Number.isSafeInteger(evidence.checks_completed_at) &&
-    evidence.checks_completed_at > 0 &&
-    evidence?.workflow_path &&
-    /^[a-f0-9]{40}$/.test(evidence.base_workflow_blob_sha ?? '') &&
-    /^[a-f0-9]{40}$/.test(evidence.merge_workflow_blob_sha ?? '') &&
-    /^[a-f0-9]{64}$/.test(evidence.base_gate_policy_digest ?? '') &&
-    /^[a-f0-9]{64}$/.test(evidence.merge_gate_policy_digest ?? '') &&
-    ['evidence-manifest-v1', 'legacy-exact-workflow-v0'].includes(
-      evidence.trust_mode ?? ''
-    )
+      /^[a-f0-9]{40}$/.test(evidence.base_sha) &&
+      /^[a-f0-9]{40}$/.test(evidence.merge_sha) &&
+      /^[1-9][0-9]{0,19}$/.test(evidence.checks_run_id) &&
+      Number.isSafeInteger(evidence.checks_completed_at) &&
+      evidence.checks_completed_at > 0 &&
+      evidence?.workflow_path &&
+      /^[a-f0-9]{40}$/.test(evidence.base_workflow_blob_sha ?? '') &&
+      /^[a-f0-9]{40}$/.test(evidence.merge_workflow_blob_sha ?? '') &&
+      /^[a-f0-9]{64}$/.test(evidence.base_gate_policy_digest ?? '') &&
+      /^[a-f0-9]{64}$/.test(evidence.merge_gate_policy_digest ?? '') &&
+      ['evidence-manifest-v1', 'legacy-exact-workflow-v0'].includes(
+        evidence.trust_mode ?? ''
+      )
   );
 }
 
@@ -2202,12 +2202,7 @@ export class ReleaseBusV2Reconciler {
       return true;
     }
     await this.replanSupersededStagingCandidates(refreshed, message);
-    const latest = await this.repository.findTrain(
-      train.id,
-      {},
-      false,
-      true
-    );
+    const latest = await this.repository.findTrain(train.id, {}, false, true);
     if (latest && !TERMINAL_TRAINS.has(latest.status))
       await this.transitionTrain(latest, {
         status: 'CANCELLED',
@@ -4218,12 +4213,7 @@ export class ReleaseBusV2Reconciler {
         null,
         false
       );
-    const current = await this.repository.findTrain(
-      train.id,
-      {},
-      false,
-      true
-    );
+    const current = await this.repository.findTrain(train.id, {}, false, true);
     if (!current) throw new Error('Rollback train disappeared');
     if (TERMINAL_TRAINS.has(current.status)) {
       await this.releaseTerminalEnvironmentLocks();
@@ -6728,12 +6718,7 @@ export class ReleaseBusV2Reconciler {
     train: ReleaseBusV2TrainRecord,
     fields: Parameters<ReleaseBusV2RepositoryClass['updateTrain']>[2]
   ): Promise<void> {
-    const current = await this.repository.findTrain(
-      train.id,
-      {},
-      false,
-      true
-    );
+    const current = await this.repository.findTrain(train.id, {}, false, true);
     if (!current) throw new Error('Release Bus v2 train disappeared');
     if (
       !(await this.repository.updateTrain(
@@ -6977,12 +6962,7 @@ export class ReleaseBusV2Reconciler {
     failureClass: ReleaseBusV2FailureClass,
     message: string
   ): Promise<void> {
-    const current = await this.repository.findTrain(
-      train.id,
-      {},
-      false,
-      true
-    );
+    const current = await this.repository.findTrain(train.id, {}, false, true);
     if (!current || TERMINAL_TRAINS.has(current.status)) return;
     const context = await this.loadContext(current);
     // PRODUCTION_DEPLOYING is entered only after advanceProductionRefs has
@@ -7097,12 +7077,7 @@ export class ReleaseBusV2Reconciler {
     train: ReleaseBusV2TrainRecord,
     message: string
   ): Promise<void> {
-    const current = await this.repository.findTrain(
-      train.id,
-      {},
-      false,
-      true
-    );
+    const current = await this.repository.findTrain(train.id, {}, false, true);
     if (!current || TERMINAL_TRAINS.has(current.status)) return;
     const context = await this.loadContext(current);
     const statusCandidates = stagingStatusCandidates(context);
@@ -7199,12 +7174,7 @@ export class ReleaseBusV2Reconciler {
     train: ReleaseBusV2TrainRecord,
     message: string
   ): Promise<void> {
-    const current = await this.repository.findTrain(
-      train.id,
-      {},
-      false,
-      true
-    );
+    const current = await this.repository.findTrain(train.id, {}, false, true);
     if (!current || TERMINAL_TRAINS.has(current.status)) return;
     const previous =
       current.failure_class === 'INFRASTRUCTURE'

--- a/src/releaseBusV2/release-bus-v2.reconciler.ts
+++ b/src/releaseBusV2/release-bus-v2.reconciler.ts
@@ -1916,7 +1916,12 @@ export class ReleaseBusV2Reconciler {
     let current = initial;
     for (let transition = 0; transition < 12; transition += 1) {
       await this.advance(current);
-      const refreshed = await this.repository.findTrain(current.id, {});
+      const refreshed = await this.repository.findTrain(
+        current.id,
+        {},
+        false,
+        true
+      );
       if (!refreshed || TERMINAL_TRAINS.has(refreshed.status)) return;
       if (refreshed.row_version === current.row_version) return;
       current = refreshed;
@@ -1951,7 +1956,12 @@ export class ReleaseBusV2Reconciler {
     const candidates = (
       await Promise.all(
         memberships.map((membership) =>
-          this.repository.findCandidateById(membership.candidate_id, {})
+          this.repository.findCandidateById(
+            membership.candidate_id,
+            {},
+            false,
+            true
+          )
         )
       )
     ).filter((candidate): candidate is ReleaseBusV2CandidateRecord =>
@@ -2068,7 +2078,8 @@ export class ReleaseBusV2Reconciler {
         const refreshed =
           (await this.repository.findOperation(
             operation.idempotency_key,
-            {}
+            {},
+            true
           )) ?? operation;
         if (operationMayStillBeRunning(refreshed))
           return { id: operation.id, stillRunning: true };
@@ -2119,7 +2130,12 @@ export class ReleaseBusV2Reconciler {
         'release-bus-v2-reconciler',
         train.id
       );
-    const currentTrain = await this.repository.findTrain(train.id, {});
+    const currentTrain = await this.repository.findTrain(
+      train.id,
+      {},
+      false,
+      true
+    );
     if (!currentTrain || TERMINAL_TRAINS.has(currentTrain.status)) return true;
     const refreshed = await this.loadContext(currentTrain);
     const superseded = stagingStatusCandidates(refreshed).filter(
@@ -2186,7 +2202,12 @@ export class ReleaseBusV2Reconciler {
       return true;
     }
     await this.replanSupersededStagingCandidates(refreshed, message);
-    const latest = await this.repository.findTrain(train.id, {});
+    const latest = await this.repository.findTrain(
+      train.id,
+      {},
+      false,
+      true
+    );
     if (latest && !TERMINAL_TRAINS.has(latest.status))
       await this.transitionTrain(latest, {
         status: 'CANCELLED',
@@ -2218,7 +2239,12 @@ export class ReleaseBusV2Reconciler {
     const returned: ReleaseBusV2CandidateRecord[] = [];
     const blocked: ReleaseBusV2CandidateRecord[] = [];
     for (const candidate of mutable) {
-      const current = await this.repository.findCandidateById(candidate.id, {});
+      const current = await this.repository.findCandidateById(
+        candidate.id,
+        {},
+        false,
+        true
+      );
       if (!current || current.status === 'CANCELLED') continue;
       const superseded = supersededIds.has(candidate.id);
       const dependencyBlocked = !superseded && blockedIds.has(candidate.id);
@@ -2364,7 +2390,9 @@ export class ReleaseBusV2Reconciler {
     ]);
     const currentAfterPreparation = await this.repository.findTrain(
       train.id,
-      {}
+      {},
+      false,
+      true
     );
     if (
       currentAfterPreparation &&
@@ -2745,7 +2773,12 @@ export class ReleaseBusV2Reconciler {
     const returnedCandidates: ReleaseBusV2CandidateRecord[] = [];
 
     for (const candidate of relevantCandidates(context)) {
-      const current = await this.repository.findCandidateById(candidate.id, {});
+      const current = await this.repository.findCandidateById(
+        candidate.id,
+        {},
+        false,
+        true
+      );
       if (
         !current ||
         ['SUPERSEDED', 'CANCELLED', 'DEREGISTERED'].includes(current.status)
@@ -2874,7 +2907,12 @@ export class ReleaseBusV2Reconciler {
     const blocked: ReleaseBusV2CandidateRecord[] = [];
     const returned: ReleaseBusV2CandidateRecord[] = [];
     for (const candidate of mutable) {
-      const current = await this.repository.findCandidateById(candidate.id, {});
+      const current = await this.repository.findCandidateById(
+        candidate.id,
+        {},
+        false,
+        true
+      );
       if (
         !current ||
         ['SUPERSEDED', 'CANCELLED', 'DEREGISTERED'].includes(current.status)
@@ -2971,7 +3009,12 @@ export class ReleaseBusV2Reconciler {
         'Independent repository candidate returned to the next staging train'
       )
     ]);
-    const current = await this.repository.findTrain(context.train.id, {});
+    const current = await this.repository.findTrain(
+      context.train.id,
+      {},
+      false,
+      true
+    );
     if (current && !TERMINAL_TRAINS.has(current.status))
       await this.transitionTrain(current, {
         status: 'FAILED',
@@ -3248,7 +3291,9 @@ export class ReleaseBusV2Reconciler {
       for (const candidate of newCandidates) {
         const current = await this.repository.findCandidateById(
           candidate.id,
-          {}
+          {},
+          false,
+          true
         );
         if (!current) continue;
         await this.repository.updateCandidate(
@@ -3313,7 +3358,12 @@ export class ReleaseBusV2Reconciler {
           : 'DEPENDENCY_EXCLUDED',
         {}
       );
-      const current = await this.repository.findCandidateById(candidate.id, {});
+      const current = await this.repository.findCandidateById(
+        candidate.id,
+        {},
+        false,
+        true
+      );
       if (
         !current ||
         ['SUPERSEDED', 'CANCELLED', 'DEREGISTERED'].includes(current.status)
@@ -3365,7 +3415,12 @@ export class ReleaseBusV2Reconciler {
         {}
       );
     if (!train.staging_baseline_manifest_id) {
-      const current = await this.repository.findTrain(train.id, {});
+      const current = await this.repository.findTrain(
+        train.id,
+        {},
+        false,
+        true
+      );
       if (!current || TERMINAL_TRAINS.has(current.status)) return;
       const context = await this.loadContext(current);
       const transition = parseStoredJson<ReleaseBusV2StagingTransition>(
@@ -4121,7 +4176,12 @@ export class ReleaseBusV2Reconciler {
           null,
           false
         );
-      const current = await this.repository.findTrain(train.id, {});
+      const current = await this.repository.findTrain(
+        train.id,
+        {},
+        false,
+        true
+      );
       if (current && !TERMINAL_TRAINS.has(current.status))
         await this.transitionTrain(current, {
           status: 'FAILED',
@@ -4158,7 +4218,12 @@ export class ReleaseBusV2Reconciler {
         null,
         false
       );
-    const current = await this.repository.findTrain(train.id, {});
+    const current = await this.repository.findTrain(
+      train.id,
+      {},
+      false,
+      true
+    );
     if (!current) throw new Error('Rollback train disappeared');
     if (TERMINAL_TRAINS.has(current.status)) {
       await this.releaseTerminalEnvironmentLocks();
@@ -5138,7 +5203,12 @@ export class ReleaseBusV2Reconciler {
           (left, right) => Number(left.created_at) - Number(right.created_at)
         );
       for (const qualification of qualifications) {
-        const current = await this.repository.findTrain(qualification.id, {});
+        const current = await this.repository.findTrain(
+          qualification.id,
+          {},
+          false,
+          true
+        );
         if (
           !current ||
           current.lane !== 'PRODUCTION_QUALIFICATION' ||
@@ -5881,7 +5951,8 @@ export class ReleaseBusV2Reconciler {
       ))
     )
       throw new Error(`${repository} main operation changed concurrently`);
-    operation = (await this.repository.findOperation(key, {})) ?? operation;
+    operation =
+      (await this.repository.findOperation(key, {}, true)) ?? operation;
   }
 
   private async reconcileDeployments(
@@ -6403,7 +6474,12 @@ export class ReleaseBusV2Reconciler {
     if (!manifestId) throw new Error('Staging validation has no manifest');
     const statusCandidates = stagingStatusCandidates(context);
     for (const candidate of statusCandidates) {
-      const current = await this.repository.findCandidateById(candidate.id, {});
+      const current = await this.repository.findCandidateById(
+        candidate.id,
+        {},
+        false,
+        true
+      );
       if (!current || candidateUnavailableForTrainUpdate(current, candidate))
         continue;
       await this.repository.updateCandidate(
@@ -6585,7 +6661,12 @@ export class ReleaseBusV2Reconciler {
     publishStatus = true
   ): Promise<void> {
     for (const candidate of candidates) {
-      const current = await this.repository.findCandidateById(candidate.id, {});
+      const current = await this.repository.findCandidateById(
+        candidate.id,
+        {},
+        false,
+        true
+      );
       if (
         !current ||
         candidateUnavailableForTrainUpdate(current, candidate) ||
@@ -6647,7 +6728,12 @@ export class ReleaseBusV2Reconciler {
     train: ReleaseBusV2TrainRecord,
     fields: Parameters<ReleaseBusV2RepositoryClass['updateTrain']>[2]
   ): Promise<void> {
-    const current = await this.repository.findTrain(train.id, {});
+    const current = await this.repository.findTrain(
+      train.id,
+      {},
+      false,
+      true
+    );
     if (!current) throw new Error('Release Bus v2 train disappeared');
     if (
       !(await this.repository.updateTrain(
@@ -6686,7 +6772,7 @@ export class ReleaseBusV2Reconciler {
   }
 
   private async releaseTerminalEnvironmentLocks(): Promise<void> {
-    const locks = await this.repository.listLocks({});
+    const locks = await this.repository.listLocks({}, false, true);
     for (const lock of locks) {
       if (
         !lock.owner_train_id ||
@@ -6694,9 +6780,19 @@ export class ReleaseBusV2Reconciler {
         !['staging-environment', 'production-environment'].includes(lock.name)
       )
         continue;
-      const train = await this.repository.findTrain(lock.owner_train_id, {});
+      const train = await this.repository.findTrain(
+        lock.owner_train_id,
+        {},
+        false,
+        true
+      );
       if (!train || !TERMINAL_TRAINS.has(train.status)) continue;
-      let operations = await this.repository.listOperations(train.id, {});
+      let operations = await this.repository.listOperations(
+        train.id,
+        {},
+        false,
+        true
+      );
       for (const operation of operations) {
         if (!operationMayStillBeRunning(operation)) continue;
         let request: {
@@ -6755,7 +6851,12 @@ export class ReleaseBusV2Reconciler {
             {}
           );
       }
-      operations = await this.repository.listOperations(train.id, {});
+      operations = await this.repository.listOperations(
+        train.id,
+        {},
+        false,
+        true
+      );
       for (const operation of operations) {
         if (
           operation.status !== 'PENDING' ||
@@ -6834,7 +6935,12 @@ export class ReleaseBusV2Reconciler {
             {}
           );
       }
-      operations = await this.repository.listOperations(train.id, {});
+      operations = await this.repository.listOperations(
+        train.id,
+        {},
+        false,
+        true
+      );
       if (
         operations.some(
           (operation) => !TERMINAL_OPERATIONS.has(operation.status)
@@ -6871,7 +6977,12 @@ export class ReleaseBusV2Reconciler {
     failureClass: ReleaseBusV2FailureClass,
     message: string
   ): Promise<void> {
-    const current = await this.repository.findTrain(train.id, {});
+    const current = await this.repository.findTrain(
+      train.id,
+      {},
+      false,
+      true
+    );
     if (!current || TERMINAL_TRAINS.has(current.status)) return;
     const context = await this.loadContext(current);
     // PRODUCTION_DEPLOYING is entered only after advanceProductionRefs has
@@ -6986,7 +7097,12 @@ export class ReleaseBusV2Reconciler {
     train: ReleaseBusV2TrainRecord,
     message: string
   ): Promise<void> {
-    const current = await this.repository.findTrain(train.id, {});
+    const current = await this.repository.findTrain(
+      train.id,
+      {},
+      false,
+      true
+    );
     if (!current || TERMINAL_TRAINS.has(current.status)) return;
     const context = await this.loadContext(current);
     const statusCandidates = stagingStatusCandidates(context);
@@ -7083,7 +7199,12 @@ export class ReleaseBusV2Reconciler {
     train: ReleaseBusV2TrainRecord,
     message: string
   ): Promise<void> {
-    const current = await this.repository.findTrain(train.id, {});
+    const current = await this.repository.findTrain(
+      train.id,
+      {},
+      false,
+      true
+    );
     if (!current || TERMINAL_TRAINS.has(current.status)) return;
     const previous =
       current.failure_class === 'INFRASTRUCTURE'
@@ -7137,7 +7258,7 @@ export class ReleaseBusV2Reconciler {
     const candidates = (
       await Promise.all(
         result.candidateIds.map((candidateId) =>
-          this.repository.findCandidateById(candidateId, {})
+          this.repository.findCandidateById(candidateId, {}, false, true)
         )
       )
     ).filter((candidate): candidate is ReleaseBusV2CandidateRecord =>
@@ -7159,7 +7280,9 @@ export class ReleaseBusV2Reconciler {
       candidates.map(async (candidate) => {
         const current = await this.repository.findCandidateById(
           candidate.id,
-          {}
+          {},
+          false,
+          true
         );
         if (
           !current ||

--- a/src/releaseBusV2/release-bus-v2.reconciler.ts
+++ b/src/releaseBusV2/release-bus-v2.reconciler.ts
@@ -1952,7 +1952,11 @@ export class ReleaseBusV2Reconciler {
   private async loadContext(
     train: ReleaseBusV2TrainRecord
   ): Promise<TrainContext> {
-    const memberships = await this.repository.listTrainCandidates(train.id, {});
+    const memberships = await this.repository.listTrainCandidates(
+      train.id,
+      {},
+      true
+    );
     const candidates = (
       await Promise.all(
         memberships.map((membership) =>
@@ -1973,7 +1977,8 @@ export class ReleaseBusV2Reconciler {
       candidates,
       dependencies: await this.repository.listDependencies(
         candidates.map(({ id }) => id),
-        {}
+        {},
+        true
       )
     };
   }

--- a/src/releaseBusV2/release-bus-v2.reconciler.ts
+++ b/src/releaseBusV2/release-bus-v2.reconciler.ts
@@ -359,8 +359,8 @@ export function canUseSingleCandidateFastPath(
   const evidence = prEvidence(candidate);
   return Boolean(
     evidence &&
-      evidence.base_sha === baseSha &&
-      /^[a-f0-9]{40}$/.test(evidence.merge_sha)
+    evidence.base_sha === baseSha &&
+    /^[a-f0-9]{40}$/.test(evidence.merge_sha)
   );
 }
 
@@ -387,19 +387,19 @@ function hasExactEvidenceAudit(
 } {
   return Boolean(
     evidence &&
-      /^[a-f0-9]{40}$/.test(evidence.base_sha) &&
-      /^[a-f0-9]{40}$/.test(evidence.merge_sha) &&
-      /^[1-9][0-9]{0,19}$/.test(evidence.checks_run_id) &&
-      Number.isSafeInteger(evidence.checks_completed_at) &&
-      evidence.checks_completed_at > 0 &&
-      evidence?.workflow_path &&
-      /^[a-f0-9]{40}$/.test(evidence.base_workflow_blob_sha ?? '') &&
-      /^[a-f0-9]{40}$/.test(evidence.merge_workflow_blob_sha ?? '') &&
-      /^[a-f0-9]{64}$/.test(evidence.base_gate_policy_digest ?? '') &&
-      /^[a-f0-9]{64}$/.test(evidence.merge_gate_policy_digest ?? '') &&
-      ['evidence-manifest-v1', 'legacy-exact-workflow-v0'].includes(
-        evidence.trust_mode ?? ''
-      )
+    /^[a-f0-9]{40}$/.test(evidence.base_sha) &&
+    /^[a-f0-9]{40}$/.test(evidence.merge_sha) &&
+    /^[1-9][0-9]{0,19}$/.test(evidence.checks_run_id) &&
+    Number.isSafeInteger(evidence.checks_completed_at) &&
+    evidence.checks_completed_at > 0 &&
+    evidence?.workflow_path &&
+    /^[a-f0-9]{40}$/.test(evidence.base_workflow_blob_sha ?? '') &&
+    /^[a-f0-9]{40}$/.test(evidence.merge_workflow_blob_sha ?? '') &&
+    /^[a-f0-9]{64}$/.test(evidence.base_gate_policy_digest ?? '') &&
+    /^[a-f0-9]{64}$/.test(evidence.merge_gate_policy_digest ?? '') &&
+    ['evidence-manifest-v1', 'legacy-exact-workflow-v0'].includes(
+      evidence.trust_mode ?? ''
+    )
   );
 }
 

--- a/src/releaseBusV2/release-bus-v2.repository.ts
+++ b/src/releaseBusV2/release-bus-v2.repository.ts
@@ -305,25 +305,27 @@ export class ReleaseBusV2Repository extends LazyDbAccessCompatibleService {
     repository: ReleaseBusV2RepositoryName,
     prNumber: number,
     headSha: string,
-    ctx: RequestContext
+    ctx: RequestContext,
+    forceWrite = false
   ): Promise<ReleaseBusV2CandidateRecord | null> {
     return this.db.oneOrNull<ReleaseBusV2CandidateRecord>(
       `select * from ${RELEASE_BUS_V2_CANDIDATES_TABLE}
        where repository = :repository and pr_number = :prNumber and head_sha = :headSha`,
       { repository, prNumber, headSha },
-      dbOptions(ctx)
+      dbOptions(ctx, forceWrite)
     );
   }
 
   public async findCandidateById(
     id: string,
     ctx: RequestContext,
-    forUpdate = false
+    forUpdate = false,
+    forceWrite = false
   ): Promise<ReleaseBusV2CandidateRecord | null> {
     return this.db.oneOrNull<ReleaseBusV2CandidateRecord>(
       `select * from ${RELEASE_BUS_V2_CANDIDATES_TABLE} where id = :id${forUpdate ? ' for update' : ''}`,
       { id },
-      dbOptions(ctx)
+      dbOptions(ctx, forceWrite)
     );
   }
 
@@ -361,7 +363,7 @@ export class ReleaseBusV2Repository extends LazyDbAccessCompatibleService {
       },
       dbOptions(ctx)
     );
-    const created = await this.findCandidateById(id, ctx);
+    const created = await this.findCandidateById(id, ctx, false, true);
     if (!created)
       throw new Error('Release Bus v2 candidate insert was not visible');
     return created;
@@ -727,12 +729,13 @@ export class ReleaseBusV2Repository extends LazyDbAccessCompatibleService {
   public async findTrain(
     id: string,
     ctx: RequestContext,
-    forUpdate = false
+    forUpdate = false,
+    forceWrite = false
   ): Promise<ReleaseBusV2TrainRecord | null> {
     return this.db.oneOrNull<ReleaseBusV2TrainRecord>(
       `select * from ${RELEASE_BUS_V2_TRAINS_TABLE} where id = :id${forUpdate ? ' for update' : ''}`,
       { id },
-      dbOptions(ctx)
+      dbOptions(ctx, forceWrite)
     );
   }
 
@@ -826,7 +829,7 @@ export class ReleaseBusV2Repository extends LazyDbAccessCompatibleService {
         dbOptions(ctx)
       );
     }
-    const train = await this.findTrain(id, ctx);
+    const train = await this.findTrain(id, ctx, false, true);
     if (!train) throw new Error('Release Bus v2 train insert was not visible');
     return train;
   }
@@ -1071,7 +1074,8 @@ export class ReleaseBusV2Repository extends LazyDbAccessCompatibleService {
       .digest('hex');
     const existing = await this.findQualificationTrain(
       input.parentTrainId,
-      ctx
+      ctx,
+      true
     );
     if (
       existing &&
@@ -1096,7 +1100,11 @@ export class ReleaseBusV2Repository extends LazyDbAccessCompatibleService {
       { id, ...input, qualificationIdentitySha256, now },
       dbOptions(ctx)
     );
-    const train = await this.findQualificationTrain(input.parentTrainId, ctx);
+    const train = await this.findQualificationTrain(
+      input.parentTrainId,
+      ctx,
+      true
+    );
     if (!train)
       throw new Error(
         'Release Bus v2 qualification train insert was not visible'
@@ -1121,19 +1129,20 @@ export class ReleaseBusV2Repository extends LazyDbAccessCompatibleService {
         dbOptions(ctx)
       );
     }
-    await this.assertQualificationTrain(train, input, ctx);
+    await this.assertQualificationTrain(train, input, ctx, true);
     return train;
   }
 
   private async findQualificationTrain(
     parentTrainId: string,
-    ctx: RequestContext
+    ctx: RequestContext,
+    forceWrite = false
   ): Promise<ReleaseBusV2TrainRecord | null> {
     return this.db.oneOrNull<ReleaseBusV2TrainRecord>(
       `select * from ${RELEASE_BUS_V2_TRAINS_TABLE}
        where parent_train_id = :parentTrainId limit 1`,
       { parentTrainId },
-      dbOptions(ctx)
+      dbOptions(ctx, forceWrite)
     );
   }
 
@@ -1149,7 +1158,8 @@ export class ReleaseBusV2Repository extends LazyDbAccessCompatibleService {
       readonly backendArtifactDigest: string | null;
       readonly candidateIds: readonly string[];
     },
-    ctx: RequestContext
+    ctx: RequestContext,
+    forceWrite = false
   ): Promise<void> {
     const immutableMatches =
       train.lane === 'PRODUCTION_QUALIFICATION' &&
@@ -1160,7 +1170,9 @@ export class ReleaseBusV2Repository extends LazyDbAccessCompatibleService {
       train.backend_composed_sha === input.backendComposedSha &&
       train.frontend_artifact_digest === input.frontendArtifactDigest &&
       train.backend_artifact_digest === input.backendArtifactDigest;
-    const candidateIds = (await this.listTrainCandidates(train.id, ctx))
+    const candidateIds = (
+      await this.listTrainCandidates(train.id, ctx, forceWrite)
+    )
       .sort((left, right) => left.sequence - right.sequence)
       .map(({ candidate_id }) => candidate_id);
     if (
@@ -1174,13 +1186,14 @@ export class ReleaseBusV2Repository extends LazyDbAccessCompatibleService {
 
   public async listTrainCandidates(
     trainId: string,
-    ctx: RequestContext
+    ctx: RequestContext,
+    forceWrite = false
   ): Promise<ReleaseBusV2TrainCandidateRecord[]> {
     return this.db.execute<ReleaseBusV2TrainCandidateRecord>(
       `select * from ${RELEASE_BUS_V2_TRAIN_CANDIDATES_TABLE}
        where train_id = :trainId order by sequence asc`,
       { trainId },
-      dbOptions(ctx)
+      dbOptions(ctx, forceWrite)
     );
   }
 
@@ -1268,7 +1281,7 @@ export class ReleaseBusV2Repository extends LazyDbAccessCompatibleService {
     },
     ctx: RequestContext
   ): Promise<ReleaseBusV2OperationRecord> {
-    const existing = await this.findOperation(input.idempotencyKey, ctx);
+    const existing = await this.findOperation(input.idempotencyKey, ctx, true);
     if (existing) {
       this.assertOperationIdentity(existing, input);
       return existing;
@@ -1300,7 +1313,7 @@ export class ReleaseBusV2Repository extends LazyDbAccessCompatibleService {
       },
       dbOptions(ctx)
     );
-    const created = await this.findOperation(input.idempotencyKey, ctx);
+    const created = await this.findOperation(input.idempotencyKey, ctx, true);
     if (!created)
       throw new Error('Release Bus v2 operation insert was not visible');
     this.assertOperationIdentity(created, input);
@@ -1353,7 +1366,8 @@ export class ReleaseBusV2Repository extends LazyDbAccessCompatibleService {
   public async listOperations(
     trainId: string,
     ctx: RequestContext,
-    forUpdate = false
+    forUpdate = false,
+    forceWrite = false
   ): Promise<ReleaseBusV2OperationRecord[]> {
     return this.db.execute<ReleaseBusV2OperationRecord>(
       `select * from ${RELEASE_BUS_V2_OPERATIONS_TABLE}
@@ -1361,7 +1375,7 @@ export class ReleaseBusV2Repository extends LazyDbAccessCompatibleService {
          forUpdate ? ' for update' : ''
        }`,
       { trainId },
-      dbOptions(ctx)
+      dbOptions(ctx, forceWrite)
     );
   }
 
@@ -1598,12 +1612,13 @@ export class ReleaseBusV2Repository extends LazyDbAccessCompatibleService {
 
   public async listLocks(
     ctx: RequestContext,
-    forUpdate = false
+    forUpdate = false,
+    forceWrite = false
   ): Promise<ReleaseBusV2LockRecord[]> {
     return this.db.execute<ReleaseBusV2LockRecord>(
       `select * from ${RELEASE_BUS_V2_LOCKS_TABLE} order by name asc${forUpdate ? ' for update' : ''}`,
       {},
-      dbOptions(ctx)
+      dbOptions(ctx, forceWrite)
     );
   }
 
@@ -1613,7 +1628,8 @@ export class ReleaseBusV2Repository extends LazyDbAccessCompatibleService {
   ): Promise<ReleaseBusV2ManifestRecord> {
     const existing = await this.findManifestByIdentity(
       input.identity_sha256,
-      ctx
+      ctx,
+      true
     );
     if (existing) {
       this.assertManifestIdentity(existing, input);
@@ -1649,7 +1665,8 @@ export class ReleaseBusV2Repository extends LazyDbAccessCompatibleService {
     );
     const created = await this.findManifestByIdentity(
       input.identity_sha256,
-      ctx
+      ctx,
+      true
     );
     if (!created)
       throw new Error('Release Bus v2 manifest insert was not visible');
@@ -1680,23 +1697,25 @@ export class ReleaseBusV2Repository extends LazyDbAccessCompatibleService {
 
   public async findManifestByIdentity(
     identitySha256: string,
-    ctx: RequestContext
+    ctx: RequestContext,
+    forceWrite = false
   ): Promise<ReleaseBusV2ManifestRecord | null> {
     return this.db.oneOrNull<ReleaseBusV2ManifestRecord>(
       `select * from ${RELEASE_BUS_V2_MANIFESTS_TABLE} where identity_sha256 = :identitySha256`,
       { identitySha256 },
-      dbOptions(ctx)
+      dbOptions(ctx, forceWrite)
     );
   }
 
   public async findManifest(
     id: string,
-    ctx: RequestContext
+    ctx: RequestContext,
+    forceWrite = false
   ): Promise<ReleaseBusV2ManifestRecord | null> {
     return this.db.oneOrNull<ReleaseBusV2ManifestRecord>(
       `select * from ${RELEASE_BUS_V2_MANIFESTS_TABLE} where id = :id`,
       { id },
-      dbOptions(ctx)
+      dbOptions(ctx, forceWrite)
     );
   }
 
@@ -2133,13 +2152,14 @@ export class ReleaseBusV2Repository extends LazyDbAccessCompatibleService {
   public async findEvent(
     id: string,
     ctx: RequestContext,
-    forUpdate = false
+    forUpdate = false,
+    forceWrite = false
   ): Promise<ReleaseBusV2EventRecord | null> {
     return this.db.oneOrNull<ReleaseBusV2EventRecord>(
       `select * from ${RELEASE_BUS_V2_EVENTS_TABLE}
        where id = :id${forUpdate ? ' for update' : ''}`,
       { id },
-      dbOptions(ctx)
+      dbOptions(ctx, forceWrite)
     );
   }
 
@@ -2148,7 +2168,8 @@ export class ReleaseBusV2Repository extends LazyDbAccessCompatibleService {
     limit: number,
     ctx: RequestContext,
     forUpdate = false,
-    createdAtGte?: number
+    createdAtGte?: number,
+    forceWrite = false
   ): Promise<ReleaseBusV2EventRecord[]> {
     const uniqueTypes = Array.from(new Set(eventTypes));
     if (uniqueTypes.length === 0 || uniqueTypes.length > 20)
@@ -2170,7 +2191,7 @@ export class ReleaseBusV2Repository extends LazyDbAccessCompatibleService {
         eventTypes: uniqueTypes,
         ...(createdAtGte === undefined ? {} : { createdAtGte })
       },
-      dbOptions(ctx)
+      dbOptions(ctx, forceWrite)
     );
   }
 

--- a/src/releaseBusV2/release-bus-v2.repository.ts
+++ b/src/releaseBusV2/release-bus-v2.repository.ts
@@ -469,7 +469,8 @@ export class ReleaseBusV2Repository extends LazyDbAccessCompatibleService {
 
   public async listDependencies(
     candidateIds: readonly string[],
-    ctx: RequestContext
+    ctx: RequestContext,
+    forceWrite = false
   ): Promise<ReleaseBusV2DependencyRecord[]> {
     const ids = Array.from(new Set(candidateIds));
     if (ids.length === 0) return [];
@@ -479,7 +480,7 @@ export class ReleaseBusV2Repository extends LazyDbAccessCompatibleService {
       `select * from ${RELEASE_BUS_V2_CANDIDATE_DEPENDENCIES_TABLE}
        where candidate_id in (:ids)`,
       { ids },
-      dbOptions(ctx)
+      dbOptions(ctx, forceWrite)
     );
   }
 


### PR DESCRIPTION
## What
- force baseline adoption evidence, frozen manifest, operation, and lifecycle safety reads to the writer
- make candidate, train, qualification, operation, and manifest creator readbacks writer-consistent
- make operation dispatch, authorization, progress, retries, and terminal readbacks writer-consistent for frontend, backend, staging, and production
- make critical reconciler CAS/readback and terminal-lock decisions use writer state
- add stale-replica regressions for final evidence and frozen train/manifest dispatch

## Live fault
The exact baseline-adoption freeze transaction committed train e208b7aa-3467-4e31-9410-0275b0084373, manifest ca58e44b-edeb-4d5b-bd6a-5b048be8cdb7, its bound operation, and the frozen event. The immediate default-pool lookup then missed the manifest on a lagging replica and failed closed before E2E. No refs, runtimes, candidate intent, or authoritative staging state changed.

## Scope
This is the shared control-plane fix, not a frontend-only workaround. The hardened helpers are also used by backend service operations and production qualification/deployed manifests.

## Verification
Published CI-first at the owners request. No broad local suite was run. Exact stale-replica regressions are included.

## Deployment
Both lanes must remain OFF/changeable and drained. After merge deploy production API first, then production releaseBus service. Keep PRODUCTION OFF. Merge main into backend 1a-staging without overwriting staging-only history, deploy staging API, re-adopt the exact deployed baseline, run the sole bound E2E, then enable STAGING only after final gates are clean.

No migration, downtime, frontend code change, or architecture-doc update is required.