### PR TITLE
Fix frontend release note baselines for custom run names

### DIFF
--- a/src/release-notes/release-note-github.service.test.ts
+++ b/src/release-notes/release-note-github.service.test.ts
@@ -34,6 +34,7 @@ const currentRun = {
   name: 'Web Deploy - PROD',
   display_title: 'Web Deploy - PROD',
   path: '.github/workflows/build-upload-deploy-prod.yml',
+  head_branch: 'main',
   head_sha: 'abc123',
   run_number: 45,
   workflow_id: 7
@@ -248,6 +249,7 @@ describe('ReleaseNoteGitHubService', () => {
               display_title:
                 'Production deploy previous-sha [frontend-prod-122]',
               path: '.github/workflows/build-upload-deploy-prod.yml',
+              head_branch: 'main',
               head_sha: 'previous-sha',
               run_number: 44,
               workflow_id: 7
@@ -274,6 +276,51 @@ describe('ReleaseNoteGitHubService', () => {
     );
   });
 
+  it('rejects a frontend release from another current workflow path', async () => {
+    (fetch as unknown as jest.Mock).mockResolvedValueOnce(
+      response({
+        ...currentRun,
+        path: '.github/workflows/deploy-staging.yml'
+      })
+    );
+
+    await expect(
+      new ReleaseNoteGitHubService().getReleaseContext(request)
+    ).rejects.toThrow(
+      'GitHub release run 123 does not match the queued release metadata'
+    );
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a frontend release without a current workflow path', async () => {
+    (fetch as unknown as jest.Mock).mockResolvedValueOnce(
+      response({ ...currentRun, path: undefined })
+    );
+
+    await expect(
+      new ReleaseNoteGitHubService().getReleaseContext(request)
+    ).rejects.toThrow(
+      'GitHub release run 123 does not match the queued release metadata'
+    );
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a frontend release from another current branch', async () => {
+    (fetch as unknown as jest.Mock).mockResolvedValueOnce(
+      response({
+        ...currentRun,
+        head_branch: '1a-staging'
+      })
+    );
+
+    await expect(
+      new ReleaseNoteGitHubService().getReleaseContext(request)
+    ).rejects.toThrow(
+      'GitHub release run 123 does not match the queued release metadata'
+    );
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
   it('does not use a custom-named run from another workflow path', async () => {
     (fetch as unknown as jest.Mock)
       .mockResolvedValueOnce(response(currentRun))
@@ -286,6 +333,64 @@ describe('ReleaseNoteGitHubService', () => {
               display_title:
                 'Production deploy previous-sha [frontend-prod-122]',
               path: '.github/workflows/deploy-staging.yml',
+              head_branch: 'main',
+              head_sha: 'previous-sha',
+              run_number: 44,
+              workflow_id: 7
+            }
+          ]
+        })
+      );
+
+    const context = await new ReleaseNoteGitHubService().getReleaseContext(
+      request
+    );
+
+    expect(context).toBeNull();
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not use a frontend production run without a workflow path', async () => {
+    (fetch as unknown as jest.Mock)
+      .mockResolvedValueOnce(response(currentRun))
+      .mockResolvedValueOnce(
+        response({
+          workflow_runs: [
+            {
+              id: 122,
+              name: 'Production deploy previous-sha [frontend-prod-122]',
+              display_title:
+                'Production deploy previous-sha [frontend-prod-122]',
+              head_branch: 'main',
+              head_sha: 'previous-sha',
+              run_number: 44,
+              workflow_id: 7
+            }
+          ]
+        })
+      );
+
+    const context = await new ReleaseNoteGitHubService().getReleaseContext(
+      request
+    );
+
+    expect(context).toBeNull();
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not use a frontend production run from another branch', async () => {
+    (fetch as unknown as jest.Mock)
+      .mockResolvedValueOnce(response(currentRun))
+      .mockResolvedValueOnce(
+        response({
+          workflow_runs: [
+            {
+              id: 122,
+              name: 'Production deploy previous-sha [frontend-prod-122]',
+              display_title:
+                'Production deploy previous-sha [frontend-prod-122]',
+              path: '.github/workflows/build-upload-deploy-prod.yml',
+              head_branch: '1a-staging',
               head_sha: 'previous-sha',
               run_number: 44,
               workflow_id: 7

--- a/src/release-notes/release-note-github.service.test.ts
+++ b/src/release-notes/release-note-github.service.test.ts
@@ -33,6 +33,7 @@ const currentRun = {
   id: 123,
   name: 'Web Deploy - PROD',
   display_title: 'Web Deploy - PROD',
+  path: '.github/workflows/build-upload-deploy-prod.yml',
   head_sha: 'abc123',
   run_number: 45,
   workflow_id: 7
@@ -229,16 +230,24 @@ describe('ReleaseNoteGitHubService', () => {
     expect(fetch).toHaveBeenCalledTimes(2);
   });
 
-  it('finds a previous production run when run_number is missing', async () => {
+  it('uses a custom-named frontend production run as the release baseline', async () => {
     (fetch as unknown as jest.Mock)
-      .mockResolvedValueOnce(response(currentRun))
+      .mockResolvedValueOnce(
+        response({
+          ...currentRun,
+          name: 'Production deploy abc123 [frontend-prod-123]',
+          display_title: 'Production deploy abc123 [frontend-prod-123]'
+        })
+      )
       .mockResolvedValueOnce(
         response({
           workflow_runs: [
             {
               id: 122,
-              name: 'Web Deploy - PROD',
-              display_title: 'Web Deploy - PROD',
+              name: 'Production deploy previous-sha [frontend-prod-122]',
+              display_title:
+                'Production deploy previous-sha [frontend-prod-122]',
+              path: '.github/workflows/build-upload-deploy-prod.yml',
               head_sha: 'previous-sha',
               run_number: 44,
               workflow_id: 7
@@ -263,6 +272,34 @@ describe('ReleaseNoteGitHubService', () => {
       'https://api.github.com/repos/6529-Collections/6529seize-frontend/actions/workflows/7/runs?status=success&branch=main&per_page=100&page=1',
       expect.any(Object)
     );
+  });
+
+  it('does not use a custom-named run from another workflow path', async () => {
+    (fetch as unknown as jest.Mock)
+      .mockResolvedValueOnce(response(currentRun))
+      .mockResolvedValueOnce(
+        response({
+          workflow_runs: [
+            {
+              id: 122,
+              name: 'Production deploy previous-sha [frontend-prod-122]',
+              display_title:
+                'Production deploy previous-sha [frontend-prod-122]',
+              path: '.github/workflows/deploy-staging.yml',
+              head_sha: 'previous-sha',
+              run_number: 44,
+              workflow_id: 7
+            }
+          ]
+        })
+      );
+
+    const context = await new ReleaseNoteGitHubService().getReleaseContext(
+      request
+    );
+
+    expect(context).toBeNull();
+    expect(fetch).toHaveBeenCalledTimes(2);
   });
 
   it('uses service-specific backend run names from the deploy workflow', async () => {

--- a/src/release-notes/release-note-github.service.ts
+++ b/src/release-notes/release-note-github.service.ts
@@ -9,6 +9,7 @@ interface GitHubWorkflowRun {
   readonly id: number;
   readonly display_title: string;
   readonly path?: string;
+  readonly head_branch?: string | null;
   readonly head_sha: string;
   readonly run_number: number;
   readonly workflow_id: number;
@@ -192,7 +193,8 @@ function isMatchingProductionRun(
   if (repoName === FRONTEND_REPO) {
     return (
       request.workflow === FRONTEND_PRODUCTION_WORKFLOW &&
-      run.path === FRONTEND_PRODUCTION_WORKFLOW_PATH
+      run.path === FRONTEND_PRODUCTION_WORKFLOW_PATH &&
+      run.head_branch === normalizeBranch(request.branch)
     );
   }
   return false;
@@ -470,7 +472,10 @@ export class ReleaseNoteGitHubService {
     if (
       String(currentRun.id) !== request.run_id ||
       currentRun.head_sha !== request.sha ||
-      !Number.isSafeInteger(currentRun.workflow_id)
+      !Number.isSafeInteger(currentRun.workflow_id) ||
+      !Number.isSafeInteger(currentRun.run_number) ||
+      (getRepoName(request.repo) === FRONTEND_REPO &&
+        !isMatchingProductionRun(currentRun, request))
     ) {
       throw new Error(
         `GitHub release run ${request.run_id} does not match the queued release metadata`

--- a/src/release-notes/release-note-github.service.ts
+++ b/src/release-notes/release-note-github.service.ts
@@ -7,8 +7,8 @@ import { isAllowedReleaseNotesPrompt } from './release-note-prompts.config';
 
 interface GitHubWorkflowRun {
   readonly id: number;
-  readonly name: string;
   readonly display_title: string;
+  readonly path?: string;
   readonly head_sha: string;
   readonly run_number: number;
   readonly workflow_id: number;
@@ -101,6 +101,8 @@ const PAGE_SIZE = 100;
 const BACKEND_REPO = '6529seize-backend';
 const FRONTEND_REPO = '6529seize-frontend';
 const FRONTEND_PRODUCTION_WORKFLOW = 'Web Deploy - PROD';
+const FRONTEND_PRODUCTION_WORKFLOW_PATH =
+  '.github/workflows/build-upload-deploy-prod.yml';
 const MAX_COMMITS = MAX_COMPARE_PAGES * PAGE_SIZE;
 const MAX_PULL_REQUESTS = 100;
 const MAX_PROMPT_LENGTH = 20000;
@@ -190,7 +192,7 @@ function isMatchingProductionRun(
   if (repoName === FRONTEND_REPO) {
     return (
       request.workflow === FRONTEND_PRODUCTION_WORKFLOW &&
-      run.name === FRONTEND_PRODUCTION_WORKFLOW
+      run.path === FRONTEND_PRODUCTION_WORKFLOW_PATH
     );
   }
   return false;

--- a/src/release-notes/release-note-github.service.ts
+++ b/src/release-notes/release-note-github.service.ts
@@ -475,6 +475,7 @@ export class ReleaseNoteGitHubService {
       !Number.isSafeInteger(currentRun.workflow_id) ||
       !Number.isSafeInteger(currentRun.run_number) ||
       (getRepoName(request.repo) === FRONTEND_REPO &&
+        request.workflow === FRONTEND_PRODUCTION_WORKFLOW &&
         !isMatchingProductionRun(currentRun, request))
     ) {
       throw new Error(


### PR DESCRIPTION
## Issue

Frontend production workflow runs now use custom names such as `Production deploy <sha> [...]`. The release-note baseline selector required prior runs to keep the static name `Web Deploy - PROD`, so it skipped successful deploys #1625–#1627 and repeatedly compared new releases against stale deploy #1611. That caused cumulative pull requests to be announced multiple times.

## Fix

Identify previous frontend production runs by the stable workflow file path, while retaining the existing signed request workflow label, exact workflow ID, branch, successful conclusion, SHA exclusion, and run-order constraints.

## Changes

- model the GitHub workflow-run `path` field used by baseline discovery
- bind frontend production baselines to `.github/workflows/build-upload-deploy-prod.yml`
- stop depending on mutable custom run names
- add regression coverage accepting a custom-named production run from the approved path
- add fail-closed coverage rejecting the same custom name from another workflow path

## Validation

- `git diff --check` passed
- focused Jest and ESLint could not run locally because three bounded locked-dependency installation attempts did not produce a usable toolchain; the regression tests are included and hosted PR CI is the execution gate

## Risk

Low. Backend service-specific release-note baseline behavior is unchanged. Frontend matching remains restricted to the signed production workflow label and exact workflow path within the already selected workflow ID.

## Deployment

No deployment performed. After merge, only `releaseNotesGenerationLoop` needs redeployment for the fix to become active.

## Review notes

Please focus on the workflow-path binding and the two custom-run-name regression cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release-note generation by accurately identifying frontend production workflow runs.
  * Added validation for workflow paths, branches, and run numbers to prevent unrelated or incomplete runs from being selected.
  * Support custom production run names while ignoring previous runs with mismatched workflow or branch information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->