### PR TITLE
Fix exact Stream development status answers

### DIFF
--- a/specs/6529-help-bot-runtime.md
+++ b/specs/6529-help-bot-runtime.md
@@ -171,7 +171,9 @@ items remaining before launch select only that record. Historical risk and
 readiness records describe the pinned review snapshot and must not be mixed into
 an answer about the current development update. The backend projects the exact
 status fields into the answer and bypasses Bedrock for those facts so figures
-and checklist items cannot be rewritten or invented.
+and checklist items cannot be rewritten or invented. Its provenance commit is
+the separately checked development commit, while the manifest source commit
+continues to identify the pinned review snapshot.
 
 ### 4.3 Future docs chunking and RAG
 

--- a/specs/6529-help-bot-runtime.md
+++ b/specs/6529-help-bot-runtime.md
@@ -16,7 +16,8 @@ backend answer path, and uses a Bedrock renderer for natural wording with a
 deterministic fallback if the model call fails or times out. It also supports a
 frontend calendar API mode for Meme Card drop timing plus a bounded public-data
 query mode for aggregate questions that are better answered from backend
-database rows than from static frontend docs.
+database rows than from static frontend docs. Stream questions use the
+frontend-published, versioned Stream review corpus described below.
 
 ## 2. Product Behavior
 
@@ -156,14 +157,30 @@ facts into the answer context. Fetches use the hardcoded five-second timeout so
 a slow index endpoint fails into the technical-failure reply path instead of
 stalling the worker.
 
-### 4.2 Future docs chunking and RAG
+### 4.2 Versioned Stream review corpus
+
+The frontend publishes the complete generated Stream review corpus under
+`/review-data/6529-stream/`, including a version manifest, a bounded search
+catalog, and checksummed evidence shards. The backend validates the published
+identity and checksums, selects a small query-relevant evidence packet, and
+never sends the whole corpus to Bedrock.
+
+The latest daily development update is a separate `development_status` record.
+Questions about current progress, contract-size headroom, work in progress, or
+items remaining before launch select only that record. Historical risk and
+readiness records describe the pinned review snapshot and must not be mixed into
+an answer about the current development update. The backend projects the exact
+status fields into the answer and bypasses Bedrock for those facts so figures
+and checklist items cannot be rewritten or invented.
+
+### 4.3 Future docs chunking and RAG
 
 The frontend index can later include generated chunks from frontend `ops/docs`,
 route metadata, component help metadata, embeddings, and eval coverage. That
 future phase should keep curated records as the higher-confidence source for
 canonical facts and URLs.
 
-### 4.3 Backend-owned business-rule records
+### 4.4 Backend-owned business-rule records
 
 The frontend owns product navigation and UI knowledge. The backend may add
 backend-owned records later for business rules that are not safe to infer from
@@ -178,7 +195,7 @@ Those records should be short, curated records or generated summaries from
 backend docs and tests. Raw code lookup should happen offline during indexing or
 authoring, not during a user request.
 
-### 4.4 Backend-owned public data query mode
+### 4.5 Backend-owned public data query mode
 
 Some questions should be answered from public indexed data, not from the
 frontend help index. Examples:
@@ -234,7 +251,7 @@ slightly warmer wording, and formal questions should stay formal, but tone never
 overrides the source facts, refusal boundaries, no-reliable-source behavior, or
 technical-failure behavior. Deterministic fallback answers remain neutral.
 
-### 4.5 Frontend-owned Memes calendar API mode
+### 4.6 Frontend-owned Memes calendar API mode
 
 Meme Card drop timing is frontend-owned because the Memes calendar helper owns
 the cadence, historic phases, skip/extra/reschedule overrides, and mint window
@@ -256,7 +273,7 @@ The backend validates the response shape before wording an answer. Calendar API
 timeouts, non-2xx responses, or invalid response bodies use the technical-failure
 reply path instead of guessing from stale static knowledge.
 
-### 4.6 Agent maintenance contract
+### 4.7 Agent maintenance contract
 
 Future agents must treat the help bot corpus as part of the user-facing product
 surface. When a backend change adds or changes behavior that users may ask
@@ -282,7 +299,7 @@ If a backend change is user-visible but intentionally should not be answerable
 by the bot yet, the PR should say why and whether a follow-up corpus update is
 needed.
 
-### 4.7 Retrieval model
+### 4.8 Retrieval model
 
 The bot should not depend on a predefined list of questions. It should retrieve
 records and chunks by:

