### PR TITLE
Restore supported zero-value transaction ingestion

### DIFF
--- a/docs/transactions-loop-ingestion-runbook.md
+++ b/docs/transactions-loop-ingestion-runbook.md
@@ -6,7 +6,9 @@
 
 - every transfer must have a non-blank Alchemy `uniqueId`;
 - token counts must agree with the transaction receipt; and
-- every mapped NFT transfer must have a matching receipt log with a safe count.
+- every mapped NFT transfer must have a matching receipt log with a safe count;
+  legitimate zero-value ERC-1155 initialization transfers remain indexed with
+  `token_count = 0`.
 
 A failed verification rejects the whole batch. This deliberately prevents the
 contract checkpoint from advancing past an unverified transfer. Skipping or

--- a/pr-reports/1896.md
+++ b/pr-reports/1896.md
@@ -1,0 +1,52 @@
+# PR Report: Restore zero-value transaction ingestion
+
+PR: https://github.com/6529-Collections/6529seize-backend/pull/1896
+Branch: `agent-prxt/fix-zero-value-initialize-claim` -> `main`
+Related PRs: #1861
+
+## Summary
+
+Restores the established ingestion of legitimate zero-value ERC-1155 token
+initialization transactions while preserving fail-closed receipt verification
+for genuinely missing or provider-omitted transfers.
+
+## What Changed
+
+- Receipt reconciliation now distinguishes a matching zero-value transfer log
+  from an absent transfer log.
+- Transaction discovery explicitly includes zero-value Alchemy transfers so
+  supported Manifold `initializeClaim` events remain discoverable.
+- Regression coverage preserves zero-address, zero-count initialization rows
+  and the existing bidirectional omission safeguards.
+- The transaction ingestion runbook documents supported zero-value
+  initialization transactions.
+
+## Backend Impact
+
+- New services: None
+- Changed services: `transactionsLoop`
+- Planned/deployed services: `transactionsLoop`; not deployed by request
+- API: Not affected
+- DB/entities/migrations: No schema or migration changes; affected
+  initialization rows continue to be stored with `token_count = 0`
+- Queues/events/integrations: Existing Alchemy discovery and canonical receipt
+  verification only
+
+## Config / Env
+
+No changes.
+
+## Backend Deployment
+
+- Deployed API: None
+- Deployed Lambdas/services: None
+- Not deployed: `transactionsLoop`
+- Deployment order executed: None
+
+Planned deployment order: `transactionsLoop`.
+
+## Release Notes
+
+Legitimate ERC-1155 token initialization transactions with zero transfer
+amounts are indexed again without weakening receipt verification for missing
+or inconsistent transfers.

--- a/src/transaction-values.test.ts
+++ b/src/transaction-values.test.ts
@@ -230,7 +230,26 @@ describe('reconcileTransactionTokenCounts', () => {
     expect(row.token_count).toBe(1);
   });
 
