### PR TITLE
Improve HelpBot natural multi-wallet routing

### DIFF
--- a/pr-reports/1917.md
+++ b/pr-reports/1917.md
@@ -6,8 +6,9 @@ Related PRs: [Frontend PR #3691](https://github.com/6529-Collections/6529seize-f
 
 ## Summary
 
-HelpBot now recognizes natural setup and capacity questions about multiple
-wallets and routes them to the appropriate consolidation guidance.
+HelpBot now recognizes natural setup, effective-limit, removal, and replacement
+questions about multiple wallets and routes them to the appropriate
+consolidation guidance.
 
 ## What Changed
 
@@ -19,6 +20,16 @@ wallets and routes them to the appropriate consolidation guidance.
 - Added a compositional wallet-limit intent that combines wallet/address,
   quantity/limit, and setup/consolidation signals, then prioritizes the
   Consolidation Use Cases record.
+- Generalized quantified setup targets so counts such as three wallets and
+  qualitative quantities such as several or more wallets are supported.
+- Distinguished strong limit wording from generic quantity questions, covering
+  natural shorthand such as max wallets and wallet limit without treating
+  unrelated wallet counts as consolidation.
+- Added semantic removal/unlink routing to consolidation revoke guidance and
+  replacement/swap routing to consolidation update guidance.
+- Excluded external wallet providers, devices, hardware wallets, and explicit
+  delegation wording unless the question also establishes consolidation
+  context.
 - Kept generic single-wallet connection and unrelated profile questions out of
   the consolidation route.
 - Kept ambiguous capability questions, bare plural wallet wording, delegation,
@@ -56,5 +67,6 @@ None.
 
 ## Release Notes
 
-HelpBot now understands varied natural wording for multi-wallet setup and
-wallet limits, directing users to the relevant consolidation guidance.
+HelpBot now understands varied natural wording across multi-wallet setup,
+effective limits, removal, and replacement, directing users to the relevant
+consolidation guidance.

--- a/pr-reports/1917.md
+++ b/pr-reports/1917.md
@@ -12,10 +12,13 @@ Delegation Center guidance.
 
 ## What Changed
 
-- Added semantic phrase families for second, additional, other, and multiple
-  wallet or address setup questions instead of matching one exact sentence.
+- Added semantic phrase families that require a setup action plus a second,
+  additional, quantified, or possessive multi-wallet target instead of
+  matching one exact sentence.
 - Kept generic single-wallet connection and unrelated profile questions out of
   the consolidation route.
+- Kept ambiguous capability questions and bare plural wallet wording out of the
+  consolidation route.
 - Classified recognized multi-wallet setup questions as supported product
   questions even when the help corpus is temporarily unavailable.
 - Corrected singular `address` matching in the existing wallet and

--- a/pr-reports/1917.md
+++ b/pr-reports/1917.md
@@ -31,10 +31,13 @@ consolidation guidance.
 - Routed bare single-wallet removal and replacement questions to clarification
   guidance so HelpBot does not confuse a connected-wallet change with an
   on-chain consolidation change.
+- Routed ambiguous requests to connect additional wallets to the same
+  clarification guidance, while retaining explicit add, link, pair, setup, and
+  consolidation wording as direct consolidation signals.
 - Excluded external wallet providers, devices, hardware wallets, and explicit
   delegation-workflow wording from consolidation shortcuts even when the same
   question also uses consolidation terms, while preserving consolidation
-  questions that simply name the Delegation Center UI.
+  questions that simply name the Delegation Center UI or documentation.
 - Kept generic single-wallet connection and unrelated profile questions out of
   the consolidation route.
 - Kept ambiguous capability questions, bare plural wallet wording, delegation,

--- a/pr-reports/1917.md
+++ b/pr-reports/1917.md
@@ -1,0 +1,53 @@
+# PR Report: Improve natural multi-wallet HelpBot routing
+
+PR: https://github.com/6529-Collections/6529seize-backend/pull/1917
+Branch: `agent-prxt/helpbot-natural-multi-wallet` -> `main`
+Related PRs: [Frontend PR #3691](https://github.com/6529-Collections/6529seize-frontend/pull/3691)
+
+## Summary
+
+HelpBot now recognizes natural questions about adding, linking, pairing, or
+using multiple wallets and routes them to the existing consolidation and
+Delegation Center guidance.
+
+## What Changed
+
+- Added semantic phrase families for second, additional, other, and multiple
+  wallet or address setup questions instead of matching one exact sentence.
+- Kept generic single-wallet connection and unrelated profile questions out of
+  the consolidation route.
+- Classified recognized multi-wallet setup questions as supported product
+  questions even when the help corpus is temporarily unavailable.
+- Corrected singular `address` matching in the existing wallet and
+  consolidation patterns.
+- Documented the natural-language routing boundary in the HelpBot runtime
+  specification.
+
+## Backend Impact
+
+- New services: None
+- Changed services: `helpBotReplyLoop`
+- Planned/deployed services: `helpBotReplyLoop`; not deployed by request
+- API: None
+- DB/entities/migrations: None
+- Queues/events/integrations: Existing HelpBot reply flow only; no contract
+  changes
+- Architecture: No service boundaries, persistence models, or API contracts
+  change
+
+## Config / Env
+
+None.
+
+## Backend Deployment
+
+- Deployed API: None
+- Deployed Lambdas/services: None
+- Not deployed: `helpBotReplyLoop`
+- Required deployment order: 1. `helpBotReplyLoop`
+- Deployment order executed: None
+
+## Release Notes
+
+HelpBot now understands varied natural wording for multi-wallet setup and
+directs users to the existing consolidation and Delegation Center guidance.

--- a/pr-reports/1917.md
+++ b/pr-reports/1917.md
@@ -26,10 +26,15 @@ consolidation guidance.
   natural shorthand such as max wallets and wallet limit without treating
   unrelated wallet counts as consolidation.
 - Added semantic removal/unlink routing to consolidation revoke guidance and
-  replacement/swap routing to consolidation update guidance.
+  replacement/swap routing to consolidation update guidance when the question
+  establishes multi-wallet or consolidation context.
+- Routed bare single-wallet removal and replacement questions to clarification
+  guidance so HelpBot does not confuse a connected-wallet change with an
+  on-chain consolidation change.
 - Excluded external wallet providers, devices, hardware wallets, and explicit
-  delegation wording unless the question also establishes consolidation
-  context.
+  delegation-workflow wording from consolidation shortcuts even when the same
+  question also uses consolidation terms, while preserving consolidation
+  questions that simply name the Delegation Center UI.
 - Kept generic single-wallet connection and unrelated profile questions out of
   the consolidation route.
 - Kept ambiguous capability questions, bare plural wallet wording, delegation,

--- a/pr-reports/1917.md
+++ b/pr-reports/1917.md
@@ -6,19 +6,23 @@ Related PRs: [Frontend PR #3691](https://github.com/6529-Collections/6529seize-f
 
 ## Summary
 
-HelpBot now recognizes natural questions about adding, linking, pairing, or
-using multiple wallets and routes them to the existing consolidation and
-Delegation Center guidance.
+HelpBot now recognizes natural setup and capacity questions about multiple
+wallets and routes them to the appropriate consolidation guidance.
 
 ## What Changed
 
 - Added semantic phrase families that require a setup action plus a second,
   additional, quantified, or possessive multi-wallet target instead of
   matching one exact sentence.
+- Made setup recognition independent of whether the action or wallet target is
+  mentioned first.
+- Added a compositional wallet-limit intent that combines wallet/address,
+  quantity/limit, and setup/consolidation signals, then prioritizes the
+  Consolidation Use Cases record.
 - Kept generic single-wallet connection and unrelated profile questions out of
   the consolidation route.
-- Kept ambiguous capability questions and bare plural wallet wording out of the
-  consolidation route.
+- Kept ambiguous capability questions, bare plural wallet wording, delegation,
+  and standalone hardware-wallet questions out of the consolidation route.
 - Classified recognized multi-wallet setup questions as supported product
   questions even when the help corpus is temporarily unavailable.
 - Corrected singular `address` matching in the existing wallet and
@@ -53,4 +57,4 @@ None.
 ## Release Notes
 
 HelpBot now understands varied natural wording for multi-wallet setup and
-directs users to the existing consolidation and Delegation Center guidance.
+wallet limits, directing users to the relevant consolidation guidance.

--- a/specs/6529-help-bot-runtime.md
+++ b/specs/6529-help-bot-runtime.md
@@ -320,11 +320,15 @@ intents compiled to backend-owned SQL.
 Natural multi-wallet setup wording such as adding, linking, pairing, or setting
 up another wallet is routed to the consolidation records when the wording
 includes both a setup action and an explicit additional, quantified, or
-possessive multi-wallet target. Generic connection questions, bare plural
-wallet wording, and capability questions about merely using multiple wallets
-remain outside that route so the bot does not incorrectly prescribe
-consolidation. Explicit delegation wording remains governed by delegation
-routing rather than this consolidation shortcut.
+possessive multi-wallet target, regardless of which appears first. Wallet-limit
+questions are routed to consolidation use cases when they combine a wallet or
+address subject, quantity or limit language, and either a setup action or
+explicit consolidation relationship. Generic connection questions, bare
+plural wallet wording, and capability questions about merely using multiple
+wallets remain outside those routes so the bot does not incorrectly prescribe
+consolidation. Explicit delegation and standalone hardware-wallet wording
+remain governed by their own context rather than these consolidation
+shortcuts.
 Direct follow-up questions first match the current user message; previous bot
 answer text is used only as fallback context so old wording does not dominate
 the next topic.

--- a/specs/6529-help-bot-runtime.md
+++ b/specs/6529-help-bot-runtime.md
@@ -331,15 +331,17 @@ multi-wallet or consolidation context routes to consolidation revoke guidance,
 while replacement and swapping wording with that context routes to update
 guidance. Bare singular requests such as removing or replacing "a wallet"
 route to clarification guidance because they may refer either to the connected
-wallet or an on-chain consolidation record. Generic connection questions, bare
+wallet or an on-chain consolidation record. Ambiguous requests to connect an
+additional wallet also route to clarification because ordinary site connection
+is distinct from consolidation. Generic connection questions, bare
 plural wallet wording, and capability questions about merely using multiple
 wallets remain outside those routes so the bot does not incorrectly prescribe
 consolidation. Explicit delegation-workflow and external wallet-provider,
 device, and hardware-wallet wording remain governed by their own context rather
 than these consolidation shortcuts, even when consolidation wording is also
-present. Naming the Delegation Center itself does not suppress an otherwise
-explicit consolidation question. Direct follow-up questions first match the
-current user message; previous bot
+present. Naming the Delegation Center or its documentation does not suppress an
+otherwise explicit consolidation question. Direct follow-up questions first
+match the current user message; previous bot
 answer text is used only as fallback context so old wording does not dominate
 the next topic.
 

--- a/specs/6529-help-bot-runtime.md
+++ b/specs/6529-help-bot-runtime.md
@@ -317,6 +317,10 @@ entire corpus.
 For V1, retrieval is alias/keyword scoring over the cached frontend records plus
 frontend calendar API calls for drop timing and Bedrock-planned public-data
 intents compiled to backend-owned SQL.
+Natural multi-wallet setup wording such as adding, linking, pairing, or using
+another wallet is routed to the consolidation records when the wording includes
+clear multi-wallet intent. Generic wallet-connection questions remain outside
+that route so the bot does not incorrectly prescribe consolidation.
 Direct follow-up questions first match the current user message; previous bot
 answer text is used only as fallback context so old wording does not dominate
 the next topic.

--- a/specs/6529-help-bot-runtime.md
+++ b/specs/6529-help-bot-runtime.md
@@ -322,13 +322,17 @@ up another wallet is routed to the consolidation records when the wording
 includes both a setup action and an explicit additional, quantified, or
 possessive multi-wallet target, regardless of which appears first. Wallet-limit
 questions are routed to consolidation use cases when they combine a wallet or
-address subject, quantity or limit language, and either a setup action or
-explicit consolidation relationship. Generic connection questions, bare
-plural wallet wording, and capability questions about merely using multiple
-wallets remain outside those routes so the bot does not incorrectly prescribe
-consolidation. Explicit delegation and standalone hardware-wallet wording
-remain governed by their own context rather than these consolidation
-shortcuts.
+address subject with either strong limit language or quantity language plus a
+counting, setup, or consolidation relationship. The answer distinguishes
+registration capacity from the effective metrics group: more than three
+addresses can have consolidation records, but only the last three count for
+consolidation purposes. Removal and unlinking wording routes to consolidation
+revoke guidance, while replacement and swapping wording routes to update
+guidance. Generic connection questions, bare plural wallet wording, and
+capability questions about merely using multiple wallets remain outside those
+routes so the bot does not incorrectly prescribe consolidation. Explicit
+delegation and external wallet-provider, device, and hardware-wallet wording
+remain governed by their own context rather than these consolidation shortcuts.
 Direct follow-up questions first match the current user message; previous bot
 answer text is used only as fallback context so old wording does not dominate
 the next topic.

--- a/specs/6529-help-bot-runtime.md
+++ b/specs/6529-help-bot-runtime.md
@@ -326,14 +326,20 @@ address subject with either strong limit language or quantity language plus a
 counting, setup, or consolidation relationship. The answer distinguishes
 registration capacity from the effective metrics group: more than three
 addresses can have consolidation records, but only the last three count for
-consolidation purposes. Removal and unlinking wording routes to consolidation
-revoke guidance, while replacement and swapping wording routes to update
-guidance. Generic connection questions, bare plural wallet wording, and
-capability questions about merely using multiple wallets remain outside those
-routes so the bot does not incorrectly prescribe consolidation. Explicit
-delegation and external wallet-provider, device, and hardware-wallet wording
-remain governed by their own context rather than these consolidation shortcuts.
-Direct follow-up questions first match the current user message; previous bot
+consolidation purposes. Removal and unlinking wording with explicit
+multi-wallet or consolidation context routes to consolidation revoke guidance,
+while replacement and swapping wording with that context routes to update
+guidance. Bare singular requests such as removing or replacing "a wallet"
+route to clarification guidance because they may refer either to the connected
+wallet or an on-chain consolidation record. Generic connection questions, bare
+plural wallet wording, and capability questions about merely using multiple
+wallets remain outside those routes so the bot does not incorrectly prescribe
+consolidation. Explicit delegation-workflow and external wallet-provider,
+device, and hardware-wallet wording remain governed by their own context rather
+than these consolidation shortcuts, even when consolidation wording is also
+present. Naming the Delegation Center itself does not suppress an otherwise
+explicit consolidation question. Direct follow-up questions first match the
+current user message; previous bot
 answer text is used only as fallback context so old wording does not dominate
 the next topic.
 
@@ -556,7 +562,7 @@ private user data beyond what is needed for debugging and abuse controls.
 - Draft frontend help index spec.
 - Draft backend runtime spec.
 - Agree on bot naming and hardcoded handle: `@help6529` (`HELP_BOT_HANDLE =
-  'help6529'`).
+'help6529'`).
 
 ### Phase 2: V1 Help Bot Plumbing - Done In PR
 

--- a/specs/6529-help-bot-runtime.md
+++ b/specs/6529-help-bot-runtime.md
@@ -317,10 +317,14 @@ entire corpus.
 For V1, retrieval is alias/keyword scoring over the cached frontend records plus
 frontend calendar API calls for drop timing and Bedrock-planned public-data
 intents compiled to backend-owned SQL.
-Natural multi-wallet setup wording such as adding, linking, pairing, or using
-another wallet is routed to the consolidation records when the wording includes
-clear multi-wallet intent. Generic wallet-connection questions remain outside
-that route so the bot does not incorrectly prescribe consolidation.
+Natural multi-wallet setup wording such as adding, linking, pairing, or setting
+up another wallet is routed to the consolidation records when the wording
+includes both a setup action and an explicit additional, quantified, or
+possessive multi-wallet target. Generic connection questions, bare plural
+wallet wording, and capability questions about merely using multiple wallets
+remain outside that route so the bot does not incorrectly prescribe
+consolidation. Explicit delegation wording remains governed by delegation
+routing rather than this consolidation shortcut.
 Direct follow-up questions first match the current user message; previous bot
 answer text is used only as fallback context so old wording does not dominate
 the next topic.

--- a/src/help-bot/help-bot-answerer.test.ts
+++ b/src/help-bot/help-bot-answerer.test.ts
@@ -878,7 +878,8 @@ describe('HelpBotAnswerer', () => {
     'what is the max wallets?',
     'how many wallets are allowed?',
     'how do i remove a wallet?',
-    'how do i replace a wallet?'
+    'how do i replace a wallet?',
+    'where do i connect an additional wallet?'
   ])(
     'treats unindexed multi-wallet question "%s" as product context',
     async (question) => {

--- a/src/help-bot/help-bot-answerer.test.ts
+++ b/src/help-bot/help-bot-answerer.test.ts
@@ -872,7 +872,9 @@ describe('HelpBotAnswerer', () => {
 
   it.each([
     'how do i register a consolidation?',
-    'how do i add another wallet?'
+    'how do i add another wallet?',
+    'how many wallets can i add?',
+    'what is the maximum number of addresses i can link?'
   ])(
     'treats unindexed multi-wallet question "%s" as product context',
     async (question) => {

--- a/src/help-bot/help-bot-answerer.test.ts
+++ b/src/help-bot/help-bot-answerer.test.ts
@@ -874,7 +874,11 @@ describe('HelpBotAnswerer', () => {
     'how do i register a consolidation?',
     'how do i add another wallet?',
     'how many wallets can i add?',
-    'what is the maximum number of addresses i can link?'
+    'what is the maximum number of addresses i can link?',
+    'what is the max wallets?',
+    'how many wallets are allowed?',
+    'how do i remove a wallet?',
+    'how do i replace a wallet?'
   ])(
     'treats unindexed multi-wallet question "%s" as product context',
     async (question) => {

--- a/src/help-bot/help-bot-answerer.test.ts
+++ b/src/help-bot/help-bot-answerer.test.ts
@@ -870,17 +870,23 @@ describe('HelpBotAnswerer', () => {
     });
   });
 
-  it('treats consolidation questions as product context when unindexed', async () => {
-    await expect(
-      answerer().answer({
-        question: 'how do i register a consolidation?',
-        baseUrl: BASE_URL
-      })
-    ).resolves.toEqual({
-      type: 'NO_RELIABLE_SOURCE',
-      escalateToTechTeam: true
-    });
-  });
+  it.each([
+    'how do i register a consolidation?',
+    'how do i add another wallet?'
+  ])(
+    'treats unindexed multi-wallet question "%s" as product context',
+    async (question) => {
+      await expect(
+        answerer().answer({
+          question,
+          baseUrl: BASE_URL
+        })
+      ).resolves.toEqual({
+        type: 'NO_RELIABLE_SOURCE',
+        escalateToTechTeam: true
+      });
+    }
+  );
 
   it('asks for a topic when the user only asks for help', async () => {
     const publicDataService = {

--- a/src/help-bot/help-bot-knowledge.test.ts
+++ b/src/help-bot/help-bot-knowledge.test.ts
@@ -314,7 +314,7 @@ describe('FrontendHelpBotKnowledgeSource', () => {
         'delegation.consolidation-use-cases',
         'delegation.wallet-architecture'
       ])
-    ]);
+    );
   });
 
   it.each([

--- a/src/help-bot/help-bot-knowledge.test.ts
+++ b/src/help-bot/help-bot-knowledge.test.ts
@@ -2,6 +2,10 @@ import {
   FrontendHelpBotKnowledgeSource,
   HelpBotKnowledgeIndex,
   HelpBotKnowledgeUnavailableError,
+  isMultiWalletLimitQuestion,
+  isMultiWalletRemovalQuestion,
+  isMultiWalletReplacementQuestion,
+  isMultiWalletSetupQuestion,
   StaticHelpBotKnowledgeSource
 } from './help-bot.knowledge';
 
@@ -12,6 +16,25 @@ function response(body: unknown, ok = true, status = 200) {
     text: async () => JSON.stringify(body)
   };
 }
+
+describe('multi-wallet intent boundaries', () => {
+  it.each([
+    'how many wallets can i connect to metamask?',
+    'what is the metamask wallet limit?',
+    'how do i replace my hardware wallet?',
+    'how do i remove a delegate wallet?',
+    'how do i change my wallet architecture?'
+  ])('does not classify unrelated wallet wording in "%s"', (question) => {
+    expect(
+      [
+        isMultiWalletSetupQuestion(question),
+        isMultiWalletLimitQuestion(question),
+        isMultiWalletRemovalQuestion(question),
+        isMultiWalletReplacementQuestion(question)
+      ].some(Boolean)
+    ).toBe(false);
+  });
+});
 
 describe('FrontendHelpBotKnowledgeSource', () => {
   it('loads snake_case frontend help index records', async () => {
@@ -256,7 +279,10 @@ describe('FrontendHelpBotKnowledgeSource', () => {
     'how do i add my other wallet?',
     'where can i link my wallets?',
     'i have another wallet; how do i add it?',
-    'there are two wallets i need to link'
+    'there are two wallets i need to link',
+    'can i add three wallets?',
+    'how do i connect several addresses?',
+    'where can i add more wallets?'
   ])('routes natural multi-wallet wording in "%s"', async (question) => {
     const source = new FrontendHelpBotKnowledgeSource(async () =>
       response({
@@ -324,7 +350,10 @@ describe('FrontendHelpBotKnowledgeSource', () => {
     'what is the maximum number of wallets i can link?',
     'is there a limit to the addresses i can pair?',
     'what is the wallet capacity for one consolidation?',
-    'how many addresses can 6529 treat together?'
+    'how many addresses can 6529 treat together?',
+    'what is the max wallets?',
+    'is there a wallet limit?',
+    'how many wallets are allowed?'
   ])('routes natural consolidation-limit wording in "%s"', async (question) => {
     const source = new FrontendHelpBotKnowledgeSource(async () =>
       response({
@@ -377,6 +406,82 @@ describe('FrontendHelpBotKnowledgeSource', () => {
   });
 
   it.each([
+    'how do i remove a wallet?',
+    'can i unlink my other address?',
+    'how do i detach a wallet from consolidation?',
+    'how do i delete a consolidated wallet?'
+  ])('routes consolidation removal wording in "%s"', async (question) => {
+    const source = new FrontendHelpBotKnowledgeSource(async () =>
+      response({
+        schema_version: 1,
+        generated_at: '2026-06-19T00:00:00.000Z',
+        commit_sha: 'test',
+        base_url: 'https://6529.io',
+        records: [
+          {
+            id: 'delegation.manage-revoke-doc',
+            title: 'How to Revoke a Delegation or Consolidation',
+            canonical_path: '/delegation/delegation-faq/manage-revoke',
+            aliases: ['revoke consolidation'],
+            keywords: ['revoke', 'remove', 'wallet', 'consolidation'],
+            facts: ['Use View/Manage to revoke a consolidation record.']
+          },
+          {
+            id: 'delegation.register-consolidation-doc',
+            title: 'Register Consolidation Guide',
+            canonical_path: '/delegation/delegation-faq/register-consolidation',
+            aliases: ['register consolidation'],
+            keywords: ['register', 'wallet', 'consolidation'],
+            facts: ['Register Consolidation connects wallets you control.']
+          }
+        ]
+      })
+    );
+
+    const match = await source.findMatch(question);
+
+    expect(match?.record.id).toBe('delegation.manage-revoke-doc');
+  });
+
+  it.each([
+    'how do i replace a wallet?',
+    'can i swap my other address?',
+    'how do i change a wallet in my consolidation?',
+    'how do i update a consolidated address?'
+  ])('routes consolidation replacement wording in "%s"', async (question) => {
+    const source = new FrontendHelpBotKnowledgeSource(async () =>
+      response({
+        schema_version: 1,
+        generated_at: '2026-06-19T00:00:00.000Z',
+        commit_sha: 'test',
+        base_url: 'https://6529.io',
+        records: [
+          {
+            id: 'delegation.manage-update-doc',
+            title: 'How to Update a Delegation or Consolidation',
+            canonical_path: '/delegation/delegation-faq/manage-update',
+            aliases: ['update consolidation'],
+            keywords: ['update', 'replace', 'wallet', 'consolidation'],
+            facts: ['Use View/Manage to update a consolidation record.']
+          },
+          {
+            id: 'delegation.manage-revoke-doc',
+            title: 'How to Revoke a Delegation or Consolidation',
+            canonical_path: '/delegation/delegation-faq/manage-revoke',
+            aliases: ['revoke consolidation'],
+            keywords: ['revoke', 'remove', 'wallet', 'consolidation'],
+            facts: ['Use View/Manage to revoke a consolidation record.']
+          }
+        ]
+      })
+    );
+
+    const match = await source.findMatch(question);
+
+    expect(match?.record.id).toBe('delegation.manage-update-doc');
+  });
+
+  it.each([
     'how do i add another profile statement?',
     'how do i connect my hardware wallet?',
     'can i use more than one wallet?',
@@ -385,7 +490,9 @@ describe('FrontendHelpBotKnowledgeSource', () => {
     'how do i add a delegate wallet?',
     'how many wallets exist?',
     'how many hardware wallets can this device connect?',
-    'how many delegate wallets can i add?'
+    'how many delegate wallets can i add?',
+    'what is the metamask wallet limit?',
+    'how many wallets can i connect to metamask?'
   ])(
     'does not misroute unrelated wallet/addition wording in "%s"',
     async (question) => {

--- a/src/help-bot/help-bot-knowledge.test.ts
+++ b/src/help-bot/help-bot-knowledge.test.ts
@@ -254,7 +254,9 @@ describe('FrontendHelpBotKnowledgeSource', () => {
     'how do i set up multiple wallets?',
     'how do i link my wallet with another wallet?',
     'how do i add my other wallet?',
-    'where can i link my wallets?'
+    'where can i link my wallets?',
+    'i have another wallet; how do i add it?',
+    'there are two wallets i need to link'
   ])('routes natural multi-wallet wording in "%s"', async (question) => {
     const source = new FrontendHelpBotKnowledgeSource(async () =>
       response({
@@ -318,12 +320,72 @@ describe('FrontendHelpBotKnowledgeSource', () => {
   });
 
   it.each([
+    'how many wallets can i add?',
+    'what is the maximum number of wallets i can link?',
+    'is there a limit to the addresses i can pair?',
+    'what is the wallet capacity for one consolidation?',
+    'how many addresses can 6529 treat together?'
+  ])('routes natural consolidation-limit wording in "%s"', async (question) => {
+    const source = new FrontendHelpBotKnowledgeSource(async () =>
+      response({
+        schema_version: 1,
+        generated_at: '2026-06-19T00:00:00.000Z',
+        commit_sha: 'test',
+        base_url: 'https://6529.io',
+        records: [
+          {
+            id: 'delegation.register-consolidation-doc',
+            title: 'Register Consolidation Guide',
+            canonical_path: '/delegation/delegation-faq/register-consolidation',
+            aliases: ['register consolidation guide'],
+            keywords: ['register', 'consolidation', 'wallet'],
+            facts: ['Register Consolidation connects wallets you control.']
+          },
+          {
+            id: 'delegation.consolidation-use-cases',
+            title: 'Consolidation Use Cases',
+            canonical_path: '/delegation/consolidation-use-cases',
+            aliases: ['consolidation use cases'],
+            keywords: ['consolidation', 'wallet', 'limit'],
+            facts: [
+              '6529 recognizes up to three addresses as one consolidation group.'
+            ]
+          },
+          {
+            id: 'delegation.wallet-architecture',
+            title: 'Wallet Architecture',
+            canonical_path: '/delegation/wallet-architecture',
+            aliases: ['wallet architecture'],
+            keywords: ['wallet', 'architecture'],
+            facts: ['Separate vault, transaction, and minting wallets.']
+          }
+        ]
+      })
+    );
+
+    const matches = await source.findMatches(question, 3);
+
+    expect(matches[0]?.record.id).toBe(
+      'delegation.consolidation-use-cases'
+    );
+    expect(matches.map((match) => match.record.id)).toEqual(
+      expect.arrayContaining([
+        'delegation.consolidation-use-cases',
+        'delegation.wallet-architecture'
+      ])
+    );
+  });
+
+  it.each([
     'how do i add another profile statement?',
     'how do i connect my hardware wallet?',
     'can i use more than one wallet?',
     'can i use two wallets?',
     'how do i link wallets?',
-    'how do i add a delegate wallet?'
+    'how do i add a delegate wallet?',
+    'how many wallets exist?',
+    'how many hardware wallets can this device connect?',
+    'how many delegate wallets can i add?'
   ])(
     'does not misroute unrelated wallet/addition wording in "%s"',
     async (question) => {

--- a/src/help-bot/help-bot-knowledge.test.ts
+++ b/src/help-bot/help-bot-knowledge.test.ts
@@ -36,8 +36,13 @@ describe('multi-wallet intent boundaries', () => {
     ).toBe(false);
   });
 
-  it.each(['how do i remove a wallet?', 'how do i replace a wallet?'])(
-    'treats bare wallet-management wording in "%s" as ambiguous',
+  it.each([
+    'how do i remove a wallet?',
+    'how do i replace a wallet?',
+    'where do i connect an additional wallet?',
+    'how many wallets can i connect?'
+  ])(
+    'treats ambiguous wallet-management wording in "%s" as clarification',
     (question) => {
       expect(isMultiWalletRemovalQuestion(question)).toBe(false);
       expect(isMultiWalletReplacementQuestion(question)).toBe(false);
@@ -288,7 +293,6 @@ describe('FrontendHelpBotKnowledgeSource', () => {
   it.each([
     'how do i add a second wallet?',
     'can i link another address to my setup?',
-    'where do i connect an additional wallet?',
     'how can i pair two wallets?',
     'how do i set up multiple wallets?',
     'how do i link my wallet with another wallet?',
@@ -297,7 +301,6 @@ describe('FrontendHelpBotKnowledgeSource', () => {
     'i have another wallet; how do i add it?',
     'there are two wallets i need to link',
     'can i add three wallets?',
-    'how do i connect several addresses?',
     'where can i add more wallets?'
   ])('routes natural multi-wallet wording in "%s"', async (question) => {
     const source = new FrontendHelpBotKnowledgeSource(async () =>
@@ -496,7 +499,12 @@ describe('FrontendHelpBotKnowledgeSource', () => {
     expect(match?.record.id).toBe('delegation.manage-update-doc');
   });
 
-  it.each(['how do i remove a wallet?', 'how do i replace a wallet?'])(
+  it.each([
+    'how do i remove a wallet?',
+    'how do i replace a wallet?',
+    'where do i connect an additional wallet?',
+    'how do i connect two wallets?'
+  ])(
     'routes ambiguous wallet-management wording in "%s" to clarification',
     async (question) => {
       const source = new FrontendHelpBotKnowledgeSource(async () =>

--- a/src/help-bot/help-bot-knowledge.test.ts
+++ b/src/help-bot/help-bot-knowledge.test.ts
@@ -251,7 +251,7 @@ describe('FrontendHelpBotKnowledgeSource', () => {
     'can i link another address to my setup?',
     'where do i connect an additional wallet?',
     'how can i pair two wallets?',
-    'can i use more than one wallet?',
+    'how do i set up multiple wallets?',
     'how do i link my wallet with another wallet?',
     'how do i add my other wallet?',
     'where can i link my wallets?'
@@ -313,7 +313,11 @@ describe('FrontendHelpBotKnowledgeSource', () => {
 
   it.each([
     'how do i add another profile statement?',
-    'how do i connect my hardware wallet?'
+    'how do i connect my hardware wallet?',
+    'can i use more than one wallet?',
+    'can i use two wallets?',
+    'how do i link wallets?',
+    'how do i add a delegate wallet?'
   ])(
     'does not misroute unrelated wallet/addition wording in "%s"',
     async (question) => {
@@ -324,6 +328,22 @@ describe('FrontendHelpBotKnowledgeSource', () => {
           commit_sha: 'test',
           base_url: 'https://6529.io',
           records: [
+            {
+              id: 'delegation.wallet-architecture',
+              title: 'Wallet Architecture',
+              canonical_path: '/delegation/wallet-architecture',
+              aliases: ['wallet architecture', 'hardware wallet setup'],
+              keywords: ['wallet', 'architecture', 'vault'],
+              facts: ['Separate vault, transaction, and minting wallets.']
+            },
+            {
+              id: 'delegation.faq',
+              title: 'Delegation FAQ',
+              canonical_path: '/delegation/delegation-faq',
+              aliases: ['set up delegation', 'delegate wallet'],
+              keywords: ['delegation', 'delegate', 'wallet'],
+              facts: ['Delegation grants scoped rights to another wallet.']
+            },
             {
               id: 'delegation.register-consolidation-doc',
               title: 'Register Consolidation Guide',
@@ -337,7 +357,11 @@ describe('FrontendHelpBotKnowledgeSource', () => {
         })
       );
 
-      await expect(source.findMatch(question)).resolves.toBeNull();
+      const matches = await source.findMatches(question, 4);
+
+      expect(matches.map((match) => match.record.id)).not.toContain(
+        'delegation.register-consolidation-doc'
+      );
     }
   );
 

--- a/src/help-bot/help-bot-knowledge.test.ts
+++ b/src/help-bot/help-bot-knowledge.test.ts
@@ -2,6 +2,7 @@ import {
   FrontendHelpBotKnowledgeSource,
   HelpBotKnowledgeIndex,
   HelpBotKnowledgeUnavailableError,
+  isAmbiguousWalletManagementQuestion,
   isMultiWalletLimitQuestion,
   isMultiWalletRemovalQuestion,
   isMultiWalletReplacementQuestion,
@@ -33,6 +34,21 @@ describe('multi-wallet intent boundaries', () => {
         isMultiWalletReplacementQuestion(question)
       ].some(Boolean)
     ).toBe(false);
+  });
+
+  it.each(['how do i remove a wallet?', 'how do i replace a wallet?'])(
+    'treats bare wallet-management wording in "%s" as ambiguous',
+    (question) => {
+      expect(isMultiWalletRemovalQuestion(question)).toBe(false);
+      expect(isMultiWalletReplacementQuestion(question)).toBe(false);
+      expect(isAmbiguousWalletManagementQuestion(question)).toBe(true);
+    }
+  );
+
+  it('does not use "together" alone as a consolidation-limit signal', () => {
+    expect(isMultiWalletLimitQuestion('how many wallets work together?')).toBe(
+      false
+    );
   });
 });
 
@@ -404,7 +420,7 @@ describe('FrontendHelpBotKnowledgeSource', () => {
   });
 
   it.each([
-    'how do i remove a wallet?',
+    'how do i remove one of my wallets?',
     'can i unlink my other address?',
     'how do i detach a wallet from consolidation?',
     'how do i delete a consolidated wallet?'
@@ -442,10 +458,11 @@ describe('FrontendHelpBotKnowledgeSource', () => {
   });
 
   it.each([
-    'how do i replace a wallet?',
+    'how do i replace one of my wallets?',
     'can i swap my other address?',
     'how do i change a wallet in my consolidation?',
-    'how do i update a consolidated address?'
+    'how do i update a consolidated address?',
+    'how do i replace a wallet in consolidation from the delegation center?'
   ])('routes consolidation replacement wording in "%s"', async (question) => {
     const source = new FrontendHelpBotKnowledgeSource(async () =>
       response({
@@ -477,6 +494,126 @@ describe('FrontendHelpBotKnowledgeSource', () => {
     const match = await source.findMatch(question);
 
     expect(match?.record.id).toBe('delegation.manage-update-doc');
+  });
+
+  it.each(['how do i remove a wallet?', 'how do i replace a wallet?'])(
+    'routes ambiguous wallet-management wording in "%s" to clarification',
+    async (question) => {
+      const source = new FrontendHelpBotKnowledgeSource(async () =>
+        response({
+          schema_version: 1,
+          generated_at: '2026-06-19T00:00:00.000Z',
+          commit_sha: 'test',
+          base_url: 'https://6529.io',
+          records: [
+            {
+              id: 'delegation.wallet-management-clarification',
+              title: 'Wallet Management Clarification',
+              canonical_path: '/delegation/delegation-center',
+              aliases: ['wallet management clarification'],
+              keywords: ['wallet', 'management', 'consolidation'],
+              facts: [
+                'Clarify whether the user means their connected wallet or a consolidation record.'
+              ]
+            },
+            {
+              id: 'delegation.manage-revoke-doc',
+              title: 'How to Revoke a Delegation or Consolidation',
+              canonical_path: '/delegation/delegation-faq/manage-revoke',
+              aliases: ['revoke consolidation'],
+              keywords: ['revoke', 'remove', 'wallet', 'consolidation'],
+              facts: ['Use View/Manage to revoke a consolidation record.']
+            },
+            {
+              id: 'delegation.manage-update-doc',
+              title: 'How to Update a Delegation or Consolidation',
+              canonical_path: '/delegation/delegation-faq/manage-update',
+              aliases: ['update consolidation'],
+              keywords: ['update', 'replace', 'wallet', 'consolidation'],
+              facts: ['Use View/Manage to update a consolidation record.']
+            }
+          ]
+        })
+      );
+
+      const match = await source.findMatch(question);
+
+      expect(match?.record.id).toBe(
+        'delegation.wallet-management-clarification'
+      );
+    }
+  );
+
+  it.each([
+    'how do i replace wallet in consolidation using metamask?',
+    'how do i remove wallet from consolidation in metamask?',
+    'what is the metamask wallet consolidation limit?',
+    'how do i replace my hardware wallet in a consolidation?',
+    'how do i remove a delegate wallet from consolidation?'
+  ])('does not bypass wallet-context exclusions in "%s"', async (question) => {
+    const consolidationRecordIds = [
+      'delegation.wallet-management-clarification',
+      'delegation.register-consolidation-doc',
+      'delegation.consolidation-use-cases',
+      'delegation.manage-revoke-doc',
+      'delegation.manage-update-doc'
+    ];
+    const source = new FrontendHelpBotKnowledgeSource(async () =>
+      response({
+        schema_version: 1,
+        generated_at: '2026-06-19T00:00:00.000Z',
+        commit_sha: 'test',
+        base_url: 'https://6529.io',
+        records: [
+          {
+            id: 'delegation.wallet-management-clarification',
+            title: 'Wallet Management Clarification',
+            canonical_path: '/delegation/delegation-center',
+            aliases: ['wallet management clarification'],
+            keywords: ['wallet', 'management'],
+            facts: ['Clarify the wallet-management context.']
+          },
+          {
+            id: 'delegation.register-consolidation-doc',
+            title: 'Register Consolidation Guide',
+            canonical_path: '/delegation/delegation-faq/register-consolidation',
+            aliases: ['register consolidation guide'],
+            keywords: ['register', 'consolidation', 'wallet'],
+            facts: ['Register Consolidation connects wallets you control.']
+          },
+          {
+            id: 'delegation.consolidation-use-cases',
+            title: 'Consolidation Use Cases',
+            canonical_path: '/delegation/consolidation-use-cases',
+            aliases: ['wallet consolidation limit'],
+            keywords: ['consolidation', 'wallet', 'limit'],
+            facts: ['Only the last three addresses count.']
+          },
+          {
+            id: 'delegation.manage-revoke-doc',
+            title: 'How to Revoke a Consolidation',
+            canonical_path: '/delegation/delegation-faq/manage-revoke',
+            aliases: ['remove wallet from consolidation'],
+            keywords: ['remove', 'wallet', 'consolidation'],
+            facts: ['Use View/Manage to revoke a consolidation record.']
+          },
+          {
+            id: 'delegation.manage-update-doc',
+            title: 'How to Update a Consolidation',
+            canonical_path: '/delegation/delegation-faq/manage-update',
+            aliases: ['replace wallet in consolidation'],
+            keywords: ['replace', 'wallet', 'consolidation'],
+            facts: ['Use View/Manage to update a consolidation record.']
+          }
+        ]
+      })
+    );
+
+    const matches = await source.findMatches(question, 5);
+
+    expect(matches.map((match) => match.record.id)).toEqual(
+      expect.not.arrayContaining(consolidationRecordIds)
+    );
   });
 
   it.each([

--- a/src/help-bot/help-bot-knowledge.test.ts
+++ b/src/help-bot/help-bot-knowledge.test.ts
@@ -394,9 +394,7 @@ describe('FrontendHelpBotKnowledgeSource', () => {
 
     const matches = await source.findMatches(question, 3);
 
-    expect(matches[0]?.record.id).toBe(
-      'delegation.consolidation-use-cases'
-    );
+    expect(matches[0]?.record.id).toBe('delegation.consolidation-use-cases');
     expect(matches.map((match) => match.record.id)).toEqual(
       expect.arrayContaining([
         'delegation.consolidation-use-cases',

--- a/src/help-bot/help-bot-knowledge.test.ts
+++ b/src/help-bot/help-bot-knowledge.test.ts
@@ -246,6 +246,101 @@ describe('FrontendHelpBotKnowledgeSource', () => {
     );
   });
 
+  it.each([
+    'how do i add a second wallet?',
+    'can i link another address to my setup?',
+    'where do i connect an additional wallet?',
+    'how can i pair two wallets?',
+    'can i use more than one wallet?',
+    'how do i link my wallet with another wallet?',
+    'how do i add my other wallet?',
+    'where can i link my wallets?'
+  ])('routes natural multi-wallet wording in "%s"', async (question) => {
+    const source = new FrontendHelpBotKnowledgeSource(async () =>
+      response({
+        schema_version: 1,
+        generated_at: '2026-06-19T00:00:00.000Z',
+        commit_sha: 'test',
+        base_url: 'https://6529.io',
+        records: [
+          {
+            id: 'delegation.wallet-architecture',
+            title: 'Wallet Architecture',
+            canonical_path: '/delegation/wallet-architecture',
+            aliases: ['wallet architecture'],
+            keywords: ['wallet', 'architecture', 'vault'],
+            facts: ['Separate vault, transaction, and minting wallets.']
+          },
+          {
+            id: 'delegation.register-consolidation-doc',
+            title: 'Register Consolidation Guide',
+            canonical_path: '/delegation/delegation-faq/register-consolidation',
+            aliases: ['register consolidation guide'],
+            keywords: ['register', 'consolidation'],
+            facts: ['Register Consolidation connects wallets you control.']
+          },
+          {
+            id: 'delegation.register-consolidation',
+            title: 'Register Consolidation',
+            canonical_path: '/delegation/register-consolidation',
+            aliases: ['register consolidation'],
+            keywords: ['register', 'consolidation'],
+            facts: ['Use the Register Consolidation form.']
+          },
+          {
+            id: 'delegation.consolidation-use-cases',
+            title: 'Consolidation Use Cases',
+            canonical_path: '/delegation/consolidation-use-cases',
+            aliases: ['consolidation use cases'],
+            keywords: ['consolidation', 'wallet'],
+            facts: [
+              '6529 recognizes up to three addresses as one consolidation group.'
+            ]
+          }
+        ]
+      })
+    );
+
+    const matches = await source.findMatches(question, 4);
+
+    expect(matches.map((match) => match.record.id)).toEqual([
+      'delegation.register-consolidation-doc',
+      'delegation.register-consolidation',
+      'delegation.consolidation-use-cases',
+      'delegation.wallet-architecture'
+    ]);
+  });
+
+  it.each([
+    'how do i add another profile statement?',
+    'how do i connect my hardware wallet?'
+  ])(
+    'does not misroute unrelated wallet/addition wording in "%s"',
+    async (question) => {
+      const source = new FrontendHelpBotKnowledgeSource(async () =>
+        response({
+          schema_version: 1,
+          generated_at: '2026-06-19T00:00:00.000Z',
+          commit_sha: 'test',
+          base_url: 'https://6529.io',
+          records: [
+            {
+              id: 'delegation.register-consolidation-doc',
+              title: 'Register Consolidation Guide',
+              canonical_path:
+                '/delegation/delegation-faq/register-consolidation',
+              aliases: ['register consolidation guide'],
+              keywords: ['register', 'consolidation', 'wallet'],
+              facts: ['Register Consolidation connects wallets you control.']
+            }
+          ]
+        })
+      );
+
+      await expect(source.findMatch(question)).resolves.toBeNull();
+    }
+  );
+
   it('does not route generic transaction display questions as wallet architecture', async () => {
     const source = new FrontendHelpBotKnowledgeSource(async () =>
       response({

--- a/src/help-bot/help-bot-knowledge.test.ts
+++ b/src/help-bot/help-bot-knowledge.test.ts
@@ -303,11 +303,17 @@ describe('FrontendHelpBotKnowledgeSource', () => {
 
     const matches = await source.findMatches(question, 4);
 
-    expect(matches.map((match) => match.record.id)).toEqual([
+    const matchIds = matches.map((match) => match.record.id);
+
+    expect(matchIds.slice(0, 2)).toEqual([
       'delegation.register-consolidation-doc',
-      'delegation.register-consolidation',
-      'delegation.consolidation-use-cases',
-      'delegation.wallet-architecture'
+      'delegation.register-consolidation'
+    ]);
+    expect(matchIds.slice(2)).toEqual(
+      expect.arrayContaining([
+        'delegation.consolidation-use-cases',
+        'delegation.wallet-architecture'
+      ])
     ]);
   });
 

--- a/src/help-bot/help-bot.answerer.ts
+++ b/src/help-bot/help-bot.answerer.ts
@@ -5,6 +5,8 @@ import {
   HelpBotKnowledgeRecord,
   HelpBotKnowledgeMatch,
   isMultiWalletLimitQuestion,
+  isMultiWalletRemovalQuestion,
+  isMultiWalletReplacementQuestion,
   isMultiWalletSetupQuestion
 } from './help-bot.knowledge';
 import {
@@ -1302,7 +1304,9 @@ function isLikelyProductText(value: string | null | undefined): boolean {
   return (
     PRODUCT_CONTEXT_PATTERNS.some((pattern) => pattern.test(normalized)) ||
     isMultiWalletSetupQuestion(normalized) ||
-    isMultiWalletLimitQuestion(normalized)
+    isMultiWalletLimitQuestion(normalized) ||
+    isMultiWalletRemovalQuestion(normalized) ||
+    isMultiWalletReplacementQuestion(normalized)
   );
 }
 

--- a/src/help-bot/help-bot.answerer.ts
+++ b/src/help-bot/help-bot.answerer.ts
@@ -4,6 +4,7 @@ import {
   HelpBotKnowledgeSource,
   HelpBotKnowledgeRecord,
   HelpBotKnowledgeMatch,
+  isAmbiguousWalletManagementQuestion,
   isMultiWalletLimitQuestion,
   isMultiWalletRemovalQuestion,
   isMultiWalletReplacementQuestion,
@@ -1306,7 +1307,8 @@ function isLikelyProductText(value: string | null | undefined): boolean {
     isMultiWalletSetupQuestion(normalized) ||
     isMultiWalletLimitQuestion(normalized) ||
     isMultiWalletRemovalQuestion(normalized) ||
-    isMultiWalletReplacementQuestion(normalized)
+    isMultiWalletReplacementQuestion(normalized) ||
+    isAmbiguousWalletManagementQuestion(normalized)
   );
 }
 

--- a/src/help-bot/help-bot.answerer.ts
+++ b/src/help-bot/help-bot.answerer.ts
@@ -3,7 +3,8 @@ import {
   frontendHelpBotKnowledgeSource,
   HelpBotKnowledgeSource,
   HelpBotKnowledgeRecord,
-  HelpBotKnowledgeMatch
+  HelpBotKnowledgeMatch,
+  isMultiWalletSetupQuestion
 } from './help-bot.knowledge';
 import {
   HelpBotCalendarService,
@@ -1297,7 +1298,10 @@ function mergeKnowledgeMatches(
 
 function isLikelyProductText(value: string | null | undefined): boolean {
   const normalized = normalizeBoundaryText(value ?? '');
-  return PRODUCT_CONTEXT_PATTERNS.some((pattern) => pattern.test(normalized));
+  return (
+    PRODUCT_CONTEXT_PATTERNS.some((pattern) => pattern.test(normalized)) ||
+    isMultiWalletSetupQuestion(normalized)
+  );
 }
 
 function isLikelyProductQuestion(

--- a/src/help-bot/help-bot.answerer.ts
+++ b/src/help-bot/help-bot.answerer.ts
@@ -4,6 +4,7 @@ import {
   HelpBotKnowledgeSource,
   HelpBotKnowledgeRecord,
   HelpBotKnowledgeMatch,
+  isMultiWalletLimitQuestion,
   isMultiWalletSetupQuestion
 } from './help-bot.knowledge';
 import {
@@ -1300,7 +1301,8 @@ function isLikelyProductText(value: string | null | undefined): boolean {
   const normalized = normalizeBoundaryText(value ?? '');
   return (
     PRODUCT_CONTEXT_PATTERNS.some((pattern) => pattern.test(normalized)) ||
-    isMultiWalletSetupQuestion(normalized)
+    isMultiWalletSetupQuestion(normalized) ||
+    isMultiWalletLimitQuestion(normalized)
   );
 }
 

--- a/src/help-bot/help-bot.knowledge.ts
+++ b/src/help-bot/help-bot.knowledge.ts
@@ -161,10 +161,12 @@ const MULTI_WALLET_SETUP_TARGET_PATTERNS = [
 
 const CONSOLIDATION_LIMIT_CONTEXT_PATTERNS = [
   /\bhow many\b/,
+  /\bnumber of\b/,
   /\bmaximum\b/,
   /\bmax\b/,
   /\blimit\b/,
   /\blimits\b/,
+  /\bcapacity\b/,
   /\bgroup size\b/,
   /\bone consolidation group\b/,
   /\bper consolidation group\b/,
@@ -481,16 +483,41 @@ function matchesAny(
 
 export function isMultiWalletSetupQuestion(question: string): boolean {
   const normalizedQuestion = normalizeText(question);
-  return MULTI_WALLET_SETUP_TARGET_PATTERNS.some((targetPattern) => {
-    const targetIndex = normalizedQuestion.search(targetPattern);
-    return (
-      targetIndex > 0 &&
-      matchesAny(
-        normalizedQuestion.slice(0, targetIndex),
-        MULTI_WALLET_SETUP_ACTION_PATTERNS
-      )
-    );
-  });
+  const hasDelegationContext = matchesAny(
+    normalizedQuestion,
+    DELEGATION_CONTEXT_PATTERNS
+  );
+  const hasConsolidationContext = matchesAny(
+    normalizedQuestion,
+    CONSOLIDATION_CONTEXT_PATTERNS
+  );
+  return (
+    (!hasDelegationContext || hasConsolidationContext) &&
+    matchesAny(normalizedQuestion, MULTI_WALLET_SETUP_ACTION_PATTERNS) &&
+    matchesAny(normalizedQuestion, MULTI_WALLET_SETUP_TARGET_PATTERNS)
+  );
+}
+
+export function isMultiWalletLimitQuestion(question: string): boolean {
+  const normalizedQuestion = normalizeText(question);
+  const hasStandaloneHardwareWalletContext =
+    /\bhardware wallets?\b/.test(normalizedQuestion);
+  const hasDelegationContext = matchesAny(
+    normalizedQuestion,
+    DELEGATION_CONTEXT_PATTERNS
+  );
+  const hasConsolidationContext = matchesAny(
+    normalizedQuestion,
+    CONSOLIDATION_CONTEXT_PATTERNS
+  );
+  return (
+    matchesAny(normalizedQuestion, WALLET_CONTEXT_PATTERNS) &&
+    matchesAny(normalizedQuestion, CONSOLIDATION_LIMIT_CONTEXT_PATTERNS) &&
+    (hasConsolidationContext ||
+      matchesAny(normalizedQuestion, MULTI_WALLET_SETUP_ACTION_PATTERNS)) &&
+    (!hasDelegationContext || hasConsolidationContext) &&
+    (!hasStandaloneHardwareWalletContext || hasConsolidationContext)
+  );
 }
 
 function parseWalletCount(rawCount: string): number | null {
@@ -555,6 +582,7 @@ interface RoutedQuestionContext {
   readonly hasExplicitArchitectureContext: boolean;
   readonly hasConsolidationContext: boolean;
   readonly hasMultiWalletSetupContext: boolean;
+  readonly hasMultiWalletLimitContext: boolean;
   readonly hasConsolidationLimitContext: boolean;
   readonly hasDelegationContext: boolean;
   readonly hasWalletCheckContext: boolean;
@@ -580,6 +608,7 @@ function routedQuestionContext(
       CONSOLIDATION_CONTEXT_PATTERNS
     ),
     hasMultiWalletSetupContext: isMultiWalletSetupQuestion(normalizedQuestion),
+    hasMultiWalletLimitContext: isMultiWalletLimitQuestion(normalizedQuestion),
     hasConsolidationLimitContext: matchesAny(
       normalizedQuestion,
       CONSOLIDATION_LIMIT_CONTEXT_PATTERNS
@@ -654,8 +683,9 @@ function addConsolidationScores(
   context: RoutedQuestionContext
 ): void {
   if (
-    context.hasConsolidationContext &&
-    context.hasConsolidationLimitContext &&
+    (context.hasMultiWalletLimitContext ||
+      (context.hasConsolidationContext &&
+        context.hasConsolidationLimitContext)) &&
     (context.hasWalletContext || context.hasArchitectureContext)
   ) {
     addRoutedPathScore(scores, CONSOLIDATION_USE_CASES_PATH, 18);

--- a/src/help-bot/help-bot.knowledge.ts
+++ b/src/help-bot/help-bot.knowledge.ts
@@ -98,7 +98,6 @@ const CONSOLIDATION_CONTEXT_PATTERNS = [
   /\bconsolidat(?:e|es|ed|ing|ion|ions)\b/,
   /\bcount(?:ed)? together\b/,
   /\btreat(?:ed)? together\b/,
-  /\bconnect(?:ed|ing)? (?:my )?(?:wallets?|address(?:es)?)\b/,
   /\bcombine(?:d|s|ing)? (?:my )?(?:wallets?|address(?:es)?)\b/
 ] as const;
 
@@ -109,13 +108,16 @@ const MULTI_WALLET_SETUP_ACTION_PATTERNS = [
   /\binclud(?:e|ing)\b/,
   /\blink(?:ing)?\b/,
   /\bpair(?:ing)?\b/,
-  /\bconnect(?:ing)?\b/,
   /\bcombin(?:e|ing)\b/,
   /\bassociat(?:e|ing)\b/,
   /\bjoin(?:ing)?\b/,
   /\b(?:tie|tying)\b/,
   /\bset(?:ting)? up\b/,
   /\bsetup\b/
+] as const;
+
+const AMBIGUOUS_WALLET_CONNECTION_ACTION_PATTERNS = [
+  /\bconnect(?:s|ed|ing)?\b/
 ] as const;
 
 const MULTI_WALLET_REMOVAL_ACTION_PATTERNS = [
@@ -277,7 +279,7 @@ const DELEGATION_CONTEXT_PATTERNS = [
 
 const DISQUALIFYING_DELEGATION_CONTEXT_PATTERNS = [
   /\bdelegat(?:e|es|ed|ing)\b/,
-  /\bdelegations?\b(?!\s+center\b)/
+  /\bdelegations?\b(?!\s+(?:center|docs?|faq|guides?|help)\b)/
 ] as const;
 
 const GENESIS_SET_PATTERNS = [/\bgenesis sets?\b/] as const;
@@ -640,14 +642,24 @@ export function isMultiWalletReplacementQuestion(question: string): boolean {
 
 export function isAmbiguousWalletManagementQuestion(question: string): boolean {
   const normalizedQuestion = normalizeText(question);
-  const hasManagementAction =
+  const hasRemovalOrReplacementAction =
     matchesAny(normalizedQuestion, MULTI_WALLET_REMOVAL_ACTION_PATTERNS) ||
     matchesAny(normalizedQuestion, MULTI_WALLET_REPLACEMENT_ACTION_PATTERNS);
+  const hasAmbiguousConnectionAction =
+    matchesAny(
+      normalizedQuestion,
+      AMBIGUOUS_WALLET_CONNECTION_ACTION_PATTERNS
+    ) &&
+    (hasMultiWalletTarget(normalizedQuestion) ||
+      matchesAny(normalizedQuestion, CONSOLIDATION_LIMIT_CONTEXT_PATTERNS));
+  const hasAmbiguousManagementAction =
+    (hasRemovalOrReplacementAction &&
+      !hasMultiWalletTarget(normalizedQuestion)) ||
+    hasAmbiguousConnectionAction;
   return (
-    hasManagementAction &&
+    hasAmbiguousManagementAction &&
     matchesAny(normalizedQuestion, WALLET_CONTEXT_PATTERNS) &&
     !matchesAny(normalizedQuestion, CONSOLIDATION_CONTEXT_PATTERNS) &&
-    !hasMultiWalletTarget(normalizedQuestion) &&
     !hasDisqualifyingWalletContext(normalizedQuestion) &&
     !/\bprofiles?\b/.test(normalizedQuestion)
   );

--- a/src/help-bot/help-bot.knowledge.ts
+++ b/src/help-bot/help-bot.knowledge.ts
@@ -626,10 +626,7 @@ export function isMultiWalletRemovalQuestion(question: string): boolean {
   return (
     matchesAny(normalizedQuestion, WALLET_CONTEXT_PATTERNS) &&
     matchesAny(normalizedQuestion, MULTI_WALLET_REMOVAL_ACTION_PATTERNS) &&
-    !hasDisqualifyingWalletContext(
-      normalizedQuestion,
-      hasConsolidationContext
-    )
+    !hasDisqualifyingWalletContext(normalizedQuestion, hasConsolidationContext)
   );
 }
 
@@ -650,10 +647,7 @@ export function isMultiWalletReplacementQuestion(question: string): boolean {
           normalizedQuestion,
           MULTI_WALLET_REPLACEMENT_ACTION_PATTERNS
         ))) &&
-    !hasDisqualifyingWalletContext(
-      normalizedQuestion,
-      hasConsolidationContext
-    )
+    !hasDisqualifyingWalletContext(normalizedQuestion, hasConsolidationContext)
   );
 }
 

--- a/src/help-bot/help-bot.knowledge.ts
+++ b/src/help-bot/help-bot.knowledge.ts
@@ -102,13 +102,61 @@ const CONSOLIDATION_CONTEXT_PATTERNS = [
   /\bcombine(?:d|s|ing)? (?:my )?(?:wallets?|address(?:es)?)\b/
 ] as const;
 
-const MULTI_WALLET_SETUP_CONTEXT_PATTERNS = [
-  /\b(?:add(?:ing)?|attach(?:ing)?|bring(?:ing)?|includ(?:e|ing)|link(?:ing)?|pair(?:ing)?|connect(?:ing)?|associat(?:e|ing)|join(?:ing)?|tie|tying|us(?:e|ing)|have)\s+(?:(?:a|an|my|the)\s+)?(?:second|another|additional|extra|new|one more|other|2nd)\s+(?:wallet|address)\b/,
-  /\b(?:set(?:ting)? up|setup)\s+(?:(?:a|an|my|the)\s+)?(?:second|another|additional|extra|new|one more|other|2nd)\s+(?:wallet|address)\b/,
-  /\b(?:add(?:ing)?|link(?:ing)?|pair(?:ing)?|connect(?:ing)?|combin(?:e|ing)|associat(?:e|ing)|join(?:ing)?)\s+(?:(?:my|the)\s+)?(?:two|2|multiple)\s+(?:wallets?|address(?:es)?)\b/,
-  /\b(?:us(?:e|ing)|have|manag(?:e|ing)|set(?:ting)? up|setup)\s+(?:more than one|multiple|two|2)\s+(?:wallets?|address(?:es)?)\b/,
-  /\b(?:link|connect|pair|associate|tie)\s+(?:my\s+)?(?:wallet|address)\s+(?:to|with)\s+(?:another|a second|an additional|one more|my other)\s+(?:wallet|address)\b/,
-  /\b(?:attach(?:ing)?|includ(?:e|ing)|link(?:ing)?|pair(?:ing)?|associat(?:e|ing)|join(?:ing)?|tie|tying)\s+(?:(?:my|the)\s+)?(?:wallets|addresses)\b/
+const MULTI_WALLET_SETUP_ACTION_PATTERNS = [
+  /\badd(?:ing)?\b/,
+  /\battach(?:ing)?\b/,
+  /\bbring(?:ing)?\b/,
+  /\binclud(?:e|ing)\b/,
+  /\blink(?:ing)?\b/,
+  /\bpair(?:ing)?\b/,
+  /\bconnect(?:ing)?\b/,
+  /\bcombin(?:e|ing)\b/,
+  /\bassociat(?:e|ing)\b/,
+  /\bjoin(?:ing)?\b/,
+  /\b(?:tie|tying)\b/,
+  /\bset(?:ting)? up\b/,
+  /\bsetup\b/
+] as const;
+
+const EXPLICIT_ADDITIONAL_WALLET_TARGET_PATTERNS = [
+  /\bsecond wallet\b/,
+  /\bsecond address\b/,
+  /\banother wallet\b/,
+  /\banother address\b/,
+  /\badditional wallet\b/,
+  /\badditional address\b/,
+  /\bextra wallet\b/,
+  /\bextra address\b/,
+  /\bnew wallet\b/,
+  /\bnew address\b/,
+  /\bone more wallet\b/,
+  /\bone more address\b/,
+  /\bother wallet\b/,
+  /\bother address\b/,
+  /\b2nd wallet\b/,
+  /\b2nd address\b/
+] as const;
+
+const QUANTIFIED_MULTI_WALLET_TARGET_PATTERNS = [
+  /\btwo wallets?\b/,
+  /\btwo address(?:es)?\b/,
+  /\b2 wallets?\b/,
+  /\b2 address(?:es)?\b/,
+  /\bmultiple wallets?\b/,
+  /\bmultiple address(?:es)?\b/
+] as const;
+
+const POSSESSIVE_MULTI_WALLET_TARGET_PATTERNS = [
+  /\bmy wallets\b/,
+  /\bmy addresses\b/,
+  /\bthe wallets\b/,
+  /\bthe addresses\b/
+] as const;
+
+const MULTI_WALLET_SETUP_TARGET_PATTERNS = [
+  ...EXPLICIT_ADDITIONAL_WALLET_TARGET_PATTERNS,
+  ...QUANTIFIED_MULTI_WALLET_TARGET_PATTERNS,
+  ...POSSESSIVE_MULTI_WALLET_TARGET_PATTERNS
 ] as const;
 
 const CONSOLIDATION_LIMIT_CONTEXT_PATTERNS = [
@@ -432,10 +480,17 @@ function matchesAny(
 }
 
 export function isMultiWalletSetupQuestion(question: string): boolean {
-  return matchesAny(
-    normalizeText(question),
-    MULTI_WALLET_SETUP_CONTEXT_PATTERNS
-  );
+  const normalizedQuestion = normalizeText(question);
+  return MULTI_WALLET_SETUP_TARGET_PATTERNS.some((targetPattern) => {
+    const targetIndex = normalizedQuestion.search(targetPattern);
+    return (
+      targetIndex > 0 &&
+      matchesAny(
+        normalizedQuestion.slice(0, targetIndex),
+        MULTI_WALLET_SETUP_ACTION_PATTERNS
+      )
+    );
+  });
 }
 
 function parseWalletCount(rawCount: string): number | null {

--- a/src/help-bot/help-bot.knowledge.ts
+++ b/src/help-bot/help-bot.knowledge.ts
@@ -134,11 +134,6 @@ const MULTI_WALLET_REPLACEMENT_ACTION_PATTERNS = [
   /\bupdat(?:e[ds]?|ing)\b/
 ] as const;
 
-const STRONG_MULTI_WALLET_REPLACEMENT_ACTION_PATTERNS = [
-  /\breplac(?:e[ds]?|ing)\b/,
-  /\bswap(?:s|ped|ping)?\b/
-] as const;
-
 const EXTERNAL_WALLET_CONTEXT_PATTERNS = [
   /\bhardware wallets?\b/,
   /\bmetamask\b/,
@@ -223,8 +218,7 @@ const CONSOLIDATION_COUNT_RELATION_PATTERNS = [
   /\bcount(?:ed|s|ing)?\b/,
   /\brecogniz(?:e|ed|es|ing)\b/,
   /\bgroup(?:ed|s|ing)?\b/,
-  /\btreat(?:ed|s|ing)?\b/,
-  /\btogether\b/
+  /\btreat(?:ed|s|ing)?\b/
 ] as const;
 
 const WALLET_CHECK_CONTEXT_PATTERNS = [
@@ -245,6 +239,8 @@ const REGISTER_CONSOLIDATION_DOC_PATH =
   '/delegation/delegation-faq/register-consolidation';
 const MANAGE_REVOKE_DOC_PATH = '/delegation/delegation-faq/manage-revoke';
 const MANAGE_UPDATE_DOC_PATH = '/delegation/delegation-faq/manage-update';
+const WALLET_MANAGEMENT_CLARIFICATION_ID =
+  'delegation.wallet-management-clarification';
 const WALLET_ARCHITECTURE_ID = 'delegation.wallet-architecture';
 const WALLET_CHECKER_ID = 'delegation.wallet-checker';
 const NETWORK_DEFINITIONS_ID = 'network.definitions';
@@ -277,6 +273,11 @@ const DELEGATION_CONTEXT_PATTERNS = [
   /\bdelegat(?:e|es|ed|ing|ion|ions)\b/,
   /\bdelegation managers?\b/,
   /\bminting delegation\b/
+] as const;
+
+const DISQUALIFYING_DELEGATION_CONTEXT_PATTERNS = [
+  /\bdelegat(?:e|es|ed|ing)\b/,
+  /\bdelegations?\b(?!\s+center\b)/
 ] as const;
 
 const GENESIS_SET_PATTERNS = [/\bgenesis sets?\b/] as const;
@@ -561,31 +562,26 @@ function hasCountedMultiWalletTarget(normalizedQuestion: string): boolean {
   return false;
 }
 
-function hasDisqualifyingWalletContext(
-  normalizedQuestion: string,
-  hasConsolidationContext: boolean
-): boolean {
+function hasMultiWalletTarget(normalizedQuestion: string): boolean {
   return (
-    !hasConsolidationContext &&
-    (matchesAny(normalizedQuestion, DELEGATION_CONTEXT_PATTERNS) ||
-      matchesAny(normalizedQuestion, EXTERNAL_WALLET_CONTEXT_PATTERNS))
+    matchesAny(normalizedQuestion, MULTI_WALLET_SETUP_TARGET_PATTERNS) ||
+    hasCountedMultiWalletTarget(normalizedQuestion)
+  );
+}
+
+function hasDisqualifyingWalletContext(normalizedQuestion: string): boolean {
+  return (
+    matchesAny(normalizedQuestion, DISQUALIFYING_DELEGATION_CONTEXT_PATTERNS) ||
+    matchesAny(normalizedQuestion, EXTERNAL_WALLET_CONTEXT_PATTERNS)
   );
 }
 
 export function isMultiWalletSetupQuestion(question: string): boolean {
   const normalizedQuestion = normalizeText(question);
-  const hasConsolidationContext = matchesAny(
-    normalizedQuestion,
-    CONSOLIDATION_CONTEXT_PATTERNS
-  );
   return (
-    !hasDisqualifyingWalletContext(
-      normalizedQuestion,
-      hasConsolidationContext
-    ) &&
+    !hasDisqualifyingWalletContext(normalizedQuestion) &&
     matchesAny(normalizedQuestion, MULTI_WALLET_SETUP_ACTION_PATTERNS) &&
-    (matchesAny(normalizedQuestion, MULTI_WALLET_SETUP_TARGET_PATTERNS) ||
-      hasCountedMultiWalletTarget(normalizedQuestion))
+    hasMultiWalletTarget(normalizedQuestion)
   );
 }
 
@@ -605,10 +601,7 @@ export function isMultiWalletLimitQuestion(question: string): boolean {
     matchesAny(normalizedQuestion, CONSOLIDATION_COUNT_RELATION_PATTERNS);
   return (
     matchesAny(normalizedQuestion, WALLET_CONTEXT_PATTERNS) &&
-    !hasDisqualifyingWalletContext(
-      normalizedQuestion,
-      hasConsolidationContext
-    ) &&
+    !hasDisqualifyingWalletContext(normalizedQuestion) &&
     (matchesAny(
       normalizedQuestion,
       STRONG_CONSOLIDATION_LIMIT_CONTEXT_PATTERNS
@@ -626,7 +619,8 @@ export function isMultiWalletRemovalQuestion(question: string): boolean {
   return (
     matchesAny(normalizedQuestion, WALLET_CONTEXT_PATTERNS) &&
     matchesAny(normalizedQuestion, MULTI_WALLET_REMOVAL_ACTION_PATTERNS) &&
-    !hasDisqualifyingWalletContext(normalizedQuestion, hasConsolidationContext)
+    (hasConsolidationContext || hasMultiWalletTarget(normalizedQuestion)) &&
+    !hasDisqualifyingWalletContext(normalizedQuestion)
   );
 }
 
@@ -638,16 +632,24 @@ export function isMultiWalletReplacementQuestion(question: string): boolean {
   );
   return (
     matchesAny(normalizedQuestion, WALLET_CONTEXT_PATTERNS) &&
-    (matchesAny(
-      normalizedQuestion,
-      STRONG_MULTI_WALLET_REPLACEMENT_ACTION_PATTERNS
-    ) ||
-      (hasConsolidationContext &&
-        matchesAny(
-          normalizedQuestion,
-          MULTI_WALLET_REPLACEMENT_ACTION_PATTERNS
-        ))) &&
-    !hasDisqualifyingWalletContext(normalizedQuestion, hasConsolidationContext)
+    matchesAny(normalizedQuestion, MULTI_WALLET_REPLACEMENT_ACTION_PATTERNS) &&
+    (hasConsolidationContext || hasMultiWalletTarget(normalizedQuestion)) &&
+    !hasDisqualifyingWalletContext(normalizedQuestion)
+  );
+}
+
+export function isAmbiguousWalletManagementQuestion(question: string): boolean {
+  const normalizedQuestion = normalizeText(question);
+  const hasManagementAction =
+    matchesAny(normalizedQuestion, MULTI_WALLET_REMOVAL_ACTION_PATTERNS) ||
+    matchesAny(normalizedQuestion, MULTI_WALLET_REPLACEMENT_ACTION_PATTERNS);
+  return (
+    hasManagementAction &&
+    matchesAny(normalizedQuestion, WALLET_CONTEXT_PATTERNS) &&
+    !matchesAny(normalizedQuestion, CONSOLIDATION_CONTEXT_PATTERNS) &&
+    !hasMultiWalletTarget(normalizedQuestion) &&
+    !hasDisqualifyingWalletContext(normalizedQuestion) &&
+    !/\bprofiles?\b/.test(normalizedQuestion)
   );
 }
 
@@ -707,6 +709,7 @@ interface RoutedQuestionContext {
   readonly hasMultiWalletLimitContext: boolean;
   readonly hasMultiWalletRemovalContext: boolean;
   readonly hasMultiWalletReplacementContext: boolean;
+  readonly hasAmbiguousWalletManagementContext: boolean;
   readonly hasConsolidationLimitContext: boolean;
   readonly hasDelegationContext: boolean;
   readonly hasWalletCheckContext: boolean;
@@ -737,6 +740,8 @@ function routedQuestionContext(
       isMultiWalletRemovalQuestion(normalizedQuestion),
     hasMultiWalletReplacementContext:
       isMultiWalletReplacementQuestion(normalizedQuestion),
+    hasAmbiguousWalletManagementContext:
+      isAmbiguousWalletManagementQuestion(normalizedQuestion),
     hasConsolidationLimitContext: matchesAny(
       normalizedQuestion,
       CONSOLIDATION_LIMIT_CONTEXT_PATTERNS
@@ -820,6 +825,27 @@ function addConsolidationManagementScores(
     addRoutedPathScore(scores, MANAGE_REVOKE_DOC_PATH, 6);
     addRoutedPathScore(scores, REGISTER_CONSOLIDATION_DOC_PATH, 5);
   }
+  if (context.hasAmbiguousWalletManagementContext) {
+    addRoutedIdScore(scores, WALLET_MANAGEMENT_CLARIFICATION_ID, 18);
+  }
+}
+
+function applyConsolidationRoutingExclusions(
+  scores: Map<string, number>,
+  context: RoutedQuestionContext
+): void {
+  if (!hasDisqualifyingWalletContext(context.normalizedQuestion)) {
+    return;
+  }
+
+  [
+    CONSOLIDATION_USE_CASES_PATH,
+    REGISTER_CONSOLIDATION_PATH,
+    REGISTER_CONSOLIDATION_DOC_PATH,
+    MANAGE_REVOKE_DOC_PATH,
+    MANAGE_UPDATE_DOC_PATH
+  ].forEach((path) => scores.set(routedPathKey(path), -100));
+  scores.set(routedIdKey(WALLET_MANAGEMENT_CLARIFICATION_ID), -100);
 }
 
 function addConsolidationScores(
@@ -914,6 +940,7 @@ function routedRecordScores(
   addNetworkDefinitionScores(scores, context);
   addTdhDefinitionScores(scores, context);
   addStreamReviewScores(scores, context);
+  applyConsolidationRoutingExclusions(scores, context);
 
   return scores;
 }

--- a/src/help-bot/help-bot.knowledge.ts
+++ b/src/help-bot/help-bot.knowledge.ts
@@ -59,7 +59,7 @@ const logger = Logger.get('HelpBotKnowledge');
 
 const WALLET_CONTEXT_PATTERNS = [
   /\bwallets?\b/,
-  /\baddresses?\b/,
+  /\baddress(?:es)?\b/,
   /\bvault\b/,
   /\bhot wallet\b/,
   /\bcold wallet\b/,
@@ -98,8 +98,17 @@ const CONSOLIDATION_CONTEXT_PATTERNS = [
   /\bconsolidat(?:e|es|ed|ing|ion|ions)\b/,
   /\bcount(?:ed)? together\b/,
   /\btreat(?:ed)? together\b/,
-  /\bconnect(?:ed|ing)? (?:my )?(?:wallets?|addresses?)\b/,
-  /\bcombine(?:d|s|ing)? (?:my )?(?:wallets?|addresses?)\b/
+  /\bconnect(?:ed|ing)? (?:my )?(?:wallets?|address(?:es)?)\b/,
+  /\bcombine(?:d|s|ing)? (?:my )?(?:wallets?|address(?:es)?)\b/
+] as const;
+
+const MULTI_WALLET_SETUP_CONTEXT_PATTERNS = [
+  /\b(?:add(?:ing)?|attach(?:ing)?|bring(?:ing)?|includ(?:e|ing)|link(?:ing)?|pair(?:ing)?|connect(?:ing)?|associat(?:e|ing)|join(?:ing)?|tie|tying|us(?:e|ing)|have)\s+(?:(?:a|an|my|the)\s+)?(?:second|another|additional|extra|new|one more|other|2nd)\s+(?:wallet|address)\b/,
+  /\b(?:set(?:ting)? up|setup)\s+(?:(?:a|an|my|the)\s+)?(?:second|another|additional|extra|new|one more|other|2nd)\s+(?:wallet|address)\b/,
+  /\b(?:add(?:ing)?|link(?:ing)?|pair(?:ing)?|connect(?:ing)?|combin(?:e|ing)|associat(?:e|ing)|join(?:ing)?)\s+(?:(?:my|the)\s+)?(?:two|2|multiple)\s+(?:wallets?|address(?:es)?)\b/,
+  /\b(?:us(?:e|ing)|have|manag(?:e|ing)|set(?:ting)? up|setup)\s+(?:more than one|multiple|two|2)\s+(?:wallets?|address(?:es)?)\b/,
+  /\b(?:link|connect|pair|associate|tie)\s+(?:my\s+)?(?:wallet|address)\s+(?:to|with)\s+(?:another|a second|an additional|one more|my other)\s+(?:wallet|address)\b/,
+  /\b(?:attach(?:ing)?|includ(?:e|ing)|link(?:ing)?|pair(?:ing)?|associat(?:e|ing)|join(?:ing)?|tie|tying)\s+(?:(?:my|the)\s+)?(?:wallets|addresses)\b/
 ] as const;
 
 const CONSOLIDATION_LIMIT_CONTEXT_PATTERNS = [
@@ -422,6 +431,13 @@ function matchesAny(
   return patterns.some((pattern) => pattern.test(normalizedQuestion));
 }
 
+export function isMultiWalletSetupQuestion(question: string): boolean {
+  return matchesAny(
+    normalizeText(question),
+    MULTI_WALLET_SETUP_CONTEXT_PATTERNS
+  );
+}
+
 function parseWalletCount(rawCount: string): number | null {
   const wordValue = WALLET_COUNT_WORDS.get(rawCount);
   if (wordValue !== undefined) {
@@ -483,6 +499,7 @@ interface RoutedQuestionContext {
   readonly hasArchitectureContext: boolean;
   readonly hasExplicitArchitectureContext: boolean;
   readonly hasConsolidationContext: boolean;
+  readonly hasMultiWalletSetupContext: boolean;
   readonly hasConsolidationLimitContext: boolean;
   readonly hasDelegationContext: boolean;
   readonly hasWalletCheckContext: boolean;
@@ -507,6 +524,7 @@ function routedQuestionContext(
       normalizedQuestion,
       CONSOLIDATION_CONTEXT_PATTERNS
     ),
+    hasMultiWalletSetupContext: isMultiWalletSetupQuestion(normalizedQuestion),
     hasConsolidationLimitContext: matchesAny(
       normalizedQuestion,
       CONSOLIDATION_LIMIT_CONTEXT_PATTERNS
@@ -593,7 +611,7 @@ function addConsolidationScores(
   }
 
   if (
-    context.hasConsolidationContext &&
+    (context.hasConsolidationContext || context.hasMultiWalletSetupContext) &&
     (context.hasWalletContext || context.hasArchitectureContext)
   ) {
     addRoutedPathScore(scores, REGISTER_CONSOLIDATION_DOC_PATH, 16);

--- a/src/help-bot/help-bot.knowledge.ts
+++ b/src/help-bot/help-bot.knowledge.ts
@@ -118,6 +118,39 @@ const MULTI_WALLET_SETUP_ACTION_PATTERNS = [
   /\bsetup\b/
 ] as const;
 
+const MULTI_WALLET_REMOVAL_ACTION_PATTERNS = [
+  /\bremov(?:e[ds]?|ing)\b/,
+  /\bunlink(?:s|ed|ing)?\b/,
+  /\bdetach(?:es|ed|ing)?\b/,
+  /\bdelet(?:e[ds]?|ing)\b/,
+  /\brevok(?:e[ds]?|ing)\b/,
+  /\bcancel(?:s|ed|led|ing|ling)?\b/
+] as const;
+
+const MULTI_WALLET_REPLACEMENT_ACTION_PATTERNS = [
+  /\breplac(?:e[ds]?|ing)\b/,
+  /\bswap(?:s|ped|ping)?\b/,
+  /\bchang(?:e[ds]?|ing)\b/,
+  /\bupdat(?:e[ds]?|ing)\b/
+] as const;
+
+const STRONG_MULTI_WALLET_REPLACEMENT_ACTION_PATTERNS = [
+  /\breplac(?:e[ds]?|ing)\b/,
+  /\bswap(?:s|ped|ping)?\b/
+] as const;
+
+const EXTERNAL_WALLET_CONTEXT_PATTERNS = [
+  /\bhardware wallets?\b/,
+  /\bmetamask\b/,
+  /\bcoinbase wallet\b/,
+  /\brainbow wallet\b/,
+  /\bledger\b/,
+  /\btrezor\b/,
+  /\bwallet apps?\b/,
+  /\bbrowser extensions?\b/,
+  /\bthis device\b/
+] as const;
+
 const EXPLICIT_ADDITIONAL_WALLET_TARGET_PATTERNS = [
   /\bsecond wallet\b/,
   /\bsecond address\b/,
@@ -143,7 +176,9 @@ const QUANTIFIED_MULTI_WALLET_TARGET_PATTERNS = [
   /\b2 wallets?\b/,
   /\b2 address(?:es)?\b/,
   /\bmultiple wallets?\b/,
-  /\bmultiple address(?:es)?\b/
+  /\bmultiple address(?:es)?\b/,
+  /\b(?:several|many|more|a few) wallets?\b/,
+  /\b(?:several|many|more|a few) address(?:es)?\b/
 ] as const;
 
 const POSSESSIVE_MULTI_WALLET_TARGET_PATTERNS = [
@@ -173,6 +208,25 @@ const CONSOLIDATION_LIMIT_CONTEXT_PATTERNS = [
   /\bcan be in\b/
 ] as const;
 
+const STRONG_CONSOLIDATION_LIMIT_CONTEXT_PATTERNS = [
+  /\bmaximum\b/,
+  /\bmax\b/,
+  /\blimit\b/,
+  /\blimits\b/,
+  /\bcapacity\b/,
+  /\bgroup size\b/
+] as const;
+
+const CONSOLIDATION_COUNT_RELATION_PATTERNS = [
+  /\ballow(?:ed|s|ing)?\b/,
+  /\bsupport(?:ed|s|ing)?\b/,
+  /\bcount(?:ed|s|ing)?\b/,
+  /\brecogniz(?:e|ed|es|ing)\b/,
+  /\bgroup(?:ed|s|ing)?\b/,
+  /\btreat(?:ed|s|ing)?\b/,
+  /\btogether\b/
+] as const;
+
 const WALLET_CHECK_CONTEXT_PATTERNS = [
   /\bcheck\b/,
   /\bview\b/,
@@ -189,6 +243,8 @@ const CONSOLIDATION_USE_CASES_PATH = '/delegation/consolidation-use-cases';
 const REGISTER_CONSOLIDATION_PATH = '/delegation/register-consolidation';
 const REGISTER_CONSOLIDATION_DOC_PATH =
   '/delegation/delegation-faq/register-consolidation';
+const MANAGE_REVOKE_DOC_PATH = '/delegation/delegation-faq/manage-revoke';
+const MANAGE_UPDATE_DOC_PATH = '/delegation/delegation-faq/manage-update';
 const WALLET_ARCHITECTURE_ID = 'delegation.wallet-architecture';
 const WALLET_CHECKER_ID = 'delegation.wallet-checker';
 const NETWORK_DEFINITIONS_ID = 'network.definitions';
@@ -481,45 +537,6 @@ function matchesAny(
   return patterns.some((pattern) => pattern.test(normalizedQuestion));
 }
 
-export function isMultiWalletSetupQuestion(question: string): boolean {
-  const normalizedQuestion = normalizeText(question);
-  const hasDelegationContext = matchesAny(
-    normalizedQuestion,
-    DELEGATION_CONTEXT_PATTERNS
-  );
-  const hasConsolidationContext = matchesAny(
-    normalizedQuestion,
-    CONSOLIDATION_CONTEXT_PATTERNS
-  );
-  return (
-    (!hasDelegationContext || hasConsolidationContext) &&
-    matchesAny(normalizedQuestion, MULTI_WALLET_SETUP_ACTION_PATTERNS) &&
-    matchesAny(normalizedQuestion, MULTI_WALLET_SETUP_TARGET_PATTERNS)
-  );
-}
-
-export function isMultiWalletLimitQuestion(question: string): boolean {
-  const normalizedQuestion = normalizeText(question);
-  const hasStandaloneHardwareWalletContext =
-    /\bhardware wallets?\b/.test(normalizedQuestion);
-  const hasDelegationContext = matchesAny(
-    normalizedQuestion,
-    DELEGATION_CONTEXT_PATTERNS
-  );
-  const hasConsolidationContext = matchesAny(
-    normalizedQuestion,
-    CONSOLIDATION_CONTEXT_PATTERNS
-  );
-  return (
-    matchesAny(normalizedQuestion, WALLET_CONTEXT_PATTERNS) &&
-    matchesAny(normalizedQuestion, CONSOLIDATION_LIMIT_CONTEXT_PATTERNS) &&
-    (hasConsolidationContext ||
-      matchesAny(normalizedQuestion, MULTI_WALLET_SETUP_ACTION_PATTERNS)) &&
-    (!hasDelegationContext || hasConsolidationContext) &&
-    (!hasStandaloneHardwareWalletContext || hasConsolidationContext)
-  );
-}
-
 function parseWalletCount(rawCount: string): number | null {
   const wordValue = WALLET_COUNT_WORDS.get(rawCount);
   if (wordValue !== undefined) {
@@ -527,6 +544,117 @@ function parseWalletCount(rawCount: string): number | null {
   }
   const parsed = Number.parseInt(rawCount, 10);
   return Number.isFinite(parsed) ? parsed : null;
+}
+
+function hasCountedMultiWalletTarget(normalizedQuestion: string): boolean {
+  WALLET_COUNT_PATTERN.lastIndex = 0;
+  for (
+    let match = WALLET_COUNT_PATTERN.exec(normalizedQuestion);
+    match;
+    match = WALLET_COUNT_PATTERN.exec(normalizedQuestion)
+  ) {
+    const rawCount = match[1];
+    if (rawCount && (parseWalletCount(rawCount) ?? 0) >= 2) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function hasDisqualifyingWalletContext(
+  normalizedQuestion: string,
+  hasConsolidationContext: boolean
+): boolean {
+  return (
+    !hasConsolidationContext &&
+    (matchesAny(normalizedQuestion, DELEGATION_CONTEXT_PATTERNS) ||
+      matchesAny(normalizedQuestion, EXTERNAL_WALLET_CONTEXT_PATTERNS))
+  );
+}
+
+export function isMultiWalletSetupQuestion(question: string): boolean {
+  const normalizedQuestion = normalizeText(question);
+  const hasConsolidationContext = matchesAny(
+    normalizedQuestion,
+    CONSOLIDATION_CONTEXT_PATTERNS
+  );
+  return (
+    !hasDisqualifyingWalletContext(
+      normalizedQuestion,
+      hasConsolidationContext
+    ) &&
+    matchesAny(normalizedQuestion, MULTI_WALLET_SETUP_ACTION_PATTERNS) &&
+    (matchesAny(normalizedQuestion, MULTI_WALLET_SETUP_TARGET_PATTERNS) ||
+      hasCountedMultiWalletTarget(normalizedQuestion))
+  );
+}
+
+export function isMultiWalletLimitQuestion(question: string): boolean {
+  const normalizedQuestion = normalizeText(question);
+  const hasConsolidationContext = matchesAny(
+    normalizedQuestion,
+    CONSOLIDATION_CONTEXT_PATTERNS
+  );
+  const hasLimitContext = matchesAny(
+    normalizedQuestion,
+    CONSOLIDATION_LIMIT_CONTEXT_PATTERNS
+  );
+  const hasLimitRelation =
+    hasConsolidationContext ||
+    matchesAny(normalizedQuestion, MULTI_WALLET_SETUP_ACTION_PATTERNS) ||
+    matchesAny(normalizedQuestion, CONSOLIDATION_COUNT_RELATION_PATTERNS);
+  return (
+    matchesAny(normalizedQuestion, WALLET_CONTEXT_PATTERNS) &&
+    !hasDisqualifyingWalletContext(
+      normalizedQuestion,
+      hasConsolidationContext
+    ) &&
+    (matchesAny(
+      normalizedQuestion,
+      STRONG_CONSOLIDATION_LIMIT_CONTEXT_PATTERNS
+    ) ||
+      (hasLimitContext && hasLimitRelation))
+  );
+}
+
+export function isMultiWalletRemovalQuestion(question: string): boolean {
+  const normalizedQuestion = normalizeText(question);
+  const hasConsolidationContext = matchesAny(
+    normalizedQuestion,
+    CONSOLIDATION_CONTEXT_PATTERNS
+  );
+  return (
+    matchesAny(normalizedQuestion, WALLET_CONTEXT_PATTERNS) &&
+    matchesAny(normalizedQuestion, MULTI_WALLET_REMOVAL_ACTION_PATTERNS) &&
+    !hasDisqualifyingWalletContext(
+      normalizedQuestion,
+      hasConsolidationContext
+    )
+  );
+}
+
+export function isMultiWalletReplacementQuestion(question: string): boolean {
+  const normalizedQuestion = normalizeText(question);
+  const hasConsolidationContext = matchesAny(
+    normalizedQuestion,
+    CONSOLIDATION_CONTEXT_PATTERNS
+  );
+  return (
+    matchesAny(normalizedQuestion, WALLET_CONTEXT_PATTERNS) &&
+    (matchesAny(
+      normalizedQuestion,
+      STRONG_MULTI_WALLET_REPLACEMENT_ACTION_PATTERNS
+    ) ||
+      (hasConsolidationContext &&
+        matchesAny(
+          normalizedQuestion,
+          MULTI_WALLET_REPLACEMENT_ACTION_PATTERNS
+        ))) &&
+    !hasDisqualifyingWalletContext(
+      normalizedQuestion,
+      hasConsolidationContext
+    )
+  );
 }
 
 function requestedOverLimitWalletCount(
@@ -583,6 +711,8 @@ interface RoutedQuestionContext {
   readonly hasConsolidationContext: boolean;
   readonly hasMultiWalletSetupContext: boolean;
   readonly hasMultiWalletLimitContext: boolean;
+  readonly hasMultiWalletRemovalContext: boolean;
+  readonly hasMultiWalletReplacementContext: boolean;
   readonly hasConsolidationLimitContext: boolean;
   readonly hasDelegationContext: boolean;
   readonly hasWalletCheckContext: boolean;
@@ -609,6 +739,10 @@ function routedQuestionContext(
     ),
     hasMultiWalletSetupContext: isMultiWalletSetupQuestion(normalizedQuestion),
     hasMultiWalletLimitContext: isMultiWalletLimitQuestion(normalizedQuestion),
+    hasMultiWalletRemovalContext:
+      isMultiWalletRemovalQuestion(normalizedQuestion),
+    hasMultiWalletReplacementContext:
+      isMultiWalletReplacementQuestion(normalizedQuestion),
     hasConsolidationLimitContext: matchesAny(
       normalizedQuestion,
       CONSOLIDATION_LIMIT_CONTEXT_PATTERNS
@@ -675,6 +809,22 @@ function addWalletCheckerScores(
   ) {
     addRoutedIdScore(scores, WALLET_CHECKER_ID, 10);
     addRoutedPathScore(scores, WALLET_CHECKER_PATH, 7);
+  }
+}
+
+function addConsolidationManagementScores(
+  scores: Map<string, number>,
+  context: RoutedQuestionContext
+): void {
+  if (context.hasMultiWalletRemovalContext) {
+    addRoutedPathScore(scores, MANAGE_REVOKE_DOC_PATH, 18);
+    addRoutedPathScore(scores, REGISTER_CONSOLIDATION_DOC_PATH, 5);
+    addRoutedIdScore(scores, WALLET_CHECKER_ID, 4);
+  }
+  if (context.hasMultiWalletReplacementContext) {
+    addRoutedPathScore(scores, MANAGE_UPDATE_DOC_PATH, 18);
+    addRoutedPathScore(scores, MANAGE_REVOKE_DOC_PATH, 6);
+    addRoutedPathScore(scores, REGISTER_CONSOLIDATION_DOC_PATH, 5);
   }
 }
 
@@ -765,6 +915,7 @@ function routedRecordScores(
   addOverLimitWalletScores(scores, context);
   addArchitectureScores(scores, context);
   addWalletCheckerScores(scores, context);
+  addConsolidationManagementScores(scores, context);
   addConsolidationScores(scores, context);
   addNetworkDefinitionScores(scores, context);
   addTdhDefinitionScores(scores, context);


### PR DESCRIPTION
## Issue

- Natural multi-wallet questions such as adding, linking, pairing, or using another wallet could fail retrieval unless users explicitly said "consolidation" or "delegation."

## Fix

- Add semantic multi-wallet setup detection that requires wallet/address context and a clear multi-wallet action or quantity.
- Route matched wording to the existing consolidation guide, form, use cases, and wallet architecture records.
- Treat unresolved natural multi-wallet wording as a 6529 product question instead of out-of-scope.

## Changes

- Recognize additional-wallet, quantified-wallet, wallet-to-wallet linking, and plural-wallet action wording.
- Preserve generic single-wallet connection questions outside consolidation routing.
- Correct singular `address` matching in existing wallet/consolidation context patterns.
- Add positive coverage across eight phrasings and negative coverage for unrelated addition/connection wording.
- Document the runtime coverage boundary.
- Related corpus update: [frontend PR #3691](https://github.com/6529-Collections/6529seize-frontend/pull/3691).

## Validation

- `./bin/6529 run test -- --runInBand src/help-bot/help-bot-knowledge.test.ts src/help-bot/help-bot-answerer.test.ts` — 84 tests passed.
- `./bin/6529 run lint` — passed.
- A root `tsc --noEmit` check was attempted, but the root-only install lacks independently packaged `api-serverless` dependencies; its diagnostics were unrelated to the HelpBot files. The focused Jest compilation and full lint passed.

## Risk

- Level: Low
- Why: Changes are limited to HelpBot retrieval/classification and retain explicit negative cases against generic wallet questions.
- Rollback: Revert this PR to restore the prior alias/keyword-only behavior.

## Deployment

- `helpBotReplyLoop` only.

## Review Notes

- Focus on the multi-wallet intent boundary: varied multi-wallet wording should route to consolidation, while generic hardware-wallet connection wording must not.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HelpBot now recognizes natural-language questions about setting up, limiting, removing, unlinking, replacing, or swapping multiple wallets.
  * Relevant wallet-management questions are routed to appropriate guidance, while unrelated wallet contexts continue using existing behavior.
  * Address matching now supports singular and plural forms more reliably.

* **Bug Fixes**
  * Improved routing for wallet consolidation and management questions.

* **Documentation**
  * Added release documentation covering multi-wallet routing behavior and deployment status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->