### PR TITLE
Fix historical staging recovery boundaries

### DIFF
--- a/src/releaseBusV2/release-bus-v2.baseline-adoption.test.ts
+++ b/src/releaseBusV2/release-bus-v2.baseline-adoption.test.ts
@@ -1495,6 +1495,32 @@ describe('ReleaseBusV2BaselineAdoptionService', () => {
     }
   );
 
+  it(
+    'promotes an adopted staging-ready candidate so the scheduler does not deploy it again',
+    async () => {
+      const context = harness({ withCandidate: true });
+      Object.assign(context.repository.candidates[0], {
+        status: 'READY_FOR_STAGING',
+        production_requested_at: null,
+        production_requested_by: null,
+        production_selection_id: null,
+        hold_reason: null
+      });
+      await prepare(context, true);
+      await freeze(context);
+      succeedBoundE2E(context);
+      await context.service.handleE2EProgress(INTENT_ID);
+      expect(context.repository.candidates[0]).toMatchObject({
+        status: 'STAGING_VALIDATED',
+        current_train_id: null,
+        staging_validated_train_id: INTENT_ID,
+        staging_live_state: 'LIVE',
+        production_requested_at: null,
+        production_selection_id: null
+      });
+    }
+  );
+
   it('never acquires or mutates independent production ownership', async () => {
     const context = harness({ productionBusy: true });
     const productionBefore = structuredClone(context.repository.locks[0]);

--- a/src/releaseBusV2/release-bus-v2.baseline-adoption.test.ts
+++ b/src/releaseBusV2/release-bus-v2.baseline-adoption.test.ts
@@ -1495,31 +1495,49 @@ describe('ReleaseBusV2BaselineAdoptionService', () => {
     }
   );
 
-  it(
-    'promotes an adopted staging-ready candidate so the scheduler does not deploy it again',
-    async () => {
-      const context = harness({ withCandidate: true });
-      Object.assign(context.repository.candidates[0], {
-        status: 'READY_FOR_STAGING',
-        production_requested_at: null,
-        production_requested_by: null,
-        production_selection_id: null,
-        hold_reason: null
-      });
-      await prepare(context, true);
-      await freeze(context);
-      succeedBoundE2E(context);
-      await context.service.handleE2EProgress(INTENT_ID);
-      expect(context.repository.candidates[0]).toMatchObject({
-        status: 'STAGING_VALIDATED',
-        current_train_id: null,
-        staging_validated_train_id: INTENT_ID,
-        staging_live_state: 'LIVE',
-        production_requested_at: null,
-        production_selection_id: null
-      });
-    }
-  );
+  it('promotes an adopted staging-ready candidate so the scheduler does not deploy it again', async () => {
+    const context = harness({ withCandidate: true });
+    Object.assign(context.repository.candidates[0], {
+      status: 'READY_FOR_STAGING',
+      production_requested_at: null,
+      production_requested_by: null,
+      production_selection_id: null,
+      hold_reason: null
+    });
+    await prepare(context, true);
+    await freeze(context);
+    succeedBoundE2E(context);
+    await context.service.handleE2EProgress(INTENT_ID);
+    expect(context.repository.candidates[0]).toMatchObject({
+      status: 'STAGING_VALIDATED',
+      current_train_id: null,
+      staging_validated_train_id: INTENT_ID,
+      staging_live_state: 'LIVE',
+      production_requested_at: null,
+      production_selection_id: null
+    });
+  });
+
+  it('preserves an adopted candidate already in the production lifecycle', async () => {
+    const context = harness({ withCandidate: true });
+    Object.assign(context.repository.candidates[0], {
+      status: 'READY_FOR_PRODUCTION',
+      production_requested_at: null,
+      production_requested_by: 'developer',
+      production_selection_id: null
+    });
+    await prepare(context, true);
+    await freeze(context);
+    succeedBoundE2E(context);
+    await context.service.handleE2EProgress(INTENT_ID);
+    expect(context.repository.candidates[0]).toMatchObject({
+      status: 'READY_FOR_PRODUCTION',
+      production_requested_at: null,
+      production_requested_by: 'developer',
+      production_selection_id: null,
+      staging_live_state: 'LIVE'
+    });
+  });
 
   it('never acquires or mutates independent production ownership', async () => {
     const context = harness({ productionBusy: true });

--- a/src/releaseBusV2/release-bus-v2.baseline-adoption.ts
+++ b/src/releaseBusV2/release-bus-v2.baseline-adoption.ts
@@ -24,6 +24,7 @@ import {
 import type { RequestContext } from '@/request.context';
 import type {
   ReleaseBusV2CandidateRecord,
+  ReleaseBusV2CandidateStatus,
   ReleaseBusV2OperationRecord,
   ReleaseBusV2Repository,
   ReleaseBusV2StagingStateRecord,
@@ -60,6 +61,15 @@ const UNIT_PATTERN = /^[A-Za-z0-9_-]{1,100}$/;
 const OPERATION_ATTEMPT_SUFFIX_PATTERN = /^a[1-9]\d{0,8}$/;
 const RELEASE_BUS_OPERATION_ATTEMPT_PATTERN =
   /^rb2:[A-Za-z0-9:._-]+:a[1-9]\d{0,8}$/;
+const PRODUCTION_CANDIDATE_STATUSES = new Set<ReleaseBusV2CandidateStatus>([
+  'READY_FOR_PRODUCTION',
+  'READY_FOR_CANDIDATE_EVIDENCE_PRODUCTION',
+  'WAITING_FOR_PRODUCTION_REPLAN',
+  'PRODUCTION_IN_TRAIN',
+  'PRODUCTION_BUILDING_OR_QUALIFYING',
+  'PRODUCTION_DEPLOYING',
+  'PRODUCTION_DEPLOYED'
+]);
 
 export type ReleaseBusV2BaselineAdoptionCandidate = {
   readonly candidate_id: string;
@@ -673,6 +683,16 @@ function sameCandidate(
     candidate.head_sha === expected.head_sha &&
     candidate.row_version === expected.row_version
   );
+}
+
+function adoptedCandidateStatus(
+  candidate: ReleaseBusV2CandidateRecord
+): ReleaseBusV2CandidateStatus {
+  const hasProductionLifecycle =
+    candidate.production_requested_at !== null ||
+    candidate.production_selection_id !== null ||
+    PRODUCTION_CANDIDATE_STATUSES.has(candidate.status);
+  return hasProductionLifecycle ? candidate.status : 'STAGING_VALIDATED';
 }
 
 function exactPreparedIntent(
@@ -2154,7 +2174,7 @@ export class ReleaseBusV2BaselineAdoptionService {
               candidate.id,
               candidate.row_version,
               {
-                status: candidate.status,
+                status: adoptedCandidateStatus(candidate),
                 stagingValidatedTrainId: train.id,
                 stagingValidatedManifestId: manifest.id,
                 stagingLiveState: 'LIVE',

--- a/src/releaseBusV2/release-bus-v2.baseline-adoption.ts
+++ b/src/releaseBusV2/release-bus-v2.baseline-adoption.ts
@@ -61,6 +61,7 @@ const UNIT_PATTERN = /^[A-Za-z0-9_-]{1,100}$/;
 const OPERATION_ATTEMPT_SUFFIX_PATTERN = /^a[1-9]\d{0,8}$/;
 const RELEASE_BUS_OPERATION_ATTEMPT_PATTERN =
   /^rb2:[A-Za-z0-9:._-]+:a[1-9]\d{0,8}$/;
+// Keep this set synchronized with every production-lifecycle candidate status.
 const PRODUCTION_CANDIDATE_STATUSES = new Set<ReleaseBusV2CandidateStatus>([
   'READY_FOR_PRODUCTION',
   'READY_FOR_CANDIDATE_EVIDENCE_PRODUCTION',
@@ -690,6 +691,7 @@ function adoptedCandidateStatus(
 ): ReleaseBusV2CandidateStatus {
   const hasProductionLifecycle =
     candidate.production_requested_at !== null ||
+    candidate.production_requested_by !== null ||
     candidate.production_selection_id !== null ||
     PRODUCTION_CANDIDATE_STATUSES.has(candidate.status);
   return hasProductionLifecycle ? candidate.status : 'STAGING_VALIDATED';

--- a/src/releaseBusV2/release-bus-v2.reconciler.test.ts
+++ b/src/releaseBusV2/release-bus-v2.reconciler.test.ts
@@ -14,6 +14,7 @@ import {
   releaseBusV2Branch,
   ReleaseBusV2Reconciler,
   relevantCandidates,
+  rollbackEvidenceSelectionForPreparation,
   stagingDeploymentCandidates
 } from '@/releaseBusV2/release-bus-v2.reconciler';
 import {
@@ -234,6 +235,14 @@ describe('Release Bus v2 deterministic orchestration', () => {
 
   it('uses the bounded legacy preparation bridge when transition-only work has no source candidate', () => {
     expect(candidateEvidenceSelectionForPreparation([], null)).toEqual({
+      mode: 'legacy-whole-train',
+      aggregateDigest: null,
+      singular: null
+    });
+  });
+
+  it('does not requalify historical candidate evidence when rebuilding a validated rollback baseline', () => {
+    expect(rollbackEvidenceSelectionForPreparation()).toEqual({
       mode: 'legacy-whole-train',
       aggregateDigest: null,
       singular: null

--- a/src/releaseBusV2/release-bus-v2.reconciler.ts
+++ b/src/releaseBusV2/release-bus-v2.reconciler.ts
@@ -516,6 +516,13 @@ export function candidateEvidenceSelectionForPreparation(
     : candidateEvidenceSelection(candidates, singleFastCandidateId);
 }
 
+export function rollbackEvidenceSelectionForPreparation(): CandidateEvidenceSelection {
+  // A rollback rebuilds the exact SHA of an already STAGING_VALIDATED
+  // manifest. Its historical candidates are identity/audit data, not fresh
+  // composition inputs, and may predate the current PR evidence schema.
+  return candidateEvidenceSelectionForPreparation([], null);
+}
+
 function artifactEnvironmentForTrain(
   train: ReleaseBusV2TrainRecord
 ): 'staging' | 'production' {
@@ -3622,14 +3629,7 @@ export class ReleaseBusV2Reconciler {
       repository,
       branch
     );
-    const evidenceSelection = candidateEvidenceSelectionForPreparation(
-      context.candidates.filter(
-        (candidate) =>
-          baseline.candidateIds.includes(candidate.id) &&
-          candidate.repository === repository
-      ),
-      null
-    );
+    const evidenceSelection = rollbackEvidenceSelectionForPreparation();
     const operation = await releaseBusV2Operations.reconcileWorkflow({
       idempotencyKey: operationKey(train.id, `rollback:prepare:${repository}`),
       trainId: train.id,


### PR DESCRIPTION
## What changed

- Rollback artifact preparation rebuilds the exact SHA from the already validated staging manifest without requalifying historical carry-forward candidates against the current PR evidence schema.
- Successful exact-baseline adoption promotes non-production candidates to STAGING_VALIDATED so the scheduler cannot immediately claim and deploy the same live candidate again.
- Production lifecycle status and intent remain unchanged.

## Root causes

The cumulative rollback path treated historical manifest candidates as fresh composition inputs. Legacy candidate frontend#3498 predates the current exact PR CI policy fields, so rollback failed closed after composing the restore artifact.

The prior baseline-adoption path recorded candidates as live but preserved READY_FOR_STAGING, causing the next scheduler tick to classify already-live PR #3535 as NEW and redeploy it.

## Impact

Historical validated baselines can be restored safely, and an adopted staging-ready candidate becomes terminally staging-validated instead of being requeued. Normal candidate preparation remains strict.

## Validation

Published CI-first as requested. Local diff checks passed; repository CI is the authoritative lint, format, test, and build gate.