-  it('ignores zero-value receipt edges excluded by the Alchemy query', () => {
+  it('preserves supported zero-value ERC1155 initialization transfers', () => {
+    const row = makeTransaction(529, 0);
+    row.from_address = ZERO_ADDRESS;
+    const receipt: ReceiptLike = {
+      logs: [
+        makeLog('TransferSingle', [
+          FROM,
+          ZERO_ADDRESS,
+          TO,
+          BigInt(529),
+          BigInt(0)
+        ])
+      ]
+    };
+
+    expect(reconcileTransactionTokenCounts([row], receipt)).toBe(0);
+    expect(row.token_count).toBe(0);
+  });
+
+  it('fails closed when Alchemy omits a supported zero-value transfer', () => {
     const row = makeTransaction(473, 1);
     const receipt: ReceiptLike = {
       logs: [
@@ -239,7 +258,9 @@ describe('reconcileTransactionTokenCounts', () => {
       ]
     };
 
-    expect(reconcileTransactionTokenCounts([row], receipt)).toBe(0);
+    expect(() => reconcileTransactionTokenCounts([row], receipt)).toThrow(
+      'No Alchemy transaction row for receipt transfer'
+    );
     expect(row.token_count).toBe(1);
   });
 

--- a/src/transaction_values.ts
+++ b/src/transaction_values.ts
@@ -1189,12 +1189,7 @@ export function reconcileTransactionTokenCounts(
   const receiptCounts = new Map<string, bigint>();
   const receiptEdgesByKey = new Map<string, NftTransferEdge>();
   extractNftTransferEdges(receipt)
-    .filter(
-      (edge) =>
-        contracts.has(edge.contract.toLowerCase()) &&
-        // Asset Transfers excludes zero-value transfers for this query.
-        edge.amount > BigInt(0)
-    )
+    .filter((edge) => contracts.has(edge.contract.toLowerCase()))
     .forEach((edge) => {
       const key = getNftTransferKey(
         edge.from,
@@ -1225,9 +1220,9 @@ export function reconcileTransactionTokenCounts(
       row.contract,
       row.token_id
     );
-    const tokenCount = receiptCounts.get(key) ?? BigInt(0);
+    const tokenCount = receiptCounts.get(key);
 
-    if (tokenCount <= BigInt(0)) {
+    if (tokenCount === undefined) {
       throw new Error(
         `No matching NFT transfer log for ${row.transaction} ${row.contract} token ${row.token_id}`
       );

--- a/src/transactions/transactions-discovery.service.test.ts
+++ b/src/transactions/transactions-discovery.service.test.ts
@@ -168,8 +168,42 @@ describe('TransactionsDiscoveryService', () => {
     getAssetTransfers.mock.calls.forEach(([params]) => {
       expect(params.order).toBe('asc');
       expect(params.toBlock).toBe('0x3');
-      expect(params.excludeZeroValue).toBe(true);
+      expect(params.excludeZeroValue).toBeUndefined();
     });
+  });
+
+  it('discovers and saves supported zero-value ERC1155 initialization transfers', async () => {
+    const initializationTransfer = makeErc1155Transfer('event-1', [
+      { tokenId: '0x211', value: '0x0' }
+    ]);
+    initializationTransfer.from =
+      '0x0000000000000000000000000000000000000000';
+    const {
+      service,
+      batchUpsertTransactions,
+      enhanceTransactionValues,
+      getAssetTransfers
+    } = createService([[initializationTransfer]]);
+
+    await service.getAndSaveTransactionsForContract(CONTRACT, 1, 1);
+
+    expect(getAssetTransfers).toHaveBeenCalledWith(
+      expect.not.objectContaining({ excludeZeroValue: true })
+    );
+    expect(enhanceTransactionValues.mock.calls[0][0]).toEqual([
+      expect.objectContaining({
+        from_address: initializationTransfer.from,
+        token_id: 529,
+        token_count: 0
+      })
+    ]);
+    expect(batchUpsertTransactions.mock.calls[0][0]).toEqual([
+      expect.objectContaining({
+        from_address: initializationTransfer.from,
+        token_id: 529,
+        token_count: 0
+      })
+    ]);
   });
 
   it('uses Alchemy indexed state when tailing the chain', async () => {

--- a/src/transactions/transactions-discovery.service.test.ts
+++ b/src/transactions/transactions-discovery.service.test.ts
@@ -10,6 +10,7 @@ jest.mock('@/ens', () => ({
 const CONTRACT = '0x1111111111111111111111111111111111111111';
 const FROM = '0x2222222222222222222222222222222222222222';
 const TO = '0x3333333333333333333333333333333333333333';
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
 const HASH = `0x${'a'.repeat(64)}`;
 
 function makeErc1155Transfer(
@@ -176,8 +177,7 @@ describe('TransactionsDiscoveryService', () => {
     const initializationTransfer = makeErc1155Transfer('event-1', [
       { tokenId: '0x211', value: '0x0' }
     ]);
-    initializationTransfer.from =
-      '0x0000000000000000000000000000000000000000';
+    initializationTransfer.from = ZERO_ADDRESS;
     const {
       service,
       batchUpsertTransactions,
@@ -187,9 +187,7 @@ describe('TransactionsDiscoveryService', () => {
 
     await service.getAndSaveTransactionsForContract(CONTRACT, 1, 1);
 
-    expect(getAssetTransfers).toHaveBeenCalledWith(
-      expect.not.objectContaining({ excludeZeroValue: true })
-    );
+    expect(getAssetTransfers.mock.calls[0][0].excludeZeroValue).toBeUndefined();
     expect(enhanceTransactionValues.mock.calls[0][0]).toEqual([
       expect.objectContaining({
         from_address: initializationTransfer.from,

--- a/src/transactions/transactions-discovery.service.ts
+++ b/src/transactions/transactions-discovery.service.ts
@@ -234,7 +234,6 @@ export class TransactionsDiscoveryService {
     return {
       category: [AssetTransfersCategory.ERC1155, AssetTransfersCategory.ERC721],
       contractAddresses: [contract],
-      excludeZeroValue: true,
       order: SortingOrder.ASCENDING,
       withMetadata: true,
       maxCount: 150,


### PR DESCRIPTION
## Issue

`transactionsLoop` stopped at a supported Manifold `initializeClaim` event for Meme 529. These transactions legitimately emit an ERC-1155 `TransferSingle` log from the zero address with amount zero and have historically been indexed as transaction rows with `token_count = 0`.

Receipt reconciliation introduced in #1861 conflated a matching zero-value log with a missing log, causing the batch to fail closed before Meme 529 could be saved.

## Fix

- Preserve in-scope zero-value receipt edges during reconciliation.
- Distinguish a missing receipt key from a present key whose summed amount is zero.
- Keep legitimate zero-value transaction rows while retaining fail-closed behavior for genuinely missing or provider-omitted receipt edges.
- Request zero-value Alchemy transfers so established initialization events remain discoverable.

## Changes

- Added regression coverage for the exact zero-address, zero-count ERC-1155 initialization shape.
- Added discovery coverage proving zero-value rows are requested, enhanced, and saved.
- Updated the ingestion runbook to document supported zero-value initialization transactions.

## Validation

- Focused transaction discovery and receipt reconciliation tests are being run locally while CI evaluates the published branch.

## Risk

- Level: Medium
- Why: This changes fail-closed transaction receipt reconciliation, but only separates a present zero-value edge from an absent edge and restores previously supported behavior.
- Rollback: Revert this PR; the loop will fail closed at the affected checkpoint rather than write partial data.

## Deployment

1. Deploy `transactionsLoop`.

No migration, backfill, or manual checkpoint change is required. The scheduled loop will resume from the unchanged checkpoint and ingest Meme 529 after deployment.

## Review Notes

Please focus on zero-value ERC-1155 receipt-key presence and preservation of the existing bidirectional omission checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Zero-value ERC-1155 initialization transfers are now discovered, validated, and indexed correctly with a token count of zero.
  * Transfers must match corresponding receipt data; unmatched transfers now fail validation instead of being silently ignored.
  * Reconciliation and persistence behavior now consistently handles legitimate zero-value NFT transfers.

* **Documentation**
  * Updated the ingestion runbook to describe receipt matching and zero-value ERC-1155 handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->