### PR TITLE
Preserve exact Stream status payload

### DIFF
--- a/src/help-bot/help-bot-answerer.test.ts
+++ b/src/help-bot/help-bot-answerer.test.ts
@@ -322,6 +322,59 @@ describe('HelpBotAnswerer', () => {
     expect(renderer.renderAnswer).not.toHaveBeenCalled();
   });
 
+  it('fails closed without the LLM when an exact Stream status packet is oversized', async () => {
+    const renderer: HelpBotLlmRenderer = {
+      renderAnswer: jest.fn().mockResolvedValue('Invented status')
+    };
+    const streamKnowledgeSource: HelpBotStreamKnowledgeSource = {
+      findMatch: jest.fn().mockResolvedValue({
+        score: 400,
+        record: {
+          id: '6529-stream@2026-08-01.1',
+          kind: 'public_review_knowledge',
+          title: '6529 Stream review evidence',
+          linkLabel: '6529 Stream Review',
+          canonicalPath: '/reviews/6529-stream#development-update',
+          aliases: ['stream'],
+          keywords: ['stream', 'development'],
+          facts: [
+            JSON.stringify({
+              id: 'status:latest-development',
+              kind: 'development_status',
+              structured: {
+                checkedAt: '2026-08-01T00:00:00.000Z',
+                exactStatusUnavailable: true
+              }
+            })
+          ],
+          relatedPaths: [],
+          tags: ['stream', 'development_status'],
+          sourceRefs: []
+        }
+      })
+    };
+
+    const answer = await new HelpBotAnswerer(
+      renderer,
+      new StaticHelpBotKnowledgeSource(TEST_INDEX),
+      undefined,
+      undefined,
+      streamKnowledgeSource
+    ).answer({
+      question: 'what is the current Stream contract-size headroom?',
+      baseUrl: BASE_URL
+    });
+
+    expect(answer.type).toBe('ANSWER');
+    if (answer.type === 'ANSWER') {
+      expect(answer.answer).toContain(
+        'could not fit in the verified evidence packet'
+      );
+      expect(answer.answer).not.toContain('Invented status');
+    }
+    expect(renderer.renderAnswer).not.toHaveBeenCalled();
+  });
+
   it('keeps Stream source links complete and inside the response budget', async () => {
     const canonicalPath =
       '/reviews/6529-stream/versions/2026-07-27.1/for-artists#fixed-price-sales';

--- a/src/help-bot/help-bot-stream-knowledge.test.ts
+++ b/src/help-bot/help-bot-stream-knowledge.test.ts
@@ -437,7 +437,10 @@ function buildFixture(version = VERSION): Fixture {
   return { files, fetcher };
 }
 
-function addDevelopmentStatusFixture(fixture: Fixture): Fixture {
+function addDevelopmentStatusFixture(
+  fixture: Fixture,
+  oversizedStructuredStatus = false
+): Fixture {
   const prefix = `/review-data/${REVIEW_ID}/versions/${VERSION}/knowledge`;
   const searchPath = `${prefix}/search-index.json`;
   const shardPath = `${prefix}/records/000.json`;
@@ -466,7 +469,8 @@ function addDevelopmentStatusFixture(fixture: Fixture): Fixture {
   const developmentEvidence = {
     ...developmentCatalog,
     canonicalPath: `/reviews/${REVIEW_ID}#development-update`,
-    summary: 'Development status narrative '.repeat(120),
+    summary:
+      'The permanent Core now meets its size target. Stream is being prepared for external audit and launch evidence.',
     provenance: {
       reviewVersion: VERSION,
       sourceCommit: '5021c8060950c3fef995271e674ed4b2007fee6d',
@@ -477,7 +481,9 @@ function addDevelopmentStatusFixture(fixture: Fixture): Fixture {
       state: 'PRE_AUDIT_DEVELOPMENT',
       headline:
         'The permanent Core now meets its size target. Stream is being prepared for external audit and launch evidence.',
-      summary: 'Development has continued since the reviewed snapshot.',
+      summary: oversizedStructuredStatus
+        ? 'Development status narrative '.repeat(120)
+        : 'Development has continued since the reviewed snapshot.',
       recentlyCompleted: [
         {
           id: 'permanent-core-size',
@@ -654,6 +660,26 @@ describe('FrontendStreamKnowledgeSource', () => {
     expect(match?.record.facts.join('\n')).not.toContain('RISK-SIZE-001');
     expect(match?.record.facts.join('\n')).not.toContain('424 bytes');
     expect(match?.record.facts.join('\n')).not.toContain('1,576 bytes');
+  });
+
+  it('fails closed inside the record budget when structured status is oversized', async () => {
+    const fixture = addDevelopmentStatusFixture(buildFixture(), true);
+    const source = new FrontendStreamKnowledgeSource(fixture.fetcher, BASE_URL);
+
+    const match = await source.findMatch('what is the current Stream status?');
+    const fact = match?.record.facts.find((entry) => entry.startsWith('{'));
+    const evidence = JSON.parse(fact ?? '{}') as {
+      readonly structured?: {
+        readonly exactStatusUnavailable?: boolean;
+        readonly beforeLaunch?: readonly unknown[];
+      };
+    };
+
+    expect(fact?.length).toBeLessThanOrEqual(
+      STREAM_KNOWLEDGE_TESTING.MAX_EVIDENCE_RECORD_CHARACTERS
+    );
+    expect(evidence.structured?.exactStatusUnavailable).toBe(true);
+    expect(evidence.structured?.beforeLaunch).toBeUndefined();
   });
 
   it.each([

--- a/src/help-bot/help-bot-stream-knowledge.test.ts
+++ b/src/help-bot/help-bot-stream-knowledge.test.ts
@@ -466,8 +466,7 @@ function addDevelopmentStatusFixture(fixture: Fixture): Fixture {
   const developmentEvidence = {
     ...developmentCatalog,
     canonicalPath: `/reviews/${REVIEW_ID}#development-update`,
-    summary:
-      'The permanent Core now meets its size target. Stream is being prepared for external audit and launch evidence.',
+    summary: 'Development status narrative '.repeat(120),
     provenance: {
       reviewVersion: VERSION,
       sourceCommit: '5021c8060950c3fef995271e674ed4b2007fee6d',
@@ -648,6 +647,10 @@ describe('FrontendStreamKnowledgeSource', () => {
     expect(match?.record.tags).toContain('development_status');
     expect(match?.record.facts.join('\n')).toContain('5,579 bytes');
     expect(structured.beforeLaunch).toHaveLength(3);
+    expect(evidence[0]?.structuredExcerpt).toBeUndefined();
+    expect(JSON.stringify(evidence[0]).length).toBeLessThanOrEqual(
+      STREAM_KNOWLEDGE_TESTING.MAX_EVIDENCE_RECORD_CHARACTERS
+    );
     expect(match?.record.facts.join('\n')).not.toContain('RISK-SIZE-001');
     expect(match?.record.facts.join('\n')).not.toContain('424 bytes');
     expect(match?.record.facts.join('\n')).not.toContain('1,576 bytes');

--- a/src/help-bot/help-bot-stream-knowledge.ts
+++ b/src/help-bot/help-bot-stream-knowledge.ts
@@ -1240,8 +1240,7 @@ function selectedDevelopmentStatusItems(value: unknown): unknown[] | undefined {
       }
       return {
         id: readString(item.id),
-        text: readString(item.text),
-        evidencePath: readString(item.evidencePath)
+        text: readString(item.text)
       };
     })
     .filter((entry): entry is NonNullable<typeof entry> => !!entry);
@@ -1269,10 +1268,32 @@ function selectedStructuredFacts(record: StreamEvidenceRecord): unknown {
   };
 }
 
+function formatDevelopmentStatusEvidence(
+  record: StreamEvidenceRecord,
+  index: number
+): string {
+  const provenance = asObject(record.provenance);
+  return JSON.stringify(
+    canonicalize({
+      evidence: index,
+      id: record.id,
+      category: record.category,
+      kind: record.kind,
+      title: record.title,
+      structured: selectedStructuredFacts(record),
+      canonicalPath: record.canonicalPath,
+      sourceCommit: readString(provenance?.sourceCommit)
+    })
+  );
+}
+
 function formatEvidenceRecord(
   record: StreamEvidenceRecord,
   index: number
 ): string {
+  if (record.kind === 'development_status') {
+    return formatDevelopmentStatusEvidence(record, index);
+  }
   const provenance = asObject(record.provenance);
   const structured = selectedStructuredFacts(record);
   const evidenceStates = Array.isArray(record.evidenceStates)

--- a/src/help-bot/help-bot-stream-knowledge.ts
+++ b/src/help-bot/help-bot-stream-knowledge.ts
@@ -1273,16 +1273,34 @@ function formatDevelopmentStatusEvidence(
   index: number
 ): string {
   const provenance = asObject(record.provenance);
+  const identity = {
+    evidence: index,
+    id: record.id,
+    category: record.category,
+    kind: record.kind,
+    title: record.title,
+    canonicalPath: record.canonicalPath,
+    sourceCommit: readString(provenance?.sourceCommit)
+  };
+  const serialized = JSON.stringify(
+    canonicalize({
+      ...identity,
+      structured: selectedStructuredFacts(record)
+    })
+  );
+  if (serialized.length <= MAX_EVIDENCE_RECORD_CHARACTERS) {
+    return serialized;
+  }
+  const structured = asObject(record.structured);
   return JSON.stringify(
     canonicalize({
-      evidence: index,
-      id: record.id,
-      category: record.category,
-      kind: record.kind,
-      title: record.title,
-      structured: selectedStructuredFacts(record),
-      canonicalPath: record.canonicalPath,
-      sourceCommit: readString(provenance?.sourceCommit)
+      ...identity,
+      structured: {
+        checkedAt: readString(structured?.checkedAt),
+        exactStatusUnavailable: true,
+        headline:
+          bounded(readString(structured?.headline) ?? '', 300) || undefined
+      }
     })
   );
 }

--- a/src/help-bot/help-bot.answerer.ts
+++ b/src/help-bot/help-bot.answerer.ts
@@ -289,6 +289,7 @@ interface StreamDevelopmentStatusItem {
 interface StreamDevelopmentStatusEvidence extends StreamEvidenceSummary {
   readonly structured?: {
     readonly checkedAt?: string;
+    readonly exactStatusUnavailable?: boolean;
     readonly headline?: string;
     readonly recentlyCompleted?: readonly StreamDevelopmentStatusItem[];
     readonly workingOn?: readonly StreamDevelopmentStatusItem[];
@@ -381,6 +382,13 @@ function buildStreamDevelopmentStatusAnswer(
   const structured = evidence?.structured;
   if (!structured) {
     return null;
+  }
+  if (structured.exactStatusUnavailable) {
+    return composeStreamAnswer(
+      'The exact current Stream development status could not fit in the verified evidence packet. Please use the linked development update for the complete figures and checklist.',
+      record,
+      baseUrl
+    );
   }
   const normalizedQuestion = question.toLowerCase();
   const wantsCompleted =


### PR DESCRIPTION
## Issue

The first live staging retest after #1897 returned the correct launch checklist but rounded the exact 5,579-byte headroom to 2.5 KB. The projected development status plus the record's long summary crossed the generic per-record budget, so the formatter replaced structured fields with a truncated excerpt and the deterministic answer path could not engage.

## Fix

- give \development_status\ a dedicated minimal evidence payload containing only identity, canonical path, provenance commit, and the exact structured status fields
- remove evidence paths from the runtime status item projection because the public answer needs the exact item IDs/text only
- stress the regression fixture with a long narrative and assert the complete structured payload remains present and within the 2,300-character record limit

## Validation

- 75 focused Help Bot tests pass
- TypeScript typecheck passes
- ESLint, Prettier, and \git diff --check\ pass
- live staging evidence that exposed the issue: checklist exact, byte value incorrectly rounded; this PR targets that packet boundary directly

## Risk

Low. The special formatter applies only to the stable \status:latest-development\ record selected in #1897. Other Stream evidence keeps the generic bounded formatter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved development-status information formatting for clearer, more compact evidence.
  * Removed unnecessary evidence details from development-status records.
  * Ensured long evidence summaries remain within supported size limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->