### PR TITLE
feat: add reset_votes_after_win for sequential APPROVE waves

### DIFF
--- a/migrations/20260810173657-add-reset-votes-after-win-column.js
+++ b/migrations/20260810173657-add-reset-votes-after-win-column.js
@@ -1,0 +1,83 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+ * We receive a dbmigrate dependency from dbmigrate initially.
+ * This enables us to not have to rely on NODE_PATH.
+ */
+exports.setup = function (options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function (db) {
+  var filePath = path.join(
+    __dirname,
+    'sqls',
+    '20260810173657-add-reset-votes-after-win-column-up.sql'
+  );
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  }).then(function (data) {
+    var statements = data
+      .split(';')
+      .map(function (statement) {
+        return statement.trim();
+      })
+      .filter(function (statement) {
+        return statement.length > 0;
+      });
+    return statements.reduce(function (promiseChain, statement) {
+      return promiseChain.then(function () {
+        return db.runSql(statement);
+      });
+    }, Promise.resolve());
+  });
+};
+
+exports.down = function (db) {
+  var filePath = path.join(
+    __dirname,
+    'sqls',
+    '20260810173657-add-reset-votes-after-win-column-down.sql'
+  );
+  return new Promise(function (resolve, reject) {
+    fs.readFile(filePath, { encoding: 'utf-8' }, function (err, data) {
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  }).then(function (data) {
+    var statements = data
+      .split(';')
+      .map(function (statement) {
+        return statement.trim();
+      })
+      .filter(function (statement) {
+        return statement.length > 0;
+      });
+    return statements.reduce(function (promiseChain, statement) {
+      return promiseChain.then(function () {
+        return db.runSql(statement);
+      });
+    }, Promise.resolve());
+  });
+};
+
+exports._meta = {
+  version: 1
+};

--- a/migrations/sqls/20260810173657-add-reset-votes-after-win-column-down.sql
+++ b/migrations/sqls/20260810173657-add-reset-votes-after-win-column-down.sql
@@ -2,3 +2,8 @@ ALTER TABLE waves
   DROP COLUMN reset_votes_after_win,
   ALGORITHM=INPLACE,
   LOCK=NONE;
+
+ALTER TABLE waves_archive
+  DROP COLUMN reset_votes_after_win,
+  ALGORITHM=INPLACE,
+  LOCK=NONE;

--- a/migrations/sqls/20260810173657-add-reset-votes-after-win-column-down.sql
+++ b/migrations/sqls/20260810173657-add-reset-votes-after-win-column-down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE waves
+  DROP COLUMN reset_votes_after_win,
+  ALGORITHM=INPLACE,
+  LOCK=NONE;

--- a/migrations/sqls/20260810173657-add-reset-votes-after-win-column-up.sql
+++ b/migrations/sqls/20260810173657-add-reset-votes-after-win-column-up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE waves
+  ADD COLUMN reset_votes_after_win tinyint(1) NOT NULL DEFAULT 0,
+  ALGORITHM=INPLACE,
+  LOCK=NONE;

--- a/migrations/sqls/20260810173657-add-reset-votes-after-win-column-up.sql
+++ b/migrations/sqls/20260810173657-add-reset-votes-after-win-column-up.sql
@@ -2,3 +2,8 @@ ALTER TABLE waves
   ADD COLUMN reset_votes_after_win tinyint(1) NOT NULL DEFAULT 0,
   ALGORITHM=INPLACE,
   LOCK=NONE;
+
+ALTER TABLE waves_archive
+  ADD COLUMN reset_votes_after_win tinyint(1) NOT NULL DEFAULT 0,
+  ALGORITHM=INPLACE,
+  LOCK=NONE;

--- a/src/api-serverless/src/drops/drop-voting.db.ts
+++ b/src/api-serverless/src/drops/drop-voting.db.ts
@@ -1099,6 +1099,79 @@ export class DropVotingDb extends LazyDbAccessCompatibleService {
     );
   }
 
+  /**
+   * Resets all vote-related state for PARTICIPATORY drops in a wave
+   * (i.e. drops that have NOT yet been formalized as winners).
+   *
+   * Used by the sequential-approve feature: when `reset_votes_after_win`
+   * is enabled on a wave, after a winner is formalized the remaining
+   * submissions have their votes cleared so the community must re-vote
+   * from scratch on the next candidate in sequence.
+   */
+  async resetVotesForParticipatoryDropsInWave(
+    waveId: string,
+    ctx: RequestContext
+  ): Promise<void> {
+    ctx.timer?.start(
+      `${this.constructor.name}->resetVotesForParticipatoryDropsInWave`
+    );
+
+    // Sub-query: PARTICIPATORY drop IDs in this wave (excludes WINNER drops)
+    const participatoryDropIds = await this.db
+      .execute<{ id: string }>(
+        `select id from ${DROPS_TABLE}
+         where wave_id = :waveId
+           and drop_type = '${DropType.PARTICIPATORY}'`,
+        { waveId },
+        { wrappedConnection: ctx.connection }
+      );
+
+    const dropIds = participatoryDropIds.map((row) => row.id);
+
+    if (dropIds.length === 0) {
+      ctx.timer?.stop(
+        `${this.constructor.name}->resetVotesForParticipatoryDropsInWave`
+      );
+      return;
+    }
+
+    // Clear vote state across all relevant tables for remaining participatory drops
+    await this.db.execute(
+      `delete from ${DROP_VOTER_STATE_TABLE} where drop_id in (:dropIds)`,
+      { dropIds },
+      { wrappedConnection: ctx.connection }
+    );
+    await this.db.execute(
+      `delete from ${DROP_RANK_TABLE} where drop_id in (:dropIds)`,
+      { dropIds },
+      { wrappedConnection: ctx.connection }
+    );
+    await this.db.execute(
+      `delete from ${DROP_REAL_VOTE_IN_TIME_TABLE} where drop_id in (:dropIds)`,
+      { dropIds },
+      { wrappedConnection: ctx.connection }
+    );
+    await this.db.execute(
+      `delete from ${DROP_REAL_VOTER_VOTE_IN_TIME_TABLE} where drop_id in (:dropIds)`,
+      { dropIds },
+      { wrappedConnection: ctx.connection }
+    );
+    await this.db.execute(
+      `delete from ${DROPS_VOTES_CREDIT_SPENDINGS_TABLE} where drop_id in (:dropIds)`,
+      { dropIds },
+      { wrappedConnection: ctx.connection }
+    );
+    await this.db.execute(
+      `delete from ${WAVE_LEADERBOARD_ENTRIES_TABLE} where drop_id in (:dropIds)`,
+      { dropIds },
+      { wrappedConnection: ctx.connection }
+    );
+
+    ctx.timer?.stop(
+      `${this.constructor.name}->resetVotesForParticipatoryDropsInWave`
+    );
+  }
+
   async getParticipationDropsRealtimeRanks(
     dropIds: string[],
     ctx: RequestContext

--- a/src/api-serverless/src/generated/models/ApiWaveConfig.ts
+++ b/src/api-serverless/src/generated/models/ApiWaveConfig.ts
@@ -42,6 +42,10 @@ export class ApiWaveConfig {
     'decisions_strategy': ApiWaveDecisionsStrategy | null;
     'next_decision_time': number | null;
     'admin_drop_deletion_enabled': boolean;
+    /**
+    * When true on an APPROVE wave, after a submission is formalized as a winner, all remaining participatory drops have their votes reset to zero, forcing the community to re-vote on the next candidate in sequence.
+    */
+    'reset_votes_after_win': boolean;
     'total_no_of_decisions': number | null;
     'no_of_decisions_done': number | null;
     'no_of_decisions_left': number | null;
@@ -114,6 +118,12 @@ export class ApiWaveConfig {
         {
             "name": "admin_drop_deletion_enabled",
             "baseName": "admin_drop_deletion_enabled",
+            "type": "boolean",
+            "format": ""
+        },
+        {
+            "name": "reset_votes_after_win",
+            "baseName": "reset_votes_after_win",
             "type": "boolean",
             "format": ""
         },

--- a/src/api-serverless/src/waves/waves.api.db.ts
+++ b/src/api-serverless/src/waves/waves.api.db.ts
@@ -1130,6 +1130,7 @@ export class WavesApiDb extends LazyDbAccessCompatibleService {
            decisions_strategy,
            next_decision_time,
            forbid_negative_votes,
+           reset_votes_after_win,
            is_direct_message${wave.serial_no !== null ? ', serial_no' : ''})
           values (:id,
                   :name,
@@ -1175,6 +1176,7 @@ export class WavesApiDb extends LazyDbAccessCompatibleService {
                   :decisions_strategy,
                   :next_decision_time,
                   :forbid_negative_votes,
+                  :reset_votes_after_win,
                   :is_direct_message${wave.serial_no !== null ? ', :serial_no' : ''})`,
         params,
         { wrappedConnection: connection }
@@ -1230,6 +1232,7 @@ export class WavesApiDb extends LazyDbAccessCompatibleService {
                             decisions_strategy,
                             serial_no,
                             forbid_negative_votes,
+                            reset_votes_after_win,
                             is_direct_message
                            )
                            values (
@@ -1278,6 +1281,7 @@ export class WavesApiDb extends LazyDbAccessCompatibleService {
                                    :decisions_strategy,
                                    :serial_no,
                                    :forbid_negative_votes,
+                                   :reset_votes_after_win,
                            :is_direct_message
                            )`,
       { ...params, serial_no: serial, now: Time.currentMillis() },

--- a/src/api-serverless/src/waves/waves.mappers.ts
+++ b/src/api-serverless/src/waves/waves.mappers.ts
@@ -253,7 +253,7 @@ export class WavesMappers {
       participation_terms: request.participation.terms,
       admin_drop_deletion_enabled: request.wave.admin_drop_deletion_enabled,
       forbid_negative_votes: request.voting.forbid_negative_votes,
-      reset_votes_after_win: request.wave.reset_votes_after_win ?? false,
+      reset_votes_after_win: request.wave.reset_votes_after_win ?? existingWaveSettings?.reset_votes_after_win ?? false,
       is_direct_message: isDirectMessage
     };
   }

--- a/src/api-serverless/src/waves/waves.mappers.ts
+++ b/src/api-serverless/src/waves/waves.mappers.ts
@@ -253,6 +253,7 @@ export class WavesMappers {
       participation_terms: request.participation.terms,
       admin_drop_deletion_enabled: request.wave.admin_drop_deletion_enabled,
       forbid_negative_votes: request.voting.forbid_negative_votes,
+      reset_votes_after_win: request.wave.reset_votes_after_win ?? false,
       is_direct_message: isDirectMessage
     };
   }
@@ -494,6 +495,7 @@ export class WavesMappers {
       decisions_strategy: waveEntity.decisions_strategy,
       next_decision_time: waveEntity.next_decision_time,
       admin_drop_deletion_enabled: waveEntity.admin_drop_deletion_enabled,
+      reset_votes_after_win: waveEntity.reset_votes_after_win,
       ...approveDecisionCounts
     };
     const waveMetrics = metrics[waveEntity.id];

--- a/src/api-serverless/src/waves/waves.routes.ts
+++ b/src/api-serverless/src/waves/waves.routes.ts
@@ -1309,7 +1309,12 @@ function createWaveConfigSchema(
     period: IntRangeSchema.optional(),
     admin_group: WaveScopeSchema.required(),
     decisions_strategy: decisionsStrategySchema.optional().allow(null),
-    admin_drop_deletion_enabled: Joi.boolean().optional().default(false)
+    admin_drop_deletion_enabled: Joi.boolean().optional().default(false),
+    reset_votes_after_win: Joi.when('type', {
+      is: Joi.string().valid(ApiWaveType.Approve),
+      then: Joi.boolean().optional().default(false),
+      otherwise: Joi.valid(false).optional().default(false)
+    })
   });
 }
 

--- a/src/api-serverless/src/waves/waves.routes.ts
+++ b/src/api-serverless/src/waves/waves.routes.ts
@@ -1322,9 +1322,11 @@ const WaveConfigSchema = createWaveConfigSchema(
   CreateWaveDecisionsStrategySchema
 );
 
+// For updates, do not default reset_votes_after_win to false —
+// preserve the existing value if the field is omitted.
 const UpdateWaveConfigSchema = createWaveConfigSchema(
   UpdateWaveDecisionsStrategySchema
-);
+).fork('reset_votes_after_win', (schema) => schema.optional());
 
 const WaveOutcomeDistributionItemSchema =
   Joi.object<ApiWaveOutcomeDistributionItem>({

--- a/src/entities/IWave.ts
+++ b/src/entities/IWave.ts
@@ -56,6 +56,7 @@ export interface WaveBaseType {
   readonly participation_terms: string | null;
   readonly admin_drop_deletion_enabled: boolean;
   readonly forbid_negative_votes: boolean;
+  readonly reset_votes_after_win: boolean;
 }
 
 export class WaveBase implements WaveBaseType {
@@ -189,6 +190,9 @@ export class WaveBase implements WaveBaseType {
 
   @Column({ type: 'boolean', nullable: false, default: false })
   readonly forbid_negative_votes!: boolean;
+
+  @Column({ type: 'boolean', nullable: false, default: false })
+  readonly reset_votes_after_win!: boolean;
 
   @Index('idx_wave_is_direct_message')
   @Column({ type: 'boolean', nullable: true, default: null })

--- a/src/waves/wave-decisions.db.ts
+++ b/src/waves/wave-decisions.db.ts
@@ -230,6 +230,20 @@ export class WaveDecisionsDb extends LazyDbAccessCompatibleService {
     ctx.timer?.stop(`${this.constructor.name}->deleteDropsRanks`);
   }
 
+  async getResetVotesAfterWin(
+    waveId: string,
+    ctx: RequestContext
+  ): Promise<boolean> {
+    ctx.timer?.start(`${this.constructor.name}->getResetVotesAfterWin`);
+    const result = await this.db.oneOrNull<{ reset_votes_after_win: number }>(
+      `select reset_votes_after_win from ${WAVES_TABLE} where id = :waveId`,
+      { waveId },
+      { wrappedConnection: ctx.connection }
+    );
+    ctx.timer?.stop(`${this.constructor.name}->getResetVotesAfterWin`);
+    return result?.reset_votes_after_win === 1;
+  }
+
   async updateWavesNextDecisionTime(
     waveId: string,
     decisionTime: number | null,

--- a/src/waves/wave-decisions.service.ts
+++ b/src/waves/wave-decisions.service.ts
@@ -639,8 +639,10 @@ export class WaveDecisionsService {
     // Sequential APPROVE: if reset_votes_after_win is enabled on this wave,
     // clear all vote state on remaining PARTICIPATORY drops so the community
     // must re-vote from scratch on the next candidate in sequence.
-    const resetVotesAfterWin =
-      await this.waveDecisionsDb.getResetVotesAfterWin(waveId, ctx);
+    const resetVotesAfterWin = await this.waveDecisionsDb.getResetVotesAfterWin(
+      waveId,
+      ctx
+    );
     if (resetVotesAfterWin) {
       this.logger.info(
         `Resetting votes for remaining participatory drops in wave ${waveId} after winner formalization`

--- a/src/waves/wave-decisions.service.ts
+++ b/src/waves/wave-decisions.service.ts
@@ -635,6 +635,22 @@ export class WaveDecisionsService {
     await this.waveDecisionsDb.deleteDropsRanks(winnerDropIds, ctx);
     await this.dropsDb.resyncParticipatoryDropCountsForWaves([waveId], ctx);
     await this.dropVotingDb.deleteStaleLeaderboardEntries(ctx);
+
+    // Sequential APPROVE: if reset_votes_after_win is enabled on this wave,
+    // clear all vote state on remaining PARTICIPATORY drops so the community
+    // must re-vote from scratch on the next candidate in sequence.
+    const resetVotesAfterWin =
+      await this.waveDecisionsDb.getResetVotesAfterWin(waveId, ctx);
+    if (resetVotesAfterWin) {
+      this.logger.info(
+        `Resetting votes for remaining participatory drops in wave ${waveId} after winner formalization`
+      );
+      await this.dropVotingDb.resetVotesForParticipatoryDropsInWave(
+        waveId,
+        ctx
+      );
+    }
+
     const announcementDropResult = await this.createAnnouncementDrop(
       waveId,
       winnerDropIds,


### PR DESCRIPTION
## Summary

Adds a new `reset_votes_after_win` boolean flag to APPROVE waves that enables **sequential approval workflows**.

When enabled, after a submission is formalized as a winner, all remaining PARTICIPATORY drops in the wave have their votes reset to zero. This forces the community to re-vote from scratch on the next candidate, ensuring that the **order of approval matters** — each submission is evaluated on its own merit in sequence rather than all submissions racing toward the threshold simultaneously.

## Use Case

An approval wave where the order in which submissions are approved is important. For example: a community-curated collection where the first approved submission gets position #1, the second gets position #2, etc. With the current APPROVE wave, all submissions accumulate votes independently — the highest-voted submission wins first, but the second-highest has already accumulated votes and may win immediately after, skipping the deliberation process. With `reset_votes_after_win`, each round starts fresh so the community deliberately chooses the next winner.

## Changes

### Database
- **Migration**: `20260810173657-add-reset-votes-after-win-column` — adds `reset_votes_after_win tinyint(1) NOT NULL DEFAULT 0` to the `waves` table (INPLACE, no lock)

### Entity
- **`src/entities/IWave.ts`**: Added `reset_votes_after_win: boolean` to `WaveBaseType` interface and `WaveBase` class

### Backend Logic
- **`src/waves/wave-decisions.db.ts`**: Added `getResetVotesAfterWin(waveId)` — queries the flag from the waves table
- **`src/waves/wave-decisions.service.ts`**: In `formalizeDecision()`, after winner formalization, checks the flag and calls `resetVotesForParticipatoryDropsInWave()` if enabled
- **`src/api-serverless/src/drops/drop-voting.db.ts`**: Added `resetVotesForParticipatoryDropsInWave(waveId)` — clears vote state across 6 tables:
  - `drop_voter_state`
  - `drop_rank`
  - `drop_real_vote_in_time`
  - `drop_real_voter_vote_in_time`
  - `drop_votes_credit_spendings`
  - `wave_leaderboard_entries`

  Only targets drops with `drop_type = PARTICIPATORY` (excludes already-formalized WINNER drops).

### API
- **`src/api-serverless/src/waves/waves.api.db.ts`**: Added `reset_votes_after_win` to both wave INSERT and wave archive INSERT SQL statements
- **`src/api-serverless/src/waves/waves.mappers.ts`**: Maps the field in both request→entity (create) and entity→response (read) directions
- **`src/api-serverless/src/waves/waves.routes.ts`**: Added to Joi config schema — only valid for APPROVE waves, defaults to `false`
- **`src/api-serverless/src/generated/models/ApiWaveConfig.ts`**: Added field to generated API model (OpenAPI spec should also be updated)

## Behavior

- **Default: `false`** — no behavior change for existing waves
- Only effective on `APPROVE` type waves (Joi schema enforces `false` for non-APPROVE)
- The reset happens inside the same transaction as `formalizeDecision()`, so it's atomic — if the decision fails, the reset rolls back too
- `winning_threshold_min_duration_ms` timers restart naturally for each remaining submission since their leaderboard entries are cleared

## Testing

The reset clears all vote-tracking tables for remaining PARTICIPATORY drops. After reset:
- Vote counts return to 0 on all remaining submissions
- Leaderboard entries are cleared (threshold duration timer restarts)
- Voters can re-cast votes immediately
- The next `createApproveDecisions` cycle will only find candidates that have重新 reached the threshold

## Notes

- The OpenAPI spec (`/openapi.yaml`) should also be updated to include the new field — the generated model has been updated directly as a stopgap
- The TypeORM entity sync (`syncEntities: true` in the migrations loop) will also create the column, but the explicit migration ensures it exists with the correct default before the service starts using it


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional “reset votes after win” setting for Approve waves.
  - When enabled, votes and related rankings are cleared from remaining participatory drops after a winner is formalized.
  - The setting is displayed in wave configuration and defaults to disabled.
  - The option is automatically disabled for unsupported wave types.
  - Updating other wave settings preserves the existing reset-votes preference when omitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->