### PR TITLE
Fix automatic staging E2E identity validation

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -637,6 +637,14 @@ backend DAG frontiers run concurrently; only shared environment mutation plus
 E2E ownership is serialized. Operation keys, workflow titles, workflow
 authorization, SHA/artifact checks, row versions, and callback identity make
 retries and duplicate reconciliation idempotent.
+Automatic staging E2E reaches the baseline-adoption decision through an API
+callback dispatched by `workflow_dispatch`. When an exact adoption intent is
+active, the API reads both workflow identities from GitHub: the staging E2E
+run must be owned by `github-actions[bot]`, use the frontend repository for
+both the run and head repository, and execute `.github/workflows/staging-e2e.yml`;
+the associated deploy run remains subject to the generic trusted-actor reader.
+Only this dedicated staging E2E reader admits the GitHub Actions bot, and every
+metadata mismatch fails closed before baseline evidence is recorded.
 Operation reads normally use the read pool. When reconciliation has just
 CAS-written a dispatch reservation and must decide whether it may call GitHub,
 it rereads that immutable operation from the writer pool. An explicit

--- a/src/releaseBusV2/release-bus-v2.baseline-adoption.test.ts
+++ b/src/releaseBusV2/release-bus-v2.baseline-adoption.test.ts
@@ -522,7 +522,7 @@ function frontendE2EIdentity() {
     actor: 'github-actions[bot]',
     attempt: 1,
     conclusion: null,
-    event: 'workflow_run',
+    event: 'workflow_dispatch',
     headBranch: 'main',
     headSha: FRONTEND_SHA,
     name: 'Staging E2E [automatic]',
@@ -605,6 +605,9 @@ function harness(options?: {
     hasActiveStagingWorkflow: jest.fn(async () => false),
     refContainsCommit: jest.fn(async () => true),
     getWorkflowRunIdentity: jest.fn(
+      async (_repository: string, runId: string) => identities[runId]
+    ),
+    getStagingE2EWorkflowRunIdentity: jest.fn(
       async (_repository: string, runId: string) => identities[runId]
     )
   };
@@ -741,6 +744,9 @@ describe('ReleaseBusV2BaselineAdoptionService', () => {
       expires_at: null
     });
     expect(context.deps.getWorkflowRunIdentity).not.toHaveBeenCalled();
+    expect(
+      context.deps.getStagingE2EWorkflowRunIdentity
+    ).not.toHaveBeenCalled();
     expect(context.repository.events).toHaveLength(0);
   });
 
