### PR TITLE
Update CI and release note headings

### DIFF
--- a/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.test.ts
+++ b/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.test.ts
@@ -178,7 +178,7 @@ describe('CiPipelineAlertService', () => {
             expect.objectContaining({
               content: expect.stringContaining(
                 [
-                  '[PROD] Seize PROD WEB DEPLOY: CI pipeline is broken!!! 🚨',
+                  '[🚀 PRODUCTION] Seize PROD WEB DEPLOY: CI pipeline is broken!!! 🚨',
                   '',
                   'abc123 - Fix deploy',
                   '',
@@ -246,7 +246,7 @@ describe('CiPipelineAlertService', () => {
             expect.objectContaining({
               content: expect.stringContaining(
                 [
-                  '[STAGING 🚧] Seize Lambda staging api DEPLOY CI pipeline complete ✅',
+                  '[🚧 STAGING] Seize Lambda staging api DEPLOY CI pipeline complete ✅',
                   '',
                   'abc123 - Fix deploy',
                   '',
@@ -269,7 +269,7 @@ describe('CiPipelineAlertService', () => {
         .parts[0].content
     ).toBe(
       [
-        '[STAGING 🚧] Seize Lambda staging api DEPLOY CI pipeline complete ✅',
+        '[🚧 STAGING] Seize Lambda staging api DEPLOY CI pipeline complete ✅',
         '',
         'abc123 - Fix deploy',
         '',
@@ -652,7 +652,7 @@ describe('CiPipelineAlertService', () => {
         .parts[0].content
     ).toBe(
       [
-        '[PROD] Desktop Publish completed 🚀 ✅',
+        '[🚀 PRODUCTION] Desktop Publish completed 🚀 ✅',
         '',
         'Production v0.3.11 publish completed with S3 and Arweave links published and CloudFront invalidated.',
         '',
@@ -678,7 +678,7 @@ describe('CiPipelineAlertService', () => {
 
       expect(
         dropCreationApiService.createDrop.mock.calls[0][0].createDropRequest.parts[0].content.startsWith(
-          '[PROD] Web Deploy - PROD 🚨'
+          '[🚀 PRODUCTION] Web Deploy - PROD 🚨'
         )
       ).toBe(true);
     }
@@ -698,8 +698,10 @@ describe('CiPipelineAlertService', () => {
     const content =
       dropCreationApiService.createDrop.mock.calls[0][0].createDropRequest
         .parts[0].content;
-    expect(content.startsWith('[PROD] Build succeeded ✅')).toBe(true);
-    expect(content.startsWith('[PROD] Build succeeded ✅ ❌ 🚨')).toBe(false);
+    expect(content.startsWith('[🚀 PRODUCTION] Build succeeded ✅')).toBe(true);
+    expect(content.startsWith('[🚀 PRODUCTION] Build succeeded ✅ ❌ 🚨')).toBe(
+      false
+    );
   });
 
   it('preserves the outcome and run metadata when text is long', async () => {

--- a/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.ts
+++ b/src/api-serverless/src/ci-pipeline-alerts/ci-pipeline-alert.service.ts
@@ -200,10 +200,14 @@ function formatAlertHeading(request: CiPipelineAlertRequest): string {
 }
 
 function formatEnvironmentPrefix(value: string | null | undefined): string {
-  const environmentLabel = formatEnvironmentLabel(value);
-  const stagingEmoji =
-    normalizeTargetEnvironment(value) === 'staging' ? ' 🚧' : '';
-  return `[${environmentLabel}${stagingEmoji}] `;
+  const targetEnvironment = normalizeTargetEnvironment(value);
+  if (targetEnvironment === 'staging') {
+    return '[🚧 STAGING] ';
+  }
+  if (targetEnvironment === 'prod') {
+    return '[🚀 PRODUCTION] ';
+  }
+  return `[${formatEnvironmentLabel(value)}] `;
 }
 
 function formatEnvironmentLabel(value: string | null | undefined): string {

--- a/src/release-notes/release-note-generation.service.test.ts
+++ b/src/release-notes/release-note-generation.service.test.ts
@@ -162,7 +162,7 @@ describe('ReleaseNoteGenerationService', () => {
     const content =
       createDrop.mock.calls[0][0].createDropRequest.parts[0].content;
     expect(content).toContain(
-      '### Backend deploy · commit [current-](https://github.com/6529-Collections/6529seize-backend/commit/current-sha) — Jul 13, 11:38 AM UTC'
+      '### Backend Deploy · commit [current-](https://github.com/6529-Collections/6529seize-backend/commit/current-sha) — Jul 13, 11:38 AM UTC'
     );
     expect(content).not.toContain('\n\n- Service:');
     expect(content).not.toContain('Runs:');
@@ -265,9 +265,9 @@ describe('ReleaseNoteGenerationService', () => {
     const content =
       createDrop.mock.calls[0][0].createDropRequest.parts[0].content;
     expect(content).toContain(
-      '### Frontend deploy [#45](https://github.com/6529-Collections/6529seize-backend/actions/runs/123) · commit [current-](https://github.com/6529-Collections/6529seize-frontend/commit/current-sha) — Jul 13, 11:38 AM UTC'
+      '### Frontend Deploy [#45](https://github.com/6529-Collections/6529seize-backend/actions/runs/123) · commit [current-](https://github.com/6529-Collections/6529seize-frontend/commit/current-sha) — Jul 13, 11:38 AM UTC'
     );
-    expect(content).not.toContain('[Frontend deploy #45]');
+    expect(content).not.toContain('[Frontend Deploy #45]');
 
     await service.generateAndPost(
       {
@@ -281,7 +281,7 @@ describe('ReleaseNoteGenerationService', () => {
     const backendContent =
       createDrop.mock.calls[1][0].createDropRequest.parts[0].content;
     expect(backendContent).toContain(
-      '### Backend deploy · commit [current-](https://github.com/6529-Collections/6529seize-backend/commit/current-sha) — Jul 13, 11:38 AM UTC'
+      '### Backend Deploy · commit [current-](https://github.com/6529-Collections/6529seize-backend/commit/current-sha) — Jul 13, 11:38 AM UTC'
     );
     expect(backendContent).toContain(
       '- Service: [api #45](https://github.com/6529-Collections/6529seize-backend/actions/runs/123)'

--- a/src/release-notes/release-note-generation.service.ts
+++ b/src/release-notes/release-note-generation.service.ts
@@ -136,9 +136,9 @@ function getReleaseHeading(request: ReleaseNoteGenerationRequest): string {
   if (surface === 'Frontend' && request.release_group_services.length === 1) {
     const runNumber = request.run_number || request.run_id;
     const run = formatMarkdownLink(`#${runNumber}`, request.run_url);
-    return `### ${surface} deploy ${run} · commit ${commit} — ${formattedDate}`;
+    return `### ${surface} Deploy ${run} · commit ${commit} — ${formattedDate}`;
   }
-  return `### ${surface} deploy · commit ${commit} — ${formattedDate}`;
+  return `### ${surface} Deploy · commit ${commit} — ${formattedDate}`;
 }
 
 function getBackendRunsByService(


### PR DESCRIPTION
## What changed

- Render staging CI posts with `[🚧 STAGING]`.
- Render production CI posts with `[🚀 PRODUCTION]`.
- Capitalize the release-note headings as `Frontend Deploy` and `Backend Deploy`.
- Update focused formatter and release-note coverage.

## Impact

Frontend and backend CI Wave posts receive the new environment headings because formatting is centralized in the backend alert receiver. Generated frontend and backend release notes use the capitalized deploy headings.

## Validation

- `git diff --check`
- Focused Jest tests were not run in the fresh worktree because Jest dependencies are not installed; CI will run full validation.