### PR TITLE
Allow historical claim season republishing

### DIFF
--- a/src/api-serverless/src/minting-claims/api-minting-claims-db.test.ts
+++ b/src/api-serverless/src/minting-claims/api-minting-claims-db.test.ts
@@ -3,7 +3,8 @@ import { sqlExecutor } from '@/sql-executor';
 
 jest.mock('@/sql-executor', () => ({
   sqlExecutor: {
-    execute: jest.fn()
+    execute: jest.fn(),
+    executeNativeQueriesInTransaction: jest.fn()
   }
 }));
 
@@ -11,13 +12,23 @@ describe('updateMintingClaimIfEditable', () => {
   const executeMock = sqlExecutor.execute as jest.MockedFunction<
     typeof sqlExecutor.execute
   >;
+  const transactionMock =
+    sqlExecutor.executeNativeQueriesInTransaction as jest.MockedFunction<
+      typeof sqlExecutor.executeNativeQueriesInTransaction
+    >;
+  const connection = { connection: {} };
 
   beforeEach(() => {
     jest.clearAllMocks();
+    transactionMock.mockImplementation(async (callback) =>
+      callback(connection)
+    );
   });
 
   it('atomically compares the stored attributes when replacing them', async () => {
-    executeMock.mockResolvedValue([0, 1] as never);
+    executeMock
+      .mockResolvedValueOnce([{ claim_id: 123 }])
+      .mockResolvedValueOnce([]);
     const expectedAttributes = JSON.stringify([
       { trait_type: 'Type - Season', value: 15 }
     ]);
@@ -33,7 +44,8 @@ describe('updateMintingClaimIfEditable', () => {
     );
 
     expect(updated).toBe(true);
-    expect(executeMock).toHaveBeenCalledWith(
+    expect(executeMock).toHaveBeenNthCalledWith(
+      1,
       expect.stringContaining(
         'AND attributes <=> CAST(:expectedAttributes AS JSON)'
       ),
@@ -41,23 +53,34 @@ describe('updateMintingClaimIfEditable', () => {
         contract: '0xabc',
         claimId: 123,
         expectedAttributes
-      })
+      }),
+      { wrappedConnection: connection }
     );
     expect(executeMock.mock.calls[0]?.[0]).toContain(
       'AND COALESCE(media_uploading, 0) = 0'
     );
+    expect(executeMock.mock.calls[0]?.[0]).toContain('FOR UPDATE');
+    expect(executeMock).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('UPDATE minting_claims'),
+      expect.any(Object),
+      { wrappedConnection: connection }
+    );
   });
 
   it('reports a failed compare-and-swap when no row matches', async () => {
-    executeMock.mockResolvedValue([0, 0] as never);
+    executeMock.mockResolvedValue([]);
 
     await expect(
       updateMintingClaimIfEditable('0xabc', 123, { name: 'Updated' }, '[]')
     ).resolves.toBe(false);
+    expect(executeMock).toHaveBeenCalledTimes(1);
   });
 
   it('does not couple non-attribute patches to the stored attributes', async () => {
-    executeMock.mockResolvedValue([0, 1] as never);
+    executeMock
+      .mockResolvedValueOnce([{ claim_id: 123 }])
+      .mockResolvedValueOnce([]);
 
     await expect(
       updateMintingClaimIfEditable('0xabc', 123, { name: 'Updated' })

--- a/src/api-serverless/src/minting-claims/api-minting-claims-db.test.ts
+++ b/src/api-serverless/src/minting-claims/api-minting-claims-db.test.ts
@@ -1,0 +1,73 @@
+import { updateMintingClaimIfEditable } from '@/api/minting-claims/api.minting-claims.db';
+import { sqlExecutor } from '@/sql-executor';
+
+jest.mock('@/sql-executor', () => ({
+  sqlExecutor: {
+    execute: jest.fn()
+  }
+}));
+
+describe('updateMintingClaimIfEditable', () => {
+  const executeMock = sqlExecutor.execute as jest.MockedFunction<
+    typeof sqlExecutor.execute
+  >;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('atomically compares the stored attributes when replacing them', async () => {
+    executeMock.mockResolvedValue([0, 1] as never);
+    const expectedAttributes = JSON.stringify([
+      { trait_type: 'Type - Season', value: 15 }
+    ]);
+
+    const updated = await updateMintingClaimIfEditable(
+      '0xABC',
+      123,
+      {
+        attributes: [{ trait_type: 'Type - Season', value: 15 }],
+        metadata_location: null
+      },
+      expectedAttributes
+    );
+
+    expect(updated).toBe(true);
+    expect(executeMock).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'AND attributes <=> CAST(:expectedAttributes AS JSON)'
+      ),
+      expect.objectContaining({
+        contract: '0xabc',
+        claimId: 123,
+        expectedAttributes
+      })
+    );
+    expect(executeMock.mock.calls[0]?.[0]).toContain(
+      'AND COALESCE(media_uploading, 0) = 0'
+    );
+  });
+
+  it('reports a failed compare-and-swap when no row matches', async () => {
+    executeMock.mockResolvedValue([0, 0] as never);
+
+    await expect(
+      updateMintingClaimIfEditable('0xabc', 123, { name: 'Updated' }, '[]')
+    ).resolves.toBe(false);
+  });
+
+  it('does not couple non-attribute patches to the stored attributes', async () => {
+    executeMock.mockResolvedValue([0, 1] as never);
+
+    await expect(
+      updateMintingClaimIfEditable('0xabc', 123, { name: 'Updated' })
+    ).resolves.toBe(true);
+
+    expect(executeMock.mock.calls[0]?.[0]).not.toContain(
+      'CAST(:expectedAttributes AS JSON)'
+    );
+    expect(executeMock.mock.calls[0]?.[1]).not.toHaveProperty(
+      'expectedAttributes'
+    );
+  });
+});

--- a/src/api-serverless/src/minting-claims/api-minting-claims-service.test.ts
+++ b/src/api-serverless/src/minting-claims/api-minting-claims-service.test.ts
@@ -13,7 +13,7 @@ import {
 import {
   fetchMaxSeasonId,
   fetchMintingClaimByClaimId,
-  updateMintingClaim
+  updateMintingClaimIfEditable
 } from '@/api/minting-claims/api.minting-claims.db';
 import { upsertAutomaticAirdropsForPhase } from '@/api/distributions/api.distributions.service';
 import { MEMES_CONTRACT } from '@/constants';
@@ -29,6 +29,7 @@ jest.mock('@/minting-claims/media-inspector', () => ({
 jest.mock('@/api/minting-claims/api.minting-claims.db', () => ({
   fetchMaxSeasonId: jest.fn(),
   fetchMintingClaimByClaimId: jest.fn(),
+  updateMintingClaimIfEditable: jest.fn(),
   updateMintingClaim: jest.fn()
 }));
 
@@ -314,6 +315,34 @@ describe('buildUpdatesForClaimPatch', () => {
     expect(updates.metadata_location).toBeNull();
   });
 
+  it('recognizes an unchanged historical season after normalizing stored attributes', async () => {
+    fetchMaxSeasonIdMock.mockResolvedValue(16);
+    const existing = baseClaim({
+      attributes: JSON.stringify([
+        { trait_type: 'Palette', value: 'Monochrome' },
+        { trait_type: ' Type - Season ', value: ' 15 ' }
+      ])
+    });
+    const body: MintingClaimUpdateRequest = {
+      attributes: [
+        { trait_type: 'Palette', value: 'Color' },
+        { trait_type: 'Type - Season', value: 15 }
+      ]
+    };
+
+    const updates = await buildUpdatesForClaimPatch(body, existing, true);
+
+    expect(fetchMaxSeasonIdMock).not.toHaveBeenCalled();
+    expect(updates.attributes).toEqual([
+      { trait_type: 'Palette', value: 'Color' },
+      {
+        trait_type: 'Type - Season',
+        value: 15,
+        display_type: 'number'
+      }
+    ]);
+  });
+
   it('keeps current-season validation when the MEMES season changes', async () => {
     fetchMaxSeasonIdMock.mockResolvedValue(16);
     const existing = baseClaim({
@@ -337,9 +366,10 @@ describe('patchMintingClaim', () => {
     fetchMintingClaimByClaimId as jest.MockedFunction<
       typeof fetchMintingClaimByClaimId
     >;
-  const updateMintingClaimMock = updateMintingClaim as jest.MockedFunction<
-    typeof updateMintingClaim
-  >;
+  const updateMintingClaimIfEditableMock =
+    updateMintingClaimIfEditable as jest.MockedFunction<
+      typeof updateMintingClaimIfEditable
+    >;
   const upsertAutomaticAirdropsForPhaseMock =
     upsertAutomaticAirdropsForPhase as jest.MockedFunction<
       typeof upsertAutomaticAirdropsForPhase
@@ -369,7 +399,7 @@ describe('patchMintingClaim', () => {
         return updated;
       }
     );
-    updateMintingClaimMock.mockResolvedValue(undefined);
+    updateMintingClaimIfEditableMock.mockResolvedValue(true);
     upsertAutomaticAirdropsForPhaseMock.mockResolvedValue(undefined);
     sqlExecutorExecuteMock.mockResolvedValue([
       { wallet: '0xc6400A5584db71e41B0E5dFbdC769b54B91256CD' }
@@ -395,6 +425,12 @@ describe('patchMintingClaim', () => {
       { forcePool: DbPoolName.WRITE }
     );
     expect(fetchMintingClaimByClaimIdMock).toHaveBeenCalledTimes(2);
+    expect(updateMintingClaimIfEditableMock).toHaveBeenCalledWith(
+      existing.contract,
+      existing.claim_id,
+      { edition_size: 500 },
+      undefined
+    );
     expect(upsertAutomaticAirdropsForPhaseMock).toHaveBeenCalledWith(
       MEMES_CONTRACT,
       existing.claim_id,
@@ -409,5 +445,111 @@ describe('patchMintingClaim', () => {
       false
     );
     expect(result).toEqual(updated);
+  });
+
+  it('rejects a stale full-attribute update instead of restoring an old season', async () => {
+    const existing = baseClaim({
+      attributes: JSON.stringify([
+        { trait_type: 'Palette', value: 'Monochrome' },
+        { trait_type: 'Type - Season', value: 15 }
+      ])
+    });
+    const concurrentlyUpdated = baseClaim({
+      attributes: JSON.stringify([
+        { trait_type: 'Palette', value: 'Monochrome' },
+        { trait_type: 'Type - Season', value: 16 }
+      ])
+    });
+    fetchMintingClaimByClaimIdMock
+      .mockResolvedValueOnce(existing)
+      .mockResolvedValueOnce(concurrentlyUpdated);
+    updateMintingClaimIfEditableMock.mockResolvedValue(false);
+
+    await expect(
+      patchMintingClaim(
+        existing.contract,
+        existing.claim_id,
+        {
+          attributes: [
+            { trait_type: 'Palette', value: 'Color' },
+            { trait_type: 'Type - Season', value: 15 }
+          ]
+        },
+        true
+      )
+    ).rejects.toThrow(
+      'Claim attributes changed while this update was being processed; refresh and retry'
+    );
+    expect(updateMintingClaimIfEditableMock).toHaveBeenCalledWith(
+      existing.contract,
+      existing.claim_id,
+      expect.any(Object),
+      existing.attributes
+    );
+  });
+
+  it('rejects a patch when a media upload starts after the initial read', async () => {
+    const existing = baseClaim();
+    fetchMintingClaimByClaimIdMock
+      .mockResolvedValueOnce(existing)
+      .mockResolvedValueOnce(baseClaim({ media_uploading: true }));
+    updateMintingClaimIfEditableMock.mockResolvedValue(false);
+
+    await expect(
+      patchMintingClaim(
+        existing.contract,
+        existing.claim_id,
+        { name: 'Updated name' },
+        true
+      )
+    ).rejects.toThrow(
+      'Claim media upload in progress; updates are temporarily blocked'
+    );
+  });
+
+  it('rejects a patch if a transient media lock prevented its changes', async () => {
+    const existing = baseClaim();
+    fetchMintingClaimByClaimIdMock
+      .mockResolvedValueOnce(existing)
+      .mockResolvedValueOnce(existing);
+    updateMintingClaimIfEditableMock.mockResolvedValue(false);
+
+    await expect(
+      patchMintingClaim(
+        existing.contract,
+        existing.claim_id,
+        { name: 'Updated name' },
+        true
+      )
+    ).rejects.toThrow(
+      'Claim changed while this update was being processed; refresh and retry'
+    );
+  });
+
+  it('accepts an idempotent attribute patch when JSON object key order differs', async () => {
+    const existing = baseClaim({
+      metadata_location: null,
+      attributes: JSON.stringify([
+        {
+          value: 15,
+          display_type: 'number',
+          trait_type: 'Type - Season'
+        }
+      ])
+    });
+    fetchMintingClaimByClaimIdMock.mockResolvedValue(existing);
+    updateMintingClaimIfEditableMock.mockResolvedValue(false);
+
+    await expect(
+      patchMintingClaim(
+        existing.contract,
+        existing.claim_id,
+        {
+          attributes: [{ trait_type: 'Type - Season', value: 15 }]
+        },
+        true
+      )
+    ).resolves.toEqual(existing);
+    expect(fetchMintingClaimByClaimIdMock).toHaveBeenCalledTimes(3);
   });
 });

--- a/src/api-serverless/src/minting-claims/api-minting-claims-service.test.ts
+++ b/src/api-serverless/src/minting-claims/api-minting-claims-service.test.ts
@@ -284,6 +284,52 @@ describe('buildUpdatesForClaimPatch', () => {
       }
     ]);
   });
+
+  it('allows other MEMES attributes to change when a historical season is unchanged', async () => {
+    fetchMaxSeasonIdMock.mockResolvedValue(16);
+    const existing = baseClaim({
+      attributes: JSON.stringify([
+        { trait_type: 'Palette', value: 'Monochrome' },
+        { trait_type: 'Type - Season', value: 15 }
+      ])
+    });
+    const body: MintingClaimUpdateRequest = {
+      attributes: [
+        { trait_type: 'Palette', value: 'Color' },
+        { trait_type: 'Type - Season', value: 15 }
+      ]
+    };
+
+    const updates = await buildUpdatesForClaimPatch(body, existing, true);
+
+    expect(fetchMaxSeasonIdMock).not.toHaveBeenCalled();
+    expect(updates.attributes).toEqual([
+      { trait_type: 'Palette', value: 'Color' },
+      {
+        trait_type: 'Type - Season',
+        value: 15,
+        display_type: 'number'
+      }
+    ]);
+    expect(updates.metadata_location).toBeNull();
+  });
+
+  it('keeps current-season validation when the MEMES season changes', async () => {
+    fetchMaxSeasonIdMock.mockResolvedValue(16);
+    const existing = baseClaim({
+      attributes: JSON.stringify([{ trait_type: 'Type - Season', value: 14 }])
+    });
+    const body: MintingClaimUpdateRequest = {
+      attributes: [{ trait_type: 'Type - Season', value: 15 }]
+    };
+
+    await expect(
+      buildUpdatesForClaimPatch(body, existing, true)
+    ).rejects.toThrow(
+      'Season must be 16 or 17 (current max season is 16), got 15'
+    );
+    expect(fetchMaxSeasonIdMock).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('patchMintingClaim', () => {

--- a/src/api-serverless/src/minting-claims/api-minting-claims-service.test.ts
+++ b/src/api-serverless/src/minting-claims/api-minting-claims-service.test.ts
@@ -552,4 +552,33 @@ describe('patchMintingClaim', () => {
     ).resolves.toEqual(existing);
     expect(fetchMintingClaimByClaimIdMock).toHaveBeenCalledTimes(3);
   });
+
+  it('resets published metadata when identical attributes are resubmitted', async () => {
+    const attributes = JSON.stringify([
+      { trait_type: 'Type - Season', value: 15, display_type: 'number' }
+    ]);
+    const existing = baseClaim({ attributes });
+    const updated = baseClaim({ attributes, metadata_location: null });
+    fetchMintingClaimByClaimIdMock
+      .mockResolvedValueOnce(existing)
+      .mockResolvedValueOnce(updated);
+    updateMintingClaimIfEditableMock.mockResolvedValue(true);
+
+    await expect(
+      patchMintingClaim(
+        existing.contract,
+        existing.claim_id,
+        {
+          attributes: [{ trait_type: 'Type - Season', value: 15 }]
+        },
+        true
+      )
+    ).resolves.toEqual(updated);
+    expect(updateMintingClaimIfEditableMock).toHaveBeenCalledWith(
+      existing.contract,
+      existing.claim_id,
+      expect.objectContaining({ metadata_location: null }),
+      existing.attributes
+    );
+  });
 });

--- a/src/api-serverless/src/minting-claims/api.minting-claims.db.ts
+++ b/src/api-serverless/src/minting-claims/api.minting-claims.db.ts
@@ -431,16 +431,32 @@ export async function updateMintingClaimIfEditable(
     params.expectedAttributes = expectedAttributes;
   }
 
-  const result = await sqlExecutor.execute<{ affectedRows: number }>(
-    `UPDATE ${MINTING_CLAIMS_TABLE}
-     SET ${setClauses.join(', ')}
-     WHERE contract = :contract
-       AND claim_id = :claimId
-       AND COALESCE(media_uploading, 0) = 0
-       ${attributesPredicate}`,
-    params
+  return await sqlExecutor.executeNativeQueriesInTransaction(
+    async (connection) => {
+      const matchingRows = await sqlExecutor.execute<{ claim_id: number }>(
+        `SELECT claim_id
+         FROM ${MINTING_CLAIMS_TABLE}
+         WHERE contract = :contract
+           AND claim_id = :claimId
+           AND COALESCE(media_uploading, 0) = 0
+           ${attributesPredicate}
+         FOR UPDATE`,
+        params,
+        { wrappedConnection: connection }
+      );
+      if (matchingRows.length === 0) return false;
+
+      await sqlExecutor.execute(
+        `UPDATE ${MINTING_CLAIMS_TABLE}
+         SET ${setClauses.join(', ')}
+         WHERE contract = :contract
+           AND claim_id = :claimId`,
+        params,
+        { wrappedConnection: connection }
+      );
+      return true;
+    }
   );
-  return getAffectedRowsFromUpdateResult(result) > 0;
 }
 
 function buildMintingClaimUpdateStatement(

--- a/src/api-serverless/src/minting-claims/api.minting-claims.db.ts
+++ b/src/api-serverless/src/minting-claims/api.minting-claims.db.ts
@@ -410,6 +410,39 @@ export async function updateMintingClaim(
   );
 }
 
+export async function updateMintingClaimIfEditable(
+  contract: string,
+  claimId: number,
+  updates: Parameters<typeof updateMintingClaim>[2],
+  expectedAttributes?: string
+): Promise<boolean> {
+  const { setClauses, params } = buildMintingClaimUpdateStatement(
+    contract,
+    claimId,
+    updates
+  );
+  if (setClauses.length === 0) return true;
+
+  const attributesPredicate =
+    expectedAttributes === undefined
+      ? ''
+      : 'AND attributes <=> CAST(:expectedAttributes AS JSON)';
+  if (expectedAttributes !== undefined) {
+    params.expectedAttributes = expectedAttributes;
+  }
+
+  const result = await sqlExecutor.execute<{ affectedRows: number }>(
+    `UPDATE ${MINTING_CLAIMS_TABLE}
+     SET ${setClauses.join(', ')}
+     WHERE contract = :contract
+       AND claim_id = :claimId
+       AND COALESCE(media_uploading, 0) = 0
+       ${attributesPredicate}`,
+    params
+  );
+  return getAffectedRowsFromUpdateResult(result) > 0;
+}
+
 function buildMintingClaimUpdateStatement(
   contract: string,
   claimId: number,

--- a/src/api-serverless/src/minting-claims/api.minting-claims.service.ts
+++ b/src/api-serverless/src/minting-claims/api.minting-claims.service.ts
@@ -1,6 +1,7 @@
 import {
   fetchMaxSeasonId,
   fetchMintingClaimByClaimId,
+  updateMintingClaimIfEditable,
   updateMintingClaim,
   type MintingClaimRow
 } from '@/api/minting-claims/api.minting-claims.db';
@@ -18,7 +19,9 @@ import {
   animationDetailsHtml
 } from '@/minting-claims/media-inspector';
 import { sqlExecutor } from '@/sql-executor';
+import { getMintingClaimSeasonWindow } from '@/minting-claims/minting-claim-season';
 import { ethers } from 'ethers';
+import { isDeepStrictEqual } from 'node:util';
 
 const MIN_EDITION_SIZE = 300;
 const TYPE_SEASON_TRAIT = 'Type - Season';
@@ -119,15 +122,14 @@ function validateRequestedSeason(
   maxSeason: number
 ): number {
   const requested = Number(requestedSeason);
-  const minSeason = 1;
-  const requiredMinSeason = Math.max(minSeason, maxSeason);
+  const { currentSeason, nextSeason } = getMintingClaimSeasonWindow(maxSeason);
   if (
     !Number.isInteger(requested) ||
-    requested < requiredMinSeason ||
-    requested > requiredMinSeason + 1
+    requested < currentSeason ||
+    requested > nextSeason
   ) {
     throw new BadRequestException(
-      `Season must be ${requiredMinSeason} or ${requiredMinSeason + 1} (current max season is ${maxSeason}), got ${requestedSeason}`
+      `Season must be ${currentSeason} or ${nextSeason} (current max season is ${maxSeason}), got ${requestedSeason}`
     );
   }
   return requested;
@@ -164,10 +166,52 @@ function extractSeasonFromAttributes(attributes: unknown): number | null {
 
 function extractSeasonFromStoredAttributes(attributes: string): number | null {
   try {
-    return extractSeasonFromAttributes(JSON.parse(attributes) as unknown);
+    return extractSeasonFromAttributes(
+      sanitizeMintingClaimAttributes(JSON.parse(attributes) as unknown)
+    );
   } catch {
     return null;
   }
+}
+
+function areStoredAttributesEquivalent(first: string, second: string): boolean {
+  try {
+    return isDeepStrictEqual(JSON.parse(first), JSON.parse(second));
+  } catch {
+    return first === second;
+  }
+}
+
+function doesClaimMatchUpdates(
+  claim: MintingClaimRow,
+  updates: MintingClaimUpdates
+): boolean {
+  const claimRecord = claim as unknown as Record<string, unknown>;
+  for (const [key, expected] of Object.entries(updates)) {
+    const actual = claimRecord[key];
+    if (
+      key === 'attributes' ||
+      key === 'image_details' ||
+      key === 'animation_details'
+    ) {
+      try {
+        const parsedActual =
+          typeof actual === 'string' ? JSON.parse(actual) : actual;
+        if (!isDeepStrictEqual(parsedActual, expected)) {
+          return false;
+        }
+      } catch {
+        return false;
+      }
+      continue;
+    }
+    if (key === 'media_uploading') {
+      if (Boolean(actual) !== expected) return false;
+      continue;
+    }
+    if (actual !== expected) return false;
+  }
+  return true;
 }
 
 function normalizeAttributesWithSeason(
@@ -411,7 +455,44 @@ export async function patchMintingClaim(
     existing,
     isMemesContract
   );
-  await updateMintingClaim(contract, claimId, updates);
+  const expectedAttributes =
+    body.attributes === undefined ? undefined : existing.attributes;
+  const didUpdate = await updateMintingClaimIfEditable(
+    contract,
+    claimId,
+    updates,
+    expectedAttributes
+  );
+
+  if (!didUpdate) {
+    const current = await fetchMintingClaimByClaimId(
+      contract,
+      claimId,
+      CLAIM_PATCH_READ_OPTIONS
+    );
+    if (current === null) return null;
+    if (current.media_uploading) {
+      throw new CustomApiCompliantException(
+        409,
+        'Claim media upload in progress; updates are temporarily blocked'
+      );
+    }
+    if (
+      expectedAttributes !== undefined &&
+      !areStoredAttributesEquivalent(current.attributes, expectedAttributes)
+    ) {
+      throw new CustomApiCompliantException(
+        409,
+        'Claim attributes changed while this update was being processed; refresh and retry'
+      );
+    }
+    if (!doesClaimMatchUpdates(current, updates)) {
+      throw new CustomApiCompliantException(
+        409,
+        'Claim changed while this update was being processed; refresh and retry'
+      );
+    }
+  }
 
   const updated = await fetchMintingClaimByClaimId(
     contract,

--- a/src/api-serverless/src/minting-claims/api.minting-claims.service.ts
+++ b/src/api-serverless/src/minting-claims/api.minting-claims.service.ts
@@ -182,36 +182,42 @@ function areStoredAttributesEquivalent(first: string, second: string): boolean {
   }
 }
 
+const JSON_CLAIM_FIELDS = new Set([
+  'attributes',
+  'image_details',
+  'animation_details'
+]);
+
+function isClaimFieldEqual(
+  key: string,
+  actual: unknown,
+  expected: unknown
+): boolean {
+  if (JSON_CLAIM_FIELDS.has(key)) {
+    try {
+      const parsedActual =
+        typeof actual === 'string' ? JSON.parse(actual) : actual;
+      return isDeepStrictEqual(parsedActual, expected);
+    } catch {
+      // Stored JSON is server-written. Fail closed on legacy corruption rather
+      // than treating an unverifiable conditional update as successful.
+      return false;
+    }
+  }
+  if (key === 'media_uploading') {
+    return Boolean(actual) === expected;
+  }
+  return actual === expected;
+}
+
 function doesClaimMatchUpdates(
   claim: MintingClaimRow,
   updates: MintingClaimUpdates
 ): boolean {
   const claimRecord = claim as unknown as Record<string, unknown>;
-  for (const [key, expected] of Object.entries(updates)) {
-    const actual = claimRecord[key];
-    if (
-      key === 'attributes' ||
-      key === 'image_details' ||
-      key === 'animation_details'
-    ) {
-      try {
-        const parsedActual =
-          typeof actual === 'string' ? JSON.parse(actual) : actual;
-        if (!isDeepStrictEqual(parsedActual, expected)) {
-          return false;
-        }
-      } catch {
-        return false;
-      }
-      continue;
-    }
-    if (key === 'media_uploading') {
-      if (Boolean(actual) !== expected) return false;
-      continue;
-    }
-    if (actual !== expected) return false;
-  }
-  return true;
+  return Object.entries(updates).every(([key, expected]) =>
+    isClaimFieldEqual(key, claimRecord[key], expected)
+  );
 }
 
 function normalizeAttributesWithSeason(
@@ -430,6 +436,45 @@ export async function buildUpdatesForClaimPatch(
   return updates;
 }
 
+async function didConditionalClaimUpdateSucceed(
+  didUpdate: boolean,
+  contract: string,
+  claimId: number,
+  expectedAttributes: string | undefined,
+  updates: MintingClaimUpdates
+): Promise<boolean> {
+  if (didUpdate) return true;
+
+  const current = await fetchMintingClaimByClaimId(
+    contract,
+    claimId,
+    CLAIM_PATCH_READ_OPTIONS
+  );
+  if (current === null) return false;
+  if (current.media_uploading) {
+    throw new CustomApiCompliantException(
+      409,
+      'Claim media upload in progress; updates are temporarily blocked'
+    );
+  }
+  if (
+    expectedAttributes !== undefined &&
+    !areStoredAttributesEquivalent(current.attributes, expectedAttributes)
+  ) {
+    throw new CustomApiCompliantException(
+      409,
+      'Claim attributes changed while this update was being processed; refresh and retry'
+    );
+  }
+  if (!doesClaimMatchUpdates(current, updates)) {
+    throw new CustomApiCompliantException(
+      409,
+      'Claim changed while this update was being processed; refresh and retry'
+    );
+  }
+  return true;
+}
+
 export async function patchMintingClaim(
   contract: string,
   claimId: number,
@@ -463,36 +508,16 @@ export async function patchMintingClaim(
     updates,
     expectedAttributes
   );
-
-  if (!didUpdate) {
-    const current = await fetchMintingClaimByClaimId(
+  if (
+    !(await didConditionalClaimUpdateSucceed(
+      didUpdate,
       contract,
       claimId,
-      CLAIM_PATCH_READ_OPTIONS
-    );
-    if (current === null) return null;
-    if (current.media_uploading) {
-      throw new CustomApiCompliantException(
-        409,
-        'Claim media upload in progress; updates are temporarily blocked'
-      );
-    }
-    if (
-      expectedAttributes !== undefined &&
-      !areStoredAttributesEquivalent(current.attributes, expectedAttributes)
-    ) {
-      throw new CustomApiCompliantException(
-        409,
-        'Claim attributes changed while this update was being processed; refresh and retry'
-      );
-    }
-    if (!doesClaimMatchUpdates(current, updates)) {
-      throw new CustomApiCompliantException(
-        409,
-        'Claim changed while this update was being processed; refresh and retry'
-      );
-    }
-  }
+      expectedAttributes,
+      updates
+    ))
+  )
+    return null;
 
   const updated = await fetchMintingClaimByClaimId(
     contract,

--- a/src/api-serverless/src/minting-claims/api.minting-claims.service.ts
+++ b/src/api-serverless/src/minting-claims/api.minting-claims.service.ts
@@ -162,6 +162,14 @@ function extractSeasonFromAttributes(attributes: unknown): number | null {
   return null;
 }
 
+function extractSeasonFromStoredAttributes(attributes: string): number | null {
+  try {
+    return extractSeasonFromAttributes(JSON.parse(attributes) as unknown);
+  } catch {
+    return null;
+  }
+}
+
 function normalizeAttributesWithSeason(
   attributes: unknown,
   season: number
@@ -261,7 +269,8 @@ async function applyAnimationFromBody(
 async function applyAttributesFromBody(
   body: MintingClaimUpdateRequest,
   updates: MintingClaimUpdates,
-  isMemesContract: boolean
+  isMemesContract: boolean,
+  existingAttributes: string
 ): Promise<boolean> {
   if (body.attributes === undefined) {
     return false;
@@ -280,10 +289,13 @@ async function applyAttributesFromBody(
     );
   }
 
-  const validatedSeason = validateRequestedSeason(
-    requestedSeason,
-    await fetchMaxSeasonId()
-  );
+  const existingSeason = extractSeasonFromStoredAttributes(existingAttributes);
+  // Historical seasons remain valid when another attribute is edited. Apply
+  // the moving current/next-season window only to an actual season change.
+  const validatedSeason =
+    requestedSeason === existingSeason
+      ? requestedSeason
+      : validateRequestedSeason(requestedSeason, await fetchMaxSeasonId());
 
   updates.attributes = normalizeAttributesWithSeason(
     sanitizedAttributes,
@@ -335,7 +347,14 @@ export async function buildUpdatesForClaimPatch(
     shouldResetMetadataLocation = true;
   }
 
-  if (await applyAttributesFromBody(body, updates, isMemesContract)) {
+  if (
+    await applyAttributesFromBody(
+      body,
+      updates,
+      isMemesContract,
+      existing.attributes
+    )
+  ) {
     shouldResetMetadataLocation = true;
   }
 

--- a/src/minting-claims/claims-media-arweave-upload.test.ts
+++ b/src/minting-claims/claims-media-arweave-upload.test.ts
@@ -7,9 +7,13 @@ import {
   uploadMintingClaimToArweave,
   validateMintingClaimReadyForArweaveUpload
 } from '@/minting-claims/claims-media-arweave-upload';
-import { fetchMemeIdByMemeName } from '@/api/minting-claims/api.minting-claims.db';
+import {
+  fetchMaxSeasonId,
+  fetchMemeIdByMemeName
+} from '@/api/minting-claims/api.minting-claims.db';
 
 jest.mock('@/api/minting-claims/api.minting-claims.db', () => ({
+  fetchMaxSeasonId: jest.fn(),
   fetchMemeIdByMemeName: jest.fn()
 }));
 
@@ -219,11 +223,15 @@ function baseClaim(overrides: Partial<MintingClaimRow> = {}): MintingClaimRow {
 }
 
 describe('validateMintingClaimReadyForArweaveUpload', () => {
+  const fetchMaxSeasonIdMock = fetchMaxSeasonId as jest.MockedFunction<
+    typeof fetchMaxSeasonId
+  >;
   const fetchMemeIdByMemeNameMock =
     fetchMemeIdByMemeName as jest.MockedFunction<typeof fetchMemeIdByMemeName>;
 
   beforeEach(() => {
     jest.clearAllMocks();
+    fetchMaxSeasonIdMock.mockResolvedValue(14);
     fetchMemeIdByMemeNameMock.mockResolvedValue(9);
   });
 
@@ -275,6 +283,7 @@ describe('validateMintingClaimReadyForArweaveUpload', () => {
       typeMemeId: 9,
       seasonValue: 1
     });
+    expect(fetchMaxSeasonIdMock).toHaveBeenCalledTimes(1);
   });
 
   it('rejects a non-positive season before Arweave upload', async () => {
@@ -292,6 +301,25 @@ describe('validateMintingClaimReadyForArweaveUpload', () => {
     ).rejects.toThrow(
       'Invalid fields for Arweave upload: Season (must be a positive integer, got 0).'
     );
+    expect(fetchMaxSeasonIdMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects a season above the current and next-season window', async () => {
+    const attributes = buildMemesRawAttributes().map((attribute) =>
+      attribute.trait_type === 'Type - Season'
+        ? { ...attribute, value: 16 }
+        : attribute
+    );
+
+    await expect(
+      validateMintingClaimReadyForArweaveUpload(
+        baseClaim({ attributes: JSON.stringify(attributes) }),
+        MEMES_CONTRACT
+      )
+    ).rejects.toThrow(
+      'Invalid fields for Arweave upload: Season (must not exceed 15; current max season is 14, got 16).'
+    );
+    expect(fetchMaxSeasonIdMock).toHaveBeenCalledTimes(1);
   });
 
   it('rejects missing MEMES traits before Arweave upload', async () => {
@@ -343,6 +371,9 @@ describe('validateMintingClaimReadyForArweaveUpload', () => {
 });
 
 describe('uploadMintingClaimToArweave', () => {
+  const fetchMaxSeasonIdMock = fetchMaxSeasonId as jest.MockedFunction<
+    typeof fetchMaxSeasonId
+  >;
   const fetchMemeIdByMemeNameMock =
     fetchMemeIdByMemeName as jest.MockedFunction<typeof fetchMemeIdByMemeName>;
   const uploadFileMock = arweaveFileUploader.uploadFile as jest.MockedFunction<
@@ -355,6 +386,7 @@ describe('uploadMintingClaimToArweave', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    fetchMaxSeasonIdMock.mockResolvedValue(14);
     fetchMemeIdByMemeNameMock.mockResolvedValue(9);
     fetchPublicUrlToBufferMock.mockResolvedValue({
       buffer: Buffer.from('image-bytes'),

--- a/src/minting-claims/claims-media-arweave-upload.test.ts
+++ b/src/minting-claims/claims-media-arweave-upload.test.ts
@@ -322,6 +322,26 @@ describe('validateMintingClaimReadyForArweaveUpload', () => {
     expect(fetchMaxSeasonIdMock).toHaveBeenCalledTimes(1);
   });
 
+  it('accepts the next season at the upper boundary', async () => {
+    const attributes = buildMemesRawAttributes().map((attribute) =>
+      attribute.trait_type === 'Type - Season'
+        ? { ...attribute, value: 15 }
+        : attribute
+    );
+
+    await expect(
+      validateMintingClaimReadyForArweaveUpload(
+        baseClaim({ attributes: JSON.stringify(attributes) }),
+        MEMES_CONTRACT
+      )
+    ).resolves.toEqual({
+      imageUrl: 'https://cdn.example.com/image.png',
+      typeMemeId: 9,
+      seasonValue: 15
+    });
+    expect(fetchMaxSeasonIdMock).toHaveBeenCalledTimes(1);
+  });
+
   it('rejects missing MEMES traits before Arweave upload', async () => {
     const attributes = buildMemesRawAttributes().filter(
       (attribute) => attribute.trait_type !== 'Boost'

--- a/src/minting-claims/claims-media-arweave-upload.test.ts
+++ b/src/minting-claims/claims-media-arweave-upload.test.ts
@@ -7,13 +7,9 @@ import {
   uploadMintingClaimToArweave,
   validateMintingClaimReadyForArweaveUpload
 } from '@/minting-claims/claims-media-arweave-upload';
-import {
-  fetchMaxSeasonId,
-  fetchMemeIdByMemeName
-} from '@/api/minting-claims/api.minting-claims.db';
+import { fetchMemeIdByMemeName } from '@/api/minting-claims/api.minting-claims.db';
 
 jest.mock('@/api/minting-claims/api.minting-claims.db', () => ({
-  fetchMaxSeasonId: jest.fn(),
   fetchMemeIdByMemeName: jest.fn()
 }));
 
@@ -223,15 +219,11 @@ function baseClaim(overrides: Partial<MintingClaimRow> = {}): MintingClaimRow {
 }
 
 describe('validateMintingClaimReadyForArweaveUpload', () => {
-  const fetchMaxSeasonIdMock = fetchMaxSeasonId as jest.MockedFunction<
-    typeof fetchMaxSeasonId
-  >;
   const fetchMemeIdByMemeNameMock =
     fetchMemeIdByMemeName as jest.MockedFunction<typeof fetchMemeIdByMemeName>;
 
   beforeEach(() => {
     jest.clearAllMocks();
-    fetchMaxSeasonIdMock.mockResolvedValue(14);
     fetchMemeIdByMemeNameMock.mockResolvedValue(9);
   });
 
@@ -264,6 +256,42 @@ describe('validateMintingClaimReadyForArweaveUpload', () => {
       typeMemeId: 9,
       seasonValue: 14
     });
+  });
+
+  it('accepts a historical positive season for Arweave republishing', async () => {
+    const attributes = buildMemesRawAttributes().map((attribute) =>
+      attribute.trait_type === 'Type - Season'
+        ? { ...attribute, value: 1 }
+        : attribute
+    );
+
+    await expect(
+      validateMintingClaimReadyForArweaveUpload(
+        baseClaim({ attributes: JSON.stringify(attributes) }),
+        MEMES_CONTRACT
+      )
+    ).resolves.toEqual({
+      imageUrl: 'https://cdn.example.com/image.png',
+      typeMemeId: 9,
+      seasonValue: 1
+    });
+  });
+
+  it('rejects a non-positive season before Arweave upload', async () => {
+    const attributes = buildMemesRawAttributes().map((attribute) =>
+      attribute.trait_type === 'Type - Season'
+        ? { ...attribute, value: 0 }
+        : attribute
+    );
+
+    await expect(
+      validateMintingClaimReadyForArweaveUpload(
+        baseClaim({ attributes: JSON.stringify(attributes) }),
+        MEMES_CONTRACT
+      )
+    ).rejects.toThrow(
+      'Invalid fields for Arweave upload: Season (must be a positive integer, got 0).'
+    );
   });
 
   it('rejects missing MEMES traits before Arweave upload', async () => {
@@ -315,9 +343,6 @@ describe('validateMintingClaimReadyForArweaveUpload', () => {
 });
 
 describe('uploadMintingClaimToArweave', () => {
-  const fetchMaxSeasonIdMock = fetchMaxSeasonId as jest.MockedFunction<
-    typeof fetchMaxSeasonId
-  >;
   const fetchMemeIdByMemeNameMock =
     fetchMemeIdByMemeName as jest.MockedFunction<typeof fetchMemeIdByMemeName>;
   const uploadFileMock = arweaveFileUploader.uploadFile as jest.MockedFunction<
@@ -330,7 +355,6 @@ describe('uploadMintingClaimToArweave', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    fetchMaxSeasonIdMock.mockResolvedValue(14);
     fetchMemeIdByMemeNameMock.mockResolvedValue(9);
     fetchPublicUrlToBufferMock.mockResolvedValue({
       buffer: Buffer.from('image-bytes'),

--- a/src/minting-claims/claims-media-arweave-upload.ts
+++ b/src/minting-claims/claims-media-arweave-upload.ts
@@ -1,8 +1,5 @@
 import type { MintingClaimRow } from '@/api/minting-claims/api.minting-claims.db';
-import {
-  fetchMaxSeasonId,
-  fetchMemeIdByMemeName
-} from '@/api/minting-claims/api.minting-claims.db';
+import { fetchMemeIdByMemeName } from '@/api/minting-claims/api.minting-claims.db';
 import { arweaveFileUploader } from '@/arweave';
 import { BadRequestException } from '@/exceptions';
 import { fetchPublicUrlToBuffer } from '@/http/safe-fetch';
@@ -917,7 +914,7 @@ export async function validateMintingClaimReadyForArweaveUpload(
 
   let seasonValue: number | null = null;
   if (memesContract) {
-    seasonValue = await appendSeasonIssues(rawAttributes, missing, invalid);
+    seasonValue = appendSeasonIssues(rawAttributes, missing, invalid);
   }
   const typeMemeId = memesContract
     ? await resolveTypeMemeId(rawAttributes, missing, invalid)
@@ -988,26 +985,20 @@ function appendEditionSizeIssues(
   }
 }
 
-async function appendSeasonIssues(
+function appendSeasonIssues(
   rawAttributes: unknown,
   missing: string[],
   invalid: string[]
-): Promise<number | null> {
+): number | null {
   const seasonValue = extractSeasonFromAttributes(rawAttributes);
   if (seasonValue == null) {
     missing.push('Season');
     return null;
   }
-  const maxSeasonId = await fetchMaxSeasonId();
-  const requiredMinSeason = Math.max(1, maxSeasonId);
-  if (
-    !Number.isInteger(seasonValue) ||
-    seasonValue < requiredMinSeason ||
-    seasonValue > requiredMinSeason + 1
-  ) {
-    invalid.push(
-      `Season (must be ${requiredMinSeason} or ${requiredMinSeason + 1}; current max season is ${maxSeasonId}, got ${seasonValue})`
-    );
+  // Publication may happen long after claim creation. Season freshness is
+  // enforced when the value changes, not while republishing stored metadata.
+  if (seasonValue < 1) {
+    invalid.push(`Season (must be a positive integer, got ${seasonValue})`);
   }
   return seasonValue;
 }

--- a/src/minting-claims/claims-media-arweave-upload.ts
+++ b/src/minting-claims/claims-media-arweave-upload.ts
@@ -3,6 +3,7 @@ import {
   fetchMaxSeasonId,
   fetchMemeIdByMemeName
 } from '@/api/minting-claims/api.minting-claims.db';
+import { getMintingClaimSeasonWindow } from '@/minting-claims/minting-claim-season';
 import { arweaveFileUploader } from '@/arweave';
 import { BadRequestException } from '@/exceptions';
 import { fetchPublicUrlToBuffer } from '@/http/safe-fetch';
@@ -1006,7 +1007,8 @@ async function appendSeasonIssues(
   }
 
   const maxSeasonId = await fetchMaxSeasonId();
-  const maxAllowedSeason = Math.max(1, maxSeasonId) + 1;
+  const { nextSeason: maxAllowedSeason } =
+    getMintingClaimSeasonWindow(maxSeasonId);
   if (seasonValue > maxAllowedSeason) {
     invalid.push(
       `Season (must not exceed ${maxAllowedSeason}; current max season is ${maxSeasonId}, got ${seasonValue})`

--- a/src/minting-claims/claims-media-arweave-upload.ts
+++ b/src/minting-claims/claims-media-arweave-upload.ts
@@ -1,5 +1,8 @@
 import type { MintingClaimRow } from '@/api/minting-claims/api.minting-claims.db';
-import { fetchMemeIdByMemeName } from '@/api/minting-claims/api.minting-claims.db';
+import {
+  fetchMaxSeasonId,
+  fetchMemeIdByMemeName
+} from '@/api/minting-claims/api.minting-claims.db';
 import { arweaveFileUploader } from '@/arweave';
 import { BadRequestException } from '@/exceptions';
 import { fetchPublicUrlToBuffer } from '@/http/safe-fetch';
@@ -914,7 +917,7 @@ export async function validateMintingClaimReadyForArweaveUpload(
 
   let seasonValue: number | null = null;
   if (memesContract) {
-    seasonValue = appendSeasonIssues(rawAttributes, missing, invalid);
+    seasonValue = await appendSeasonIssues(rawAttributes, missing, invalid);
   }
   const typeMemeId = memesContract
     ? await resolveTypeMemeId(rawAttributes, missing, invalid)
@@ -985,20 +988,29 @@ function appendEditionSizeIssues(
   }
 }
 
-function appendSeasonIssues(
+async function appendSeasonIssues(
   rawAttributes: unknown,
   missing: string[],
   invalid: string[]
-): number | null {
+): Promise<number | null> {
   const seasonValue = extractSeasonFromAttributes(rawAttributes);
   if (seasonValue == null) {
     missing.push('Season');
     return null;
   }
-  // Publication may happen long after claim creation. Season freshness is
-  // enforced when the value changes, not while republishing stored metadata.
+  // Publication may happen long after claim creation, so historical seasons
+  // remain valid. Keep the upper bound to prevent bad future metadata.
   if (seasonValue < 1) {
     invalid.push(`Season (must be a positive integer, got ${seasonValue})`);
+    return seasonValue;
+  }
+
+  const maxSeasonId = await fetchMaxSeasonId();
+  const maxAllowedSeason = Math.max(1, maxSeasonId) + 1;
+  if (seasonValue > maxAllowedSeason) {
+    invalid.push(
+      `Season (must not exceed ${maxAllowedSeason}; current max season is ${maxSeasonId}, got ${seasonValue})`
+    );
   }
   return seasonValue;
 }

--- a/src/minting-claims/minting-claim-season.ts
+++ b/src/minting-claims/minting-claim-season.ts
@@ -1,0 +1,25 @@
+export interface MintingClaimSeasonWindow {
+  readonly currentSeason: number;
+  readonly nextSeason: number;
+}
+
+export function getMintingClaimSeasonWindow(
+  maxSeasonId: number
+): MintingClaimSeasonWindow {
+  const currentSeason = Math.max(1, maxSeasonId);
+  return {
+    currentSeason,
+    nextSeason: currentSeason + 1
+  };
+}
+
+export function isSeasonInMintingClaimCreationWindow(
+  season: number,
+  maxSeasonId: number
+): boolean {
+  const { currentSeason, nextSeason } =
+    getMintingClaimSeasonWindow(maxSeasonId);
+  return (
+    Number.isInteger(season) && season >= currentSeason && season <= nextSeason
+  );
+}

--- a/src/minting-claims/minting-claims-service.test.ts
+++ b/src/minting-claims/minting-claims-service.test.ts
@@ -1,8 +1,13 @@
 import { DropsDb } from '@/drops/drops.db';
+import { fetchPublicUrlToBuffer } from '@/http/safe-fetch';
 import { RequestContext } from '@/request.context';
 import { MemeCardDropMappingsDb } from './meme-card-drop-mappings.db';
 import { MintingClaimsDb } from './minting-claims.db';
 import { MintingClaimsService } from './minting-claims.service';
+
+jest.mock('@/http/safe-fetch', () => ({
+  fetchPublicUrlToBuffer: jest.fn()
+}));
 
 type MappingInvoker = {
   saveMemeCardMappingIfMainStageWinner(
@@ -10,6 +15,13 @@ type MappingInvoker = {
     memeCardId: number,
     ctx: RequestContext
   ): Promise<void>;
+};
+
+type SeasonInvoker = {
+  resolveSeasonForClaimBuild(
+    claimId: number,
+    ctx: RequestContext
+  ): Promise<number>;
 };
 
 describe('MintingClaimsService Main Stage mapping', () => {
@@ -44,5 +56,61 @@ describe('MintingClaimsService Main Stage mapping', () => {
       'main-stage-wave',
       ctx
     );
+  });
+});
+
+describe('MintingClaimsService claim season resolution', () => {
+  const fetchPublicUrlToBufferMock =
+    fetchPublicUrlToBuffer as jest.MockedFunction<
+      typeof fetchPublicUrlToBuffer
+    >;
+  const getMaxSeasonIdMock = jest.fn().mockResolvedValue(16);
+  const ctx = { connection: {} } as RequestContext;
+  const service = new MintingClaimsService(
+    {} as DropsDb,
+    { getMaxSeasonId: getMaxSeasonIdMock } as unknown as MintingClaimsDb,
+    {} as MemeCardDropMappingsDb,
+    () => null
+  ) as unknown as SeasonInvoker;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getMaxSeasonIdMock.mockResolvedValue(16);
+  });
+
+  async function resolveCalendarSeason(season: unknown): Promise<number> {
+    fetchPublicUrlToBufferMock.mockResolvedValue({
+      buffer: Buffer.from(JSON.stringify({ season })),
+      contentType: 'application/json',
+      finalUrl: 'https://6529.io/api/meme-calendar/521'
+    });
+    return await service.resolveSeasonForClaimBuild(521, ctx);
+  }
+
+  it.each([
+    ['current', 16],
+    ['next', 17]
+  ])('accepts the %s season for a new claim', async (_label, season) => {
+    await expect(resolveCalendarSeason(season)).resolves.toBe(season);
+  });
+
+  it.each([
+    ['historical', 15],
+    ['too-far future', 18],
+    ['nonpositive', 0]
+  ])(
+    'falls back to the current season for a %s calendar season',
+    async (_label, season) => {
+      await expect(resolveCalendarSeason(season)).resolves.toBe(16);
+    }
+  );
+
+  it('fetches the season maximum once when the calendar request fails', async () => {
+    fetchPublicUrlToBufferMock.mockRejectedValue(new Error('calendar down'));
+
+    await expect(service.resolveSeasonForClaimBuild(521, ctx)).resolves.toBe(
+      16
+    );
+    expect(getMaxSeasonIdMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/minting-claims/minting-claims.service.ts
+++ b/src/minting-claims/minting-claims.service.ts
@@ -23,6 +23,10 @@ import { fetchPublicUrlToBuffer } from '@/http/safe-fetch';
 import { Logger } from '@/logging';
 import { getMaxMemeId } from '@/nftsLoop/db.nfts';
 import { numbers } from '@/numbers';
+import {
+  getMintingClaimSeasonWindow,
+  isSeasonInMintingClaimCreationWindow
+} from '@/minting-claims/minting-claim-season';
 import { RequestContext } from '@/request.context';
 import { sqlExecutor } from '@/sql-executor';
 import { ethers } from 'ethers';
@@ -232,6 +236,9 @@ export class MintingClaimsService {
     claimId: number,
     ctx: RequestContext
   ): Promise<number> {
+    const maxSeasonId = await this.mintingClaimsDb.getMaxSeasonId(ctx);
+    const { currentSeason, nextSeason } =
+      getMintingClaimSeasonWindow(maxSeasonId);
     const calendarUrl = `${MEME_CALENDAR_API_BASE}/${claimId}`;
     try {
       const { buffer } = await fetchPublicUrlToBuffer(calendarUrl, {
@@ -245,22 +252,25 @@ export class MintingClaimsService {
         season?: unknown;
       };
       const season = numbers.parseIntOrNull(parsed?.season);
-      if (season !== null && season > 0) {
+      if (
+        season !== null &&
+        isSeasonInMintingClaimCreationWindow(season, maxSeasonId)
+      ) {
         this.logger.info(
           `Using meme-calendar season=${season} for claim_id=${claimId}`
         );
         return season;
       }
       this.logger.warn(
-        `Invalid season from meme-calendar for claim_id=${claimId}, value=${parsed?.season}; falling back to max season`
+        `Invalid season from meme-calendar for claim_id=${claimId}, value=${parsed?.season}; expected ${currentSeason} or ${nextSeason}, falling back to current season`
       );
     } catch (error) {
       this.logger.warn(
-        `Failed to resolve season from meme-calendar for claim_id=${claimId}; falling back to max season`,
+        `Failed to resolve season from meme-calendar for claim_id=${claimId}; falling back to current season`,
         { error }
       );
     }
-    return await this.mintingClaimsDb.getMaxSeasonId(ctx);
+    return currentSeason;
   }
 
   private async resolveNextClaimId(ctx: RequestContext): Promise<number> {


### PR DESCRIPTION
## Issue

- Drop Forge permits metadata edits on historical MEMES claims, but Arweave publication rejected a stored season once it fell outside the moving current/current+1 window.
- Full attribute replacements can include an unchanged season, and concurrent replacements could restore stale attributes after another administrator changed the season.
- Claim creation trusted any positive meme-calendar season, which became unsafe once publication began allowing historical seasons.

## Fix

- Preserve an unchanged historical season during metadata edits while enforcing the current/current+1 rule whenever the season actually changes.
- Allow positive historical seasons during Arweave publication while retaining the current+1 upper bound against impossible future metadata.
- Enforce the current/current+1 window when a new claim is created, falling back to the current season when the calendar returns a stale, future, invalid, or unavailable value.
- Normalize stored attributes before comparing seasons and use a transactional row lock for full attribute replacements. Stale writes now return `409` instead of overwriting newer metadata, while idempotent writes succeed independently of MySQL changed-row reporting.

## Changes

- Added one shared season-window policy used by claim creation, API edits, and Arweave preflight.
- Added stored-season normalization for legacy whitespace and string-number representations.
- Added a transactional attribute predicate and media-upload guard to claim PATCH writes.
- Kept non-attribute PATCHes independent from attribute revisions.
- Added regression coverage for creation boundaries, unchanged historical seasons, normalized stored metadata, future-season rejection, stale concurrent writes, upload races, published/idempotent JSON updates, and Arweave republishing.

## Validation

- Focused Jest coverage: 47 tests passed across the four affected suites; the final two-suite regression rerun passed 22 tests.
- Follow-up transactional and boundary regression coverage: 44 tests passed across three affected suites.
- Backend ESLint passed with zero warnings.
- TypeScript compilation passed with no emit.
- Prettier and diff checks passed.

## Risk

- Scoped to minting-claim creation, metadata PATCH concurrency, and MEMES season validation.
- New and changed seasons retain the current/current+1 restriction.
- Existing historical seasons may be edited and republished but cannot be silently restored by a stale full-attribute request.
- No API schema or database migration is required.

## Deployment

No deployment is included in this PR task. When deployed, use this order to avoid mixed-version windows:

1. `claimsBuilder`
2. `claimsMediaArweaveUploader`
3. `api`
