### PR TITLE
Align subscription coverage eligibility

### DIFF
--- a/pr-reports/1919.md
+++ b/pr-reports/1919.md
@@ -1,0 +1,63 @@
+# PR Report: Align subscription coverage eligibility
+
+PR: https://github.com/6529-Collections/6529seize-backend/pull/1919
+Branch: `agent-prxt/subscription-coverage-eligibility` -> `main`
+Related PRs: None
+
+## Summary
+
+Subscription coverage now applies the same minimum eligibility of one as the
+operational subscription-details and minting paths, preventing valid profiles
+with zero current-season Meme sets from being reported as having no current
+eligibility.
+
+## What Changed
+
+- Added a shared minimum subscription-eligibility constant and normalization
+  helper.
+- Applied the shared normalization to both operational subscription reads and
+  subscription coverage reads.
+- Defaulted known consolidation keys to eligibility one when their current
+  season row is missing or reports zero sets, while preserving higher set
+  counts.
+- Preserved unavailable coverage data as `null` when no season data exists.
+- Advanced the coverage calculation version so persisted forecasts and
+  fingerprints reflect the corrected eligibility policy.
+- Added focused tests for zero, missing, positive, and invalid set counts.
+
+## Backend Impact
+
+- New services: None
+- Changed services: `api`, `subscriptionsDaily`
+- Planned/deployed services: `api`, then `subscriptionsDaily`; not deployed by
+  request
+- API: Existing subscription coverage responses now use minimum eligibility
+  one instead of returning `NO_CURRENT_ELIGIBILITY` solely because the current
+  Meme set count is zero; no route or response-shape change
+- DB/entities/migrations: None
+- Queues/events/integrations: Existing subscription coverage reconciliation
+  and notification flow only; no contract changes
+- Architecture: No service boundaries, persistence models, or API contracts
+  change
+
+## Config / Env
+
+- No new configuration.
+- For rollout, enable the existing `SUBSCRIPTION_COVERAGE_BASELINE_ONLY` mode
+  for one complete reconciliation sweep before restoring normal alert
+  delivery, because the calculation-version change refreshes coverage
+  fingerprints.
+
+## Backend Deployment
+
+- Deployed API: None
+- Deployed Lambdas/services: None
+- Not deployed: `api`, `subscriptionsDaily`
+- Required deployment order: 1. `api`; 2. `subscriptionsDaily`
+- Deployment order executed: None
+
+## Release Notes
+
+Subscription coverage now agrees with subscription details that every valid
+profile has at least one mint of eligibility, while still honoring additional
+eligibility from Meme sets.

--- a/pr-reports/1919.md
+++ b/pr-reports/1919.md
@@ -17,12 +17,16 @@ eligibility.
   helper.
 - Applied the shared normalization to both operational subscription reads and
   subscription coverage reads.
+- Reused the shared minimum anywhere subscription eligibility needs a fallback;
+  literal one-edition subscription choices remain separate policy.
 - Defaulted known consolidation keys to eligibility one when their current
   season row is missing or reports zero sets, while preserving higher set
   counts.
 - Preserved unavailable coverage data as `null` when no season data exists.
 - Advanced the coverage calculation version so persisted forecasts and
   fingerprints reflect the corrected eligibility policy.
+- Ensured calculation-version-only fingerprint changes are persisted without
+  creating a user notification.
 - Added focused tests for zero, missing, positive, and invalid set counts.
 
 ## Backend Impact

--- a/src/api-serverless/src/subscriptions/api.subscriptions.db.ts
+++ b/src/api-serverless/src/subscriptions/api.subscriptions.db.ts
@@ -40,6 +40,7 @@ import {
   fetchSubscriptionEligibility,
   fetchSubscriptionEligibilityForKeys
 } from '@/subscriptionsDaily/db.subscriptions';
+import { MINIMUM_SUBSCRIPTION_ELIGIBILITY } from '@/subscriptionsDaily/subscription-eligibility';
 import { Time } from '@/time';
 import { markSubscriptionCoverageDirty } from '@/subscription-coverage/subscription-coverage-dirty';
 