@@ -765,6 +771,14 @@ describe('ReleaseBusV2BaselineAdoptionService', () => {
     expect(context.repository.trains).toHaveLength(0);
     expect(context.repository.operations).toHaveLength(0);
     expect(context.operations.reconcileWorkflow).not.toHaveBeenCalled();
+    expect(context.deps.getStagingE2EWorkflowRunIdentity).toHaveBeenCalledWith(
+      'frontend',
+      FRONTEND_E2E_RUN_ID
+    );
+    expect(context.deps.getWorkflowRunIdentity).toHaveBeenCalledWith(
+      'frontend',
+      FRONTEND_DEPLOY_RUN_ID
+    );
   });
 
   it.each([

--- a/src/releaseBusV2/release-bus-v2.baseline-adoption.ts
+++ b/src/releaseBusV2/release-bus-v2.baseline-adoption.ts
@@ -260,6 +260,10 @@ type BaselineAdoptionDependencies = {
     repository: ReleaseBusV2Repository,
     workflowRunId: string
   ) => Promise<ReleaseBusWorkflowRunIdentity>;
+  readonly getStagingE2EWorkflowRunIdentity: (
+    repository: ReleaseBusV2Repository,
+    workflowRunId: string
+  ) => Promise<ReleaseBusWorkflowRunIdentity>;
 };
 
 export class ReleaseBusV2BaselineAdoptionError extends Error {
@@ -434,7 +438,12 @@ const dependencies: BaselineAdoptionDependencies = {
   refContainsCommit: (repository, ref, sha) =>
     releaseBusGitHubApp.refContainsCommit(repository, ref, sha),
   getWorkflowRunIdentity: (repository, workflowRunId) =>
-    releaseBusGitHubApp.getWorkflowRunIdentity(repository, workflowRunId)
+    releaseBusGitHubApp.getWorkflowRunIdentity(repository, workflowRunId),
+  getStagingE2EWorkflowRunIdentity: (repository, workflowRunId) =>
+    releaseBusGitHubApp.getStagingE2EWorkflowRunIdentity(
+      repository,
+      workflowRunId
+    )
 };
 
 function normalizedCandidateInput(
@@ -730,7 +739,7 @@ function assertFrontendWorkflowIdentities(
   if (
     e2e.status !== 'in_progress' ||
     e2e.conclusion !== null ||
-    e2e.event !== 'workflow_run' ||
+    e2e.event !== 'workflow_dispatch' ||
     e2e.path !== '.github/workflows/staging-e2e.yml' ||
     !isTrustedStagingE2EWorkflowName(e2e.name) ||
     deploy.status !== 'completed' ||
@@ -989,7 +998,7 @@ export class ReleaseBusV2BaselineAdoptionService {
       this.assertUnexpired(intent);
       const [e2eIdentity, deployIdentity, currentRef, runtimeSha] =
         await Promise.all([
-          this.deps.getWorkflowRunIdentity(
+          this.deps.getStagingE2EWorkflowRunIdentity(
             'frontend',
             input.e2e_workflow_run_id
           ),

--- a/src/releaseBusV2/release-bus-v2.github-app.test.ts
+++ b/src/releaseBusV2/release-bus-v2.github-app.test.ts
@@ -1218,6 +1218,84 @@ describe('GitHub workflow operation identity', () => {
     }
   });
 
+  it('parses the GitHub Actions actor through the exact Staging E2E reader', async () => {
+    const app = appWithCachedToken();
+    const fetchMock = fetch as jest.MockedFunction<typeof fetch>;
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          id: 32120573187,
+          run_attempt: 1,
+          name: 'Staging E2E [automatic]',
+          path: '.github/workflows/staging-e2e.yml',
+          display_title: 'Staging E2E [automatic]',
+          status: 'in_progress',
+          conclusion: null,
+          head_branch: 'main',
+          head_sha: 'a'.repeat(40),
+          html_url: 'https://github.com/example/actions/runs/32120573187',
+          event: 'workflow_dispatch',
+          repository: { full_name: '6529-Collections/6529seize-frontend' },
+          head_repository: {
+            full_name: '6529-Collections/6529seize-frontend'
+          },
+          actor: { login: 'github-actions[bot]' }
+        })
+      )
+    );
+
+    try {
+      await expect(
+        app.getStagingE2EWorkflowRunIdentity('frontend', '32120573187')
+      ).resolves.toMatchObject({
+        actor: 'github-actions[bot]',
+        attempt: 1,
+        conclusion: null,
+        event: 'workflow_dispatch',
+        path: '.github/workflows/staging-e2e.yml',
+        displayTitle: 'Staging E2E [automatic]',
+        status: 'in_progress'
+      });
+    } finally {
+      fetchMock.mockReset();
+    }
+  });
+
+  it('rejects the GitHub Actions actor outside the Staging E2E workflow', async () => {
+    const app = appWithCachedToken();
+    const fetchMock = fetch as jest.MockedFunction<typeof fetch>;
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          id: 32120573187,
+          run_attempt: 1,
+          name: 'Staging E2E [automatic]',
+          path: '.github/workflows/production-e2e.yml',
+          display_title: 'Staging E2E [automatic]',
+          status: 'in_progress',
+          conclusion: null,
+          head_branch: 'main',
+          head_sha: 'a'.repeat(40),
+          html_url: 'https://github.com/example/actions/runs/32120573187',
+          event: 'workflow_dispatch',
+          repository: { full_name: '6529-Collections/6529seize-frontend' },
+          head_repository: {
+            full_name: '6529-Collections/6529seize-frontend'
+          },
+          actor: { login: 'github-actions[bot]' }
+        })
+      )
+    );
+
+    try {
+      await expect(
+        app.getStagingE2EWorkflowRunIdentity('frontend', '32120573187')
+      ).rejects.toThrow('GitHub workflow run is not a Staging E2E qualifier');
+    } finally {
+      fetchMock.mockReset();
+    }
+  });
+
   it('rejects the GitHub Actions actor through the shared workflow reader', async () => {
     const app = appWithCachedToken();
     const fetchMock = fetch as jest.MockedFunction<typeof fetch>;

--- a/src/releaseBusV2/release-bus-v2.github-app.test.ts
+++ b/src/releaseBusV2/release-bus-v2.github-app.test.ts
@@ -1252,6 +1252,8 @@ describe('GitHub workflow operation identity', () => {
         attempt: 1,
         conclusion: null,
         event: 'workflow_dispatch',
+        repository: '6529-Collections/6529seize-frontend',
+        headRepository: '6529-Collections/6529seize-frontend',
         path: '.github/workflows/staging-e2e.yml',
         displayTitle: 'Staging E2E [automatic]',
         status: 'in_progress'
@@ -1291,6 +1293,63 @@ describe('GitHub workflow operation identity', () => {
       await expect(
         app.getStagingE2EWorkflowRunIdentity('frontend', '32120573187')
       ).rejects.toThrow('GitHub workflow run is not a Staging E2E qualifier');
+    } finally {
+      fetchMock.mockReset();
+    }
+  });
+
+  it.each([
+    [
+      'actor',
+      { actor: { login: 'unexpected[bot]' } },
+      'GitHub workflow run has no valid actor'
+    ],
+    [
+      'event',
+      { event: 'workflow_run' },
+      'GitHub workflow run is not a Staging E2E qualifier'
+    ],
+    [
+      'repository',
+      { repository: { full_name: 'example/other-frontend' } },
+      'GitHub workflow run is not a Staging E2E qualifier'
+    ],
+    [
+      'head repository',
+      { head_repository: { full_name: 'example/other-frontend' } },
+      'GitHub workflow run is not a Staging E2E qualifier'
+    ]
+  ])('rejects a mismatched Staging E2E %s', async (_field, override, error) => {
+    const app = appWithCachedToken();
+    const fetchMock = fetch as jest.MockedFunction<typeof fetch>;
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          id: 32120573187,
+          run_attempt: 1,
+          name: 'Staging E2E [automatic]',
+          path: '.github/workflows/staging-e2e.yml',
+          display_title: 'Staging E2E [automatic]',
+          status: 'in_progress',
+          conclusion: null,
+          head_branch: 'main',
+          head_sha: 'a'.repeat(40),
+          html_url: 'https://github.com/example/actions/runs/32120573187',
+          event: 'workflow_dispatch',
+          repository: { full_name: '6529-Collections/6529seize-frontend' },
+          head_repository: {
+            full_name: '6529-Collections/6529seize-frontend'
+          },
+          actor: { login: 'github-actions[bot]' },
+          ...override
+        })
+      )
+    );
+
+    try {
+      await expect(
+        app.getStagingE2EWorkflowRunIdentity('frontend', '32120573187')
+      ).rejects.toThrow(error);
     } finally {
       fetchMock.mockReset();
     }

--- a/src/releaseBusV2/release-bus-v2.github-app.test.ts
+++ b/src/releaseBusV2/release-bus-v2.github-app.test.ts
@@ -1355,6 +1355,23 @@ describe('GitHub workflow operation identity', () => {
     }
   });
 