--- a/src/help-bot/help-bot-answerer.test.ts
+++ b/src/help-bot/help-bot-answerer.test.ts
@@ -268,7 +268,7 @@ describe('HelpBotAnswerer', () => {
                 headline: 'The permanent Core now meets its size target.',
                 recentlyCompleted: [
                   {
-                    text: `The permanent Core fits within Ethereum's contract-size limit with 5,579 bytes of headroom.`
+                    text: 'The permanent Core is 5,579 bytes under the EIP-170 limit.'
                   }
                 ],
                 workingOn: [],
@@ -307,7 +307,7 @@ describe('HelpBotAnswerer', () => {
 
     expect(answer.type).toBe('ANSWER');
     if (answer.type === 'ANSWER') {
-      expect(answer.answer).toContain('5,579 bytes of headroom');
+      expect(answer.answer).toContain('5,579 bytes under the EIP-170 limit');
       expect(answer.answer).toContain(
         'Run the public testnet rehearsal and publish the verified addresses and source.'
       );

--- a/src/help-bot/help-bot-answerer.test.ts
+++ b/src/help-bot/help-bot-answerer.test.ts
@@ -243,6 +243,85 @@ describe('HelpBotAnswerer', () => {
     expect(genericSource.findMatch).not.toHaveBeenCalled();
   });
 
+  it('renders exact Stream development status without giving the LLM factual latitude', async () => {
+    const renderer: HelpBotLlmRenderer = {
+      renderAnswer: jest.fn().mockResolvedValue('There are 1,536 bytes left.')
+    };
+    const streamKnowledgeSource: HelpBotStreamKnowledgeSource = {
+      findMatch: jest.fn().mockResolvedValue({
+        score: 400,
+        record: {
+          id: '6529-stream@2026-08-01.1',
+          kind: 'public_review_knowledge',
+          title: '6529 Stream review evidence',
+          linkLabel: '6529 Stream Review',
+          canonicalPath: '/reviews/6529-stream#development-update',
+          aliases: ['stream'],
+          keywords: ['stream', 'development'],
+          facts: [
+            JSON.stringify({
+              id: 'status:latest-development',
+              kind: 'development_status',
+              title: 'Latest Stream development update',
+              structured: {
+                checkedAt: '2026-08-01T00:00:00.000Z',
+                headline: 'The permanent Core now meets its size target.',
+                recentlyCompleted: [
+                  {
+                    text: `The permanent Core fits within Ethereum's contract-size limit with 5,579 bytes of headroom.`
+                  }
+                ],
+                workingOn: [],
+                beforeLaunch: [
+                  {
+                    text: 'Run the public testnet rehearsal and publish the verified addresses and source.'
+                  },
+                  {
+                    text: 'Complete an independent external audit and retest every accepted fix.'
+                  },
+                  {
+                    text: 'Approve the final settings, deployment records, and operating rehearsals.'
+                  }
+                ]
+              }
+            })
+          ],
+          relatedPaths: [],
+          tags: ['stream', 'development_status'],
+          sourceRefs: []
+        }
+      })
+    };
+
+    const answer = await new HelpBotAnswerer(
+      renderer,
+      new StaticHelpBotKnowledgeSource(TEST_INDEX),
+      undefined,
+      undefined,
+      streamKnowledgeSource
+    ).answer({
+      question:
+        'According to the current Stream development update, what is the contract-size headroom and what remains before launch?',
+      baseUrl: BASE_URL
+    });
+
+    expect(answer.type).toBe('ANSWER');
+    if (answer.type === 'ANSWER') {
+      expect(answer.answer).toContain('5,579 bytes of headroom');
+      expect(answer.answer).toContain(
+        'Run the public testnet rehearsal and publish the verified addresses and source.'
+      );
+      expect(answer.answer).toContain(
+        'Complete an independent external audit and retest every accepted fix.'
+      );
+      expect(answer.answer).toContain(
+        'Approve the final settings, deployment records, and operating rehearsals.'
+      );
+      expect(answer.answer).not.toContain('1,536');
+    }
+    expect(renderer.renderAnswer).not.toHaveBeenCalled();
+  });
+
   it('keeps Stream source links complete and inside the response budget', async () => {
     const canonicalPath =
       '/reviews/6529-stream/versions/2026-07-27.1/for-artists#fixed-price-sales';

--- a/src/help-bot/help-bot-stream-knowledge.test.ts
+++ b/src/help-bot/help-bot-stream-knowledge.test.ts
@@ -520,7 +520,8 @@ function addDevelopmentStatusFixture(fixture: Fixture): Fixture {
     title: 'Historical contract size snapshot',
     name: 'contract size',
     aliases: ['contract size', 'headroom'],
-    searchText: 'contract size headroom launch blocker 424 bytes',
+    searchText:
+      'contract size headroom launch blocker reviewed version historical snapshot 424 bytes',
     recordShard: 0
   };
   const staleRiskEvidence = {
@@ -650,6 +651,34 @@ describe('FrontendStreamKnowledgeSource', () => {
     expect(match?.record.facts.join('\n')).not.toContain('RISK-SIZE-001');
     expect(match?.record.facts.join('\n')).not.toContain('424 bytes');
     expect(match?.record.facts.join('\n')).not.toContain('1,576 bytes');
+  });
+
+  it.each([
+    'what was the Stream headroom in the pinned snapshot?',
+    'what remains before launch for the reviewed Stream version?'
+  ])(
+    'keeps historical status questions on snapshot evidence: %s',
+    async (question) => {
+      const fixture = addDevelopmentStatusFixture(buildFixture());
+      const source = new FrontendStreamKnowledgeSource(
+        fixture.fetcher,
+        BASE_URL
+      );
+
+      const match = await source.findMatch(question);
+
+      expect(match?.record.facts.join('\n')).toContain('RISK-SIZE-001');
+      expect(match?.record.facts.join('\n')).not.toContain(
+        'status:latest-development'
+      );
+    }
+  );
+
+  it('does not route an unscoped headroom question into Stream', async () => {
+    const fixture = addDevelopmentStatusFixture(buildFixture());
+    const source = new FrontendStreamKnowledgeSource(fixture.fetcher, BASE_URL);
+
+    await expect(source.findMatch('what is the headroom?')).resolves.toBeNull();
   });
 
   it.each([

--- a/src/help-bot/help-bot-stream-knowledge.test.ts
+++ b/src/help-bot/help-bot-stream-knowledge.test.ts
@@ -437,6 +437,122 @@ function buildFixture(version = VERSION): Fixture {
   return { files, fetcher };
 }
 
+function addDevelopmentStatusFixture(fixture: Fixture): Fixture {
+  const prefix = `/review-data/${REVIEW_ID}/versions/${VERSION}/knowledge`;
+  const searchPath = `${prefix}/search-index.json`;
+  const shardPath = `${prefix}/records/000.json`;
+  const manifestPath = `${prefix}/manifest.json`;
+  const searchIndex = JSON.parse(fixture.files.get(searchPath)!) as {
+    records: Array<Record<string, unknown>>;
+  };
+  const shard = JSON.parse(fixture.files.get(shardPath)!) as {
+    records: Array<Record<string, unknown>>;
+  };
+  const manifest = JSON.parse(fixture.files.get(manifestPath)!) as Record<
+    string,
+    unknown
+  >;
+  const developmentCatalog = {
+    id: 'status:latest-development',
+    category: 'status',
+    kind: 'development_status',
+    title: 'Latest Stream development update',
+    name: 'latest development status',
+    aliases: ['stream development', 'stream progress'],
+    searchText:
+      'latest current development progress headroom working on before launch',
+    recordShard: 0
+  };
+  const developmentEvidence = {
+    ...developmentCatalog,
+    canonicalPath: `/reviews/${REVIEW_ID}#development-update`,
+    summary:
+      'The permanent Core now meets its size target. Stream is being prepared for external audit and launch evidence.',
+    provenance: {
+      reviewVersion: VERSION,
+      sourceCommit: '5021c8060950c3fef995271e674ed4b2007fee6d',
+      sourcePath: 'config/public-reviews/6529-stream.development-status.json'
+    },
+    structured: {
+      checkedAt: '2026-08-01T00:00:00.000Z',
+      state: 'PRE_AUDIT_DEVELOPMENT',
+      headline:
+        'The permanent Core now meets its size target. Stream is being prepared for external audit and launch evidence.',
+      summary: 'Development has continued since the reviewed snapshot.',
+      recentlyCompleted: [
+        {
+          id: 'permanent-core-size',
+          text: `The permanent Core fits within Ethereum's contract-size limit with 5,579 bytes of headroom.`,
+          evidencePath: 'release-artifacts/latest/bytecode-release-proof.json'
+        }
+      ],
+      workingOn: [
+        {
+          id: 'launch-configuration',
+          text: 'Confirming the exact contract set, permissions, settings, and connections for launch.',
+          evidencePath: 'docs/release-readiness.md'
+        }
+      ],
+      beforeLaunch: [
+        {
+          id: 'public-testnet-rehearsal',
+          text: 'Run the public testnet rehearsal and publish the verified addresses and source.',
+          evidencePath: 'release-artifacts/latest/public-beta-evidence.json'
+        },
+        {
+          id: 'external-audit',
+          text: 'Complete an independent external audit and retest every accepted fix.',
+          evidencePath: 'docs/audit-package.md'
+        },
+        {
+          id: 'launch-records',
+          text: 'Approve the final settings, deployment records, and operating rehearsals.',
+          evidencePath: 'docs/release-readiness.md'
+        }
+      ]
+    },
+    relationships: { relatedEditorialIds: [] }
+  };
+  const staleRiskCatalog = {
+    id: 'risk:current-implementation-and-readiness:RISK-SIZE-001',
+    category: 'status',
+    kind: 'risk_register_entry',
+    title: 'Historical contract size snapshot',
+    name: 'contract size',
+    aliases: ['contract size', 'headroom'],
+    searchText: 'contract size headroom launch blocker 424 bytes',
+    recordShard: 0
+  };
+  const staleRiskEvidence = {
+    ...staleRiskCatalog,
+    canonicalPath: `/reviews/${REVIEW_ID}/versions/${VERSION}/current-implementation-and-readiness`,
+    summary:
+      'The reviewed snapshot had 424 bytes of EIP-170 headroom and was 1,576 bytes below the release gate.',
+    provenance: { reviewVersion: VERSION, sourceCommit: COMMIT },
+    relationships: { relatedEditorialIds: [] }
+  };
+  searchIndex.records.push(developmentCatalog, staleRiskCatalog);
+  shard.records.push(developmentEvidence, staleRiskEvidence);
+  const searchText = JSON.stringify(searchIndex);
+  const shardText = JSON.stringify(shard);
+  const searchManifest = manifest.searchIndex as Record<string, unknown>;
+  searchManifest.sha256 = sha256(searchText);
+  searchManifest.recordCount = searchIndex.records.length;
+  const shardManifest = (
+    manifest.recordShards as Array<Record<string, unknown>>
+  )[0]!;
+  shardManifest.sha256 = sha256(shardText);
+  shardManifest.recordCount = shard.records.length;
+  (manifest.counts as Record<string, unknown>).total =
+    searchIndex.records.length;
+  delete manifest.knowledgeSha256;
+  manifest.knowledgeSha256 = sha256(stableJson(manifest));
+  fixture.files.set(searchPath, searchText);
+  fixture.files.set(shardPath, shardText);
+  fixture.files.set(manifestPath, JSON.stringify(manifest));
+  return fixture;
+}
+
 describe('FrontendStreamKnowledgeSource', () => {
   it('canonicalizes object keys with frontend-compatible code-unit ordering', () => {
     expect(
@@ -510,6 +626,30 @@ describe('FrontendStreamKnowledgeSource', () => {
     expect(firstEvidence.id).toBe(id);
     expect(match?.record.facts.join('\n')).toContain(VERSION);
     expect(match?.record.facts.join('\n')).toContain(COMMIT);
+  });
+
+  it('isolates the latest development update from historical snapshot status', async () => {
+    const fixture = addDevelopmentStatusFixture(buildFixture());
+    const source = new FrontendStreamKnowledgeSource(fixture.fetcher, BASE_URL);
+
+    const match = await source.findMatch(
+      'According to the current Stream development update, what is the contract-size headroom and what remains before launch?'
+    );
+    const evidence = (match?.record.facts ?? [])
+      .filter((fact) => fact.startsWith('{'))
+      .map((fact) => JSON.parse(fact) as Record<string, unknown>);
+    const structured = evidence[0]?.structured as {
+      readonly beforeLaunch?: readonly unknown[];
+    };
+
+    expect(evidence).toHaveLength(1);
+    expect(evidence[0]?.id).toBe('status:latest-development');
+    expect(match?.record.tags).toContain('development_status');
+    expect(match?.record.facts.join('\n')).toContain('5,579 bytes');
+    expect(structured.beforeLaunch).toHaveLength(3);
+    expect(match?.record.facts.join('\n')).not.toContain('RISK-SIZE-001');
+    expect(match?.record.facts.join('\n')).not.toContain('424 bytes');
+    expect(match?.record.facts.join('\n')).not.toContain('1,576 bytes');
   });
 
   it.each([

--- a/src/help-bot/help-bot-stream-knowledge.ts
+++ b/src/help-bot/help-bot-stream-knowledge.ts
@@ -540,13 +540,19 @@ function parseEvidenceShard(
     const kind = readString(record?.kind);
     const title = readString(record?.title);
     const canonicalPath = readString(record?.canonicalPath);
+    const reviewRoot = `/reviews/${REVIEW_ID}`;
     if (
       !record ||
       !id ||
       !category ||
       !kind ||
       !title ||
-      !canonicalPath?.startsWith(`/reviews/${REVIEW_ID}/`)
+      !canonicalPath ||
+      !(
+        canonicalPath === reviewRoot ||
+        canonicalPath.startsWith(`${reviewRoot}/`) ||
+        canonicalPath.startsWith(`${reviewRoot}#`)
+      )
     ) {
       return null;
     }
@@ -791,6 +797,29 @@ function queryIntent(
       tokens(question).size <= 1,
     contextualFollowUp
   };
+}
+
+function asksLatestDevelopmentStatus(question: string): boolean {
+  const normalized = splitSearchText(question).replace(/\s+/g, ' ').trim();
+  if (
+    /\b(?:pinned|snapshot|reviewed source|source commit|candidate snapshot)\b/.test(
+      normalized
+    )
+  ) {
+    return false;
+  }
+  const statusContext =
+    /\b(?:latest|current|today|daily|development|progress|checked|update)\b/.test(
+      normalized
+    ) &&
+    /\b(?:status|development|progress|update|headroom|launch|working|completed|finished|remain|remaining|size)\b/.test(
+      normalized
+    );
+  const exactDevelopmentFact =
+    /\b(?:headroom|before launch|working on|recently completed|what remains|size target)\b/.test(
+      normalized
+    );
+  return statusContext || exactDevelopmentFact;
 }
 
 function extractedExactQueryKeys(question: string): string[] {
@@ -1196,12 +1225,53 @@ function selectedTechnicalFacts(record: StreamEvidenceRecord): unknown {
   };
 }
 
+function selectedDevelopmentStatusItems(value: unknown): unknown[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  return value
+    .map((entry) => {
+      const item = asObject(entry);
+      if (!item) {
+        return null;
+      }
+      return {
+        id: readString(item.id),
+        text: readString(item.text),
+        evidencePath: readString(item.evidencePath)
+      };
+    })
+    .filter((entry): entry is NonNullable<typeof entry> => !!entry);
+}
+
+function selectedStructuredFacts(record: StreamEvidenceRecord): unknown {
+  if (record.kind !== 'development_status') {
+    return record.structured;
+  }
+  const structured = asObject(record.structured);
+  if (!structured) {
+    return undefined;
+  }
+  return {
+    checkedAt: readString(structured.checkedAt),
+    state: readString(structured.state),
+    headline: readString(structured.headline),
+    summary: readString(structured.summary),
+    evidenceSummary: structured.evidenceSummary,
+    recentlyCompleted: selectedDevelopmentStatusItems(
+      structured.recentlyCompleted
+    ),
+    workingOn: selectedDevelopmentStatusItems(structured.workingOn),
+    beforeLaunch: selectedDevelopmentStatusItems(structured.beforeLaunch)
+  };
+}
+
 function formatEvidenceRecord(
   record: StreamEvidenceRecord,
   index: number
 ): string {
   const provenance = asObject(record.provenance);
-  const structured = record.structured;
+  const structured = selectedStructuredFacts(record);
   const evidenceStates = Array.isArray(record.evidenceStates)
     ? record.evidenceStates
     : undefined;
@@ -1222,6 +1292,7 @@ function formatEvidenceRecord(
     canonicalPath: record.canonicalPath,
     sourceLink: record.sourceLink,
     sourcePath: readString(provenance?.sourcePath),
+    sourceCommit: readString(provenance?.sourceCommit),
     lineRange: asObject(provenance?.range)
   };
   let serialized = JSON.stringify(canonicalize(payload));
@@ -1322,6 +1393,7 @@ function evidencePacketRecord(
     relatedPaths,
     tags: [
       'stream',
+      selection.primary.kind,
       manifest.publication.lifecycleState.toLowerCase(),
       manifest.publication.auditStatus.toLowerCase(),
       manifest.publication.deploymentStatus.toLowerCase()
@@ -1369,6 +1441,41 @@ export class FrontendStreamKnowledgeSource implements HelpBotStreamKnowledgeSour
         : directExact;
     if (!intent.explicitlyStreamScoped && exact.length === 0) {
       return null;
+    }
+    if (
+      intent.explicitlyStreamScoped &&
+      asksLatestDevelopmentStatus(question)
+    ) {
+      const latestDevelopment = corpus.catalog.find(
+        (record) => record.kind === 'development_status'
+      );
+      if (!latestDevelopment) {
+        return null;
+      }
+      try {
+        const [primary] = await this.loadRecords(corpus, [latestDevelopment]);
+        if (!primary) {
+          return null;
+        }
+        return {
+          score: 400,
+          record: evidencePacketRecord(
+            {
+              records: [primary],
+              primary,
+              score: 400,
+              ambiguity: null
+            },
+            corpus.manifest
+          )
+        };
+      } catch (error) {
+        this.logger.warn(
+          'Could not load the latest Stream development status',
+          error
+        );
+        return null;
+      }
     }
     const fuzzy = fuzzyMatches(question, corpus, intent);
     const initial = selectInitialCandidates(exact, fuzzy);

--- a/src/help-bot/help-bot-stream-knowledge.ts
+++ b/src/help-bot/help-bot-stream-knowledge.ts
@@ -799,13 +799,16 @@ function queryIntent(
   };
 }
 
+function asksHistoricalSnapshotStatus(question: string): boolean {
+  const normalized = splitSearchText(question).replace(/\s+/g, ' ').trim();
+  return /\b(?:pinned|snapshot|historical|reviewed|review version|source commit|candidate snapshot)\b/.test(
+    normalized
+  );
+}
+
 function asksLatestDevelopmentStatus(question: string): boolean {
   const normalized = splitSearchText(question).replace(/\s+/g, ' ').trim();
-  if (
-    /\b(?:pinned|snapshot|reviewed source|source commit|candidate snapshot)\b/.test(
-      normalized
-    )
-  ) {
+  if (asksHistoricalSnapshotStatus(question)) {
     return false;
   }
   const statusContext =
@@ -1446,10 +1449,8 @@ export class FrontendStreamKnowledgeSource implements HelpBotStreamKnowledgeSour
       intent.explicitlyStreamScoped &&
       asksLatestDevelopmentStatus(question)
     ) {
-      const latestDevelopment = corpus.catalog.find(
-        (record) => record.kind === 'development_status'
-      );
-      if (!latestDevelopment) {
+      const latestDevelopment = corpus.byId.get('status:latest-development');
+      if (latestDevelopment?.kind !== 'development_status') {
         return null;
       }
       try {
@@ -1477,8 +1478,15 @@ export class FrontendStreamKnowledgeSource implements HelpBotStreamKnowledgeSour
         return null;
       }
     }
+    const historicalSnapshotQuestion = asksHistoricalSnapshotStatus(question);
+    const eligibleExact = historicalSnapshotQuestion
+      ? exact.filter((match) => match.record.kind !== 'development_status')
+      : exact;
     const fuzzy = fuzzyMatches(question, corpus, intent);
-    const initial = selectInitialCandidates(exact, fuzzy);
+    const eligibleFuzzy = historicalSnapshotQuestion
+      ? fuzzy.filter((match) => match.record.kind !== 'development_status')
+      : fuzzy;
+    const initial = selectInitialCandidates(eligibleExact, eligibleFuzzy);
     if (initial.length === 0) {
       return null;
     }
@@ -1486,8 +1494,8 @@ export class FrontendStreamKnowledgeSource implements HelpBotStreamKnowledgeSour
       question,
       corpus,
       initial,
-      exact,
-      fuzzy
+      eligibleExact,
+      eligibleFuzzy
     );
     if (!selection) {
       return null;

--- a/src/help-bot/help-bot.answerer.ts
+++ b/src/help-bot/help-bot.answerer.ts
@@ -366,6 +366,12 @@ function appendNumberedStatusItems(
   items.forEach((item, index) => lines.push(`${index + 1}. ${item}`));
 }
 
+function isContractSizeStatusQuestion(question: string): boolean {
+  return /\b(?:headroom|bytecode|contract[ -]size|size target)\b/.test(
+    question
+  );
+}
+
 function buildStreamDevelopmentStatusAnswer(
   question: string,
   record: HelpBotKnowledgeRecord,
@@ -378,9 +384,8 @@ function buildStreamDevelopmentStatusAnswer(
   }
   const normalizedQuestion = question.toLowerCase();
   const wantsCompleted =
-    /\b(?:completed|finished|done|headroom|bytecode|contract[ -]size|size target)\b/.test(
-      normalizedQuestion
-    );
+    /\b(?:completed|finished|done)\b/.test(normalizedQuestion) ||
+    isContractSizeStatusQuestion(normalizedQuestion);
   const wantsWorking = /\b(?:working|in progress|progress|underway)\b/.test(
     normalizedQuestion
   );
@@ -398,16 +403,19 @@ function buildStreamDevelopmentStatusAnswer(
   if (!specificQuestion && structured.headline) {
     lines.push(structured.headline);
   }
+  const substantiveLineStart = lines.length;
 
   const completed = developmentStatusTexts(structured.recentlyCompleted);
-  const completedItems =
-    /\b(?:headroom|bytecode|contract[ -]size|size target)\b/.test(
-      normalizedQuestion
-    )
-      ? completed.filter((item) =>
-          /\b(?:headroom|contract-size|size limit)\b/i.test(item)
-        )
-      : completed;
+  const matchingCompletedItems = isContractSizeStatusQuestion(
+    normalizedQuestion
+  )
+    ? completed.filter((item) =>
+        /\b(?:headroom|contract-size|size limit)\b/i.test(item)
+      )
+    : completed;
+  const completedItems = matchingCompletedItems.length
+    ? matchingCompletedItems
+    : completed;
   if (wantsCompleted) {
     appendNumberedStatusItems(lines, 'Recently completed', completedItems);
   }
@@ -424,6 +432,24 @@ function buildStreamDevelopmentStatusAnswer(
       'Before launch',
       developmentStatusTexts(structured.beforeLaunch)
     );
+  }
+  if (lines.length === substantiveLineStart) {
+    if (structured.headline) {
+      lines.push(structured.headline);
+    }
+    appendNumberedStatusItems(
+      lines,
+      'Work in progress',
+      developmentStatusTexts(structured.workingOn)
+    );
+    appendNumberedStatusItems(
+      lines,
+      'Before launch',
+      developmentStatusTexts(structured.beforeLaunch)
+    );
+  }
+  if (!lines.length) {
+    return null;
   }
   return composeStreamAnswer(lines.join('\n'), record, baseUrl);
 }

--- a/src/help-bot/help-bot.answerer.ts
+++ b/src/help-bot/help-bot.answerer.ts
@@ -264,6 +264,7 @@ function ensureKnowledgeMarkdownLinks({
 }
 
 interface StreamEvidenceSummary {
+  readonly kind?: string;
   readonly title?: string;
   readonly scope?: string;
   readonly classification?: string;
@@ -278,6 +279,20 @@ interface StreamEvidenceSummary {
       readonly visibility?: string;
       readonly stateMutability?: string;
     };
+  };
+}
+
+interface StreamDevelopmentStatusItem {
+  readonly text?: string;
+}
+
+interface StreamDevelopmentStatusEvidence extends StreamEvidenceSummary {
+  readonly structured?: {
+    readonly checkedAt?: string;
+    readonly headline?: string;
+    readonly recentlyCompleted?: readonly StreamDevelopmentStatusItem[];
+    readonly workingOn?: readonly StreamDevelopmentStatusItem[];
+    readonly beforeLaunch?: readonly StreamDevelopmentStatusItem[];
   };
 }
 
@@ -309,6 +324,108 @@ function streamEvidenceSummary(fact: string): string | null {
   } catch {
     return null;
   }
+}
+
+function streamDevelopmentStatusEvidence(
+  record: HelpBotKnowledgeRecord
+): StreamDevelopmentStatusEvidence | null {
+  if (!record.tags.includes('development_status')) {
+    return null;
+  }
+  for (const fact of record.facts) {
+    if (!fact.startsWith('{')) {
+      continue;
+    }
+    try {
+      const evidence = JSON.parse(fact) as StreamDevelopmentStatusEvidence;
+      if (evidence.kind === 'development_status' && evidence.structured) {
+        return evidence;
+      }
+    } catch {
+      // Ignore non-evidence facts.
+    }
+  }
+  return null;
+}
+
+function developmentStatusTexts(
+  items: readonly StreamDevelopmentStatusItem[] | undefined
+): string[] {
+  return (items ?? []).map((item) => item.text?.trim() ?? '').filter(Boolean);
+}
+
+function appendNumberedStatusItems(
+  lines: string[],
+  label: string,
+  items: readonly string[]
+): void {
+  if (!items.length) {
+    return;
+  }
+  lines.push(`${label}:`);
+  items.forEach((item, index) => lines.push(`${index + 1}. ${item}`));
+}
+
+function buildStreamDevelopmentStatusAnswer(
+  question: string,
+  record: HelpBotKnowledgeRecord,
+  baseUrl: string
+): string | null {
+  const evidence = streamDevelopmentStatusEvidence(record);
+  const structured = evidence?.structured;
+  if (!structured) {
+    return null;
+  }
+  const normalizedQuestion = question.toLowerCase();
+  const wantsCompleted =
+    /\b(?:completed|finished|done|headroom|bytecode|contract[ -]size|size target)\b/.test(
+      normalizedQuestion
+    );
+  const wantsWorking = /\b(?:working|in progress|progress|underway)\b/.test(
+    normalizedQuestion
+  );
+  const wantsBeforeLaunch =
+    /\b(?:before launch|launch|remain|remaining|still needed|left to do)\b/.test(
+      normalizedQuestion
+    );
+  const specificQuestion = wantsCompleted || wantsWorking || wantsBeforeLaunch;
+  const lines: string[] = [];
+  if (structured.checkedAt) {
+    lines.push(
+      `The latest checked Stream development update is dated ${structured.checkedAt.slice(0, 10)}.`
+    );
+  }
+  if (!specificQuestion && structured.headline) {
+    lines.push(structured.headline);
+  }
+
+  const completed = developmentStatusTexts(structured.recentlyCompleted);
+  const completedItems =
+    /\b(?:headroom|bytecode|contract[ -]size|size target)\b/.test(
+      normalizedQuestion
+    )
+      ? completed.filter((item) =>
+          /\b(?:headroom|contract-size|size limit)\b/i.test(item)
+        )
+      : completed;
+  if (wantsCompleted) {
+    appendNumberedStatusItems(lines, 'Recently completed', completedItems);
+  }
+  if (wantsWorking || !specificQuestion) {
+    appendNumberedStatusItems(
+      lines,
+      'Work in progress',
+      developmentStatusTexts(structured.workingOn)
+    );
+  }
+  if (wantsBeforeLaunch || !specificQuestion) {
+    appendNumberedStatusItems(
+      lines,
+      'Before launch',
+      developmentStatusTexts(structured.beforeLaunch)
+    );
+  }
+  return composeStreamAnswer(lines.join('\n'), record, baseUrl);
 }
 
 function truncateAtNaturalBoundary(value: string, maxLength: number): string {
@@ -1488,6 +1605,20 @@ export class HelpBotAnswerer {
 
     const maybeWithWeakCaveat = (answer: string) =>
       escalateToTechTeam ? appendWeakMatchPrefix(answer) : answer;
+
+    const developmentStatusAnswer = buildStreamDevelopmentStatusAnswer(
+      request.question,
+      answerRecord,
+      request.baseUrl
+    );
+    if (developmentStatusAnswer) {
+      return {
+        type: 'ANSWER',
+        answer: maybeWithWeakCaveat(developmentStatusAnswer),
+        record: answerRecord,
+        escalateToTechTeam
+      };
+    }
 
     if (!this.renderer) {
       return {


### PR DESCRIPTION
## Issue

The live Stream Help Bot path could mix the current daily development update with historical snapshot evidence, and Bedrock could then invent exact bytecode figures or launch checklist items. Root-anchored review evidence paths were also rejected by the shard validator.

## Fix

- route current Stream development questions to the single versioned \development_status\ record
- project its exact checked date, completed work, work in progress, and before-launch checklist into a bounded packet
- render those status facts deterministically while keeping Bedrock for ordinary Stream explanations
- accept validated Stream root-anchor evidence paths
- document current-status precedence in the runtime spec

## Validation

- 72 focused Help Bot tests pass
- repository TypeScript typecheck passes after installing root and API dependencies
- full source ESLint passes with zero warnings
- Prettier and \git diff --check\ pass

## Risk

Low and scoped to Stream Help Bot retrieval/rendering. Pinned snapshot questions keep the existing evidence path; only clearly current/development-status questions use the deterministic projection.

## Review notes

The regression fixture intentionally contains both the current 5,579-byte headroom fact and older 424/1,576-byte snapshot facts, proving that the current answer packet contains only the dated development record.