### PR TITLE
Enforce safe Storm content limits

### DIFF
--- a/src/api-serverless/openapi.yaml
+++ b/src/api-serverless/openapi.yaml
@@ -14939,6 +14939,12 @@ components:
         content:
           type: string
           maxLength: 25000
+          description: >-
+            Runtime validation allows at most 25,000 JavaScript UTF-16 code
+            units and 65,535 UTF-8 bytes for this part. The byte limit is
+            additional to maxLength and is enforced by the API.
+          x-6529-max-utf16-code-units: 25000
+          x-6529-max-utf8-bytes: 65535
           nullable: true
         quoted_drop:
           anyOf:
@@ -15580,6 +15586,11 @@ components:
         parts:
           type: array
           minItems: 1
+          description: >-
+            Across all parts, runtime validation allows at most 50,000
+            JavaScript UTF-16 code units. Each part is also subject to the
+            per-part UTF-16 and UTF-8 limits documented on ApiCreateDropPart.
+          x-6529-max-total-utf16-code-units: 50000
           items:
             $ref: "#/components/schemas/ApiCreateDropPart"
         referenced_nfts:
@@ -16177,6 +16188,11 @@ components:
         content:
           type: string
           maxLength: 25000
+          description: >-
+            Content is returned only when it satisfies the API's 25,000
+            JavaScript UTF-16-code-unit and 65,535 UTF-8-byte per-part limits.
+          x-6529-max-utf16-code-units: 25000
+          x-6529-max-utf8-bytes: 65535
           nullable: true
         media:
           type: array
@@ -16213,6 +16229,11 @@ components:
         content:
           type: string
           maxLength: 25000
+          description: >-
+            Runtime validation allows at most 25,000 JavaScript UTF-16 code
+            units and 65,535 UTF-8 bytes for this part.
+          x-6529-max-utf16-code-units: 25000
+          x-6529-max-utf8-bytes: 65535
         media:
           type: array
           items:

--- a/src/api-serverless/openapi.yaml
+++ b/src/api-serverless/openapi.yaml
@@ -14938,11 +14938,10 @@ components:
       properties:
         content:
           type: string
-          maxLength: 25000
           description: >-
             Runtime validation allows at most 25,000 JavaScript UTF-16 code
             units and 65,535 UTF-8 bytes for this part. The byte limit is
-            additional to maxLength and is enforced by the API.
+            enforced independently by the API.
           x-6529-max-utf16-code-units: 25000
           x-6529-max-utf8-bytes: 65535
           nullable: true
@@ -16187,12 +16186,6 @@ components:
           format: int64
         content:
           type: string
-          maxLength: 25000
-          description: >-
-            Content is returned only when it satisfies the API's 25,000
-            JavaScript UTF-16-code-unit and 65,535 UTF-8-byte per-part limits.
-          x-6529-max-utf16-code-units: 25000
-          x-6529-max-utf8-bytes: 65535
           nullable: true
         media:
           type: array
@@ -16228,12 +16221,6 @@ components:
           minimum: 1
         content:
           type: string
-          maxLength: 25000
-          description: >-
-            Runtime validation allows at most 25,000 JavaScript UTF-16 code
-            units and 65,535 UTF-8 bytes for this part.
-          x-6529-max-utf16-code-units: 25000
-          x-6529-max-utf8-bytes: 65535
         media:
           type: array
           items:

--- a/src/api-serverless/src/competitions/phase-0-openapi-compatibility.test.ts
+++ b/src/api-serverless/src/competitions/phase-0-openapi-compatibility.test.ts
@@ -17,6 +17,11 @@ const ACCEPTED_NULLABLE_REFERENCE_EXTENSIONS = new Set([
   'schema ApiNotificationV2.properties.related_identity'
 ]);
 
