### PR TITLE
Improve header profile search latency

### DIFF
--- a/src/api-serverless/src/community-members/community-members.routes.ts
+++ b/src/api-serverless/src/community-members/community-members.routes.ts
@@ -16,11 +16,13 @@ import { ApiCommunityMemberMinimal } from '../generated/models/ApiCommunityMembe
 import { ApiCommunityMembersPage } from '../generated/models/ApiCommunityMembersPage';
 import { ApiCommunityMembersSortOption } from '../generated/models/ApiCommunityMembersSortOption';
 import { identityFetcher } from '../identities/identity.fetcher';
+import { cacheRequest } from '@/api/request-cache';
 
 const router = asyncRouter();
 
 router.get(
   `/`,
+  cacheRequest(),
   async function (
     req: Request<
       any,

--- a/src/api-serverless/src/competitions/phase-0-runtime-route-census.test.ts
+++ b/src/api-serverless/src/competitions/phase-0-runtime-route-census.test.ts
@@ -24,6 +24,8 @@ const RETIRED_RELEASE_BUS_V1_ROUTES = new Set([
   '/deploy/release-trains/:id'
 ]);
 
+const ACCEPTED_CACHE_EXTENSIONS = new Set(['/api/community-members']);
+
 const repositoryRoot = path.resolve(__dirname, '../../../..');
 const fixtureRoot = path.resolve(
   __dirname,
@@ -180,7 +182,14 @@ describe('Phase 0 permanent mounted GET route census', () => {
       ) {
         failures.push(`${route.path}: required auth has no static evidence`);
       }
-      if (best.cache !== route.cache) {
+      if (
+        best.cache !== route.cache &&
+        !(
+          route.cache === 'uncached' &&
+          best.cache === 'cached' &&
+          ACCEPTED_CACHE_EXTENSIONS.has(route.path)
+        )
+      ) {
         failures.push(
           `${route.path}: cache changed from ${route.cache} to ${best.cache}`
         );

--- a/src/api-serverless/src/identities/identity-fetcher.test.ts
+++ b/src/api-serverless/src/identities/identity-fetcher.test.ts
@@ -6,6 +6,38 @@ import type { IdentitySubscriptionsDb } from '@/api/identity-subscriptions/ident
 import { IdentityFetcher } from './identity.fetcher';
 
 describe('IdentityFetcher', () => {
+  const createIdentity = ({
+    consolidationKey,
+    handle,
+    address
+  }: {
+    consolidationKey: string;
+    handle: string;
+    address: string;
+  }): IdentityEntity =>
+    ({
+      consolidation_key: consolidationKey,
+      profile_id: consolidationKey,
+      primary_address: address,
+      handle,
+      normalised_handle: handle.toLowerCase(),
+      tdh: 1,
+      level_raw: 0,
+      cic: 0,
+      pfp: null
+    }) as IdentityEntity;
+
+  const createFetcher = (identitiesDb: IdentitiesDb) =>
+    new IdentityFetcher(
+      identitiesDb,
+      {} as IdentitySubscriptionsDb,
+      {} as CicDb,
+      {} as RatingsDb,
+      () => {
+        throw new Error('Alchemy is not used by community-member search');
+      }
+    );
+
   it('runs handle and ENS community-member searches concurrently', async () => {
     let resolveHandleSearch: (members: IdentityEntity[]) => void = () =>
       undefined;
@@ -26,15 +58,7 @@ describe('IdentityFetcher', () => {
         .mockReturnValue(handleSearch),
       searchCommunityMembersWhereEnsLike: jest.fn().mockReturnValue(ensSearch)
     } as unknown as IdentitiesDb;
-    const fetcher = new IdentityFetcher(
-      identitiesDb,
-      {} as IdentitySubscriptionsDb,
-      {} as CicDb,
-      {} as RatingsDb,
-      () => {
-        throw new Error('Alchemy is not used by community-member search');
-      }
-    );
+    const fetcher = createFetcher(identitiesDb);
 
     const result = fetcher.searchCommunityMemberMinimalsOfClosestMatches({
       param: 'signers',
@@ -59,5 +83,41 @@ describe('IdentityFetcher', () => {
     resolveHandleSearch([]);
     resolveEnsSearch([]);
     await expect(result).resolves.toEqual([]);
+  });
+
+  it('preserves ENS ranking data when handle and ENS matches overlap', async () => {
+    const overlappingIdentity = createIdentity({
+      consolidationKey: 'profile-with-ens',
+      handle: 'bravo-signers',
+      address: '0x0000000000000000000000000000000000000001'
+    });
+    const otherIdentity = createIdentity({
+      consolidationKey: 'profile-without-ens',
+      handle: 'alpha-signers',
+      address: '0x0000000000000000000000000000000000000002'
+    });
+    const identitiesDb = {
+      searchCommunityMembersWhereHandleLike: jest
+        .fn()
+        .mockResolvedValue([otherIdentity, overlappingIdentity]),
+      searchCommunityMembersWhereEnsLike: jest.fn().mockResolvedValue([
+        {
+          ...overlappingIdentity,
+          ens: 'signers.eth'
+        }
+      ])
+    } as unknown as IdentitiesDb;
+    const fetcher = createFetcher(identitiesDb);
+
+    const result = await fetcher.searchCommunityMemberMinimalsOfClosestMatches({
+      param: 'signers',
+      onlyProfileOwners: false,
+      limit: 10
+    });
+
+    expect(result.map((member) => member.profile_id)).toEqual([
+      'profile-with-ens',
+      'profile-without-ens'
+    ]);
   });
 });

--- a/src/api-serverless/src/identities/identity-fetcher.test.ts
+++ b/src/api-serverless/src/identities/identity-fetcher.test.ts
@@ -1,0 +1,63 @@
+import type { CicDb } from '@/cic/cic.db';
+import type { IdentityEntity } from '@/entities/IIdentity';
+import type { IdentitiesDb } from '@/identities/identities.db';
+import type { RatingsDb } from '@/rates/ratings.db';
+import type { IdentitySubscriptionsDb } from '@/api/identity-subscriptions/identity-subscriptions.db';
+import { IdentityFetcher } from './identity.fetcher';
+
+describe('IdentityFetcher', () => {
+  it('runs handle and ENS community-member searches concurrently', async () => {
+    let resolveHandleSearch: (members: IdentityEntity[]) => void = () =>
+      undefined;
+    let resolveEnsSearch: (
+      members: (IdentityEntity & { ens: string })[]
+    ) => void = () => undefined;
+    const handleSearch = new Promise<IdentityEntity[]>((resolve) => {
+      resolveHandleSearch = resolve;
+    });
+    const ensSearch = new Promise<(IdentityEntity & { ens: string })[]>(
+      (resolve) => {
+        resolveEnsSearch = resolve;
+      }
+    );
+    const identitiesDb = {
+      searchCommunityMembersWhereHandleLike: jest
+        .fn()
+        .mockReturnValue(handleSearch),
+      searchCommunityMembersWhereEnsLike: jest.fn().mockReturnValue(ensSearch)
+    } as unknown as IdentitiesDb;
+    const fetcher = new IdentityFetcher(
+      identitiesDb,
+      {} as IdentitySubscriptionsDb,
+      {} as CicDb,
+      {} as RatingsDb,
+      () => {
+        throw new Error('Alchemy is not used by community-member search');
+      }
+    );
+
+    const result = fetcher.searchCommunityMemberMinimalsOfClosestMatches({
+      param: 'signers',
+      onlyProfileOwners: false,
+      limit: 10
+    });
+
+    expect(
+      identitiesDb.searchCommunityMembersWhereHandleLike
+    ).toHaveBeenCalledWith({
+      handle: 'signers',
+      limit: 30
+    });
+    expect(
+      identitiesDb.searchCommunityMembersWhereEnsLike
+    ).toHaveBeenCalledWith({
+      ensCandidate: 'signers',
+      onlyProfileOwners: false,
+      limit: 30
+    });
+
+    resolveHandleSearch([]);
+    resolveEnsSearch([]);
+    await expect(result).resolves.toEqual([]);
+  });
+});

--- a/src/api-serverless/src/identities/identity.fetcher.ts
+++ b/src/api-serverless/src/identities/identity.fetcher.ts
@@ -731,15 +731,25 @@ export class IdentityFetcher {
         })
       ]);
       const dedupedMembers: (IdentityEntity & { ens?: string | null })[] = [];
-      const seenProfKeys = new Set<string>();
+      const memberIndexesByProfileKey = new Map<string, number>();
       for (const prof of [...membersByHandles, ...profilesByEnsNames]) {
         const profKey = String(
           prof.consolidation_key ?? prof.profile_id ?? prof.primary_address
         );
-        if (seenProfKeys.has(profKey)) {
+        const existingMemberIndex = memberIndexesByProfileKey.get(profKey);
+        if (existingMemberIndex !== undefined) {
+          const existingMember = dedupedMembers[existingMemberIndex];
+          const profEns =
+            'ens' in prof && typeof prof.ens === 'string' ? prof.ens : null;
+          if (!existingMember.ens && profEns) {
+            dedupedMembers[existingMemberIndex] = {
+              ...existingMember,
+              ens: profEns
+            };
+          }
           continue;
         }
-        seenProfKeys.add(profKey);
+        memberIndexesByProfileKey.set(profKey, dedupedMembers.length);
         dedupedMembers.push(prof);
       }
 

--- a/src/api-serverless/src/identities/identity.fetcher.ts
+++ b/src/api-serverless/src/identities/identity.fetcher.ts
@@ -719,17 +719,17 @@ export class IdentityFetcher {
       );
       return communityMember ? [communityMember] : [];
     } else {
-      const membersByHandles =
-        await this.identitiesDb.searchCommunityMembersWhereHandleLike({
+      const [membersByHandles, profilesByEnsNames] = await Promise.all([
+        this.identitiesDb.searchCommunityMembersWhereHandleLike({
           handle: param,
           limit: limit * 3
-        });
-      const profilesByEnsNames =
-        await this.identitiesDb.searchCommunityMembersWhereEnsLike({
+        }),
+        this.identitiesDb.searchCommunityMembersWhereEnsLike({
           ensCandidate: param,
           onlyProfileOwners,
           limit: limit * 3
-        });
+        })
+      ]);
       const dedupedMembers: (IdentityEntity & { ens?: string | null })[] = [];
       const seenProfKeys = new Set<string>();
       for (const prof of [...membersByHandles, ...profilesByEnsNames]) {

--- a/src/competitions/contract-fixtures/phase-0/README.md
+++ b/src/competitions/contract-fixtures/phase-0/README.md
@@ -43,3 +43,9 @@ The obsolete `ApiSeizeSettings.all_drops_notifications_subscribers_limit`
 field is retired by the accepted all-message notification limit removal. The
 immutable Phase 0 snapshot remains unchanged, and the compatibility test
 permits no other settings-field removal.
+
+## Accepted cache extension
+
+`GET /api/community-members` may add response caching without changing its
+request or response semantics. The immutable Phase 0 runtime manifest remains
+unchanged, and the route census permits no other uncached-to-cached transition.

--- a/src/identities/identities-db.test.ts
+++ b/src/identities/identities-db.test.ts
@@ -73,6 +73,29 @@ describe('IdentitiesDb', () => {
     });
   });
 
+  it('searches community member handles without joining ENS', async () => {
+    const execute = jest.fn().mockResolvedValue([]);
+    const repo = new IdentitiesDb(
+      () =>
+        ({
+          execute
+        }) as any
+    );
+
+    await repo.searchCommunityMembersWhereHandleLike({
+      handle: 'signers',
+      limit: 30
+    });
+
+    const [sql, params] = execute.mock.calls[0];
+    expect(sql).toContain('from identities i');
+    expect(sql).toContain(
+      "i.normalised_handle like concat('%', lower(:handle), '%')"
+    );
+    expect(sql).not.toContain('join ens');
+    expect(params).toEqual({ handle: 'signers', limit: 30 });
+  });
+
   it('restricts wave mention candidates to the supplied eligibility view', async () => {
     const execute = jest.fn().mockResolvedValue([]);
     const repo = new IdentitiesDb(

--- a/src/identities/identities.db.ts
+++ b/src/identities/identities.db.ts
@@ -1183,13 +1183,11 @@ export class IdentitiesDb extends LazyDbAccessCompatibleService {
   }: {
     limit: number;
     handle: string;
-  }): Promise<(IdentityEntity & { ens: string })[]> {
+  }): Promise<IdentityEntity[]> {
     const sql = `
       select
-          i.*,
-          e.display as ens
+          i.*
       from ${IDENTITIES_TABLE} i
-           left join ${ENS_TABLE} e on lower(e.wallet) = i.primary_address
       where i.normalised_handle like concat('%', lower(:handle), '%')
       order by i.tdh desc
       limit :limit


### PR DESCRIPTION
﻿## Issue

The global header search modal waits several seconds for profile results. Production tracing for `signers` showed the profile endpoint taking about 1.8 seconds, with handle and ENS lookups executing serially and repeat requests recomputing the same public result.

## Fix

Run the independent handle and ENS searches concurrently, remove the unused ENS join from the handle-only query, and cache successful public community-member searches for the existing one-minute request-cache TTL.

## Notable changes

- Starts handle and ENS lookup branches together.
- Removes an ENS table join whose value cannot be used for a handle match.
- Adds request caching to `GET /community-members`.
- Preserves ENS ranking data when handle and ENS matches overlap.
- Records the narrowly accepted uncached-to-cached route contract extension while keeping the immutable Phase 0 fixture unchanged.
- Adds focused concurrency, ranking, and SQL-shape regression tests.

## Validation

- `6529 run test -- --runInBand src/api-serverless/src/competitions/phase-0-runtime-route-census.test.ts src/api-serverless/src/identities/identity-fetcher.test.ts src/identities/identities-db.test.ts` (9 tests passed)
- `6529 run lint`
- `6529 run build:ci`
- Local API: cold `signers` request 328 ms; cached repeats 53?57 ms with `X-Cache: HIT`.

## Risk

Low. Response shape and ranking are unchanged. Cached public search results may be up to one minute old.

## Review notes

Runtime mapping: `/api/community-members` is mounted in the `api-serverless` application and served by its sole `handler` function; the release-bus deployable unit is `api`. Coupled frontend: https://github.com/6529-Collections/6529seize-frontend/pull/3729. Deploy this backend change before the frontend PR. No architecture or help-corpus update is needed because the API boundary and user-visible search behavior are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Community-member searches now run concurrently, improving response times.
  * Search requests are cached to reduce repeated processing.

* **Search Improvements**
  * Handle searches now use case-insensitive partial matching.
  * Results remain deduplicated, ranked, filtered, and consistently formatted.

* **Bug Fixes**
  * Improved handling of combined handle and ENS searches, including empty-result scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

