### PR TITLE
Fix failed baseline adoption operation cleanup

### DIFF
--- a/src/releaseBusV2/release-bus-v2.baseline-adoption.test.ts
+++ b/src/releaseBusV2/release-bus-v2.baseline-adoption.test.ts
@@ -1381,6 +1381,59 @@ describe('ReleaseBusV2BaselineAdoptionService', () => {
     );
   });
 
+  it('keeps failed intent reads stable when recovery races, then retries cleanup', async () => {
+    const context = harness();
+    await prepare(context);
+    await freeze(context);
+    Object.assign(context.repository.operations[0], {
+      status: 'PENDING',
+      external_id: null
+    });
+    context.repository.operations.push({
+      ...structuredClone(context.repository.operations[0]),
+      id: '60000000-0000-4000-8000-000000000007',
+      idempotency_key: `rb2:${INTENT_ID}:e2e:staging:duplicate`,
+      status: 'SUCCEEDED'
+    });
+    await context.service.handleE2EProgress(INTENT_ID);
+    Object.assign(context.repository.operations[0], {
+      status: 'PENDING',
+      failure_class: null,
+      failure_message: null,
+      completed_at: null,
+      row_version: context.repository.operations[0].row_version + 1
+    });
+    context.repository.events = context.repository.events.filter(
+      ({ event_type }) =>
+        event_type !== 'EXACT_STAGING_BASELINE_UNDISPATCHED_E2E_CANCELLED'
+    );
+    context.repository.updateOperation.mockImplementationOnce(
+      async () => false
+    );
+
+    await expect(
+      context.service.execute(input(), 'owner')
+    ).resolves.toMatchObject({
+      adoption_id: INTENT_ID,
+      status: 'FAILED',
+      reused: true
+    });
+    expect(context.repository.operations[0].status).toBe('PENDING');
+    expect(context.repository.events).not.toContainEqual(
+      expect.objectContaining({
+        event_type: 'EXACT_STAGING_BASELINE_UNDISPATCHED_E2E_CANCELLED'
+      })
+    );
+
+    await expect(
+      context.service.execute(input(), 'owner')
+    ).resolves.toMatchObject({
+      status: 'FAILED',
+      reused: true
+    });
+    expect(context.repository.operations[0].status).toBe('CANCELLED');
+  });
+
   it('does not guess that a reserved E2E operation was never dispatched', async () => {
     const context = harness();
     await prepare(context);

--- a/src/releaseBusV2/release-bus-v2.baseline-adoption.test.ts
+++ b/src/releaseBusV2/release-bus-v2.baseline-adoption.test.ts
@@ -431,6 +431,29 @@ class FakeRepository {
     return operation;
   });
 
+  public updateOperation = jest.fn(
+    async (id: string, rowVersion: number, fields: any) => {
+      const operation = this.operations.find((item) => item.id === id);
+      if (!operation || operation.row_version !== rowVersion) return false;
+      Object.assign(operation, {
+        status: fields.status,
+        external_id:
+          fields.externalId === undefined
+            ? operation.external_id
+            : fields.externalId,
+        result_json:
+          fields.result === undefined ? operation.result_json : fields.result,
+        next_retry_at: fields.nextRetryAt ?? null,
+        failure_class: fields.failureClass ?? null,
+        failure_message: fields.failureMessage ?? null,
+        attempt: fields.attempt ?? operation.attempt,
+        completed_at: fields.completedAt ?? null,
+        row_version: operation.row_version + 1
+      });
+      return true;
+    }
+  );
+
   public updateStagingState = jest.fn(
     async (rowVersion: number, fields: any) => {
       if (this.state.row_version !== rowVersion) return false;
@@ -1272,6 +1295,117 @@ describe('ReleaseBusV2BaselineAdoptionService', () => {
     await ambiguous.service.handleE2EProgress(INTENT_ID);
     expect(ambiguous.repository.state.row_version).toBe(23);
     expect(ambiguous.repository.trains[0].status).toBe('FAILED');
+  });
+
+  it('terminalizes an exact E2E operation that failed before dispatch reservation', async () => {
+    const context = harness();
+    await prepare(context);
+    await freeze(context);
+    Object.assign(context.repository.operations[0], {
+      status: 'PENDING',
+      external_id: null
+    });
+    context.repository.operations.push({
+      ...structuredClone(context.repository.operations[0]),
+      id: '60000000-0000-4000-8000-000000000007',
+      idempotency_key: `rb2:${INTENT_ID}:e2e:staging:duplicate`,
+      status: 'SUCCEEDED'
+    });
+
+    await context.service.handleE2EProgress(INTENT_ID);
+
+    expect(context.repository.operations[0]).toMatchObject({
+      status: 'CANCELLED',
+      external_id: null,
+      failure_class: 'CONTROL_PLANE'
+    });
+    expect(context.repository.events).toContainEqual(
+      expect.objectContaining({
+        train_id: INTENT_ID,
+        operation_id: context.repository.operations[0].id,
+        event_type: 'EXACT_STAGING_BASELINE_UNDISPATCHED_E2E_CANCELLED',
+        actor: 'release-bus-v2',
+        payload_json: expect.objectContaining({
+          previous_status: 'PENDING',
+          operation_status: 'CANCELLED',
+          dispatch_reservation_observed: false,
+          external_workflow_run_observed: false
+        })
+      })
+    );
+  });
+
+  it('repairs a previously failed intent whose exact E2E operation was left pending', async () => {
+    const context = harness();
+    await prepare(context);
+    await freeze(context);
+    Object.assign(context.repository.operations[0], {
+      status: 'PENDING',
+      external_id: null
+    });
+    context.repository.operations.push({
+      ...structuredClone(context.repository.operations[0]),
+      id: '60000000-0000-4000-8000-000000000007',
+      idempotency_key: `rb2:${INTENT_ID}:e2e:staging:duplicate`,
+      status: 'SUCCEEDED'
+    });
+    await context.service.handleE2EProgress(INTENT_ID);
+
+    Object.assign(context.repository.operations[0], {
+      status: 'PENDING',
+      failure_class: null,
+      failure_message: null,
+      completed_at: null,
+      row_version: context.repository.operations[0].row_version + 1
+    });
+    context.repository.events = context.repository.events.filter(
+      ({ event_type }) =>
+        event_type !== 'EXACT_STAGING_BASELINE_UNDISPATCHED_E2E_CANCELLED'
+    );
+    context.repository.updateOperation.mockClear();
+
+    await expect(
+      context.service.execute(input(), 'owner')
+    ).resolves.toMatchObject({
+      adoption_id: INTENT_ID,
+      status: 'FAILED',
+      reused: true
+    });
+    expect(context.repository.operations[0].status).toBe('CANCELLED');
+    expect(context.repository.updateOperation).toHaveBeenCalledTimes(1);
+    expect(context.repository.events).toContainEqual(
+      expect.objectContaining({
+        event_type: 'EXACT_STAGING_BASELINE_UNDISPATCHED_E2E_CANCELLED',
+        actor: 'owner'
+      })
+    );
+  });
+
+  it('does not guess that a reserved E2E operation was never dispatched', async () => {
+    const context = harness();
+    await prepare(context);
+    await freeze(context);
+    Object.assign(context.repository.operations[0], {
+      status: 'DISPATCHED',
+      external_id: null
+    });
+    context.repository.operations.push({
+      ...structuredClone(context.repository.operations[0]),
+      id: '60000000-0000-4000-8000-000000000007',
+      idempotency_key: `rb2:${INTENT_ID}:e2e:staging:duplicate`,
+      status: 'SUCCEEDED'
+    });
+
+    await context.service.handleE2EProgress(INTENT_ID);
+    await context.service.execute(input(), 'owner');
+
+    expect(context.repository.operations[0].status).toBe('DISPATCHED');
+    expect(context.repository.updateOperation).not.toHaveBeenCalled();
+    expect(context.repository.events).not.toContainEqual(
+      expect.objectContaining({
+        event_type: 'EXACT_STAGING_BASELINE_UNDISPATCHED_E2E_CANCELLED'
+      })
+    );
   });
 
   it('rolls back all authoritative changes when a known-candidate CAS fails', async () => {

--- a/src/releaseBusV2/release-bus-v2.baseline-adoption.test.ts
+++ b/src/releaseBusV2/release-bus-v2.baseline-adoption.test.ts
@@ -1322,7 +1322,6 @@ describe('ReleaseBusV2BaselineAdoptionService', () => {
     expect(context.repository.events).toContainEqual(
       expect.objectContaining({
         train_id: INTENT_ID,
-        operation_id: context.repository.operations[0].id,
         event_type: 'EXACT_STAGING_BASELINE_UNDISPATCHED_E2E_CANCELLED',
         actor: 'release-bus-v2',
         payload_json: expect.objectContaining({

--- a/src/releaseBusV2/release-bus-v2.baseline-adoption.test.ts
+++ b/src/releaseBusV2/release-bus-v2.baseline-adoption.test.ts
@@ -1380,7 +1380,7 @@ describe('ReleaseBusV2BaselineAdoptionService', () => {
     );
   });
 
-  it('keeps failed intent reads stable when recovery races, then retries cleanup', async () => {
+  it('keeps failed intent reads stable when recovery races', async () => {
     const context = harness();
     await prepare(context);
     await freeze(context);
@@ -1423,14 +1423,6 @@ describe('ReleaseBusV2BaselineAdoptionService', () => {
         event_type: 'EXACT_STAGING_BASELINE_UNDISPATCHED_E2E_CANCELLED'
       })
     );
-
-    await expect(
-      context.service.execute(input(), 'owner')
-    ).resolves.toMatchObject({
-      status: 'FAILED',
-      reused: true
-    });
-    expect(context.repository.operations[0].status).toBe('CANCELLED');
   });
 
   it('does not guess that a reserved E2E operation was never dispatched', async () => {

--- a/src/releaseBusV2/release-bus-v2.baseline-adoption.ts
+++ b/src/releaseBusV2/release-bus-v2.baseline-adoption.ts
@@ -833,12 +833,6 @@ export class ReleaseBusV2BaselineAdoptionService {
             {},
             false,
             true
-          )) &&
-          !(await this.repository.findEvent(
-            failureEventId(exact.intent_id),
-            {},
-            false,
-            true
           ))
         )
           await this.failIntent(
@@ -2373,29 +2367,43 @@ export class ReleaseBusV2BaselineAdoptionService {
     intent: PreparedIntent,
     actor: string
   ): Promise<void> {
-    await this.repository.executeNativeQueriesInTransaction(
-      async (connection) => {
-        const ctx = { connection };
-        const failed = await this.repository.findEvent(
-          failureEventId(intent.intent_id),
-          ctx,
-          true
-        );
-        const train = await this.repository.findTrain(
-          intent.intent_id,
-          ctx,
-          true
-        );
-        if (!failed || train?.status !== 'FAILED') return;
-        await this.cancelExactUndispatchedOperation(
-          intent,
-          train,
-          'Cancelled an exact undispatched E2E operation after its baseline-adoption train failed closed',
-          actor,
-          ctx
-        );
-      }
-    );
+    try {
+      await this.repository.executeNativeQueriesInTransaction(
+        async (connection) => {
+          const ctx = { connection };
+          const failed = await this.repository.findEvent(
+            failureEventId(intent.intent_id),
+            ctx,
+            true
+          );
+          const train = await this.repository.findTrain(
+            intent.intent_id,
+            ctx,
+            true
+          );
+          if (!failed || train?.status !== 'FAILED') return;
+          await this.cancelExactUndispatchedOperation(
+            intent,
+            train,
+            'Cancelled an exact undispatched E2E operation after its baseline-adoption train failed closed',
+            actor,
+            ctx
+          );
+        }
+      );
+    } catch (error) {
+      this.logger.error(
+        '[BASELINE_ADOPTION] failed undispatched operation recovery deferred',
+        {
+          intent_id: intent.intent_id,
+          error_fingerprint_sha256: sha256(
+            error instanceof Error
+              ? { name: error.name, message: error.message }
+              : { type: typeof error }
+          )
+        }
+      );
+    }
   }
 
   private async releaseOwnedStagingLock(trainId: string): Promise<void> {

--- a/src/releaseBusV2/release-bus-v2.baseline-adoption.ts
+++ b/src/releaseBusV2/release-bus-v2.baseline-adoption.ts
@@ -2344,7 +2344,6 @@ export class ReleaseBusV2BaselineAdoptionService {
       {
         eventId: undispatchedOperationCancelledEventId(intent.intent_id),
         trainId: train.id,
-        operationId: operation.id,
         eventType: UNDISPATCHED_OPERATION_CANCELLED_EVENT,
         actor,
         payload: {

--- a/src/releaseBusV2/release-bus-v2.baseline-adoption.ts
+++ b/src/releaseBusV2/release-bus-v2.baseline-adoption.ts
@@ -2312,11 +2312,7 @@ export class ReleaseBusV2BaselineAdoptionService {
       ctx,
       true
     );
-    if (
-      !operation ||
-      operation.status !== 'PENDING' ||
-      operation.external_id !== null
-    )
+    if (operation?.status !== 'PENDING' || operation.external_id !== null)
       return;
     const manifest = train.manifest_id
       ? await this.repository.findManifest(train.manifest_id, ctx, true)
@@ -2390,7 +2386,7 @@ export class ReleaseBusV2BaselineAdoptionService {
           ctx,
           true
         );
-        if (!failed || !train || train.status !== 'FAILED') return;
+        if (!failed || train?.status !== 'FAILED') return;
         await this.cancelExactUndispatchedOperation(
           intent,
           train,

--- a/src/releaseBusV2/release-bus-v2.baseline-adoption.ts
+++ b/src/releaseBusV2/release-bus-v2.baseline-adoption.ts
@@ -627,11 +627,11 @@ function controlsAreSafe(
 function lockIsWhollyFree(lock: ReleaseBusV2LockRecord | undefined): boolean {
   return Boolean(
     lock &&
-      lock.owner_train_id === null &&
-      lock.lease_owner === null &&
-      lock.lease_token === null &&
-      lock.heartbeat_at === null &&
-      lock.expires_at === null
+    lock.owner_train_id === null &&
+    lock.lease_owner === null &&
+    lock.lease_token === null &&
+    lock.heartbeat_at === null &&
+    lock.expires_at === null
   );
 }
 

--- a/src/releaseBusV2/release-bus-v2.baseline-adoption.ts
+++ b/src/releaseBusV2/release-bus-v2.baseline-adoption.ts
@@ -21,6 +21,7 @@ import {
   type ReleaseBusV2ManifestRecord,
   type ReleaseBusV2Repository as ReleaseBusV2RepositoryClass
 } from '@/releaseBusV2/release-bus-v2.repository';
+import type { RequestContext } from '@/request.context';
 import type {
   ReleaseBusV2CandidateRecord,
   ReleaseBusV2OperationRecord,
@@ -38,6 +39,8 @@ const BACKEND_VERIFIED_EVENT = 'EXACT_STAGING_BASELINE_BACKEND_UNIT_VERIFIED';
 const DEFERRED_EVENT = 'EXACT_STAGING_BASELINE_AUTOMATIC_E2E_DEFERRED';
 const FROZEN_EVENT = 'EXACT_STAGING_BASELINE_MANIFEST_FROZEN';
 const ADOPTED_EVENT = 'EXACT_STAGING_BASELINE_ADOPTED';
+const UNDISPATCHED_OPERATION_CANCELLED_EVENT =
+  'EXACT_STAGING_BASELINE_UNDISPATCHED_E2E_CANCELLED';
 const INTENT_EVENT_TYPES = [
   PREPARED_EVENT,
   FAILED_EVENT,
@@ -331,6 +334,12 @@ function frozenEventId(intentId: string): string {
   return deterministicUuid(`baseline-adoption:${intentId}:frozen`);
 }
 
+function undispatchedOperationCancelledEventId(intentId: string): string {
+  return deterministicUuid(
+    `baseline-adoption:${intentId}:undispatched-operation-cancelled`
+  );
+}
+
 function frontendEvidenceEventId(intentId: string): string {
   return deterministicUuid(`baseline-adoption:${intentId}:frontend`);
 }
@@ -618,11 +627,11 @@ function controlsAreSafe(
 function lockIsWhollyFree(lock: ReleaseBusV2LockRecord | undefined): boolean {
   return Boolean(
     lock &&
-    lock.owner_train_id === null &&
-    lock.lease_owner === null &&
-    lock.lease_token === null &&
-    lock.heartbeat_at === null &&
-    lock.expires_at === null
+      lock.owner_train_id === null &&
+      lock.lease_owner === null &&
+      lock.lease_token === null &&
+      lock.heartbeat_at === null &&
+      lock.expires_at === null
   );
 }
 
@@ -810,7 +819,14 @@ export class ReleaseBusV2BaselineAdoptionService {
             'CONFLICT',
             'Baseline adoption idempotency key has a different immutable intent'
           );
-        if (
+        const failed = await this.repository.findEvent(
+          failureEventId(exact.intent_id),
+          {},
+          false,
+          true
+        );
+        if (failed) await this.recoverFailedUndispatchedOperation(exact, actor);
+        else if (
           exact.expires_at <= this.deps.now() &&
           !(await this.repository.findEvent(
             frozenEventId(exact.intent_id),
@@ -2270,10 +2286,120 @@ export class ReleaseBusV2BaselineAdoptionService {
             },
             ctx
           );
+          if (current)
+            await this.cancelExactUndispatchedOperation(
+              intent,
+              current,
+              message,
+              'release-bus-v2',
+              ctx
+            );
           return current?.id ?? null;
         }
       );
     if (failedTrainId) await this.releaseOwnedStagingLock(failedTrainId);
+  }
+
+  private async cancelExactUndispatchedOperation(
+    intent: PreparedIntent,
+    train: ReleaseBusV2TrainRecord,
+    message: string,
+    actor: string,
+    ctx: RequestContext
+  ): Promise<void> {
+    const operation = await this.repository.findOperation(
+      intent.operation_key,
+      ctx,
+      true
+    );
+    if (
+      !operation ||
+      operation.status !== 'PENDING' ||
+      operation.external_id !== null
+    )
+      return;
+    const manifest = train.manifest_id
+      ? await this.repository.findManifest(train.manifest_id, ctx, true)
+      : null;
+    if (
+      !manifest ||
+      !this.isExactBoundOperation(
+        train,
+        manifest,
+        operation,
+        intent.operation_key
+      )
+    )
+      throw new Error(
+        'Failed baseline-adoption operation identity is ambiguous'
+      );
+    const completedAt = this.deps.now();
+    if (
+      !(await this.repository.updateOperation(
+        operation.id,
+        operation.row_version,
+        {
+          status: 'CANCELLED',
+          failureClass: 'CONTROL_PLANE',
+          failureMessage: message,
+          completedAt
+        },
+        ctx
+      ))
+    )
+      throw new Error(
+        'Failed baseline-adoption operation changed concurrently'
+      );
+    await this.repository.appendEvent(
+      {
+        eventId: undispatchedOperationCancelledEventId(intent.intent_id),
+        trainId: train.id,
+        operationId: operation.id,
+        eventType: UNDISPATCHED_OPERATION_CANCELLED_EVENT,
+        actor,
+        payload: {
+          intent_id: intent.intent_id,
+          intent_identity_sha256: intent.intent_identity_sha256,
+          operation_id: operation.id,
+          operation_key: operation.idempotency_key,
+          previous_status: 'PENDING',
+          operation_status: 'CANCELLED',
+          dispatch_reservation_observed: false,
+          external_workflow_run_observed: false,
+          failure_message: message
+        }
+      },
+      ctx
+    );
+  }
+
+  private async recoverFailedUndispatchedOperation(
+    intent: PreparedIntent,
+    actor: string
+  ): Promise<void> {
+    await this.repository.executeNativeQueriesInTransaction(
+      async (connection) => {
+        const ctx = { connection };
+        const failed = await this.repository.findEvent(
+          failureEventId(intent.intent_id),
+          ctx,
+          true
+        );
+        const train = await this.repository.findTrain(
+          intent.intent_id,
+          ctx,
+          true
+        );
+        if (!failed || !train || train.status !== 'FAILED') return;
+        await this.cancelExactUndispatchedOperation(
+          intent,
+          train,
+          'Cancelled an exact undispatched E2E operation after its baseline-adoption train failed closed',
+          actor,
+          ctx
+        );
+      }
+    );
   }
 
   private async releaseOwnedStagingLock(trainId: string): Promise<void> {


### PR DESCRIPTION
## What changed

- terminalize an exact baseline-adoption E2E operation when its train fails before dispatch reservation
- make the operator-only idempotent adoption endpoint repair an older failed intent left in that proven-undispatched state
- append deterministic audited recovery evidence
- refuse to cancel DISPATCHED/ambiguous operations

## Root cause

The failed baseline-adoption path marked the manifest and train FAILED and released the staging lock, but could leave the already-created E2E operation PENDING. Manual fallback correctly treats that nonterminal operation as a drain blocker.

## Impact

The same shared control-plane logic now cleans this state for staging frontend/backend baseline adoption, while preserving ambiguous workflow state for reconciliation. The fix is deployed through both production and staging API/control-plane runtimes before STAGING is enabled.

## Validation

CI-first per owner request. Added focused regressions for new failures, recovery of the existing state, and refusal to guess after dispatch reservation. Formatting and diff checks passed locally; broad suites are delegated to PR CI.