+const ACCEPTED_REMOVED_RESPONSE_MAX_LENGTHS = new Set([
+  'schema ApiDropPart.properties.content.maxLength',
+  'schema ApiDropPartV2.properties.content.maxLength'
+]);
+
 const fixtureRoot = path.resolve(
   __dirname,
   '../../../competitions/contract-fixtures/phase-0'
@@ -61,6 +66,13 @@ function assertSchemaCompatible(
   }
   for (const [key, baselineValue] of Object.entries(baselineObject)) {
     if (['description', 'example', 'examples', 'title'].includes(key)) continue;
+    if (
+      key === 'maxLength' &&
+      ACCEPTED_REMOVED_RESPONSE_MAX_LENGTHS.has(`${location}.${key}`) &&
+      !(key in currentObject)
+    ) {
+      continue;
+    }
     expect(currentObject).toHaveProperty(key);
     if (key === 'properties') {
       const currentProperties = semanticObject(currentObject[key]);

--- a/src/api-serverless/src/drops/drop-validator.test.ts
+++ b/src/api-serverless/src/drops/drop-validator.test.ts
@@ -1,5 +1,12 @@
 import { ApiDropType } from '@/api/generated/models/ApiDropType';
-import { NewDropSchema, UpdateDropSchema } from '@/api/drops/drop.validator';
+import {
+  DROP_PART_MAX_UTF16_CODE_UNITS,
+  DROP_PART_MAX_UTF8_BYTES,
+  DROP_TOTAL_MAX_UTF16_CODE_UNITS,
+  NewDropSchema,
+  NewWaveDropSchema,
+  UpdateDropSchema
+} from '@/api/drops/drop.validator';
 
 describe('NewDropSchema', () => {
   const futureTimestamp = Date.now() + 60_000;
@@ -400,6 +407,142 @@ describe('UpdateDropSchema', () => {
 
     expect(result.error?.message).toContain(
       '"hide_link_preview" is not allowed'
+    );
+  });
+});
+
+describe('shared drop content limits', () => {
+  const schemas = [
+    [
+      'create drop',
+      NewDropSchema,
+      { wave_id: 'wave-1', drop_type: ApiDropType.Chat }
+    ],
+    ['update drop', UpdateDropSchema, {}],
+    ['create-wave initial drop', NewWaveDropSchema, {}]
+  ] as const;
+
+  function validate(
+    schema: (typeof schemas)[number][1],
+    parts: Array<{ content: string }>
+  ) {
+    return schema.validate({
+      ...(schema === NewDropSchema
+        ? { wave_id: 'wave-1', drop_type: ApiDropType.Chat }
+        : {}),
+      title: null,
+      parts,
+      referenced_nfts: [],
+      mentioned_users: [],
+      mentioned_waves: [],
+      metadata: [],
+      signature: null
+    });
+  }
+
+  it.each(schemas)(
+    '%s accepts exactly %s UTF-16 code units in one part and rejects +1',
+    (_name, schema) => {
+      const exact = validate(schema, [
+        { content: 'a'.repeat(DROP_PART_MAX_UTF16_CODE_UNITS) }
+      ]);
+      expect(exact.error).toBeUndefined();
+
+      const secret = 'content-that-must-not-appear-in-validation-errors';
+      const over = validate(schema, [
+        {
+          content: 'a'.repeat(DROP_PART_MAX_UTF16_CODE_UNITS + 1) + secret
+        }
+      ]);
+      expect(over.error?.message).toContain('UTF-16 code units');
+      expect(over.error?.message).not.toContain(secret);
+    }
+  );
+
+  it.each(schemas)(
+    '%s accepts exactly %s UTF-8 bytes for BMP text and rejects +1 byte',
+    (_name, schema) => {
+      const exact = validate(schema, [{ content: '漢'.repeat(21_845) }]);
+      expect(exact.error).toBeUndefined();
+
+      const over = validate(schema, [{ content: '漢'.repeat(21_846) }]);
+      expect(over.error?.message).toContain('UTF-8 bytes');
+      expect(over.error?.message).not.toContain('漢');
+    }
+  );
+
+  it.each(schemas)(
+    '%s counts emoji surrogate pairs as two UTF-16 code units',
+    (_name, schema) => {
+      const exact = validate(schema, [
+        { content: '😀'.repeat(DROP_PART_MAX_UTF16_CODE_UNITS / 2) }
+      ]);
+      expect(exact.error).toBeUndefined();
+      expect(exact.value.parts[0].content.length).toBe(
+        DROP_PART_MAX_UTF16_CODE_UNITS
+      );
+
+      const over = validate(schema, [
+        {
+          content: '😀'.repeat(DROP_PART_MAX_UTF16_CODE_UNITS / 2) + '😀'
+        }
+      ]);
+      expect(over.error?.message).toContain('UTF-16 code units');
+    }
+  );
+
+  it.each(schemas)(
+    '%s applies the UTF-8 byte boundary to unpaired surrogate code units',
+    (_name, schema) => {
+      const exact = validate(schema, [
+        { content: String.fromCharCode(0xd800).repeat(21_845) }
+      ]);
+      expect(exact.error).toBeUndefined();
+
+      const over = validate(schema, [
+        { content: String.fromCharCode(0xd800).repeat(21_846) }
+      ]);
+      expect(over.error?.message).toContain('UTF-8 bytes');
+    }
+  );
+
+  it.each(schemas)(
+    '%s accepts exactly %s total UTF-16 code units and rejects +1',
+    (_name, schema) => {
+      const exact = validate(schema, [
+        { content: 'a'.repeat(25_000) },
+        { content: 'b'.repeat(25_000) }
+      ]);
+      expect(exact.error).toBeUndefined();
+
+      const over = validate(schema, [
+        { content: 'a'.repeat(25_000) },
+        { content: 'b'.repeat(25_000) },
+        { content: 'c' }
+      ]);
+      expect(over.error?.message).toContain('total content');
+      expect(over.error?.message).toContain('UTF-16 code units');
+    }
+  );
+
+  it('uses distinct error messages for the byte and aggregate limits', () => {
+    const byteError = validate(NewDropSchema, [
+      { content: '漢'.repeat(21_846) }
+    ]);
+    const aggregateError = validate(NewDropSchema, [
+      { content: 'a'.repeat(25_000) },
+      { content: 'b'.repeat(25_000) },
+      { content: 'c' }
+    ]);
+
+    expect(byteError.error?.message).toContain(
+      `${DROP_PART_MAX_UTF8_BYTES} UTF-8 bytes`
+    );
+    expect(aggregateError.error?.message).toContain(
+      `${DROP_TOTAL_MAX_UTF16_CODE_UNITS} UTF-16 code units`
+    );
+    expect(aggregateError.error?.message).not.toContain(
+      `${DROP_PART_MAX_UTF8_BYTES} UTF-8 bytes`
     );
   });
 });

--- a/src/api-serverless/src/drops/drop.validator.ts
+++ b/src/api-serverless/src/drops/drop.validator.ts
@@ -16,6 +16,20 @@ import { ApiDropAttachmentReference } from '../generated/models/ApiDropAttachmen
 import { ApiCreateDropPollRequest } from '../generated/models/ApiCreateDropPollRequest';
 import { Time } from '@/time';
 
+/**
+ * Drop content limits are measured in the same representations used by the
+ * runtime and storage boundaries:
+ *
+ * - JavaScript `string.length` for UTF-16 code units.
+ * - Node's UTF-8 byte length for the encoded value sent to MySQL.
+ *
+ * These are application limits. The DropPart entity remains a MySQL TEXT
+ * column; no schema change is required or permitted for this contract.
+ */
+export const DROP_PART_MAX_UTF16_CODE_UNITS = 25_000;
+export const DROP_PART_MAX_UTF8_BYTES = 65_535;
+export const DROP_TOTAL_MAX_UTF16_CODE_UNITS = 50_000;
+
 function parseSerialNos(value: string, helpers: Joi.CustomHelpers): number[] {
   const parts = value.split(',').map((part) => part.trim());
   const serialNos = parts.map((part) => Number(part));
@@ -158,6 +172,56 @@ const NewDropPartSchema: Joi.ObjectSchema<ApiCreateDropPart> = Joi.object({
     .default([])
 });
 
+function validateDropParts(
+  parts: ApiCreateDropPart[],
+  helpers: Joi.CustomHelpers
+): ApiCreateDropPart[] | Joi.ErrorReport {
+  let totalUtf16CodeUnits = 0;
+
+  for (let partIndex = 0; partIndex < parts.length; partIndex++) {
+    const part = parts[partIndex];
+    const content = part.content ?? '';
+    const utf16CodeUnits = content.length;
+    if (utf16CodeUnits > DROP_PART_MAX_UTF16_CODE_UNITS) {
+      return helpers.error('dropPart.contentUtf16Max', {
+        limit: DROP_PART_MAX_UTF16_CODE_UNITS,
+        partIndex: partIndex + 1
+      });
+    }
+
+    const utf8Bytes = Buffer.byteLength(content, 'utf8');
+    if (utf8Bytes > DROP_PART_MAX_UTF8_BYTES) {
+      return helpers.error('dropPart.contentUtf8Max', {
+        limit: DROP_PART_MAX_UTF8_BYTES,
+        partIndex: partIndex + 1
+      });
+    }
+
+    totalUtf16CodeUnits += utf16CodeUnits;
+    if (totalUtf16CodeUnits > DROP_TOTAL_MAX_UTF16_CODE_UNITS) {
+      return helpers.error('dropParts.totalUtf16Max', {
+        limit: DROP_TOTAL_MAX_UTF16_CODE_UNITS
+      });
+    }
+  }
+
+  return parts;
+}
+
+const DropPartsSchema = Joi.array()
+  .required()
+  .items(NewDropPartSchema)
+  .min(1)
+  .custom(validateDropParts)
+  .messages({
+    'dropPart.contentUtf16Max':
+      'drop part {{#partIndex}} content must be at most {{#limit}} UTF-16 code units',
+    'dropPart.contentUtf8Max':
+      'drop part {{#partIndex}} content must be at most {{#limit}} UTF-8 bytes',
+    'dropParts.totalUtf16Max':
+      'total content across all drop parts must be at most {{#limit}} UTF-16 code units'
+  });
+
 const NewDropPollSchema: Joi.ObjectSchema<ApiCreateDropPollRequest> =
   Joi.object<ApiCreateDropPollRequest>({
     options: Joi.array()
@@ -185,7 +249,7 @@ const baseDropFieldsValidators = {
     .empty('')
     .default(null)
     .allow(null),
-  parts: Joi.array().required().items(NewDropPartSchema).min(1),
+  parts: DropPartsSchema,
   referenced_nfts: Joi.array()
     .optional()
     .items(NftSchema)

--- a/src/api-serverless/src/drops/drop.validator.ts
+++ b/src/api-serverless/src/drops/drop.validator.ts
@@ -15,12 +15,7 @@ import { ApiDropGroupMention } from '../generated/models/ApiDropGroupMention';
 import { ApiDropAttachmentReference } from '../generated/models/ApiDropAttachmentReference';
 import { ApiCreateDropPollRequest } from '../generated/models/ApiCreateDropPollRequest';
 import { Time } from '@/time';
-import {
-  getDropContentLimitViolation,
-  DROP_PART_MAX_UTF16_CODE_UNITS,
-  DROP_PART_MAX_UTF8_BYTES,
-  DROP_TOTAL_MAX_UTF16_CODE_UNITS
-} from '@/drops/drop-content-limits';
+import { getDropContentLimitViolation } from '@/drops/drop-content-limits';
 
 export {
   DROP_PART_MAX_UTF16_CODE_UNITS,

--- a/src/api-serverless/src/drops/drop.validator.ts
+++ b/src/api-serverless/src/drops/drop.validator.ts
@@ -15,20 +15,18 @@ import { ApiDropGroupMention } from '../generated/models/ApiDropGroupMention';
 import { ApiDropAttachmentReference } from '../generated/models/ApiDropAttachmentReference';
 import { ApiCreateDropPollRequest } from '../generated/models/ApiCreateDropPollRequest';
 import { Time } from '@/time';
+import {
+  getDropContentLimitViolation,
+  DROP_PART_MAX_UTF16_CODE_UNITS,
+  DROP_PART_MAX_UTF8_BYTES,
+  DROP_TOTAL_MAX_UTF16_CODE_UNITS
+} from '@/drops/drop-content-limits';
 
-/**
- * Drop content limits are measured in the same representations used by the
- * runtime and storage boundaries:
- *
- * - JavaScript `string.length` for UTF-16 code units.
- * - Node's UTF-8 byte length for the encoded value sent to MySQL.
- *
- * These are application limits. The DropPart entity remains a MySQL TEXT
- * column; no schema change is required or permitted for this contract.
- */
-export const DROP_PART_MAX_UTF16_CODE_UNITS = 25_000;
-export const DROP_PART_MAX_UTF8_BYTES = 65_535;
-export const DROP_TOTAL_MAX_UTF16_CODE_UNITS = 50_000;
+export {
+  DROP_PART_MAX_UTF16_CODE_UNITS,
+  DROP_PART_MAX_UTF8_BYTES,
+  DROP_TOTAL_MAX_UTF16_CODE_UNITS
+} from '@/drops/drop-content-limits';
 
 function parseSerialNos(value: string, helpers: Joi.CustomHelpers): number[] {
   const parts = value.split(',').map((part) => part.trim());
@@ -176,32 +174,23 @@ function validateDropParts(
   parts: ApiCreateDropPart[],
   helpers: Joi.CustomHelpers
 ): ApiCreateDropPart[] | Joi.ErrorReport {
-  let totalUtf16CodeUnits = 0;
-
-  for (let partIndex = 0; partIndex < parts.length; partIndex++) {
-    const part = parts[partIndex];
-    const content = part.content ?? '';
-    const utf16CodeUnits = content.length;
-    if (utf16CodeUnits > DROP_PART_MAX_UTF16_CODE_UNITS) {
-      return helpers.error('dropPart.contentUtf16Max', {
-        limit: DROP_PART_MAX_UTF16_CODE_UNITS,
-        partIndex: partIndex + 1
-      });
-    }
-
-    const utf8Bytes = Buffer.byteLength(content, 'utf8');
-    if (utf8Bytes > DROP_PART_MAX_UTF8_BYTES) {
-      return helpers.error('dropPart.contentUtf8Max', {
-        limit: DROP_PART_MAX_UTF8_BYTES,
-        partIndex: partIndex + 1
-      });
-    }
-
-    totalUtf16CodeUnits += utf16CodeUnits;
-    if (totalUtf16CodeUnits > DROP_TOTAL_MAX_UTF16_CODE_UNITS) {
-      return helpers.error('dropParts.totalUtf16Max', {
-        limit: DROP_TOTAL_MAX_UTF16_CODE_UNITS
-      });
+  const violation = getDropContentLimitViolation(parts);
+  if (violation) {
+    switch (violation.kind) {
+      case 'part-utf16':
+        return helpers.error('dropPart.contentUtf16Max', {
+          limit: violation.limit,
+          partIndex: violation.partIndex
+        });
+      case 'part-utf8':
+        return helpers.error('dropPart.contentUtf8Max', {
+          limit: violation.limit,
+          partIndex: violation.partIndex
+        });
+      case 'total-utf16':
+        return helpers.error('dropParts.totalUtf16Max', {
+          limit: violation.limit
+        });
     }
   }
 

--- a/src/api-serverless/src/drops/drops.routes.ts
+++ b/src/api-serverless/src/drops/drops.routes.ts
@@ -195,14 +195,6 @@ router.post(
         'Each drop part must have content, media, or attachments'
       );
     }
-    const contentLength = newDrop.parts
-      .map((part) => part.content ?? '')
-      .join('').length;
-    if (contentLength > 32768) {
-      throw new BadRequestException(
-        'Total content length of all parts must be less than 32768 characters'
-      );
-    }
     await assertDropIsCorrectlySigned(apiRequest, authorProfileId);
     const createDropRequest: ApiCreateDropRequest & {
       author: { external_id: string };

--- a/src/api-serverless/src/generated/models/ApiCreateDropPart.ts
+++ b/src/api-serverless/src/generated/models/ApiCreateDropPart.ts
@@ -16,6 +16,9 @@ import { ApiQuotedDrop } from '../models/ApiQuotedDrop';
 import { HttpFile } from '../http/http';
 
 export class ApiCreateDropPart {
+    /**
+    * Runtime validation allows at most 25,000 JavaScript UTF-16 code units and 65,535 UTF-8 bytes for this part. The byte limit is enforced independently by the API.
+    */
     'content'?: string | null;
     'quoted_drop'?: ApiQuotedDrop | null;
     'media': Array<ApiCreateDropMedia>;

--- a/src/api-serverless/src/generated/models/ApiCreateDropRequest.ts
+++ b/src/api-serverless/src/generated/models/ApiCreateDropRequest.ts
@@ -33,6 +33,9 @@ export class ApiCreateDropRequest {
     */
     'hide_link_preview'?: boolean;
     'title'?: string | null;
+    /**
+    * Across all parts, runtime validation allows at most 50,000 JavaScript UTF-16 code units. Each part is also subject to the per-part UTF-16 and UTF-8 limits documented on ApiCreateDropPart.
+    */
     'parts': Array<ApiCreateDropPart>;
     'referenced_nfts': Array<ApiDropReferencedNFT>;
     'mentioned_users': Array<ApiDropMentionedUser>;

--- a/src/api-serverless/src/generated/models/ApiCreateWaveDropRequest.ts
+++ b/src/api-serverless/src/generated/models/ApiCreateWaveDropRequest.ts
@@ -19,6 +19,9 @@ import { HttpFile } from '../http/http';
 
 export class ApiCreateWaveDropRequest {
     'title'?: string | null;
+    /**
+    * Across all parts, runtime validation allows at most 50,000 JavaScript UTF-16 code units. Each part is also subject to the per-part UTF-16 and UTF-8 limits documented on ApiCreateDropPart.
+    */
     'parts': Array<ApiCreateDropPart>;
     'referenced_nfts': Array<ApiDropReferencedNFT>;
     'mentioned_users': Array<ApiDropMentionedUser>;

--- a/src/api-serverless/src/generated/models/ApiUpdateDropRequest.ts
+++ b/src/api-serverless/src/generated/models/ApiUpdateDropRequest.ts
@@ -19,6 +19,9 @@ import { HttpFile } from '../http/http';
 
 export class ApiUpdateDropRequest {
     'title'?: string | null;
+    /**
+    * Across all parts, runtime validation allows at most 50,000 JavaScript UTF-16 code units. Each part is also subject to the per-part UTF-16 and UTF-8 limits documented on ApiCreateDropPart.
+    */
     'parts': Array<ApiCreateDropPart>;
     'referenced_nfts': Array<ApiDropReferencedNFT>;
     'mentioned_users': Array<ApiDropMentionedUser>;

--- a/src/api-serverless/src/ws/ws-listeners-notifier.test.ts
+++ b/src/api-serverless/src/ws/ws-listeners-notifier.test.ts
@@ -1,5 +1,67 @@
 import { ApiDropType } from '@/api/generated/models/ApiDropType';
-import { WsListenersNotifier } from '@/api/ws/ws-listeners-notifier';
+import { ApiWaveCreditScope } from '@/api/generated/models/ApiWaveCreditScope';
+import { ApiWaveCreditType } from '@/api/generated/models/ApiWaveCreditType';
+import {
+  serializeDropMessageForRecipient,
+  serializeDropRatingUpdateForRecipient,
+  serializeDropReactionUpdateForRecipient,
+  serializeDropUpdateForRecipient,
+  WsListenersNotifier
+} from '@/api/ws/ws-listeners-notifier';
+import {
+  DROP_UPDATE_MAX_UTF8_BYTES,
+  DropUpdateRefType,
+  WsMessageType
+} from '@/api/ws/ws-message';
+import { Logger } from '@/logging';
+
+function createDrop(content: string, dropType = ApiDropType.Chat) {
+  return {
+    id: 'drop-1',
+    serial_no: 42,
+    drop_type: dropType,
+    author: { id: 'author-1', subscribed_actions: [] },
+    wave: {
+      id: 'wave-1',
+      visibility_group_id: null,
+      voting_credit_type: ApiWaveCreditType.Tdh,
+      voting_credit_scope: ApiWaveCreditScope.Wave
+    },
+    parts: [{ content }]
+  } as any;
+}
+
+function findMaximumSafeAsciiContentLength(
+  creditLeft: number,
+  dropType = ApiDropType.Chat,
+  updateType: DropUpdateRefType = WsMessageType.DROP_UPDATE,
+  reason?: string
+): number {
+  let low = 0;
+  let high = 40_000;
+  while (low < high) {
+    const candidate = Math.ceil((low + high) / 2);
+    const serialized =
+      updateType === WsMessageType.DROP_UPDATE
+        ? serializeDropUpdateForRecipient(
+            createDrop('a'.repeat(candidate), dropType),
+            creditLeft,
+            reason
+          )
+        : serializeDropMessageForRecipient(
+            createDrop('a'.repeat(candidate), dropType),
+            creditLeft,
+            updateType
+          );
+    const message = JSON.parse(serialized);
+    if (message.type === updateType) {
+      low = candidate;
+    } else {
+      high = candidate - 1;
+    }
+  }
+  return low;
+}
 
 describe('WsListenersNotifier', () => {
   it('sends notification invalidations only to subscribed recipient connections', async () => {
@@ -85,10 +147,245 @@ describe('WsListenersNotifier', () => {
     );
 
     const message = JSON.parse(appWebSockets.send.mock.calls[0][0].message);
+    expect(message.type).toBe(WsMessageType.DROP_UPDATE);
     expect(message.data.poll).toMatchObject({
       anonymous: true,
       voted: [],
       options: [{ option_no: 1, option_string: 'First', votes: 4 }]
     });
   });
+
+  it.each([
+    WsMessageType.DROP_UPDATE,
+    WsMessageType.DROP_RATING_UPDATE,
+    WsMessageType.DROP_REACTION_UPDATE
+  ] as DropUpdateRefType[])(
+    'switches at the documented UTF-8 ceiling for %s',
+    (updateType) => {
+      const safeContentLength = findMaximumSafeAsciiContentLength(
+        0,
+        ApiDropType.Chat,
+        updateType
+      );
+      const safeMessage = serializeDropMessageForRecipient(
+        createDrop('a'.repeat(safeContentLength)),
+        0,
+        updateType
+      );
+      const oversizedMessage = serializeDropMessageForRecipient(
+        createDrop('a'.repeat(safeContentLength + 1)),
+        0,
+        updateType
+      );
+
+      expect(Buffer.byteLength(safeMessage, 'utf8')).toBe(
+        DROP_UPDATE_MAX_UTF8_BYTES
+      );
+      expect(JSON.parse(safeMessage).type).toBe(updateType);
+      expect(JSON.parse(oversizedMessage)).toEqual({
+        type: WsMessageType.DROP_UPDATE_REF,
+        data: {
+          drop_id: 'drop-1',
+          wave_id: 'wave-1',
+          serial_no: 42,
+          update_type: updateType
+        }
+      });
+      expect(oversizedMessage).not.toContain('a'.repeat(10));
+    }
+  );
+
+  it('preserves the original reason in an oversized content update ref', () => {
+    const safeContentLength = findMaximumSafeAsciiContentLength(
+      0,
+      ApiDropType.Chat,
+      WsMessageType.DROP_UPDATE,
+      'POLL_RESPONSE'
+    );
+    const message = JSON.parse(
+      serializeDropUpdateForRecipient(
+        createDrop('a'.repeat(safeContentLength + 1)),
+        0,
+        'POLL_RESPONSE'
+      )
+    );
+
+    expect(message).toEqual({
+      type: WsMessageType.DROP_UPDATE_REF,
+      data: {
+        drop_id: 'drop-1',
+        wave_id: 'wave-1',
+        serial_no: 42,
+        update_type: WsMessageType.DROP_UPDATE,
+        reason: 'POLL_RESPONSE'
+      }
+    });
+  });
+
+  it('keeps rating and reaction refs distinct when they share a serial', () => {
+    const content = 'a'.repeat(
+      findMaximumSafeAsciiContentLength(
+        0,
+        ApiDropType.Chat,
+        WsMessageType.DROP_RATING_UPDATE
+      ) + 1
+    );
+    const drop = createDrop(content);
+    const rating = JSON.parse(serializeDropRatingUpdateForRecipient(drop, 0));
+    const reaction = JSON.parse(
+      serializeDropReactionUpdateForRecipient(drop, 0)
+    );
+
+    expect(rating).toEqual({
+      type: WsMessageType.DROP_UPDATE_REF,
+      data: {
+        drop_id: 'drop-1',
+        wave_id: 'wave-1',
+        serial_no: 42,
+        update_type: WsMessageType.DROP_RATING_UPDATE
+      }
+    });
+    expect(reaction).toEqual({
+      type: WsMessageType.DROP_UPDATE_REF,
+      data: {
+        drop_id: 'drop-1',
+        wave_id: 'wave-1',
+        serial_no: 42,
+        update_type: WsMessageType.DROP_REACTION_UPDATE
+      }
+    });
+  });
+
+  it('measures recipient-specific final payloads independently', async () => {
+    const appWebSockets = {
+      send: jest.fn().mockResolvedValue(undefined)
+    };
+    const wsConnectionRepository = {
+      getCurrentlyOnlineCommunityMemberConnectionIds: jest
+        .fn()
+        .mockResolvedValue([
+          { connectionId: 'connection-small', profileId: 'profile-small' },
+          { connectionId: 'connection-large', profileId: 'profile-large' }
+        ]),
+      getCreditLeftForProfilesForTdhBasedWave: jest.fn().mockResolvedValue({
+        'profile-small': 0,
+        'profile-large': Number.MAX_SAFE_INTEGER
+      })
+    };
+    const notifier = new WsListenersNotifier(
+      appWebSockets as any,
+      wsConnectionRepository as any
+    );
+    const contentLength = findMaximumSafeAsciiContentLength(
+      0,
+      ApiDropType.Participatory
+    );
+
+    await notifier.notifyAboutDropUpdate(
+      createDrop('a'.repeat(contentLength), ApiDropType.Participatory),
+      {}
+    );
+
+    const messagesByConnection = Object.fromEntries(
+      appWebSockets.send.mock.calls.map(([call]) => [
+        call.connectionId,
+        JSON.parse(call.message)
+      ])
+    );
+    expect(messagesByConnection['connection-small'].type).toBe(
+      WsMessageType.DROP_UPDATE
+    );
+    expect(messagesByConnection['connection-large']).toEqual({
+      type: WsMessageType.DROP_UPDATE_REF,
+      data: {
+        drop_id: 'drop-1',
+        wave_id: 'wave-1',
+        serial_no: 42,
+        update_type: WsMessageType.DROP_UPDATE
+      }
+    });
+  });
+
+  it('does not reject the notification operation when a recipient send fails', async () => {
+    const appWebSockets = {
+      send: jest
+        .fn()
+        .mockRejectedValueOnce(new Error('simulated send failure'))
+        .mockResolvedValueOnce(undefined)
+    };
+    const wsConnectionRepository = {
+      getCurrentlyOnlineCommunityMemberConnectionIds: jest
+        .fn()
+        .mockResolvedValue([
+          { connectionId: 'connection-1', profileId: null },
+          { connectionId: 'connection-2', profileId: null }
+        ])
+    };
+    const notifier = new WsListenersNotifier(
+      appWebSockets as any,
+      wsConnectionRepository as any
+    );
+
+    await expect(
+      notifier.notifyAboutDropUpdate(createDrop('ordinary update'), {})
+    ).resolves.toBeUndefined();
+    expect(appWebSockets.send).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    {
+      label: 'DROP_UPDATE',
+      notify: (notifier: WsListenersNotifier, drop: any) =>
+        notifier.notifyAboutDropUpdate(drop, {})
+    },
+    {
+      label: 'DROP_RATING_UPDATE',
+      notify: (notifier: WsListenersNotifier, drop: any) =>
+        notifier.notifyAboutDropRatingUpdate(drop, {})
+    },
+    {
+      label: 'DROP_REACTION_UPDATE',
+      notify: (notifier: WsListenersNotifier, drop: any) =>
+        notifier.notifyAboutDropReactionUpdate(drop, {})
+    }
+  ])(
+    'does not log drop content when $label notification fails',
+    async ({ label, notify }) => {
+      const secret = 'storm-content-secret-that-must-not-be-logged';
+      const logger = Logger.get(WsListenersNotifier.name);
+      const loggerError = jest
+        .spyOn(logger, 'error')
+        .mockImplementation(() => undefined);
+      const appWebSockets = {
+        send: jest.fn().mockRejectedValue(new Error('send failed'))
+      };
+      const wsConnectionRepository = {
+        getCurrentlyOnlineCommunityMemberConnectionIds: jest
+          .fn()
+          .mockResolvedValue([
+            { connectionId: 'connection-1', profileId: null }
+          ])
+      };
+      const notifier = new WsListenersNotifier(
+        appWebSockets as any,
+        wsConnectionRepository as any
+      );
+      const drop = {
+        ...createDrop(secret),
+        serial_no: 77,
+        wave: { ...createDrop(secret).wave, id: 'wave-secret' }
+      };
+
+      await notify(notifier, drop);
+
+      expect(loggerError).toHaveBeenCalledTimes(1);
+      const message = String(loggerError.mock.calls[0][0]);
+      expect(message).toContain(label);
+      expect(message).toContain('drop_id=drop-1');
+      expect(message).toContain('wave_id=wave-secret');
+      expect(message).toContain('serial_no=77');
+      expect(message).not.toContain(secret);
+      loggerError.mockRestore();
+    }
+  );
 });

--- a/src/api-serverless/src/ws/ws-listeners-notifier.test.ts
+++ b/src/api-serverless/src/ws/ws-listeners-notifier.test.ts
@@ -187,6 +187,7 @@ describe('WsListenersNotifier', () => {
         data: {
           drop_id: 'drop-1',
           wave_id: 'wave-1',
+          author_id: 'author-1',
           serial_no: 42,
           update_type: updateType
         }
@@ -215,6 +216,7 @@ describe('WsListenersNotifier', () => {
       data: {
         drop_id: 'drop-1',
         wave_id: 'wave-1',
+        author_id: 'author-1',
         serial_no: 42,
         update_type: WsMessageType.DROP_UPDATE,
         reason: 'POLL_RESPONSE'
@@ -241,6 +243,7 @@ describe('WsListenersNotifier', () => {
       data: {
         drop_id: 'drop-1',
         wave_id: 'wave-1',
+        author_id: 'author-1',
         serial_no: 42,
         update_type: WsMessageType.DROP_RATING_UPDATE
       }
@@ -250,6 +253,7 @@ describe('WsListenersNotifier', () => {
       data: {
         drop_id: 'drop-1',
         wave_id: 'wave-1',
+        author_id: 'author-1',
         serial_no: 42,
         update_type: WsMessageType.DROP_REACTION_UPDATE
       }
@@ -300,6 +304,7 @@ describe('WsListenersNotifier', () => {
       data: {
         drop_id: 'drop-1',
         wave_id: 'wave-1',
+        author_id: 'author-1',
         serial_no: 42,
         update_type: WsMessageType.DROP_UPDATE
       }

--- a/src/api-serverless/src/ws/ws-listeners-notifier.ts
+++ b/src/api-serverless/src/ws/ws-listeners-notifier.ts
@@ -153,6 +153,7 @@ export function serializeDropMessageForRecipient(
   const refData = {
     drop_id: inputDrop.id,
     wave_id: inputDrop.wave.id,
+    author_id: inputDrop.author.id,
     serial_no: inputDrop.serial_no,
     update_type: updateType,
     ...(reason !== undefined && updateType === WsMessageType.DROP_UPDATE
@@ -161,6 +162,7 @@ export function serializeDropMessageForRecipient(
   } satisfies {
     drop_id: string;
     wave_id: string;
+    author_id: string;
     serial_no: number;
     update_type: DropUpdateRefType;
     reason?: string;

--- a/src/api-serverless/src/ws/ws-listeners-notifier.ts
+++ b/src/api-serverless/src/ws/ws-listeners-notifier.ts
@@ -11,6 +11,10 @@ import {
   dropRatingUpdateMessage,
   dropReactionUpdateMessage,
   dropUpdateMessage,
+  dropUpdateRefMessage,
+  DROP_UPDATE_MAX_UTF8_BYTES,
+  DropUpdateRefType,
+  WsMessageType,
   nftLinkUpdatedMessage,
   identityNotificationsChangedMessage,
   userIsTypingMessage
@@ -28,6 +32,177 @@ import { ApiProfileClassification } from '../generated/models/ApiProfileClassifi
 import { profileWavesDb } from '@/profiles/profile-waves.db';
 import { ApiNftLinkData } from '@/api/generated/models/ApiNftLinkData';
 import { ApiAttachment } from '@/api/generated/models/ApiAttachment';
+
+const scalarForLog = (value: unknown): string =>
+  typeof value === 'string' ||
+  typeof value === 'number' ||
+  typeof value === 'boolean'
+    ? String(value)
+    : 'unknown';
+
+const dropNotificationIdentityForLog = (drop: ApiDrop): string =>
+  `drop_id=${scalarForLog(drop.id)} wave_id=${scalarForLog(
+    drop.wave?.id
+  )} serial_no=${scalarForLog(drop.serial_no)}`;
+
+const normalizedErrorForLog = (error: unknown): string => {
+  if (error instanceof Error) {
+    return `${error.name}: ${error.message}`;
+  }
+  if (typeof error === 'string') {
+    return error;
+  }
+  if (error && typeof error === 'object') {
+    const value = error as Record<string, unknown>;
+    const metadata = Object.fromEntries(
+      ['name', 'message', 'code', 'status', 'statusCode']
+        .filter((key) => {
+          const candidate = value[key];
+          return (
+            typeof candidate === 'string' ||
+            typeof candidate === 'number' ||
+            typeof candidate === 'boolean'
+          );
+        })
+        .map((key) => [key, value[key]])
+    );
+    return Object.keys(metadata).length
+      ? JSON.stringify(metadata)
+      : 'Unknown error';
+  }
+  return 'Unknown error';
+};
+
+const logDropNotificationFailure = (
+  logger: Logger,
+  operation: string,
+  drop: ApiDrop,
+  error: unknown
+): void => {
+  logger.error(
+    `${operation} websocket notification failed: ${dropNotificationIdentityForLog(
+      drop
+    )} error=${normalizedErrorForLog(error)}`
+  );
+};
+
+function removeDropsAuthRequestContext(
+  drop: ApiDrop | ApiDropWithoutWave,
+  creditLeft: number
+): ApiDrop {
+  const modifiedDrop: ApiDrop = JSON.parse(JSON.stringify(drop));
+  const maybeWave = (drop as ApiDrop).wave;
+  const modifiedWave = maybeWave ? { ...maybeWave } : undefined;
+  if (modifiedWave) {
+    (modifiedWave as any).authenticated_user_eligible_to_vote = undefined;
+    (modifiedWave as any).authenticated_user_eligible_to_participate =
+      undefined;
+    (modifiedWave as any).authenticated_user_eligible_to_chat = undefined;
+    (modifiedWave as any).authenticated_user_admin = undefined;
+    (modifiedWave as any).credit_left = creditLeft;
+    (modifiedDrop.wave as any) = modifiedWave;
+    (modifiedDrop.author as any).subscribed_actions = undefined;
+    (modifiedDrop as any).context_profile_context = undefined;
+  }
+  if (modifiedDrop.poll?.anonymous) {
+    modifiedDrop.poll.voted = [];
+  }
+  for (const part of modifiedDrop.parts) {
+    if (part.quoted_drop?.drop) {
+      part.quoted_drop.drop = removeDropsAuthRequestContext(
+        part.quoted_drop.drop,
+        creditLeft
+      );
+    }
+  }
+  if (modifiedDrop.reply_to?.drop) {
+    modifiedDrop.reply_to.drop = removeDropsAuthRequestContext(
+      modifiedDrop.reply_to.drop,
+      creditLeft
+    );
+  }
+  return modifiedDrop;
+}
+
+/**
+ * Serializes the exact recipient-scoped message that will be sent. The byte
+ * check intentionally happens after auth-context removal, credit injection,
+ * anonymous-poll redaction, and reason inclusion so a recipient's payload
+ * cannot cross the application ceiling unexpectedly.
+ */
+type DropMessageType = DropUpdateRefType;
+
+export function serializeDropMessageForRecipient(
+  inputDrop: ApiDrop,
+  creditLeft: number,
+  updateType: DropMessageType,
+  reason?: string
+): string {
+  const recipientDrop = removeDropsAuthRequestContext(inputDrop, creditLeft);
+  const fullMessage = JSON.stringify(
+    updateType === WsMessageType.DROP_UPDATE
+      ? dropUpdateMessage(recipientDrop, reason)
+      : updateType === WsMessageType.DROP_RATING_UPDATE
+        ? dropRatingUpdateMessage(recipientDrop)
+        : dropReactionUpdateMessage(recipientDrop)
+  );
+  if (Buffer.byteLength(fullMessage, 'utf8') <= DROP_UPDATE_MAX_UTF8_BYTES) {
+    return fullMessage;
+  }
+
+  const refData = {
+    drop_id: inputDrop.id,
+    wave_id: inputDrop.wave.id,
+    serial_no: inputDrop.serial_no,
+    update_type: updateType,
+    ...(reason !== undefined && updateType === WsMessageType.DROP_UPDATE
+      ? { reason }
+      : {})
+  } satisfies {
+    drop_id: string;
+    wave_id: string;
+    serial_no: number;
+    update_type: DropUpdateRefType;
+    reason?: string;
+  };
+
+  return JSON.stringify(dropUpdateRefMessage(refData));
+}
+
+export function serializeDropUpdateForRecipient(
+  inputDrop: ApiDrop,
+  creditLeft: number,
+  reason?: string
+): string {
+  return serializeDropMessageForRecipient(
+    inputDrop,
+    creditLeft,
+    WsMessageType.DROP_UPDATE,
+    reason
+  );
+}
+
+export function serializeDropRatingUpdateForRecipient(
+  inputDrop: ApiDrop,
+  creditLeft: number
+): string {
+  return serializeDropMessageForRecipient(
+    inputDrop,
+    creditLeft,
+    WsMessageType.DROP_RATING_UPDATE
+  );
+}
+
+export function serializeDropReactionUpdateForRecipient(
+  inputDrop: ApiDrop,
+  creditLeft: number
+): string {
+  return serializeDropMessageForRecipient(
+    inputDrop,
+    creditLeft,
+    WsMessageType.DROP_REACTION_UPDATE
+  );
+}
 
 export class WsListenersNotifier {
   private readonly logger: Logger = Logger.get(this.constructor.name);
@@ -103,24 +278,16 @@ export class WsListenersNotifier {
         onlineProfiles.map(({ connectionId, profileId }) =>
           this.appWebSockets.send({
             connectionId,
-            message: JSON.stringify(
-              dropUpdateMessage(
-                this.removeDropsAuthRequestContext(
-                  inputDrop,
-                  profileId === null ? 0 : (creditLefts[profileId] ?? 0)
-                ),
-                reason
-              )
+            message: serializeDropUpdateForRecipient(
+              inputDrop,
+              profileId === null ? 0 : (creditLefts[profileId] ?? 0),
+              reason
             )
           })
         )
       );
     } catch (e) {
-      this.logger.error(
-        `Sending data to websockets failed. Params: ${JSON.stringify(
-          inputDrop
-        )}. Error: ${JSON.stringify(e)}`
-      );
+      logDropNotificationFailure(this.logger, 'DROP_UPDATE', inputDrop, e);
     }
 
     ctx.timer?.stop(`${this.constructor.name}->notifyAboutDrop`);
@@ -148,23 +315,15 @@ export class WsListenersNotifier {
         onlineProfiles.map(({ connectionId, profileId }) =>
           this.appWebSockets.send({
             connectionId,
-            message: JSON.stringify(
-              dropRatingUpdateMessage(
-                this.removeDropsAuthRequestContext(
-                  drop,
-                  profileId === null ? 0 : (creditLefts[profileId] ?? 0)
-                )
-              )
+            message: serializeDropRatingUpdateForRecipient(
+              drop,
+              profileId === null ? 0 : (creditLefts[profileId] ?? 0)
             )
           })
         )
       );
     } catch (e) {
-      this.logger.error(
-        `Sending data to websockets failed. Params: ${JSON.stringify(
-          drop
-        )}. Error: ${JSON.stringify(e)}`
-      );
+      logDropNotificationFailure(this.logger, 'DROP_RATING_UPDATE', drop, e);
     }
 
     ctx.timer?.stop(`${this.constructor.name}->notifyAboutDropRatingUpdate`);
@@ -192,23 +351,15 @@ export class WsListenersNotifier {
         onlineProfiles.map(({ connectionId, profileId }) =>
           this.appWebSockets.send({
             connectionId,
-            message: JSON.stringify(
-              dropReactionUpdateMessage(
-                this.removeDropsAuthRequestContext(
-                  drop,
-                  profileId === null ? 0 : (creditLefts[profileId] ?? 0)
-                )
-              )
+            message: serializeDropReactionUpdateForRecipient(
+              drop,
+              profileId === null ? 0 : (creditLefts[profileId] ?? 0)
             )
           })
         )
       );
     } catch (e) {
-      this.logger.error(
-        `Sending data to websockets failed. Params: ${JSON.stringify(
-          drop
-        )}. Error: ${JSON.stringify(e)}`
-      );
+      logDropNotificationFailure(this.logger, 'DROP_REACTION_UPDATE', drop, e);
     }
   }
 
@@ -339,44 +490,6 @@ export class WsListenersNotifier {
       )
     );
     ctx.timer?.stop(`${this.constructor.name}->notifyAboutDropDelete`);
-  }
-
-  private removeDropsAuthRequestContext(
-    drop: ApiDrop | ApiDropWithoutWave,
-    creditLeft: number
-  ): ApiDrop {
-    const modifiedDrop: ApiDrop = JSON.parse(JSON.stringify(drop));
-    const maybeWave = (drop as ApiDrop).wave;
-    const modifiedWave = maybeWave ? { ...maybeWave } : undefined;
-    if (modifiedWave) {
-      (modifiedWave as any).authenticated_user_eligible_to_vote = undefined;
-      (modifiedWave as any).authenticated_user_eligible_to_participate =
-        undefined;
-      (modifiedWave as any).authenticated_user_eligible_to_chat = undefined;
-      (modifiedWave as any).authenticated_user_admin = undefined;
-      (modifiedWave as any).credit_left = creditLeft;
-      (modifiedDrop.wave as any) = modifiedWave;
-      (modifiedDrop.author as any).subscribed_actions = undefined;
-      (modifiedDrop as any).context_profile_context = undefined;
-    }
-    if (modifiedDrop.poll?.anonymous) {
-      modifiedDrop.poll.voted = [];
-    }
-    for (const part of modifiedDrop.parts) {
-      if (part.quoted_drop?.drop) {
-        part.quoted_drop.drop = this.removeDropsAuthRequestContext(
-          part.quoted_drop.drop,
-          creditLeft
-        );
-      }
-    }
-    if (modifiedDrop.reply_to?.drop) {
-      modifiedDrop.reply_to.drop = this.removeDropsAuthRequestContext(
-        modifiedDrop.reply_to.drop,
-        creditLeft
-      );
-    }
-    return modifiedDrop;
   }
 
   async notifyAboutAttachmentStatusUpdate(

--- a/src/api-serverless/src/ws/ws-listeners-notifier.ts
+++ b/src/api-serverless/src/ws/ws-listeners-notifier.ts
@@ -139,13 +139,15 @@ export function serializeDropMessageForRecipient(
   reason?: string
 ): string {
   const recipientDrop = removeDropsAuthRequestContext(inputDrop, creditLeft);
-  const fullMessage = JSON.stringify(
-    updateType === WsMessageType.DROP_UPDATE
-      ? dropUpdateMessage(recipientDrop, reason)
-      : updateType === WsMessageType.DROP_RATING_UPDATE
-        ? dropRatingUpdateMessage(recipientDrop)
-        : dropReactionUpdateMessage(recipientDrop)
-  );
+  let fullMessage: string;
+  if (updateType === WsMessageType.DROP_UPDATE) {
+    fullMessage = JSON.stringify(dropUpdateMessage(recipientDrop, reason));
+  } else if (updateType === WsMessageType.DROP_RATING_UPDATE) {
+    fullMessage = JSON.stringify(dropRatingUpdateMessage(recipientDrop));
+  } else {
+    fullMessage = JSON.stringify(dropReactionUpdateMessage(recipientDrop));
+  }
+
   if (Buffer.byteLength(fullMessage, 'utf8') <= DROP_UPDATE_MAX_UTF8_BYTES) {
     return fullMessage;
   }

--- a/src/api-serverless/src/ws/ws-message.test.ts
+++ b/src/api-serverless/src/ws/ws-message.test.ts
@@ -38,6 +38,7 @@ describe('ws-message', () => {
       dropUpdateRefMessage({
         drop_id: 'drop-1',
         wave_id: 'wave-1',
+        author_id: 'author-1',
         serial_no: 42,
         update_type: WsMessageType.DROP_UPDATE
       })
@@ -46,6 +47,7 @@ describe('ws-message', () => {
       data: {
         drop_id: 'drop-1',
         wave_id: 'wave-1',
+        author_id: 'author-1',
         serial_no: 42,
         update_type: WsMessageType.DROP_UPDATE
       }
@@ -57,6 +59,7 @@ describe('ws-message', () => {
       dropUpdateRefMessage({
         drop_id: 'drop-1',
         wave_id: 'wave-1',
+        author_id: 'author-1',
         serial_no: 42,
         update_type: WsMessageType.DROP_UPDATE,
         reason: DROP_UPDATE_REASON_POLL_RESPONSE
@@ -66,6 +69,7 @@ describe('ws-message', () => {
       data: {
         drop_id: 'drop-1',
         wave_id: 'wave-1',
+        author_id: 'author-1',
         serial_no: 42,
         update_type: WsMessageType.DROP_UPDATE,
         reason: DROP_UPDATE_REASON_POLL_RESPONSE

--- a/src/api-serverless/src/ws/ws-message.test.ts
+++ b/src/api-serverless/src/ws/ws-message.test.ts
@@ -2,6 +2,7 @@ import { ApiDrop } from '@/api/generated/models/ApiDrop';
 import {
   DROP_UPDATE_REASON_POLL_RESPONSE,
   dropUpdateMessage,
+  dropUpdateRefMessage,
   identityNotificationsChangedMessage,
   notificationIdentitiesSyncedMessage,
   WsMessageType
@@ -29,6 +30,46 @@ describe('ws-message', () => {
       type: WsMessageType.DROP_UPDATE,
       data: { id: 'drop-1' },
       reason: 'POLL_RESPONSE'
+    });
+  });
+
+  it('builds the additive stable-reference message without mutable content', () => {
+    expect(
+      dropUpdateRefMessage({
+        drop_id: 'drop-1',
+        wave_id: 'wave-1',
+        serial_no: 42,
+        update_type: WsMessageType.DROP_UPDATE
+      })
+    ).toEqual({
+      type: WsMessageType.DROP_UPDATE_REF,
+      data: {
+        drop_id: 'drop-1',
+        wave_id: 'wave-1',
+        serial_no: 42,
+        update_type: WsMessageType.DROP_UPDATE
+      }
+    });
+  });
+
+  it('preserves a source update reason without carrying content', () => {
+    expect(
+      dropUpdateRefMessage({
+        drop_id: 'drop-1',
+        wave_id: 'wave-1',
+        serial_no: 42,
+        update_type: WsMessageType.DROP_UPDATE,
+        reason: DROP_UPDATE_REASON_POLL_RESPONSE
+      })
+    ).toEqual({
+      type: WsMessageType.DROP_UPDATE_REF,
+      data: {
+        drop_id: 'drop-1',
+        wave_id: 'wave-1',
+        serial_no: 42,
+        update_type: WsMessageType.DROP_UPDATE,
+        reason: DROP_UPDATE_REASON_POLL_RESPONSE
+      }
     });
   });
 

--- a/src/api-serverless/src/ws/ws-message.ts
+++ b/src/api-serverless/src/ws/ws-message.ts
@@ -62,6 +62,7 @@ export function dropUpdateMessage(
 export interface DropUpdateRefMessageData {
   readonly drop_id: string;
   readonly wave_id: string;
+  readonly author_id: string;
   readonly serial_no: number;
   readonly update_type: DropUpdateRefType;
   readonly reason?: string;

--- a/src/api-serverless/src/ws/ws-message.ts
+++ b/src/api-serverless/src/ws/ws-message.ts
@@ -5,6 +5,7 @@ import { ApiAttachment } from '@/api/generated/models/ApiAttachment';
 
 export enum WsMessageType {
   DROP_UPDATE = 'DROP_UPDATE',
+  DROP_UPDATE_REF = 'DROP_UPDATE_REF',
   DROP_DELETE = 'DROP_DELETE',
   DROP_RATING_UPDATE = 'DROP_RATING_UPDATE',
   DROP_REACTION_UPDATE = 'DROP_REACTION_UPDATE',
@@ -29,6 +30,21 @@ export interface WsMessage<MESSAGE_DATA> {
 export const DROP_UPDATE_REASON_POLL_RESPONSE = 'POLL_RESPONSE';
 export const DROP_UPDATE_REASON_MEDIA_STATUS = 'MEDIA_STATUS';
 
+/**
+ * Application ceiling for serialized drop updates. API Gateway permits a
+ * 32 KiB WebSocket frame; keeping full updates below 28 KiB leaves room for
+ * transport/protocol evolution. The decision is made after recipient-specific
+ * mutation and UTF-8 serialization. Oversized updates use DROP_UPDATE_REF so
+ * clients can refetch the canonical drop instead of receiving a truncated or
+ * rejected frame.
+ */
+export const DROP_UPDATE_MAX_UTF8_BYTES = 28 * 1024;
+
+export type DropUpdateRefType =
+  | WsMessageType.DROP_UPDATE
+  | WsMessageType.DROP_RATING_UPDATE
+  | WsMessageType.DROP_REACTION_UPDATE;
+
 export function dropUpdateMessage(
   data: ApiDrop,
   reason?: string
@@ -41,6 +57,23 @@ export function dropUpdateMessage(
     message.reason = reason;
   }
   return message;
+}
+
+export interface DropUpdateRefMessageData {
+  readonly drop_id: string;
+  readonly wave_id: string;
+  readonly serial_no: number;
+  readonly update_type: DropUpdateRefType;
+  readonly reason?: string;
+}
+
+export function dropUpdateRefMessage(
+  data: DropUpdateRefMessageData
+): WsMessage<DropUpdateRefMessageData> {
+  return {
+    type: WsMessageType.DROP_UPDATE_REF,
+    data
+  };
 }
 
 export function dropRatingUpdateMessage(data: ApiDrop): WsMessage<ApiDrop> {

--- a/src/drops/create-or-update-drop-use-case.test.ts
+++ b/src/drops/create-or-update-drop-use-case.test.ts
@@ -180,6 +180,31 @@ describe('CreateOrUpdateDropUseCase', () => {
     };
   }
 
+  it('rejects oversized content before an update can delete existing rows', async () => {
+    const deleteDropUseCase = { execute: jest.fn() };
+    const useCase = createUseCaseWithMocks({ deleteDropUseCase });
+
+    await expect(
+      useCase.execute(
+        createChatDropModel({
+          drop_id: 'drop-1',
+          parts: [
+            {
+              content: 'a'.repeat(25_001),
+              quoted_drop: null,
+              media: []
+            }
+          ]
+        }),
+        false,
+        { connection: {} as any }
+      )
+    ).rejects.toThrow(
+      'drop part 1 content must be at most 25000 UTF-16 code units'
+    );
+    expect(deleteDropUseCase.execute).not.toHaveBeenCalled();
+  });
+
   it('does not increment inserted-drop metrics when editing a drop', async () => {
     const dropsDb = {
       findDropById: jest.fn().mockResolvedValue({

--- a/src/drops/create-or-update-drop.use-case.ts
+++ b/src/drops/create-or-update-drop.use-case.ts
@@ -4,6 +4,10 @@ import {
   DropPartIdentifierModel,
   DropReferencedNftModel
 } from './create-or-update-drop.model';
+import {
+  formatDropContentLimitViolation,
+  getDropContentLimitViolation
+} from './drop-content-limits';
 import { Time, Timer } from '@/time';
 import { ConnectionWrapper } from '@/sql-executor';
 import { dropsDb, DropsDb } from './drops.db';
@@ -271,6 +275,15 @@ export class CreateOrUpdateDropUseCase {
     private readonly dropMediaUploadsDb: DropMediaUploadsDb
   ) {}
 
+  private assertDropContentLimits(
+    parts: readonly CreateOrUpdateDropPartModel[]
+  ): void {
+    const violation = getDropContentLimitViolation(parts);
+    if (violation) {
+      throw new BadRequestException(formatDropContentLimitViolation(violation));
+    }
+  }
+
   private getRequiredAuthorId(model: CreateOrUpdateDropModel): string {
     const authorId = model.author_id;
     if (!authorId) {
@@ -323,6 +336,7 @@ export class CreateOrUpdateDropUseCase {
     }
   ): Promise<{ drop_id: string; pending_push_notification_ids: number[] }> {
     let resolvedModel = sanitizeDropStructuredFields(model);
+    this.assertDropContentLimits(resolvedModel.parts);
     timer?.start(`${CreateOrUpdateDropUseCase.name}->execute`);
     let authorId = resolvedModel.author_id;
     if (!authorId) {
@@ -441,6 +455,7 @@ export class CreateOrUpdateDropUseCase {
       bypassChatSlowModeRestrictions?: boolean;
     }
   ): Promise<{ drop_id: string; pending_push_notification_ids: number[] }> {
+    this.assertDropContentLimits(model.parts);
     if (model.drop_type === DropType.WINNER) {
       throw new BadRequestException(`Can't modify a winner drop`);
     }
@@ -1555,6 +1570,7 @@ export class CreateOrUpdateDropUseCase {
     // Keep this guard at the persistence boundary too; this method can be
     // reused independently of execute() and the normalization is idempotent.
     const model = this.normalizeMentionedGroups(inputModel);
+    this.assertDropContentLimits(model.parts);
     const dropId = this.getRequiredDropId(model);
     const authorId = this.getRequiredAuthorId(model);
     const parts = model.parts;

--- a/src/drops/drop-content-limits.test.ts
+++ b/src/drops/drop-content-limits.test.ts
@@ -1,0 +1,58 @@
+import {
+  DROP_PART_MAX_UTF16_CODE_UNITS,
+  DROP_PART_MAX_UTF8_BYTES,
+  DROP_TOTAL_MAX_UTF16_CODE_UNITS,
+  getDropContentLimitViolation
+} from './drop-content-limits';
+
+describe('drop content limits', () => {
+  it('accepts every exact boundary', () => {
+    expect(
+      getDropContentLimitViolation([
+        { content: 'a'.repeat(DROP_PART_MAX_UTF16_CODE_UNITS) },
+        { content: 'b'.repeat(DROP_PART_MAX_UTF16_CODE_UNITS) }
+      ])
+    ).toBeNull();
+    expect(
+      getDropContentLimitViolation([
+        { content: '漢'.repeat(DROP_PART_MAX_UTF8_BYTES / 3) }
+      ])
+    ).toBeNull();
+    expect(
+      getDropContentLimitViolation([
+        { content: '😀'.repeat(DROP_PART_MAX_UTF16_CODE_UNITS / 2) }
+      ])
+    ).toBeNull();
+  });
+
+  it('rejects the first unit beyond each boundary', () => {
+    expect(
+      getDropContentLimitViolation([
+        { content: 'a'.repeat(DROP_PART_MAX_UTF16_CODE_UNITS + 1) }
+      ])
+    ).toEqual({
+      kind: 'part-utf16',
+      limit: DROP_PART_MAX_UTF16_CODE_UNITS,
+      partIndex: 1
+    });
+    expect(
+      getDropContentLimitViolation([
+        { content: '漢'.repeat(DROP_PART_MAX_UTF8_BYTES / 3 + 1) }
+      ])
+    ).toEqual({
+      kind: 'part-utf8',
+      limit: DROP_PART_MAX_UTF8_BYTES,
+      partIndex: 1
+    });
+    expect(
+      getDropContentLimitViolation([
+        { content: 'a'.repeat(DROP_TOTAL_MAX_UTF16_CODE_UNITS / 2) },
+        { content: 'b'.repeat(DROP_TOTAL_MAX_UTF16_CODE_UNITS / 2) },
+        { content: 'c' }
+      ])
+    ).toEqual({
+      kind: 'total-utf16',
+      limit: DROP_TOTAL_MAX_UTF16_CODE_UNITS
+    });
+  });
+});

--- a/src/drops/drop-content-limits.ts
+++ b/src/drops/drop-content-limits.ts
@@ -1,0 +1,69 @@
+export const DROP_PART_MAX_UTF16_CODE_UNITS = 25_000;
+export const DROP_PART_MAX_UTF8_BYTES = 65_535;
+export const DROP_TOTAL_MAX_UTF16_CODE_UNITS = 50_000;
+
+export type DropContentLimitViolation =
+  | {
+      readonly kind: 'part-utf16';
+      readonly limit: number;
+      readonly partIndex: number;
+    }
+  | {
+      readonly kind: 'part-utf8';
+      readonly limit: number;
+      readonly partIndex: number;
+    }
+  | { readonly kind: 'total-utf16'; readonly limit: number };
+
+interface DropContentPart {
+  readonly content?: string | null;
+}
+
+export function getDropContentLimitViolation(
+  parts: readonly DropContentPart[]
+): DropContentLimitViolation | null {
+  let totalUtf16CodeUnits = 0;
+
+  for (let partIndex = 0; partIndex < parts.length; partIndex++) {
+    const content = parts[partIndex]?.content ?? '';
+    const utf16CodeUnits = content.length;
+    if (utf16CodeUnits > DROP_PART_MAX_UTF16_CODE_UNITS) {
+      return {
+        kind: 'part-utf16',
+        limit: DROP_PART_MAX_UTF16_CODE_UNITS,
+        partIndex: partIndex + 1
+      };
+    }
+
+    if (Buffer.byteLength(content, 'utf8') > DROP_PART_MAX_UTF8_BYTES) {
+      return {
+        kind: 'part-utf8',
+        limit: DROP_PART_MAX_UTF8_BYTES,
+        partIndex: partIndex + 1
+      };
+    }
+
+    totalUtf16CodeUnits += utf16CodeUnits;
+    if (totalUtf16CodeUnits > DROP_TOTAL_MAX_UTF16_CODE_UNITS) {
+      return {
+        kind: 'total-utf16',
+        limit: DROP_TOTAL_MAX_UTF16_CODE_UNITS
+      };
+    }
+  }
+
+  return null;
+}
+
+export function formatDropContentLimitViolation(
+  violation: DropContentLimitViolation
+): string {
+  switch (violation.kind) {
+    case 'part-utf16':
+      return `drop part ${violation.partIndex} content must be at most ${violation.limit} UTF-16 code units`;
+    case 'part-utf8':
+      return `drop part ${violation.partIndex} content must be at most ${violation.limit} UTF-8 bytes`;
+    case 'total-utf16':
+      return `total content across all drop parts must be at most ${violation.limit} UTF-16 code units`;
+  }
+}

--- a/src/help-bot/help-bot-interactions-db.test.ts
+++ b/src/help-bot/help-bot-interactions-db.test.ts
@@ -8,7 +8,10 @@ import {
   HelpBotInteractionsDb
 } from './help-bot-interactions.db';
 import { Time } from '@/time';
-import { HELP_BOT_ANSWERING_LEASE_MS } from './help-bot.config';
+import {
+  HELP_BOT_ANSWERING_LEASE_MS,
+  HELP_BOT_INTERACTION_QUESTION_MAX_UTF8_BYTES
+} from './help-bot.config';
 import { ConnectionWrapper } from '@/sql-executor';
 
 describe('HelpBotInteractionsDb', () => {
@@ -98,6 +101,32 @@ describe('HelpBotInteractionsDb', () => {
 
     expect(result.created).toBe(true);
     expect(sqlExecutor.getAffectedRows).toHaveBeenCalledWith([0, 1]);
+  });
+
+  it('rejects a question that cannot fit in the unchanged TEXT column', async () => {
+    const sqlExecutor = createSqlExecutor({ executeResult: [0, 1] });
+    const db = createDb(sqlExecutor);
+
+    await expect(
+      db.insertSeen(
+        {
+          triggerDropId: 'trigger-drop',
+          targetDropId: 'trigger-drop',
+          waveId: 'wave-1',
+          authorProfileId: 'author-1',
+          triggerType: HelpBotInteractionTriggerType.MENTION,
+          question: '漢'.repeat(21_846),
+          parentBotDropId: null
+        },
+        ctx
+      )
+    ).rejects.toThrow(
+      `${HELP_BOT_INTERACTION_QUESTION_MAX_UTF8_BYTES} UTF-8 bytes`
+    );
+    expect(sqlExecutor.execute).not.toHaveBeenCalled();
+    expect(
+      sqlExecutor.executeNativeQueriesInTransaction
+    ).not.toHaveBeenCalled();
   });
 
   it('inserts and reads back seen interactions on one transactional connection', async () => {

--- a/src/help-bot/help-bot-interactions.db.ts
+++ b/src/help-bot/help-bot-interactions.db.ts
@@ -9,6 +9,7 @@ import { Time } from '@/time';
 import { randomUUID } from 'node:crypto';
 import {
   HELP_BOT_ANSWERING_LEASE_MS,
+  HELP_BOT_INTERACTION_QUESTION_MAX_UTF8_BYTES,
   HELP_BOT_KNOWLEDGE_VERSION
 } from './help-bot.config';
 
@@ -56,6 +57,14 @@ export class HelpBotInteractionsDb extends LazyDbAccessCompatibleService {
     request: InsertHelpBotInteractionRequest,
     ctx: RequestContext
   ): Promise<InsertHelpBotInteractionResult> {
+    if (
+      Buffer.byteLength(request.question, 'utf8') >
+      HELP_BOT_INTERACTION_QUESTION_MAX_UTF8_BYTES
+    ) {
+      throw new Error(
+        `Help bot interaction question exceeds ${HELP_BOT_INTERACTION_QUESTION_MAX_UTF8_BYTES} UTF-8 bytes`
+      );
+    }
     if (!ctx.connection) {
       return await this.executeNativeQueriesInTransaction((connection) =>
         this.insertSeen(request, { ...ctx, connection })

--- a/src/help-bot/help-bot-trigger-service.test.ts
+++ b/src/help-bot/help-bot-trigger-service.test.ts
@@ -3,6 +3,7 @@ import { ApiDrop } from '@/api/generated/models/ApiDrop';
 import {
   HELP_BOT_INSUFFICIENT_CREDITS_REACTION,
   HELP_BOT_INSUFFICIENT_CREDITS_REPLY,
+  HELP_BOT_INTERACTION_QUESTION_MAX_UTF8_BYTES,
   HELP_BOT_SEEN_REACTION,
   HELP_BOT_SPAM_REACTION
 } from './help-bot.config';
@@ -169,6 +170,46 @@ describe('HelpBotTriggerService', () => {
       {
         createDropRequest: createRequest('@help6529 what is tdh'),
         createdDrop: createDrop({ id: 'drop-1' }),
+        authorProfileId: 'user-profile'
+      },
+      {} as never
+    );
+
+    expect(interactionsDb.insertSeen).not.toHaveBeenCalled();
+    expect(sqs.sendToQueueName).not.toHaveBeenCalled();
+  });
+
+  it('skips an oversized derived question without touching help-bot persistence', async () => {
+    const { service, interactionsDb, sqs } = createService({
+      wave: {
+        visibility_group_id: null,
+        is_direct_message: false
+      }
+    });
+    const repeatedBmpText = '漢'.repeat(21_830);
+    const request = createRequest('');
+    request.parts = [
+      {
+        content: `@help6529 what is tdh ${repeatedBmpText}`,
+        media: []
+      },
+      {
+        content: repeatedBmpText,
+        media: []
+      }
+    ];
+
+    expect(
+      Buffer.byteLength(
+        request.parts.map((part) => part.content ?? '').join('\n'),
+        'utf8'
+      )
+    ).toBeGreaterThan(HELP_BOT_INTERACTION_QUESTION_MAX_UTF8_BYTES);
+
+    await service.handleCreatedDrop(
+      {
+        createDropRequest: request,
+        createdDrop: createDrop({ id: 'oversized-help-drop' }),
         authorProfileId: 'user-profile'
       },
       {} as never

--- a/src/help-bot/help-bot-trigger.service.ts
+++ b/src/help-bot/help-bot-trigger.service.ts
@@ -10,6 +10,7 @@ import {
   HELP_BOT_FAILURE_REACTION,
   HELP_BOT_INSUFFICIENT_CREDITS_REACTION,
   HELP_BOT_INSUFFICIENT_CREDITS_REPLY,
+  HELP_BOT_INTERACTION_QUESTION_MAX_UTF8_BYTES,
   HELP_BOT_REPLY_QUEUE_NAME,
   HELP_BOT_SEEN_REACTION,
   HELP_BOT_SPAM_REACTION,
@@ -91,6 +92,16 @@ export class HelpBotTriggerService {
       if (!trigger) {
         this.logger.debug(
           `Help bot trigger skipped for drop ${createdDrop.id}: no trigger detected`
+        );
+        return;
+      }
+
+      if (
+        Buffer.byteLength(trigger.question, 'utf8') >
+        HELP_BOT_INTERACTION_QUESTION_MAX_UTF8_BYTES
+      ) {
+        this.logger.info(
+          `Help bot trigger skipped for drop ${createdDrop.id}: derived question exceeds ${HELP_BOT_INTERACTION_QUESTION_MAX_UTF8_BYTES} UTF-8 bytes`
         );
         return;
       }

--- a/src/help-bot/help-bot.config.ts
+++ b/src/help-bot/help-bot.config.ts
@@ -37,6 +37,15 @@ export const HELP_BOT_PUBLIC_DATA_QUERY_TIMEOUT_MS = 5000;
 export const HELP_BOT_PUBLIC_DATA_MAX_ROWS = 10;
 export const HELP_BOT_KNOWLEDGE_VERSION = 'frontend-help-index-v1';
 export const HELP_BOT_REPLY_QUEUE_NAME = 'help-bot-replies';
+
+/**
+ * help_bot_interactions.question remains a MySQL TEXT column. Keep the
+ * derived question at or below TEXT's 65,535 UTF-8-byte limit so a long Storm
+ * mentioning @help6529 cannot turn a successful drop into a persistence
+ * failure. This is a fail-safe for the secondary help-bot path, not a drop
+ * content limit.
+ */
+export const HELP_BOT_INTERACTION_QUESTION_MAX_UTF8_BYTES = 65_535;
 export const HELP_BOT_ANSWERING_LEASE_MS = 180_000;
 export const HELP_BOT_SEEN_REACTION = ':eyes:';
 export const HELP_BOT_SUCCESS_REACTION = ':white_check_mark:';


### PR DESCRIPTION
## Outcome
Raises Storm capacity without changing the MySQL `TEXT` schema, and preserves realtime delivery for large events.

## Enforced API contract
- each part: at most 25,000 JavaScript UTF-16 code units
- each part: at most 65,535 UTF-8 bytes
- all parts: at most 50,000 JavaScript UTF-16 code units
- exact boundaries accepted
- applies to drop create, update, and Wave-drop creation

## Realtime safety
- measures final recipient-scoped serialized UTF-8 payloads
- retains existing full messages at or below 28 KiB
- emits content-free `DROP_UPDATE_REF` for larger creation, rating, and reaction updates
- removes full drop bodies from notification failure logs

## Secondary persistence safety
Oversized help-bot derived questions are skipped before the existing MySQL `TEXT` interaction write, with a second guard at the DB adapter. The primary post remains successful.

## Release order
Frontend compatibility PR 6529-Collections/6529seize-frontend#3633 must be in production before this backend reaches production.

## Validation
- 5 focused suites / 79 tests: pass
- changed TypeScript ESLint: pass
- full TypeScript compile (`tsc --noEmit`): pass
- targeted Prettier: pass
- `codex-diff-check`: pass