@@ -792,7 +793,8 @@ function getAutomaticSubscriptionEffectiveCount(
   autoSubEligibilityMap: Map<string, number>
 ): number {
   const eligibility =
-    autoSubEligibilityMap.get(autoSub.consolidation_key.toLowerCase()) ?? 1;
+    autoSubEligibilityMap.get(autoSub.consolidation_key.toLowerCase()) ??
+    MINIMUM_SUBSCRIPTION_ELIGIBILITY;
   const subscribedCount = autoSub.subscribe_all_editions ? eligibility : 1;
 
   return getEffectiveSubscriptionCount(

--- a/src/api-serverless/src/subscriptions/subscription-coverage-api-mapper.test.ts
+++ b/src/api-serverless/src/subscriptions/subscription-coverage-api-mapper.test.ts
@@ -77,7 +77,7 @@ describe('mapSubscriptionCoverageToApi', () => {
         horizon_start_token_id: 528,
         horizon_end_token_id: 534,
         horizon_drop_count: 7,
-        calculation_version: 1,
+        calculation_version: 2,
         unknown_reason: null
       }
     });

--- a/src/subscription-coverage/subscription-coverage-forecast.test.ts
+++ b/src/subscription-coverage/subscription-coverage-forecast.test.ts
@@ -86,6 +86,7 @@ describe('subscription coverage forecast', () => {
     expect(result.fundedThrough?.tokenId).toBe(FIRST_TOKEN_ID + 6);
     expect(result.nextUnfunded?.tokenId).toBe(FIRST_TOKEN_ID + 7);
     expect(result.recommendedTopUp).toBeNull();
+    expect(result.forecast.calculationVersion).toBe(2);
   });
 
   it('treats a partially funded immediate xN drop as critical', () => {

--- a/src/subscription-coverage/subscription-coverage-policy.ts
+++ b/src/subscription-coverage/subscription-coverage-policy.ts
@@ -1,6 +1,6 @@
 import { SubscriptionCoverageStatus } from './subscription-coverage.types';
 
-export const SUBSCRIPTION_COVERAGE_CALCULATION_VERSION = 1;
+export const SUBSCRIPTION_COVERAGE_CALCULATION_VERSION = 2;
 
 export const SUBSCRIPTION_COVERAGE_POLICY = Object.freeze({
   coveredMinimumDrops: 7,

--- a/src/subscription-coverage/subscription-coverage-reconciliation.service.test.ts
+++ b/src/subscription-coverage/subscription-coverage-reconciliation.service.test.ts
@@ -133,7 +133,7 @@ describe('SubscriptionCoverageReconciliationService reads', () => {
     expect(forecast.nextUnfunded).toBeNull();
   });
 
-  it('skips row transactions for a materially unchanged full-scan snapshot', async () => {
+  it('skips exact snapshots but persists fingerprint-only changes without notification', async () => {
     const source: SubscriptionCoverageSourceData = {
       consolidationKey: 'profile-key',
       hasDemonstratedIntent: true,
@@ -145,7 +145,13 @@ describe('SubscriptionCoverageReconciliationService reads', () => {
       eligibilityCount: 1,
       selections: []
     };
-    const applyAlertSnapshot = jest.fn();
+    let currentFingerprint = '';
+    const applyAlertSnapshot = jest.fn(async () => ({
+      notificationIds: [],
+      notificationStatus: null,
+      decisionReason: 'UNCHANGED' as const,
+      createdBaseline: false
+    }));
     const repository = {
       listDemonstratedIntentKeys: jest.fn(async () => ['profile-key']),
       loadSourceData: jest.fn(async () => new Map([['profile-key', source]])),
@@ -157,7 +163,7 @@ describe('SubscriptionCoverageReconciliationService reads', () => {
               'profile-key',
               {
                 current_status: 'ACTION_REQUIRED',
-                current_fingerprint: 'older-balance-fingerprint',
+                current_fingerprint: currentFingerprint,
                 current_at_risk_token_id: 528,
                 current_fully_funded_drops: 0,
                 current_requested_mints: 1,
@@ -193,16 +199,23 @@ describe('SubscriptionCoverageReconciliationService reads', () => {
       scheduleProvider,
       () => Date.parse('2026-07-26T22:00:00.000Z')
     );
+    const forecast = await service.calculateCoverage('profile-key');
+    currentFingerprint = forecast.fingerprint;
 
-    const result = await service.reconcileFullPage(undefined, 100, {
+    const options = {
       dryRun: false,
       notificationsEnabled: true,
       baselineOnly: false,
       notifyInitialCritical: false,
       pushEnabled: true
-    });
+    };
+    const unchangedResult = await service.reconcileFullPage(
+      undefined,
+      100,
+      options
+    );
 
-    expect(result).toMatchObject({
+    expect(unchangedResult).toMatchObject({
       scanned: 1,
       succeeded: 1,
       failed: 0,
@@ -211,6 +224,26 @@ describe('SubscriptionCoverageReconciliationService reads', () => {
       pushesQueued: 0
     });
     expect(applyAlertSnapshot).not.toHaveBeenCalled();
+
+    currentFingerprint = 'version-1-fingerprint';
+    const fingerprintChangeResult = await service.reconcileFullPage(
+      undefined,
+      100,
+      options
+    );
+
+    expect(fingerprintChangeResult).toMatchObject({
+      scanned: 1,
+      succeeded: 1,
+      failed: 0,
+      deduplicatedOrSuppressed: 1,
+      notificationsCreated: 0,
+      pushesQueued: 0
+    });
+    expect(applyAlertSnapshot).toHaveBeenCalledWith(
+      expect.objectContaining({ fingerprint: forecast.fingerprint }),
+      expect.objectContaining({ notificationsEnabled: true })
+    );
     expect(mockSendIdentityPushNotifications).not.toHaveBeenCalled();
   });
 

--- a/src/subscription-coverage/subscription-coverage-reconciliation.service.ts
+++ b/src/subscription-coverage/subscription-coverage-reconciliation.service.ts
@@ -212,6 +212,7 @@ function materiallyMatchesStoredState(
 ): boolean {
   return (
     state.current_status === snapshot.status &&
+    state.current_fingerprint === snapshot.fingerprint &&
     state.current_at_risk_token_id === snapshot.atRiskTokenId &&
     state.current_fully_funded_drops === snapshot.fullyFundedDrops &&
     state.current_requested_mints === snapshot.requestedMints &&

--- a/src/subscription-coverage/subscription-coverage.repository.test.ts
+++ b/src/subscription-coverage/subscription-coverage.repository.test.ts
@@ -4,7 +4,12 @@ import {
   SubscriptionCoverageRepository
 } from './subscription-coverage.repository';
 
-function createExecutor() {
+function createExecutor(
+  eligibilityRows: ReadonlyArray<{
+    readonly consolidation_key: string;
+    readonly sets: number;
+  }> = []
+) {
   const execute = jest.fn(async (sql: string) => {
     if (sql.includes('CAST(balance AS CHAR)')) {
       return [
@@ -44,7 +49,7 @@ function createExecutor() {
       ];
     }
     if (sql.includes('FROM owners_balances_memes_consolidation')) {
-      return [];
+      return eligibilityRows;
     }
     return [];
   });
@@ -60,7 +65,7 @@ function createExecutor() {
 }
 
 describe('SubscriptionCoverageRepository source loading', () => {
-  it('uses exact balance text, normalized intent evidence, and zero eligibility', async () => {
+  it('uses exact balance text, normalized intent evidence, and minimum eligibility', async () => {
     const { executor, execute } = createExecutor();
     const repository = new SubscriptionCoverageRepository(() => executor);
 
@@ -74,7 +79,7 @@ describe('SubscriptionCoverageRepository source loading', () => {
         automatic: true,
         subscribeAllEditions: true
       },
-      eligibilityCount: 0,
+      eligibilityCount: 1,
       selections: [
         {
           tokenId: 528,
@@ -92,6 +97,24 @@ describe('SubscriptionCoverageRepository source loading', () => {
     expect(sql).toContain('token_id >= :firstFutureTokenId');
     expect(sql).not.toContain('token_id IN (:tokenIds)');
     expect(sql).not.toContain('subscriptions_logs');
+  });
+
+  it('normalizes zero-set and positive-set coverage eligibility', async () => {
+    const { executor } = createExecutor([
+      { consolidation_key: 'zero-sets', sets: 0 },
+      { consolidation_key: 'multiple-sets', sets: 3 }
+    ]);
+    const repository = new SubscriptionCoverageRepository(() => executor);
+
+    const result = await repository.loadSourceData(
+      ['ZERO-SETS', 'MULTIPLE-SETS', 'MISSING-ROW'],
+      [528],
+      {}
+    );
+
+    expect(result.get('zero-sets')?.eligibilityCount).toBe(1);
+    expect(result.get('multiple-sets')?.eligibilityCount).toBe(3);
+    expect(result.get('missing-row')?.eligibilityCount).toBe(1);
   });
 
   it('routes only a single canonical profile row', async () => {

--- a/src/subscription-coverage/subscription-coverage.repository.test.ts
+++ b/src/subscription-coverage/subscription-coverage.repository.test.ts
@@ -7,7 +7,7 @@ import {
 function createExecutor(
   eligibilityRows: ReadonlyArray<{
     readonly consolidation_key: string;
-    readonly sets: number;
+    readonly sets: number | string;
   }> = []
 ) {
   const execute = jest.fn(async (sql: string) => {
@@ -102,7 +102,7 @@ describe('SubscriptionCoverageRepository source loading', () => {
   it('normalizes zero-set and positive-set coverage eligibility', async () => {
     const { executor } = createExecutor([
       { consolidation_key: 'zero-sets', sets: 0 },
-      { consolidation_key: 'multiple-sets', sets: 3 }
+      { consolidation_key: 'multiple-sets', sets: '3' }
     ]);
     const repository = new SubscriptionCoverageRepository(() => executor);
 

--- a/src/subscription-coverage/subscription-coverage.repository.ts
+++ b/src/subscription-coverage/subscription-coverage.repository.ts
@@ -28,6 +28,10 @@ import {
   LazyDbAccessCompatibleService,
   SqlExecutor
 } from '@/sql-executor';
+import {
+  MINIMUM_SUBSCRIPTION_ELIGIBILITY,
+  normalizeSubscriptionEligibility
+} from '@/subscriptionsDaily/subscription-eligibility';
 import { Time } from '@/time';
 import {
   decideSubscriptionCoverageAlert,
@@ -1011,7 +1015,7 @@ export class SubscriptionCoverageRepository extends LazyDbAccessCompatibleServic
     ctx: RequestContext
   ): Promise<Map<string, number | null>> {
     const eligibility = new Map<string, number | null>(
-      keys.map((key) => [key, 0])
+      keys.map((key) => [key, MINIMUM_SUBSCRIPTION_ELIGIBILITY])
     );
     const season = await this.db.oneOrNull<{ max_id: number | string | null }>(
       `SELECT MAX(id) AS max_id FROM ${MEMES_SEASONS_TABLE}`,
@@ -1037,7 +1041,7 @@ export class SubscriptionCoverageRepository extends LazyDbAccessCompatibleServic
     for (const row of rows) {
       eligibility.set(
         row.consolidation_key.toLowerCase(),
-        toSafeNonNegativeInteger(row.sets)
+        normalizeSubscriptionEligibility(toSafeNonNegativeInteger(row.sets))
       );
     }
     return eligibility;

--- a/src/subscription-coverage/subscription-coverage.repository.ts
+++ b/src/subscription-coverage/subscription-coverage.repository.ts
@@ -1041,7 +1041,7 @@ export class SubscriptionCoverageRepository extends LazyDbAccessCompatibleServic
     for (const row of rows) {
       eligibility.set(
         row.consolidation_key.toLowerCase(),
-        normalizeSubscriptionEligibility(toSafeNonNegativeInteger(row.sets))
+        normalizeSubscriptionEligibility(row.sets)
       );
     }
     return eligibility;

--- a/src/subscriptionsDaily/db.subscriptions.ts
+++ b/src/subscriptionsDaily/db.subscriptions.ts
@@ -13,6 +13,10 @@ import {
 } from '../entities/ISubscription';
 import { insertWithoutUpdate } from '../orm_helpers';
 import { sqlExecutor } from '../sql-executor';
+import {
+  MINIMUM_SUBSCRIPTION_ELIGIBILITY,
+  normalizeSubscriptionEligibility
+} from './subscription-eligibility';
 
 export async function fetchAllAutoSubscriptions() {
   return await getDataSource()
@@ -101,7 +105,10 @@ export async function fetchSubscriptionEligibility(
   const eligibility = await fetchSubscriptionEligibilityForKeys([
     consolidationKey
   ]);
-  return eligibility.get(consolidationKey.toLowerCase()) ?? 1;
+  return (
+    eligibility.get(consolidationKey.toLowerCase()) ??
+    MINIMUM_SUBSCRIPTION_ELIGIBILITY
+  );
 }
 
 const ELIGIBILITY_KEYS_CHUNK_SIZE = 5000;
@@ -117,7 +124,7 @@ export async function fetchSubscriptionEligibilityForKeys(
   const eligibility = new Map<string, number>();
   consolidationKeys.forEach((key) => {
     if (key) {
-      eligibility.set(key.toLowerCase(), 1);
+      eligibility.set(key.toLowerCase(), MINIMUM_SUBSCRIPTION_ELIGIBILITY);
     }
   });
   if (eligibility.size === 0) {
@@ -146,8 +153,11 @@ export async function fetchSubscriptionEligibilityForKeys(
       { chunk, seasonId }
     );
     cardSetsResult.forEach((row) => {
-      if (row.consolidation_key && row.sets) {
-        eligibility.set(row.consolidation_key.toLowerCase(), row.sets);
+      if (row.consolidation_key) {
+        eligibility.set(
+          row.consolidation_key.toLowerCase(),
+          normalizeSubscriptionEligibility(row.sets)
+        );
       }
     });
   }

--- a/src/subscriptionsDaily/subscription-eligibility.test.ts
+++ b/src/subscriptionsDaily/subscription-eligibility.test.ts
@@ -9,9 +9,12 @@ describe('normalizeSubscriptionEligibility', () => {
     [0, 1],
     [1, 1],
     [2, 2],
-    [3, 3],
+    ['3', 3],
     [Number.NaN, 1],
-    [1.5, 1]
+    [1.5, 1],
+    [Number.MAX_SAFE_INTEGER + 1, 1],
+    [null, 1],
+    [undefined, 1]
   ])('normalizes %s Meme sets to eligibility %s', (memeSets, expected) => {
     expect(normalizeSubscriptionEligibility(memeSets)).toBe(expected);
   });

--- a/src/subscriptionsDaily/subscription-eligibility.test.ts
+++ b/src/subscriptionsDaily/subscription-eligibility.test.ts
@@ -1,0 +1,22 @@
+import {
+  MINIMUM_SUBSCRIPTION_ELIGIBILITY,
+  normalizeSubscriptionEligibility
+} from './subscription-eligibility';
+
+describe('normalizeSubscriptionEligibility', () => {
+  it.each([
+    [-1, 1],
+    [0, 1],
+    [1, 1],
+    [2, 2],
+    [3, 3],
+    [Number.NaN, 1],
+    [1.5, 1]
+  ])('normalizes %s Meme sets to eligibility %s', (memeSets, expected) => {
+    expect(normalizeSubscriptionEligibility(memeSets)).toBe(expected);
+  });
+
+  it('exports the operational minimum eligibility', () => {
+    expect(MINIMUM_SUBSCRIPTION_ELIGIBILITY).toBe(1);
+  });
+});

--- a/src/subscriptionsDaily/subscription-eligibility.ts
+++ b/src/subscriptionsDaily/subscription-eligibility.ts
@@ -1,8 +1,12 @@
 export const MINIMUM_SUBSCRIPTION_ELIGIBILITY = 1;
 
-export function normalizeSubscriptionEligibility(memeSets: number): number {
-  if (!Number.isSafeInteger(memeSets)) {
+export function normalizeSubscriptionEligibility(memeSets: unknown): number {
+  const parsedMemeSets =
+    typeof memeSets === 'number' || typeof memeSets === 'string'
+      ? Number(memeSets)
+      : Number.NaN;
+  if (!Number.isSafeInteger(parsedMemeSets)) {
     return MINIMUM_SUBSCRIPTION_ELIGIBILITY;
   }
-  return Math.max(MINIMUM_SUBSCRIPTION_ELIGIBILITY, memeSets);
+  return Math.max(MINIMUM_SUBSCRIPTION_ELIGIBILITY, parsedMemeSets);
 }

--- a/src/subscriptionsDaily/subscription-eligibility.ts
+++ b/src/subscriptionsDaily/subscription-eligibility.ts
@@ -1,0 +1,8 @@
+export const MINIMUM_SUBSCRIPTION_ELIGIBILITY = 1;
+
+export function normalizeSubscriptionEligibility(memeSets: number): number {
+  if (!Number.isSafeInteger(memeSets)) {
+    return MINIMUM_SUBSCRIPTION_ELIGIBILITY;
+  }
+  return Math.max(MINIMUM_SUBSCRIPTION_ELIGIBILITY, memeSets);
+}

--- a/src/subscriptionsDaily/subscriptions.ts
+++ b/src/subscriptionsDaily/subscriptions.ts
@@ -42,6 +42,7 @@ import {
   persistNFTFinalSubscriptions,
   persistSubscriptions
 } from './db.subscriptions';
+import { MINIMUM_SUBSCRIPTION_ELIGIBILITY } from './subscription-eligibility';
 import { markSubscriptionCoverageDirty } from '../subscription-coverage/subscription-coverage-dirty';
 
 const logger = Logger.get('SUBSCRIPTIONS');
@@ -121,8 +122,9 @@ async function populateAutoSubscriptionsForMemeId(
     autoSubscriptionsDelta.forEach((s) => {
       let subscribedCount = 1;
       const eligibilityCount = s.consolidation_key
-        ? (eligibilityByKey.get(s.consolidation_key.toLowerCase()) ?? 1)
-        : 1;
+        ? (eligibilityByKey.get(s.consolidation_key.toLowerCase()) ??
+          MINIMUM_SUBSCRIPTION_ELIGIBILITY)
+        : MINIMUM_SUBSCRIPTION_ELIGIBILITY;
       if (s.subscribe_all_editions) {
         subscribedCount = eligibilityCount;
       }
@@ -309,8 +311,9 @@ async function addFundedFinalSubscription(
   }
   const subscribedAt = Time.millis(createdAt).toIsoString();
   const eligibilityCount = sub.consolidation_key
-    ? (eligibilityByKey.get(sub.consolidation_key.toLowerCase()) ?? 1)
-    : 1;
+    ? (eligibilityByKey.get(sub.consolidation_key.toLowerCase()) ??
+      MINIMUM_SUBSCRIPTION_ELIGIBILITY)
+    : MINIMUM_SUBSCRIPTION_ELIGIBILITY;
   const airdropAddress = await fetchAirdropAddressForConsolidationKey(
     sub.consolidation_key
   );


### PR DESCRIPTION
## Issue

The subscription coverage path treated a current-season Meme set count of zero as zero mint eligibility, while the operational subscription/details path enforces a minimum eligibility of one. That mismatch caused funded profiles such as `crimsonovoidchk` to receive `NO_CURRENT_ELIGIBILITY` from the coverage endpoint even though subscription details reported `subscription_eligibility_count: 1`.

## Fix

Use one shared minimum-one eligibility normalization for both operational subscription reads and subscription coverage reads.

## Changes

- add a shared `MINIMUM_SUBSCRIPTION_ELIGIBILITY` constant and normalization helper
- initialize coverage eligibility to one for known consolidation keys
- normalize zero-set coverage rows to one while preserving higher Meme set counts
- preserve `null` coverage eligibility when season data is unavailable
- bump the coverage calculation version to 2 so persisted forecasts reflect the corrected policy
- add focused repository and normalization coverage

## Validation

- focused subscription/coverage suite: 4 suites, 47 tests passed
- backend lint passed
- root TypeScript build (`build:ci`) passed
- API serverless package build passed
- the broad root Jest build was stopped after unrelated Release Bus performance failures on macOS Bash (`mapfile` unavailable); no subscription suite failed

## Risk

Low code-surface risk: the change only aligns coverage with existing operational eligibility semantics. The calculation-version change may produce new reconciliation fingerprints, so the first deployment should run one complete subscription-coverage sweep with the existing baseline-only mode enabled before normal alert delivery resumes.

## Deployment

Not deployed. A later rollout affects `subscriptionsDaily` (including coverage reconciliation) and `api`; no frontend change is required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Subscription coverage now consistently reports a minimum eligibility of one, including when current-season counts are missing or zero.
  * Higher eligibility values remain unchanged, while unavailable data continues to be reported as unavailable.
  * Coverage state updates now recognize forecast changes without generating unnecessary notifications or pushes.

* **Improvements**
  * Coverage forecasts now use calculation version 2 for consistent results across services.

* **Documentation**
  * Added a release report covering coverage behavior, rollout configuration, deployment sequencing, and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->