+  it('rejects a non-frontend Staging E2E repository before reading GitHub metadata', async () => {
+    const app = appWithCachedToken();
+    const fetchMock = fetch as jest.MockedFunction<typeof fetch>;
+    fetchMock.mockClear();
+
+    try {
+      await expect(
+        app.getStagingE2EWorkflowRunIdentity('backend', '32120573187')
+      ).rejects.toThrow(
+        'Staging E2E identity must use the frontend repository'
+      );
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      fetchMock.mockReset();
+    }
+  });
+
   it('rejects the GitHub Actions actor through the shared workflow reader', async () => {
     const app = appWithCachedToken();
     const fetchMock = fetch as jest.MockedFunction<typeof fetch>;

--- a/src/releaseBusV2/release-bus-v2.github-app.ts
+++ b/src/releaseBusV2/release-bus-v2.github-app.ts
@@ -59,8 +59,8 @@ export function workflowRunMatchesOperation(
 
 export function isValidGitHubWorkflowActor(actor: string): boolean {
   // The shared parser admits only operators and the Release Bus App. The
-  // GitHub Actions actor is accepted through the dedicated Production E2E
-  // reader, whose workflow and repository boundary is narrower than this one.
+  // GitHub Actions actor is accepted through dedicated E2E readers, whose
+  // workflow and repository boundaries are narrower than this one.
   return (
     /^[A-Za-z0-9-]{1,39}$/.test(actor) || isReleaseBusGitHubAppActor(actor)
   );
@@ -2183,6 +2183,29 @@ export class ReleaseBusGitHubApp {
       identity.headRepository !== expectedRepository
     )
       throw new Error('GitHub workflow run is not a Production E2E qualifier');
+    return identity;
+  }
+
+  public async getStagingE2EWorkflowRunIdentity(
+    repository: ReleaseBusV2Repository,
+    workflowRunId: string
+  ): Promise<ReleaseBusWorkflowRunIdentity> {
+    if (repository !== 'frontend')
+      throw new Error('Staging E2E identity must use the frontend repository');
+    const identity = await this.readWorkflowRunIdentity(
+      repository,
+      workflowRunId,
+      (actor) => actor === 'github-actions[bot]'
+    );
+    const expectedRepository = `${this.owner}/${REPOSITORIES.frontend}`;
+    if (
+      identity.actor !== 'github-actions[bot]' ||
+      identity.event !== 'workflow_dispatch' ||
+      identity.path !== '.github/workflows/staging-e2e.yml' ||
+      identity.repository !== expectedRepository ||
+      identity.headRepository !== expectedRepository
+    )
+      throw new Error('GitHub workflow run is not a Staging E2E qualifier');
     return identity;
   }
 


### PR DESCRIPTION
## Summary

- add a narrowly scoped workflow-identity reader for automatic frontend Staging E2E runs
- allow `github-actions[bot]` only when the run is the exact frontend `staging-e2e.yml` workflow dispatched through `workflow_dispatch`
- align baseline-adoption validation with the workflow's actual dispatch event while keeping the generic workflow reader strict
- add regression coverage for the accepted automatic E2E identity and rejection outside the expected workflow boundary

## Why

Automatic baseline adoption was validating the Staging E2E run through the generic workflow reader, which rejects `github-actions[bot]`. It also expected a `workflow_run` event even though the automatic E2E workflow is dispatched with `workflow_dispatch`. Together these checks prevented valid automatic staging E2E evidence from being recorded once an active baseline-adoption intent exercised the guarded path.

## Validation

Focused tests passed: 2 suites, 105 tests. Changed files also pass Prettier and `git diff --check`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dedicated validation for frontend staging E2E workflow runs.
  * Staging E2E runs now require a manually dispatched workflow from the expected staging workflow and repository.

* **Bug Fixes**
  * Prevented legacy E2E paths from using staging-specific identity validation.
  * Improved validation to reject production workflow runs incorrectly presented as staging runs.

* **Documentation**
  * Documented stricter validation requirements for automatic staging E2E baseline adoption.

* **Tests**
  * Added coverage for valid staging E2E runs and invalid workflow, trigger, and identity scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->