### PR TITLE
Handle large release ranges and retry alerts

### DIFF
--- a/src/release-notes/release-note-github.service.test.ts
+++ b/src/release-notes/release-note-github.service.test.ts
@@ -257,10 +257,7 @@ describe('ReleaseNoteGitHubService', () => {
           ]
         })
       )
-      .mockResolvedValueOnce(
-        response({ sha: 'abc123', parents: [{ sha: 'previous-sha' }] })
-      )
-      .mockResolvedValueOnce(response([]));
+      .mockResolvedValueOnce(response({ commits: [], total_commits: 0 }));
 
     const context = await new ReleaseNoteGitHubService().getReleaseContext(
       request
@@ -271,7 +268,7 @@ describe('ReleaseNoteGitHubService', () => {
       current_sha: 'abc123',
       pull_requests: []
     });
-    expect(fetch).toHaveBeenCalledTimes(4);
+    expect(fetch).toHaveBeenCalledTimes(3);
     expect(fetch).toHaveBeenNthCalledWith(
       2,
       'https://api.github.com/repos/6529-Collections/6529seize-frontend/actions/workflows/7/runs?status=success&branch=main&per_page=100&page=1',
@@ -279,7 +276,49 @@ describe('ReleaseNoteGitHubService', () => {
     );
   });
 
-  it('walks the previous production Publish first-parent history without expanding imported renderer history', async () => {
+  it('paginates release comparisons beyond 300 commits', async () => {
+    const commits = Array.from({ length: 1023 }, (_, index) => ({
+      sha: `commit-${index + 1}`,
+      commit: { message: `Commit ${index + 1}` }
+    }));
+    (fetch as unknown as jest.Mock).mockImplementation((url: string) => {
+      if (url.includes('/compare/previous-sha...abc123')) {
+        const page = Number(new URL(url).searchParams.get('page'));
+        const start = (page - 1) * 100;
+        return Promise.resolve(
+          response({
+            commits: commits.slice(start, start + 100),
+            total_commits: commits.length
+          })
+        );
+      }
+      throw new Error(`Unexpected GitHub request: ${url}`);
+    });
+
+    const service = new ReleaseNoteGitHubService() as unknown as {
+      getComparedCommits(
+        repository: string,
+        previousSha: string,
+        currentSha: string
+      ): Promise<Array<{ readonly sha: string }>>;
+    };
+    const comparedCommits = await service.getComparedCommits(
+      '6529-Collections/6529seize-frontend',
+      'previous-sha',
+      'abc123'
+    );
+
+    expect(comparedCommits).toHaveLength(1023);
+    expect(comparedCommits[0].sha).toBe('commit-1');
+    expect(comparedCommits[1022].sha).toBe('commit-1023');
+    const compareCalls = (fetch as unknown as jest.Mock).mock.calls.filter(
+      ([url]) => String(url).includes('/compare/previous-sha...abc123')
+    );
+    expect(compareCalls).toHaveLength(11);
+    expect(compareCalls[10][0]).toContain('per_page=100&page=11');
+  });
+
+  it('uses the previous production Publish across version branches and excludes imported renderer history', async () => {
     const previousSha = '1111111111111111111111111111111111111111';
     const currentSha = '4444444444444444444444444444444444444444';
     const outerMergeSha = '3333333333333333333333333333333333333333';
@@ -324,30 +363,35 @@ describe('ReleaseNoteGitHubService', () => {
           })
         );
       }
-      if (url.endsWith(`/commits/${currentSha}`)) {
+      if (url.includes(`/compare/${previousSha}...${currentSha}`)) {
         return Promise.resolve(
           response({
-            sha: currentSha,
-            parents: [{ sha: outerMergeSha }],
-            commit: { message: 'Improve desktop update prompts' }
-          })
-        );
-      }
-      if (url.endsWith(`/commits/${outerMergeSha}`)) {
-        return Promise.resolve(
-          response({
-            sha: outerMergeSha,
-            parents: [{ sha: boundaryMergeSha }, { sha: 'pull-web-branch' }],
-            commit: { message: 'Merge pull request #225 from pull-web' }
-          })
-        );
-      }
-      if (url.endsWith(`/commits/${boundaryMergeSha}`)) {
-        return Promise.resolve(
-          response({
-            sha: boundaryMergeSha,
-            parents: [{ sha: 'older-main' }, { sha: previousSha }],
-            commit: { message: 'Merge previous Desktop release' }
+            commits: [
+              {
+                sha: 'imported-frontend-commit',
+                parents: [{ sha: 'imported-parent' }],
+                commit: { message: 'Imported web-only change' }
+              },
+              {
+                sha: boundaryMergeSha,
+                parents: [{ sha: 'older-main' }, { sha: previousSha }],
+                commit: { message: 'Merge previous Desktop release' }
+              },
+              {
+                sha: outerMergeSha,
+                parents: [
+                  { sha: boundaryMergeSha },
+                  { sha: 'pull-web-branch' }
+                ],
+                commit: { message: 'Merge pull request #225 from pull-web' }
+              },
+              {
+                sha: currentSha,
+                parents: [{ sha: outerMergeSha }],
+                commit: { message: 'Improve desktop update prompts' }
+              }
+            ],
+            total_commits: 4
           })
         );
       }
@@ -427,11 +471,6 @@ describe('ReleaseNoteGitHubService', () => {
     expect(
       context?.commit_messages?.some((message) =>
         message.includes('Imported web-only change')
-      )
-    ).toBe(false);
-    expect(
-      (fetch as unknown as jest.Mock).mock.calls.some(([url]) =>
-        String(url).includes('/compare/')
       )
     ).toBe(false);
   });
@@ -595,18 +634,19 @@ describe('ReleaseNoteGitHubService', () => {
       )
       .mockResolvedValueOnce(
         response({
-          sha: 'current-sha',
-          parents: [{ sha: 'api-commit' }],
-          author: { login: 'ragnep' },
-          commit: { message: 'Update claims builder' }
-        })
-      )
-      .mockResolvedValueOnce(
-        response({
-          sha: 'api-commit',
-          parents: [{ sha: 'previous-sha' }],
-          author: { login: 'simo6529' },
-          commit: { message: 'Improve API validation' }
+          commits: [
+            {
+              sha: 'api-commit',
+              author: { login: 'simo6529' },
+              commit: { message: 'Improve API validation' }
+            },
+            {
+              sha: 'claims-commit',
+              author: { login: 'ragnep' },
+              commit: { message: 'Update claims builder' }
+            }
+          ],
+          total_commits: 2
         })
       )
       .mockResolvedValueOnce(
@@ -742,9 +782,13 @@ describe('ReleaseNoteGitHubService', () => {
       )
       .mockResolvedValueOnce(
         response({
-          sha: 'current-sha',
-          parents: [{ sha: 'previous-sha' }],
-          commit: { message: 'Improve API validation' }
+          commits: [
+            {
+              sha: 'api-commit',
+              commit: { message: 'Improve API validation' }
+            }
+          ],
+          total_commits: 1
         })
       )
       .mockResolvedValueOnce(
@@ -802,21 +846,20 @@ describe('ReleaseNoteGitHubService', () => {
           })
         );
       }
-      if (url.endsWith('/commits/abc123')) {
+      if (url.includes('/compare/previous-sha...abc123')) {
         return Promise.resolve(
           response({
-            sha: 'abc123',
-            parents: [{ sha: 'large-merge' }],
-            commit: { message: 'Improve navigation' }
-          })
-        );
-      }
-      if (url.endsWith('/commits/large-merge')) {
-        return Promise.resolve(
-          response({
-            sha: 'large-merge',
-            parents: [{ sha: 'previous-sha' }],
-            commit: { message: 'Add exact Stream public review snapshot' }
+            commits: [
+              {
+                sha: 'large-merge',
+                commit: { message: 'Add exact Stream public review snapshot' }
+              },
+              {
+                sha: 'normal-merge',
+                commit: { message: 'Improve navigation' }
+              }
+            ],
+            total_commits: 2
           })
         );
       }
@@ -836,7 +879,7 @@ describe('ReleaseNoteGitHubService', () => {
           ])
         );
       }
-      if (url.includes('/commits/abc123/pulls')) {
+      if (url.includes('/commits/normal-merge/pulls')) {
         return Promise.resolve(
           response([
             {
@@ -1029,13 +1072,7 @@ describe('ReleaseNoteGitHubService', () => {
           ]
         })
       )
-      .mockResolvedValueOnce(
-        response({
-          sha: 'current-sha',
-          parents: [{ sha: 'previous-sha' }]
-        })
-      )
-      .mockResolvedValueOnce(response([]));
+      .mockResolvedValueOnce(response({ commits: [], total_commits: 0 }));
 
     const context = await new ReleaseNoteGitHubService().getReleaseContext({
       ...request,

--- a/src/release-notes/release-note-github.service.test.ts
+++ b/src/release-notes/release-note-github.service.test.ts
@@ -318,6 +318,33 @@ describe('ReleaseNoteGitHubService', () => {
     expect(compareCalls[10][0]).toContain('per_page=100&page=11');
   });
 
+  it('stops malformed comparison pagination after 100 full pages', async () => {
+    const fullPage = Array.from({ length: 100 }, (_, index) => ({
+      sha: `commit-${index + 1}`
+    }));
+    (fetch as unknown as jest.Mock).mockResolvedValue(
+      response({ commits: fullPage })
+    );
+    const service = new ReleaseNoteGitHubService() as unknown as {
+      getComparedCommits(
+        repository: string,
+        previousSha: string,
+        currentSha: string
+      ): Promise<Array<{ readonly sha: string }>>;
+    };
+
+    await expect(
+      service.getComparedCommits(
+        '6529-Collections/6529seize-frontend',
+        'previous-sha',
+        'abc123'
+      )
+    ).rejects.toThrow(
+      'Release comparison did not complete within 10000 commits'
+    );
+    expect(fetch).toHaveBeenCalledTimes(100);
+  });
+
   it('uses the previous production Publish across version branches and excludes imported renderer history', async () => {
     const previousSha = '1111111111111111111111111111111111111111';
     const currentSha = '4444444444444444444444444444444444444444';

--- a/src/release-notes/release-note-github.service.test.ts
+++ b/src/release-notes/release-note-github.service.test.ts
@@ -257,7 +257,10 @@ describe('ReleaseNoteGitHubService', () => {
           ]
         })
       )
-      .mockResolvedValueOnce(response({ commits: [], total_commits: 0 }));
+      .mockResolvedValueOnce(
+        response({ sha: 'abc123', parents: [{ sha: 'previous-sha' }] })
+      )
+      .mockResolvedValueOnce(response([]));
 
     const context = await new ReleaseNoteGitHubService().getReleaseContext(
       request
@@ -268,7 +271,7 @@ describe('ReleaseNoteGitHubService', () => {
       current_sha: 'abc123',
       pull_requests: []
     });
-    expect(fetch).toHaveBeenCalledTimes(3);
+    expect(fetch).toHaveBeenCalledTimes(4);
     expect(fetch).toHaveBeenNthCalledWith(
       2,
       'https://api.github.com/repos/6529-Collections/6529seize-frontend/actions/workflows/7/runs?status=success&branch=main&per_page=100&page=1',
@@ -276,7 +279,7 @@ describe('ReleaseNoteGitHubService', () => {
     );
   });
 
-  it('uses the previous production Publish across version branches and excludes imported renderer history', async () => {
+  it('walks the previous production Publish first-parent history without expanding imported renderer history', async () => {
     const previousSha = '1111111111111111111111111111111111111111';
     const currentSha = '4444444444444444444444444444444444444444';
     const outerMergeSha = '3333333333333333333333333333333333333333';
@@ -321,35 +324,30 @@ describe('ReleaseNoteGitHubService', () => {
           })
         );
       }
-      if (url.includes(`/compare/${previousSha}...${currentSha}`)) {
+      if (url.endsWith(`/commits/${currentSha}`)) {
         return Promise.resolve(
           response({
-            commits: [
-              {
-                sha: 'imported-frontend-commit',
-                parents: [{ sha: 'imported-parent' }],
-                commit: { message: 'Imported web-only change' }
-              },
-              {
-                sha: boundaryMergeSha,
-                parents: [{ sha: 'older-main' }, { sha: previousSha }],
-                commit: { message: 'Merge previous Desktop release' }
-              },
-              {
-                sha: outerMergeSha,
-                parents: [
-                  { sha: boundaryMergeSha },
-                  { sha: 'pull-web-branch' }
-                ],
-                commit: { message: 'Merge pull request #225 from pull-web' }
-              },
-              {
-                sha: currentSha,
-                parents: [{ sha: outerMergeSha }],
-                commit: { message: 'Improve desktop update prompts' }
-              }
-            ],
-            total_commits: 4
+            sha: currentSha,
+            parents: [{ sha: outerMergeSha }],
+            commit: { message: 'Improve desktop update prompts' }
+          })
+        );
+      }
+      if (url.endsWith(`/commits/${outerMergeSha}`)) {
+        return Promise.resolve(
+          response({
+            sha: outerMergeSha,
+            parents: [{ sha: boundaryMergeSha }, { sha: 'pull-web-branch' }],
+            commit: { message: 'Merge pull request #225 from pull-web' }
+          })
+        );
+      }
+      if (url.endsWith(`/commits/${boundaryMergeSha}`)) {
+        return Promise.resolve(
+          response({
+            sha: boundaryMergeSha,
+            parents: [{ sha: 'older-main' }, { sha: previousSha }],
+            commit: { message: 'Merge previous Desktop release' }
           })
         );
       }
@@ -429,6 +427,11 @@ describe('ReleaseNoteGitHubService', () => {
     expect(
       context?.commit_messages?.some((message) =>
         message.includes('Imported web-only change')
+      )
+    ).toBe(false);
+    expect(
+      (fetch as unknown as jest.Mock).mock.calls.some(([url]) =>
+        String(url).includes('/compare/')
       )
     ).toBe(false);
   });
@@ -592,19 +595,18 @@ describe('ReleaseNoteGitHubService', () => {
       )
       .mockResolvedValueOnce(
         response({
-          commits: [
-            {
-              sha: 'api-commit',
-              author: { login: 'simo6529' },
-              commit: { message: 'Improve API validation' }
-            },
-            {
-              sha: 'claims-commit',
-              author: { login: 'ragnep' },
-              commit: { message: 'Update claims builder' }
-            }
-          ],
-          total_commits: 2
+          sha: 'current-sha',
+          parents: [{ sha: 'api-commit' }],
+          author: { login: 'ragnep' },
+          commit: { message: 'Update claims builder' }
+        })
+      )
+      .mockResolvedValueOnce(
+        response({
+          sha: 'api-commit',
+          parents: [{ sha: 'previous-sha' }],
+          author: { login: 'simo6529' },
+          commit: { message: 'Improve API validation' }
         })
       )
       .mockResolvedValueOnce(
@@ -740,13 +742,9 @@ describe('ReleaseNoteGitHubService', () => {
       )
       .mockResolvedValueOnce(
         response({
-          commits: [
-            {
-              sha: 'api-commit',
-              commit: { message: 'Improve API validation' }
-            }
-          ],
-          total_commits: 1
+          sha: 'current-sha',
+          parents: [{ sha: 'previous-sha' }],
+          commit: { message: 'Improve API validation' }
         })
       )
       .mockResolvedValueOnce(
@@ -804,20 +802,21 @@ describe('ReleaseNoteGitHubService', () => {
           })
         );
       }
-      if (url.includes('/compare/previous-sha...abc123')) {
+      if (url.endsWith('/commits/abc123')) {
         return Promise.resolve(
           response({
-            commits: [
-              {
-                sha: 'large-merge',
-                commit: { message: 'Add exact Stream public review snapshot' }
-              },
-              {
-                sha: 'normal-merge',
-                commit: { message: 'Improve navigation' }
-              }
-            ],
-            total_commits: 2
+            sha: 'abc123',
+            parents: [{ sha: 'large-merge' }],
+            commit: { message: 'Improve navigation' }
+          })
+        );
+      }
+      if (url.endsWith('/commits/large-merge')) {
+        return Promise.resolve(
+          response({
+            sha: 'large-merge',
+            parents: [{ sha: 'previous-sha' }],
+            commit: { message: 'Add exact Stream public review snapshot' }
           })
         );
       }
@@ -837,7 +836,7 @@ describe('ReleaseNoteGitHubService', () => {
           ])
         );
       }
-      if (url.includes('/commits/normal-merge/pulls')) {
+      if (url.includes('/commits/abc123/pulls')) {
         return Promise.resolve(
           response([
             {
@@ -1030,7 +1029,13 @@ describe('ReleaseNoteGitHubService', () => {
           ]
         })
       )
-      .mockResolvedValueOnce(response({ commits: [], total_commits: 0 }));
+      .mockResolvedValueOnce(
+        response({
+          sha: 'current-sha',
+          parents: [{ sha: 'previous-sha' }]
+        })
+      )
+      .mockResolvedValueOnce(response([]));
 
     const context = await new ReleaseNoteGitHubService().getReleaseContext({
       ...request,

--- a/src/release-notes/release-note-github.service.ts
+++ b/src/release-notes/release-note-github.service.ts
@@ -96,6 +96,7 @@ interface BoundedGitHubCollection<T> {
   readonly incomplete: boolean;
 }
 
+const MAX_COMPARE_PAGES = 100;
 const MAX_PULL_REQUEST_COMMIT_PAGES = 3;
 const MAX_FILE_PAGES = 3;
 const MAX_WORKFLOW_RUN_PAGES = 10;
@@ -597,7 +598,7 @@ export class ReleaseNoteGitHubService {
   ): Promise<GitHubCommit[]> {
     const commits: GitHubCommit[] = [];
 
-    for (let page = 1; ; page++) {
+    for (let page = 1; page <= MAX_COMPARE_PAGES; page++) {
       const payload = await this.api<GitHubCompareResponse>(
         `/repos/${repository}/compare/${encodeURIComponent(previousSha)}...${encodeURIComponent(currentSha)}?per_page=${PAGE_SIZE}&page=${page}`
       );
@@ -613,6 +614,10 @@ export class ReleaseNoteGitHubService {
         return commits;
       }
     }
+
+    throw new Error(
+      `Release comparison did not complete within ${MAX_COMPARE_PAGES * PAGE_SIZE} commits`
+    );
   }
 
   private async getPullRequests(

--- a/src/release-notes/release-note-github.service.ts
+++ b/src/release-notes/release-note-github.service.ts
@@ -35,6 +35,8 @@ interface GitHubCommit {
 }
 
 interface GitHubCompareResponse {
+  readonly commits?: GitHubCommit[];
+  readonly total_commits?: number;
   readonly status?: string;
 }
 
@@ -107,7 +109,6 @@ const FRONTEND_PRODUCTION_WORKFLOW_PATH =
 const CORE_PRODUCTION_WORKFLOW_PATH =
   '.github/workflows/build-all-platforms.yml';
 const CORE_PRODUCTION_RUN_PREFIX = 'FLOW: Publish / ENV: Production - v';
-const MAX_RELEASE_COMMITS = 300;
 const MAX_PULL_REQUESTS = 100;
 const MAX_PROMPT_LENGTH = 20000;
 const MAX_GITHUB_RESPONSE_BYTES = 5 * 1024 * 1024;
@@ -208,6 +209,48 @@ function isMatchingProductionRun(
     );
   }
   return false;
+}
+
+function getFirstParentReleaseCommits(
+  commits: GitHubCommit[],
+  previousSha: string,
+  currentSha: string
+): GitHubCommit[] {
+  const commitsBySha = new Map(commits.map((commit) => [commit.sha, commit]));
+  const releaseCommits: GitHubCommit[] = [];
+  const visited = new Set<string>();
+  let cursor = currentSha;
+
+  while (cursor !== previousSha) {
+    if (visited.has(cursor)) {
+      throw new Error('Desktop release first-parent history contains a cycle');
+    }
+    visited.add(cursor);
+    const commit = commitsBySha.get(cursor);
+    if (!commit) {
+      throw new Error(
+        `Desktop release first-parent commit ${cursor} is missing from the GitHub comparison`
+      );
+    }
+    const parents = commit.parents ?? [];
+    if (parents[0]?.sha === previousSha) {
+      releaseCommits.push(commit);
+      return releaseCommits.reverse();
+    }
+    if (parents.slice(1).some((parent) => parent.sha === previousSha)) {
+      return releaseCommits.reverse();
+    }
+    releaseCommits.push(commit);
+    const firstParent = parents[0]?.sha;
+    if (!firstParent) {
+      throw new Error(
+        `Desktop release history did not reach previous production commit ${previousSha}`
+      );
+    }
+    cursor = firstParent;
+  }
+
+  return releaseCommits.reverse();
 }
 
 function mergeAssociatedPullRequests(
@@ -391,12 +434,19 @@ export class ReleaseNoteGitHubService {
       return null;
     }
 
-    const commits = await this.getFirstParentReleaseCommits(
+    const comparedCommits = await this.getComparedCommits(
       repository,
       previousRun.head_sha,
       request.sha
     );
     const desktopRelease = getRepoName(request.repo) === CORE_REPO;
+    const commits = desktopRelease
+      ? getFirstParentReleaseCommits(
+          comparedCommits,
+          previousRun.head_sha,
+          request.sha
+        )
+      : comparedCommits;
     const pullRequests = await this.getPullRequests(
       repository,
       desktopRelease ? 'main' : normalizeBranch(request.branch),
@@ -540,56 +590,29 @@ export class ReleaseNoteGitHubService {
     );
   }
 
-  private async getFirstParentReleaseCommits(
+  private async getComparedCommits(
     repository: string,
     previousSha: string,
     currentSha: string
   ): Promise<GitHubCommit[]> {
-    const releaseCommits: GitHubCommit[] = [];
-    const visited = new Set<string>();
-    let cursor = currentSha;
+    const commits: GitHubCommit[] = [];
 
-    while (cursor !== previousSha) {
-      if (visited.has(cursor)) {
-        throw new Error(
-          `Release first-parent history for ${repository} contains a cycle at ${cursor}`
-        );
-      }
-      if (releaseCommits.length >= MAX_RELEASE_COMMITS) {
-        throw new Error(
-          `Release first-parent range for ${repository} from ${previousSha} to ${currentSha} exceeds ${MAX_RELEASE_COMMITS} commits`
-        );
-      }
-      visited.add(cursor);
-
-      const commit = await this.api<GitHubCommit>(
-        `/repos/${repository}/commits/${encodeURIComponent(cursor)}`
+    for (let page = 1; ; page++) {
+      const payload = await this.api<GitHubCompareResponse>(
+        `/repos/${repository}/compare/${encodeURIComponent(previousSha)}...${encodeURIComponent(currentSha)}?per_page=${PAGE_SIZE}&page=${page}`
       );
-      if (commit.sha !== cursor) {
-        throw new Error(
-          `GitHub returned commit ${commit.sha} while traversing ${repository} at ${cursor}`
-        );
+      const pageCommits = payload.commits ?? [];
+      const totalCommits = payload.total_commits;
+      commits.push(...pageCommits);
+      if (
+        pageCommits.length < PAGE_SIZE ||
+        (typeof totalCommits === 'number' &&
+          totalCommits > 0 &&
+          commits.length >= totalCommits)
+      ) {
+        return commits;
       }
-      const parents = commit.parents ?? [];
-      if (parents[0]?.sha === previousSha) {
-        releaseCommits.push(commit);
-        return releaseCommits.reverse();
-      }
-      if (parents.slice(1).some((parent) => parent.sha === previousSha)) {
-        return releaseCommits.reverse();
-      }
-
-      releaseCommits.push(commit);
-      const firstParent = parents[0]?.sha;
-      if (!firstParent) {
-        throw new Error(
-          `Release first-parent history for ${repository} from ${currentSha} did not reach previous production commit ${previousSha}`
-        );
-      }
-      cursor = firstParent;
     }
-
-    return releaseCommits.reverse();
   }
 
   private async getPullRequests(

--- a/src/release-notes/release-note-github.service.ts
+++ b/src/release-notes/release-note-github.service.ts
@@ -35,8 +35,6 @@ interface GitHubCommit {
 }
 
 interface GitHubCompareResponse {
-  readonly commits?: GitHubCommit[];
-  readonly total_commits?: number;
   readonly status?: string;
 }
 
@@ -96,7 +94,6 @@ interface BoundedGitHubCollection<T> {
   readonly incomplete: boolean;
 }
 
-const MAX_COMPARE_PAGES = 3;
 const MAX_PULL_REQUEST_COMMIT_PAGES = 3;
 const MAX_FILE_PAGES = 3;
 const MAX_WORKFLOW_RUN_PAGES = 10;
@@ -110,7 +107,7 @@ const FRONTEND_PRODUCTION_WORKFLOW_PATH =
 const CORE_PRODUCTION_WORKFLOW_PATH =
   '.github/workflows/build-all-platforms.yml';
 const CORE_PRODUCTION_RUN_PREFIX = 'FLOW: Publish / ENV: Production - v';
-const MAX_COMMITS = MAX_COMPARE_PAGES * PAGE_SIZE;
+const MAX_RELEASE_COMMITS = 300;
 const MAX_PULL_REQUESTS = 100;
 const MAX_PROMPT_LENGTH = 20000;
 const MAX_GITHUB_RESPONSE_BYTES = 5 * 1024 * 1024;
@@ -211,48 +208,6 @@ function isMatchingProductionRun(
     );
   }
   return false;
-}
-
-function getFirstParentReleaseCommits(
-  commits: GitHubCommit[],
-  previousSha: string,
-  currentSha: string
-): GitHubCommit[] {
-  const commitsBySha = new Map(commits.map((commit) => [commit.sha, commit]));
-  const releaseCommits: GitHubCommit[] = [];
-  const visited = new Set<string>();
-  let cursor = currentSha;
-
-  while (cursor !== previousSha) {
-    if (visited.has(cursor)) {
-      throw new Error('Desktop release first-parent history contains a cycle');
-    }
-    visited.add(cursor);
-    const commit = commitsBySha.get(cursor);
-    if (!commit) {
-      throw new Error(
-        `Desktop release first-parent commit ${cursor} is missing from the GitHub comparison`
-      );
-    }
-    const parents = commit.parents ?? [];
-    if (parents[0]?.sha === previousSha) {
-      releaseCommits.push(commit);
-      return releaseCommits.reverse();
-    }
-    if (parents.slice(1).some((parent) => parent.sha === previousSha)) {
-      return releaseCommits.reverse();
-    }
-    releaseCommits.push(commit);
-    const firstParent = parents[0]?.sha;
-    if (!firstParent) {
-      throw new Error(
-        `Desktop release history did not reach previous production commit ${previousSha}`
-      );
-    }
-    cursor = firstParent;
-  }
-
-  return releaseCommits.reverse();
 }
 
 function mergeAssociatedPullRequests(
@@ -436,19 +391,12 @@ export class ReleaseNoteGitHubService {
       return null;
     }
 
-    const comparedCommits = await this.getComparedCommits(
+    const commits = await this.getFirstParentReleaseCommits(
       repository,
       previousRun.head_sha,
       request.sha
     );
     const desktopRelease = getRepoName(request.repo) === CORE_REPO;
-    const commits = desktopRelease
-      ? getFirstParentReleaseCommits(
-          comparedCommits,
-          previousRun.head_sha,
-          request.sha
-        )
-      : comparedCommits;
     const pullRequests = await this.getPullRequests(
       repository,
       desktopRelease ? 'main' : normalizeBranch(request.branch),
@@ -592,46 +540,56 @@ export class ReleaseNoteGitHubService {
     );
   }
 
-  private async getComparedCommits(
+  private async getFirstParentReleaseCommits(
     repository: string,
     previousSha: string,
     currentSha: string
   ): Promise<GitHubCommit[]> {
-    const commits: GitHubCommit[] = [];
+    const releaseCommits: GitHubCommit[] = [];
+    const visited = new Set<string>();
+    let cursor = currentSha;
 
-    for (let page = 1; page <= MAX_COMPARE_PAGES; page++) {
-      const payload = await this.api<GitHubCompareResponse>(
-        `/repos/${repository}/compare/${encodeURIComponent(previousSha)}...${encodeURIComponent(currentSha)}?per_page=${PAGE_SIZE}&page=${page}`
+    while (cursor !== previousSha) {
+      if (visited.has(cursor)) {
+        throw new Error(
+          `Release first-parent history for ${repository} contains a cycle at ${cursor}`
+        );
+      }
+      if (releaseCommits.length >= MAX_RELEASE_COMMITS) {
+        throw new Error(
+          `Release first-parent range for ${repository} from ${previousSha} to ${currentSha} exceeds ${MAX_RELEASE_COMMITS} commits`
+        );
+      }
+      visited.add(cursor);
+
+      const commit = await this.api<GitHubCommit>(
+        `/repos/${repository}/commits/${encodeURIComponent(cursor)}`
       );
-      const pageCommits = payload.commits ?? [];
-      const totalCommits = payload.total_commits;
-      if (typeof totalCommits === 'number' && totalCommits > MAX_COMMITS) {
+      if (commit.sha !== cursor) {
         throw new Error(
-          `Release range contains ${totalCommits} commits; maximum is ${MAX_COMMITS}`
+          `GitHub returned commit ${commit.sha} while traversing ${repository} at ${cursor}`
         );
       }
-      commits.push(...pageCommits);
-      if (commits.length > MAX_COMMITS) {
+      const parents = commit.parents ?? [];
+      if (parents[0]?.sha === previousSha) {
+        releaseCommits.push(commit);
+        return releaseCommits.reverse();
+      }
+      if (parents.slice(1).some((parent) => parent.sha === previousSha)) {
+        return releaseCommits.reverse();
+      }
+
+      releaseCommits.push(commit);
+      const firstParent = parents[0]?.sha;
+      if (!firstParent) {
         throw new Error(
-          `Release range exceeds maximum of ${MAX_COMMITS} commits`
+          `Release first-parent history for ${repository} from ${currentSha} did not reach previous production commit ${previousSha}`
         );
       }
-      if (
-        pageCommits.length < PAGE_SIZE ||
-        (typeof totalCommits === 'number' &&
-          totalCommits > 0 &&
-          commits.length >= totalCommits)
-      ) {
-        return commits;
-      }
-      if (page === MAX_COMPARE_PAGES) {
-        throw new Error(
-          `Release range exceeds pagination maximum of ${MAX_COMMITS} commits`
-        );
-      }
+      cursor = firstParent;
     }
 
-    return commits;
+    return releaseCommits.reverse();
   }
 
   private async getPullRequests(

--- a/src/releaseNotesGenerationLoop/index.test.ts
+++ b/src/releaseNotesGenerationLoop/index.test.ts
@@ -194,6 +194,7 @@ describe('release-note Sentry retry policy', () => {
 
     expect(thrown).toBeInstanceOf(Error);
     expect((thrown as Error).message).toBe(error.message);
+    expect((thrown as Error & { cause: unknown }).cause).toBe(error);
     expect(shouldCaptureReleaseNoteError(thrown)).toBe(false);
   });
 

--- a/src/releaseNotesGenerationLoop/index.test.ts
+++ b/src/releaseNotesGenerationLoop/index.test.ts
@@ -1,8 +1,10 @@
 import { ReleaseNoteGenerationRequest } from '@/release-notes/release-note-generation-queue';
 import {
   parseReleaseNoteMessage,
+  prepareReleaseNoteErrorForRetry,
   processRequest,
-  processRequestWithRetryPolicy
+  processRequestWithRetryPolicy,
+  shouldCaptureReleaseNoteError
 } from './index';
 
 const request: ReleaseNoteGenerationRequest = {
@@ -182,6 +184,25 @@ describe('Desktop retry policy', () => {
     ).rejects.toThrow('terminal alert failed and must move to the DLQ');
     expect(process).not.toHaveBeenCalled();
     expect(postFailure).not.toHaveBeenCalled();
+  });
+});
+
+describe('release-note Sentry retry policy', () => {
+  it('suppresses Sentry reporting while an SQS request will retry', () => {
+    const error = new Error('Temporary GitHub comparison failure');
+    const thrown = prepareReleaseNoteErrorForRetry(error, 4);
+
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).message).toBe(error.message);
+    expect(shouldCaptureReleaseNoteError(thrown)).toBe(false);
+  });
+
+  it('reports the original error to Sentry on the final SQS attempt', () => {
+    const error = new Error('Persistent GitHub comparison failure');
+    const thrown = prepareReleaseNoteErrorForRetry(error, 5);
+
+    expect(thrown).toBe(error);
+    expect(shouldCaptureReleaseNoteError(thrown)).toBe(true);
   });
 });
 

--- a/src/releaseNotesGenerationLoop/index.ts
+++ b/src/releaseNotesGenerationLoop/index.ts
@@ -19,7 +19,29 @@ const RELEASE_NOTE_DEDUPE_TTL_SECONDS = 90 * 24 * 60 * 60;
 const RELEASE_NOTE_PROCESSING_TTL_SECONDS = 20 * 60;
 const RELEASE_GROUP_TTL_SECONDS = RELEASE_NOTE_DEDUPE_TTL_SECONDS;
 const DESKTOP_RELEASE_NOTE_FINAL_ATTEMPT = 4;
+const RELEASE_NOTE_FINAL_ATTEMPT = 5;
 type ReleaseNotesRedis = NonNullable<ReturnType<typeof getRedisClient>>;
+
+class RetryableReleaseNoteError extends Error {
+  public constructor(error: unknown) {
+    super(getErrorMessage(error));
+    this.name = 'RetryableReleaseNoteError';
+    Object.setPrototypeOf(this, RetryableReleaseNoteError.prototype);
+  }
+}
+
+export function shouldCaptureReleaseNoteError(error: unknown): boolean {
+  return !(error instanceof RetryableReleaseNoteError);
+}
+
+export function prepareReleaseNoteErrorForRetry(
+  error: unknown,
+  receiveCount: number
+): unknown {
+  return receiveCount < RELEASE_NOTE_FINAL_ATTEMPT
+    ? new RetryableReleaseNoteError(error)
+    : error;
+}
 
 function requireString(
   payload: Record<string, unknown>,
@@ -523,24 +545,44 @@ export async function processRequestWithRetryPolicy(
 }
 
 const sqsHandler: SQSHandler = async (event) => {
-  await doInDbContext(
-    async () => {
-      for (const record of event.Records) {
-        const request = parseReleaseNoteMessage(record.body);
-        logger.info(
-          `Generating release notes for ${request.repo} run ${request.run_id}`
-        );
-        const receiveCount = Number(record.attributes.ApproximateReceiveCount);
-        await processRequestWithRetryPolicy(
-          request,
-          Number.isSafeInteger(receiveCount) && receiveCount > 0
-            ? receiveCount
-            : 1
-        );
-      }
-    },
-    { logger }
+  const firstReceiveCount = Number(
+    event.Records[0]?.attributes.ApproximateReceiveCount
   );
+  const invocationReceiveCount =
+    Number.isSafeInteger(firstReceiveCount) && firstReceiveCount > 0
+      ? firstReceiveCount
+      : 1;
+  try {
+    await doInDbContext(
+      async () => {
+        for (const record of event.Records) {
+          const request = parseReleaseNoteMessage(record.body);
+          logger.info(
+            `Generating release notes for ${request.repo} run ${request.run_id}`
+          );
+          const receiveCount = Number(
+            record.attributes.ApproximateReceiveCount
+          );
+          await processRequestWithRetryPolicy(
+            request,
+            Number.isSafeInteger(receiveCount) && receiveCount > 0
+              ? receiveCount
+              : 1
+          );
+        }
+      },
+      { logger }
+    );
+  } catch (error) {
+    if (invocationReceiveCount < RELEASE_NOTE_FINAL_ATTEMPT) {
+      logger.warn(
+        `Release note attempt ${invocationReceiveCount} failed and will retry: ${getErrorMessage(error)}`
+      );
+    }
+    throw prepareReleaseNoteErrorForRetry(error, invocationReceiveCount);
+  }
 };
 
-export const handler = sentryContext.wrapLambdaHandler(sqsHandler);
+export const handler = sentryContext.wrapLambdaHandler(sqsHandler, {
+  shouldCaptureException: shouldCaptureReleaseNoteError
+});

--- a/src/releaseNotesGenerationLoop/index.ts
+++ b/src/releaseNotesGenerationLoop/index.ts
@@ -23,9 +23,12 @@ const RELEASE_NOTE_FINAL_ATTEMPT = 5;
 type ReleaseNotesRedis = NonNullable<ReturnType<typeof getRedisClient>>;
 
 class RetryableReleaseNoteError extends Error {
+  public readonly cause: unknown;
+
   public constructor(error: unknown) {
     super(getErrorMessage(error));
     this.name = 'RetryableReleaseNoteError';
+    this.cause = error;
     Object.setPrototypeOf(this, RetryableReleaseNoteError.prototype);
   }
 }
@@ -545,6 +548,7 @@ export async function processRequestWithRetryPolicy(
 }
 
 const sqsHandler: SQSHandler = async (event) => {
+  // serverless.yaml fixes this event source at batchSize: 1.
   const firstReceiveCount = Number(
     event.Records[0]?.attributes.ApproximateReceiveCount
   );

--- a/src/sentry.context.ts
+++ b/src/sentry.context.ts
@@ -1,16 +1,27 @@
 import * as Sentry from '@sentry/serverless';
 import type { Handler } from 'aws-lambda';
 
+interface LambdaSentryOptions {
+  readonly shouldCaptureException?: (error: unknown) => boolean;
+}
+
 export function isConfigured() {
   return !!process.env.SENTRY_DSN;
 }
 
-export function wrapLambdaHandler(handler: Handler): Handler {
+export function wrapLambdaHandler(
+  handler: Handler,
+  options: LambdaSentryOptions = {}
+): Handler {
   if (isConfigured()) {
     Sentry.init({
       dsn: process.env.SENTRY_DSN,
       environment: process.env.SENTRY_ENVIRONMENT,
-      debug: process.env.SENTRY_DEBUG === 'true'
+      debug: process.env.SENTRY_DEBUG === 'true',
+      beforeSend: (event, hint) =>
+        options.shouldCaptureException?.(hint.originalException) === false
+          ? null
+          : event
     });
     return Sentry.AWSLambda.wrapHandler(handler);
   }


### PR DESCRIPTION
## Summary\n\n- keep the existing GitHub compare, pull-request discovery, and contributor-tagging behavior unchanged\n- remove the artificial 300-commit ceiling and paginate comparison results up to a 100-page / 10,000-commit safety limit\n- keep failing Lambda invocations so SQS retries, while suppressing Sentry events for attempts that have retries remaining\n- preserve the original error for the final SQS attempt so terminal failures produce one Sentry event and follow the existing DLQ path\n\n## Behavior\n\nA comparison containing 1,023 commits is read across 11 GitHub pages and then processed by the existing PR and contributor logic. No first-parent traversal or release-selection behavior is introduced. A malformed GitHub response that keeps returning full pages cannot loop until Lambda timeout; it stops after 100 pages.\n\nRetryable failures remain visible in CloudWatch as warnings and still fail the Lambda invocation. Sentry ignores only the marked intermediate retry errors. The fifth and final SQS attempt retains the original error and is reported normally. Existing Desktop terminal-alert behavior remains unchanged.\n\n## Validation\n\n- Prettier check passed for the touched files\n- ESLint passed for the touched files\n- full Jest and build validation delegated to PR CI as requested