### PR TITLE
Add agent-native Release Bus process diagram

### DIFF
--- a/ops/deployment-bus/simple-release-bus-v2-process.html
+++ b/ops/deployment-bus/simple-release-bus-v2-process.html
@@ -293,7 +293,7 @@
               aria-controls="step-6-info"
               tabindex="-1"
             >
-              Agent checks the staging deployment route
+              Agent prepares the final deployment plan
             </button>
           </li>
           <li>
@@ -304,7 +304,7 @@
               aria-controls="step-7-info"
               tabindex="-1"
             >
-              Exact PR versions and deployment details are saved in Release Bus
+              Agent checks the staging deployment route
             </button>
           </li>
           <li>
@@ -315,7 +315,7 @@
               aria-controls="step-8-info"
               tabindex="-1"
             >
-              Release Bus creates a staging train
+              Agent sends exact PRs to Release Bus for checks
             </button>
           </li>
           <li>
@@ -326,7 +326,8 @@
               aria-controls="step-9-info"
               tabindex="-1"
             >
-              GitHub Actions build and deploy staging
+              Release Bus checks waiting PRs and prepares the next staging
+              deployment
             </button>
           </li>
           <li>
@@ -337,7 +338,7 @@
               aria-controls="step-10-info"
               tabindex="-1"
             >
-              Staging E2E tests pass
+              GitHub Actions combine the selected PRs and check for conflicts
             </button>
           </li>
           <li>
@@ -348,7 +349,7 @@
               aria-controls="step-11-info"
               tabindex="-1"
             >
-              Agent checks the production deployment route
+              GitHub Actions build and deploy staging
             </button>
           </li>
           <li>
@@ -359,7 +360,7 @@
               aria-controls="step-12-info"
               tabindex="-1"
             >
-              Production is selected explicitly
+              Staging E2E tests pass
             </button>
           </li>
           <li>
@@ -370,7 +371,7 @@
               aria-controls="step-13-info"
               tabindex="-1"
             >
-              A fresh production build is deployed
+              Agent checks the production deployment route
             </button>
           </li>
           <li>
@@ -379,6 +380,28 @@
               type="button"
               aria-expanded="false"
               aria-controls="step-14-info"
+              tabindex="-1"
+            >
+              Production is selected explicitly
+            </button>
+          </li>
+          <li>
+            <button
+              class="step-button"
+              type="button"
+              aria-expanded="false"
+              aria-controls="step-15-info"
+              tabindex="-1"
+            >
+              A fresh production build is deployed
+            </button>
+          </li>
+          <li>
+            <button
+              class="step-button"
+              type="button"
+              aria-expanded="false"
+              aria-controls="step-16-info"
               tabindex="-1"
             >
               Production E2E tests pass
@@ -405,8 +428,9 @@
           >
             <strong>Someone tells the agent what to deploy and where</strong>
             <p>
-              The request names the feature. It also says whether the frontend,
-              backend, or both are included.
+              Tell the agent what feature to deploy. Say whether it includes
+              the frontend, backend, or both. Then say how far to go: open PRs
+              only, staging, or production.
             </p>
             <strong class="detail-heading">For example</strong>
             <ul>
@@ -455,7 +479,9 @@
               <li>Loop code &rarr; deploy that loop</li>
               <li>Shared code &rarr; deploy every service that uses it</li>
             </ul>
-            <p>The result becomes the deployment plan.</p>
+            <p>
+              This gives the agent a first list of what may need to be deployed.
+            </p>
           </div>
           <div
             class="step-info"
@@ -519,6 +545,24 @@
             aria-label="Step 6 information"
             hidden
           >
+            <strong>The agent makes the final plan from the reviewed PRs</strong>
+            <ul>
+              <li>Which backend services to deploy</li>
+              <li>Which services must go first</li>
+              <li>Which services can deploy together</li>
+            </ul>
+            <p>
+              Review fixes may change the plan, so it is finalized after
+              review. Frontend PRs do not need a backend service plan.
+            </p>
+          </div>
+          <div
+            class="step-info"
+            id="step-7-info"
+            role="region"
+            aria-label="Step 7 information"
+            hidden
+          >
             <strong>The staging lane is checked before deployment</strong>
             <p>The status check reports both lanes. This step uses staging.</p>
             <ul>
@@ -536,12 +580,23 @@
           </div>
           <div
             class="step-info"
-            id="step-7-info"
+            id="step-8-info"
             role="region"
-            aria-label="Step 7 information"
+            aria-label="Step 8 information"
             hidden
           >
-            <strong>Release Bus saves each PR as a candidate</strong>
+            <strong>Release Bus checks each PR before accepting it</strong>
+            <ul>
+              <li>The PR is open and its exact SHA still matches</li>
+              <li>The required CI passed for that exact code</li>
+              <li>The PR can be merged into its current base</li>
+              <li>The deployment plan and related PR links are valid</li>
+            </ul>
+            <p>
+              If every check passes, Release Bus saves the PR as waiting for
+              staging. If a check fails, the PR is not added.
+            </p>
+            <strong class="detail-heading">What is saved</strong>
             <ul>
               <li>Repository and PR number</li>
               <li>Exact SHA</li>
@@ -579,30 +634,69 @@
           </div>
           <div
             class="step-info"
-            id="step-8-info"
-            role="region"
-            aria-label="Step 8 information"
-            hidden
-          ></div>
-          <div
-            class="step-info"
             id="step-9-info"
             role="region"
             aria-label="Step 9 information"
             hidden
-          ></div>
+          >
+            <strong>A scheduled worker prepares the next staging list</strong>
+            <p>
+              AWS starts the worker once every minute. It looks at PRs accepted
+              in step 8.
+            </p>
+            <ul>
+              <li>The exact branch SHA has not changed</li>
+              <li>Staging is enabled, free, and safe</li>
+              <li>All required related PRs are present</li>
+              <li>The saved deployment order is complete</li>
+            </ul>
+            <p>
+              The worker uses the CI result saved in step 8. When all checks
+              pass, it creates one exact list for the next staging deployment.
+              Waiting PRs are checked again on the next run.
+            </p>
+            <p>
+              The finished list goes to GitHub Actions. In the next step, the
+              selected PRs are combined and checked together.
+            </p>
+          </div>
           <div
             class="step-info"
             id="step-10-info"
             role="region"
             aria-label="Step 10 information"
             hidden
-          ></div>
+          >
+            <strong>GitHub Actions combine the exact selected versions</strong>
+            <p>
+              For each repository, GitHub Actions starts from the current base
+              and adds the selected PRs one by one at their exact SHAs.
+            </p>
+            <p>
+              This checks that PRs from the same repository work together. A
+              clean combined version moves to the build. A PR that conflicts
+              needs to be rebased, and PRs that depend on it wait.
+            </p>
+          </div>
           <div
             class="step-info"
             id="step-11-info"
             role="region"
             aria-label="Step 11 information"
+            hidden
+          ></div>
+          <div
+            class="step-info"
+            id="step-12-info"
+            role="region"
+            aria-label="Step 12 information"
+            hidden
+          ></div>
+          <div
+            class="step-info"
+            id="step-13-info"
+            role="region"
+            aria-label="Step 13 information"
             hidden
           >
             <strong>The production lane is checked before production</strong>
@@ -625,23 +719,23 @@
           </div>
           <div
             class="step-info"
-            id="step-12-info"
-            role="region"
-            aria-label="Step 12 information"
-            hidden
-          ></div>
-          <div
-            class="step-info"
-            id="step-13-info"
-            role="region"
-            aria-label="Step 13 information"
-            hidden
-          ></div>
-          <div
-            class="step-info"
             id="step-14-info"
             role="region"
             aria-label="Step 14 information"
+            hidden
+          ></div>
+          <div
+            class="step-info"
+            id="step-15-info"
+            role="region"
+            aria-label="Step 15 information"
+            hidden
+          ></div>
+          <div
+            class="step-info"
+            id="step-16-info"
+            role="region"
+            aria-label="Step 16 information"
             hidden
           ></div>
           <section class="gap-panel" aria-label="Issues and gaps">
@@ -658,20 +752,26 @@
             </div>
             <div class="step-gap" id="step-5-gap" hidden></div>
             <div class="step-gap" id="step-6-gap" hidden>
+              The <code>write-prs</code> skill asks for a service list and
+              order. The <code>deploy-6529</code> skill asks for a Release Bus
+              plan. It does not say exactly how the first becomes the second.
+            </div>
+            <div class="step-gap" id="step-7-gap" hidden>
               This diagram currently shows only the Release Bus ON path for
               staging. The safe manual staging path is not shown.
             </div>
-            <div class="step-gap" id="step-7-gap" hidden></div>
             <div class="step-gap" id="step-8-gap" hidden></div>
             <div class="step-gap" id="step-9-gap" hidden></div>
             <div class="step-gap" id="step-10-gap" hidden></div>
-            <div class="step-gap" id="step-11-gap" hidden>
+            <div class="step-gap" id="step-11-gap" hidden></div>
+            <div class="step-gap" id="step-12-gap" hidden></div>
+            <div class="step-gap" id="step-13-gap" hidden>
               This diagram currently shows only the Release Bus ON path for
               production. The safe manual production path is not shown.
             </div>
-            <div class="step-gap" id="step-12-gap" hidden></div>
-            <div class="step-gap" id="step-13-gap" hidden></div>
             <div class="step-gap" id="step-14-gap" hidden></div>
+            <div class="step-gap" id="step-15-gap" hidden></div>
+            <div class="step-gap" id="step-16-gap" hidden></div>
           </section>
         </aside>
       </div>

--- a/ops/deployment-bus/simple-release-bus-v2-process.html
+++ b/ops/deployment-bus/simple-release-bus-v2-process.html
@@ -173,6 +173,18 @@
         padding-left: 20px;
       }
 
+      .review-loop {
+        display: grid;
+        gap: 4px;
+        margin-top: 10px;
+        text-align: center;
+      }
+
+      .review-loop .loop-arrow {
+        color: #a1a1aa;
+        font-size: 18px;
+      }
+
       ol > li:not(:last-child)::after {
         position: absolute;
         top: calc(100% + 5px);
@@ -237,7 +249,7 @@
               aria-controls="step-2-info"
               tabindex="-1"
             >
-              Changes are chosen for deployment
+              Agent is told what to deploy and where
             </button>
           </li>
           <li>
@@ -270,7 +282,7 @@
               aria-controls="step-5-info"
               tabindex="-1"
             >
-              PR review and CI pass
+              Every PR goes through review, fixes, and re-checks
             </button>
           </li>
           <li>
@@ -281,7 +293,7 @@
               aria-controls="step-6-info"
               tabindex="-1"
             >
-              Agent checks whether Release Bus is available
+              Agent checks the staging deployment route
             </button>
           </li>
           <li>
@@ -336,7 +348,7 @@
               aria-controls="step-11-info"
               tabindex="-1"
             >
-              Production is selected explicitly
+              Agent checks the production deployment route
             </button>
           </li>
           <li>
@@ -347,7 +359,7 @@
               aria-controls="step-12-info"
               tabindex="-1"
             >
-              A fresh production build is deployed
+              Production is selected explicitly
             </button>
           </li>
           <li>
@@ -356,6 +368,17 @@
               type="button"
               aria-expanded="false"
               aria-controls="step-13-info"
+              tabindex="-1"
+            >
+              A fresh production build is deployed
+            </button>
+          </li>
+          <li>
+            <button
+              class="step-button"
+              type="button"
+              aria-expanded="false"
+              aria-controls="step-14-info"
               tabindex="-1"
             >
               Production E2E tests pass
@@ -380,19 +403,38 @@
             aria-label="Step 2 information"
             hidden
           >
-            <strong>Someone tells the agent what to ship</strong>
+            <strong>Someone tells the agent what to deploy and where</strong>
             <p>
-              For example: “Hey agent, please ship the new search feature.”
+              The request names the feature. It also says whether the frontend,
+              backend, or both are included.
             </p>
-            <strong class="detail-heading">The request may include</strong>
+            <strong class="detail-heading">For example</strong>
             <ul>
-              <li>One backend change</li>
-              <li>One frontend change</li>
-              <li>Related backend and frontend changes</li>
-              <li>Several related changes</li>
+              <li>
+                <strong>Review only:</strong> “Open PRs for the new search page
+                and API. Do not deploy them.”
+              </li>
+              <li>
+                <strong>Frontend only:</strong> “Deploy the new search page to
+                staging.”
+              </li>
+              <li>
+                <strong>Backend only:</strong> “Deploy the new search API to
+                staging.”
+              </li>
+              <li>
+                <strong>Frontend and backend:</strong> “Deploy the new search
+                page and API to staging.”
+              </li>
+              <li>
+                <strong>Staging and production:</strong> “Deploy the new search
+                page and API to staging, then production.”
+              </li>
             </ul>
             <p>
-              This tells the agent which completed work to inspect next.
+              Frontend and backend can be handled separately or together.
+              Production needs a version that passed staging. It starts as a
+              separate action.
             </p>
           </div>
           <div
@@ -444,14 +486,54 @@
             role="region"
             aria-label="Step 5 information"
             hidden
-          ></div>
+          >
+            <strong>The agent works through a review loop</strong>
+            <div class="review-loop">
+              <span>CI and reviewers check the latest PR version</span>
+              <span class="loop-arrow" aria-hidden="true">&darr;</span>
+              <span>The agent handles valid findings</span>
+              <span class="loop-arrow" aria-hidden="true">&darr;</span>
+              <span>The agent runs checks and pushes the fixes</span>
+              <span class="loop-arrow" aria-hidden="true">&darr;</span>
+              <span>CI and reviewers check the new version</span>
+              <span class="loop-arrow" aria-hidden="true">&darr;</span>
+              <span>Repeat until the PR is ready</span>
+            </div>
+            <p>
+              The PR is ready when required CI passes, required approval is
+              present, and no blocking findings remain.
+            </p>
+            <p>
+              Invalid review suggestions can be explained instead of
+              implemented.
+            </p>
+            <p>
+              If a blocker remains, the PR stays in this review loop. The agent
+              reports the exact reason and asks for help when needed.
+            </p>
+          </div>
           <div
             class="step-info"
             id="step-6-info"
             role="region"
             aria-label="Step 6 information"
             hidden
-          ></div>
+          >
+            <strong>The staging lane is checked before deployment</strong>
+            <p>The status check reports both lanes. This step uses staging.</p>
+            <ul>
+              <li>Staging ON &rarr; use Release Bus</li>
+              <li>
+                Staging OFF and manual fallback allowed &rarr; use the safe
+                manual deployment process
+              </li>
+              <li>
+                Status missing, unclear, or unsafe &rarr; stop and report the
+                problem
+              </li>
+            </ul>
+            <p>The result decides how staging may be deployed.</p>
+          </div>
           <div
             class="step-info"
             id="step-7-info"
@@ -522,7 +604,25 @@
             role="region"
             aria-label="Step 11 information"
             hidden
-          ></div>
+          >
+            <strong>The production lane is checked before production</strong>
+            <p>The status check reports both lanes. This step uses production.</p>
+            <ul>
+              <li>
+                Production ON &rarr; select the validated candidates in Release
+                Bus
+              </li>
+              <li>
+                Production OFF and manual fallback allowed &rarr; use the safe
+                manual production process with owner approval
+              </li>
+              <li>
+                Status missing, unclear, or unsafe &rarr; stop and report the
+                problem
+              </li>
+            </ul>
+            <p>The result decides how production may be deployed.</p>
+          </div>
           <div
             class="step-info"
             id="step-12-info"
@@ -535,6 +635,13 @@
             id="step-13-info"
             role="region"
             aria-label="Step 13 information"
+            hidden
+          ></div>
+          <div
+            class="step-info"
+            id="step-14-info"
+            role="region"
+            aria-label="Step 14 information"
             hidden
           ></div>
           <section class="gap-panel" aria-label="Issues and gaps">
@@ -550,14 +657,21 @@
               numbers or cross-PR dependency links in this step.
             </div>
             <div class="step-gap" id="step-5-gap" hidden></div>
-            <div class="step-gap" id="step-6-gap" hidden></div>
+            <div class="step-gap" id="step-6-gap" hidden>
+              This diagram currently shows only the Release Bus ON path for
+              staging. The safe manual staging path is not shown.
+            </div>
             <div class="step-gap" id="step-7-gap" hidden></div>
             <div class="step-gap" id="step-8-gap" hidden></div>
             <div class="step-gap" id="step-9-gap" hidden></div>
             <div class="step-gap" id="step-10-gap" hidden></div>
-            <div class="step-gap" id="step-11-gap" hidden></div>
+            <div class="step-gap" id="step-11-gap" hidden>
+              This diagram currently shows only the Release Bus ON path for
+              production. The safe manual production path is not shown.
+            </div>
             <div class="step-gap" id="step-12-gap" hidden></div>
             <div class="step-gap" id="step-13-gap" hidden></div>
+            <div class="step-gap" id="step-14-gap" hidden></div>
           </section>
         </aside>
       </div>

--- a/ops/deployment-bus/simple-release-bus-v2-process.html
+++ b/ops/deployment-bus/simple-release-bus-v2-process.html
@@ -1,0 +1,651 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Release process</title>
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        padding: 24px;
+        background: #080808;
+        color: #f4f4f5;
+        font: 16px/1.4 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+
+      main {
+        max-width: 1080px;
+        margin: auto;
+      }
+
+      h1 {
+        margin: 0 0 24px;
+        text-align: center;
+        font-size: 26px;
+      }
+
+      .process-layout {
+        display: grid;
+        grid-template-columns: minmax(0, 620px) minmax(280px, 1fr);
+        gap: 24px;
+        align-items: start;
+      }
+
+      ol {
+        counter-reset: step;
+        display: grid;
+        gap: 36px;
+        margin: 0;
+        padding: 0;
+        list-style: none;
+      }
+
+      ol > li {
+        counter-increment: step;
+        position: relative;
+        padding: 0;
+      }
+
+      ol > li::before {
+        position: absolute;
+        top: 13px;
+        left: 12px;
+        z-index: 1;
+        display: grid;
+        width: 32px;
+        height: 32px;
+        place-items: center;
+        border: 1px solid #52525b;
+        border-radius: 7px;
+        background: #18181b;
+        content: counter(step);
+        font-weight: 700;
+        pointer-events: none;
+      }
+
+      .step-button {
+        width: 100%;
+        min-height: 58px;
+        padding: 16px 58px;
+        border: 1px solid #52525b;
+        border-radius: 10px;
+        background: #111113;
+        color: #f4f4f5;
+        cursor: pointer;
+        text-align: center;
+        font: 650 16px/1.4 -apple-system, BlinkMacSystemFont, "Segoe UI",
+          sans-serif;
+      }
+
+      .step-button:hover {
+        border-color: #71717a;
+      }
+
+      .step-button:focus-visible {
+        outline: 2px solid #93c5fd;
+        outline-offset: 2px;
+      }
+
+      .is-active .step-button {
+        border-color: #60a5fa;
+        background: #172033;
+      }
+
+      .is-active::before {
+        border-color: #60a5fa;
+        background: #1d4ed8;
+      }
+
+      .step-info {
+        min-height: 180px;
+        padding: 14px;
+        border: 1px solid #52525b;
+        border-radius: 8px;
+        background: #18181b;
+        color: #f4f4f5;
+        text-align: left;
+        font-size: 13px;
+        font-weight: 400;
+      }
+
+      .details-panel {
+        position: sticky;
+        top: 24px;
+      }
+
+      .gap-panel {
+        min-height: 110px;
+        margin-top: 14px;
+        padding: 14px;
+        border: 1px dashed #52525b;
+        border-radius: 8px;
+        background: #101012;
+        color: #f4f4f5;
+        font-size: 13px;
+      }
+
+      .gap-panel > strong {
+        display: block;
+        margin-bottom: 8px;
+      }
+
+      .step-gap[hidden] {
+        display: none;
+      }
+
+      .step-info[hidden] {
+        display: none;
+      }
+
+      .step-info strong,
+      .step-info > code {
+        display: block;
+      }
+
+      .step-info .detail-heading {
+        margin-top: 14px;
+      }
+
+      .step-info > code {
+        margin: 4px 0 12px;
+        color: #bfdbfe;
+      }
+
+      .step-info pre {
+        margin: 4px 0 0;
+        overflow: auto;
+        color: #d4d4d8;
+        font: 12px/1.4 ui-monospace, SFMono-Regular, Menlo, monospace;
+        white-space: pre-wrap;
+      }
+
+      .step-info p {
+        margin: 10px 0 0;
+        color: #a1a1aa;
+      }
+
+      .step-info ul {
+        margin: 8px 0 0;
+        padding-left: 20px;
+      }
+
+      ol > li:not(:last-child)::after {
+        position: absolute;
+        top: calc(100% + 5px);
+        left: 50%;
+        content: "↓";
+        transform: translateX(-50%);
+        color: #a1a1aa;
+        font-size: 22px;
+        font-weight: 400;
+      }
+
+      @media (max-width: 900px) {
+        .process-layout {
+          grid-template-columns: 1fr;
+        }
+
+        .details-panel {
+          position: static;
+          margin-top: 10px;
+        }
+
+        .step-info {
+          min-height: 64px;
+        }
+      }
+
+      @media (max-width: 480px) {
+        body {
+          padding: 16px;
+        }
+
+        h1 {
+          font-size: 23px;
+        }
+
+        .step-button {
+          padding: 14px 52px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Release process</h1>
+      <div class="process-layout">
+        <ol aria-label="Release process steps">
+          <li class="is-active">
+            <button
+              class="step-button"
+              type="button"
+              aria-expanded="true"
+              aria-controls="step-1-info"
+            >
+              Code is ready for deployment preparation
+            </button>
+          </li>
+          <li>
+            <button
+              class="step-button"
+              type="button"
+              aria-expanded="false"
+              aria-controls="step-2-info"
+              tabindex="-1"
+            >
+              Changes are chosen for deployment
+            </button>
+          </li>
+          <li>
+            <button
+              class="step-button"
+              type="button"
+              aria-expanded="false"
+              aria-controls="step-3-info"
+              tabindex="-1"
+            >
+              Agent finds which parts of the system need updating
+            </button>
+          </li>
+          <li>
+            <button
+              class="step-button"
+              type="button"
+              aria-expanded="false"
+              aria-controls="step-4-info"
+              tabindex="-1"
+            >
+              Agent opens the needed PRs with deployment details
+            </button>
+          </li>
+          <li>
+            <button
+              class="step-button"
+              type="button"
+              aria-expanded="false"
+              aria-controls="step-5-info"
+              tabindex="-1"
+            >
+              PR review and CI pass
+            </button>
+          </li>
+          <li>
+            <button
+              class="step-button"
+              type="button"
+              aria-expanded="false"
+              aria-controls="step-6-info"
+              tabindex="-1"
+            >
+              Agent checks whether Release Bus is available
+            </button>
+          </li>
+          <li>
+            <button
+              class="step-button"
+              type="button"
+              aria-expanded="false"
+              aria-controls="step-7-info"
+              tabindex="-1"
+            >
+              Exact PR versions and deployment details are saved in Release Bus
+            </button>
+          </li>
+          <li>
+            <button
+              class="step-button"
+              type="button"
+              aria-expanded="false"
+              aria-controls="step-8-info"
+              tabindex="-1"
+            >
+              Release Bus creates a staging train
+            </button>
+          </li>
+          <li>
+            <button
+              class="step-button"
+              type="button"
+              aria-expanded="false"
+              aria-controls="step-9-info"
+              tabindex="-1"
+            >
+              GitHub Actions build and deploy staging
+            </button>
+          </li>
+          <li>
+            <button
+              class="step-button"
+              type="button"
+              aria-expanded="false"
+              aria-controls="step-10-info"
+              tabindex="-1"
+            >
+              Staging E2E tests pass
+            </button>
+          </li>
+          <li>
+            <button
+              class="step-button"
+              type="button"
+              aria-expanded="false"
+              aria-controls="step-11-info"
+              tabindex="-1"
+            >
+              Production is selected explicitly
+            </button>
+          </li>
+          <li>
+            <button
+              class="step-button"
+              type="button"
+              aria-expanded="false"
+              aria-controls="step-12-info"
+              tabindex="-1"
+            >
+              A fresh production build is deployed
+            </button>
+          </li>
+          <li>
+            <button
+              class="step-button"
+              type="button"
+              aria-expanded="false"
+              aria-controls="step-13-info"
+              tabindex="-1"
+            >
+              Production E2E tests pass
+            </button>
+          </li>
+        </ol>
+
+        <aside class="details-panel" aria-label="Active step information">
+          <div
+            class="step-info"
+            id="step-1-info"
+            role="region"
+            aria-label="Step 1 information"
+          >
+            The feature or fix has been written. It is now ready to enter the
+            deployment process.
+          </div>
+          <div
+            class="step-info"
+            id="step-2-info"
+            role="region"
+            aria-label="Step 2 information"
+            hidden
+          >
+            <strong>Someone tells the agent what to ship</strong>
+            <p>
+              For example: “Hey agent, please ship the new search feature.”
+            </p>
+            <strong class="detail-heading">The request may include</strong>
+            <ul>
+              <li>One backend change</li>
+              <li>One frontend change</li>
+              <li>Related backend and frontend changes</li>
+              <li>Several related changes</li>
+            </ul>
+            <p>
+              This tells the agent which completed work to inspect next.
+            </p>
+          </div>
+          <div
+            class="step-info"
+            id="step-3-info"
+            role="region"
+            aria-label="Step 3 information"
+            hidden
+          >
+            <strong>The agent checks the chosen changes</strong>
+            <ul>
+              <li>Frontend code &rarr; deploy the frontend</li>
+              <li>API code &rarr; deploy <code>api</code></li>
+              <li>
+                Database change &rarr; deploy
+                <code>dbMigrationsLoop</code> first
+              </li>
+              <li>Loop code &rarr; deploy that loop</li>
+              <li>Shared code &rarr; deploy every service that uses it</li>
+            </ul>
+            <p>The result becomes the deployment plan.</p>
+          </div>
+          <div
+            class="step-info"
+            id="step-4-info"
+            role="region"
+            aria-label="Step 4 information"
+            hidden
+          >
+            <strong>The agent gets each PR ready for review</strong>
+            <ul>
+              <li>Adds the completed code for that repository</li>
+              <li>Explains what changed and why</li>
+              <li>Lists the checks that were run</li>
+              <li>Notes important risks</li>
+              <li>Lists what must be deployed and in which order</li>
+            </ul>
+            <p>
+              Example: deploy <code>dbMigrationsLoop</code> first, then deploy
+              <code>api</code>.
+            </p>
+            <p>
+              Each PR records its own services and deployment order.
+            </p>
+          </div>
+          <div
+            class="step-info"
+            id="step-5-info"
+            role="region"
+            aria-label="Step 5 information"
+            hidden
+          ></div>
+          <div
+            class="step-info"
+            id="step-6-info"
+            role="region"
+            aria-label="Step 6 information"
+            hidden
+          ></div>
+          <div
+            class="step-info"
+            id="step-7-info"
+            role="region"
+            aria-label="Step 7 information"
+            hidden
+          >
+            <strong>Release Bus saves each PR as a candidate</strong>
+            <ul>
+              <li>Repository and PR number</li>
+              <li>Exact SHA</li>
+              <li>Deployment plan</li>
+              <li>Links to required candidates</li>
+            </ul>
+            <p>
+              Related candidates are linked by candidate ID. These saved links
+              become the source of truth for deployment order.
+            </p>
+            <strong class="detail-heading">API path</strong>
+            <code>POST /deploy/release-bus-v2/candidates</code>
+            <strong>Body structure</strong>
+            <pre>{
+  "repository": "frontend | backend",
+  "pr_number": 123,
+  "branch_name": "feature/name",
+  "expected_head_sha": "40-character SHA",
+  "deploy_plan": {
+    "units": ["api"],
+    "edges": [],
+    "publish_release_notes": true
+  },
+  "dependencies": [
+    {
+      "candidate_id": "UUID",
+      "environment": "STAGING | PRODUCTION | BOTH"
+    }
+  ]
+}</pre>
+            <p>
+              Frontend uses <code>"deploy_plan": null</code>. Dependencies may
+              be empty.
+            </p>
+          </div>
+          <div
+            class="step-info"
+            id="step-8-info"
+            role="region"
+            aria-label="Step 8 information"
+            hidden
+          ></div>
+          <div
+            class="step-info"
+            id="step-9-info"
+            role="region"
+            aria-label="Step 9 information"
+            hidden
+          ></div>
+          <div
+            class="step-info"
+            id="step-10-info"
+            role="region"
+            aria-label="Step 10 information"
+            hidden
+          ></div>
+          <div
+            class="step-info"
+            id="step-11-info"
+            role="region"
+            aria-label="Step 11 information"
+            hidden
+          ></div>
+          <div
+            class="step-info"
+            id="step-12-info"
+            role="region"
+            aria-label="Step 12 information"
+            hidden
+          ></div>
+          <div
+            class="step-info"
+            id="step-13-info"
+            role="region"
+            aria-label="Step 13 information"
+            hidden
+          ></div>
+          <section class="gap-panel" aria-label="Issues and gaps">
+            <strong>Issues / gaps</strong>
+            <div class="step-gap" id="step-1-gap"></div>
+            <div class="step-gap" id="step-2-gap" hidden></div>
+            <div class="step-gap" id="step-3-gap" hidden>
+              There is no automatic tool that guarantees every affected service
+              is found. The agent follows the skill rules and uses judgment.
+            </div>
+            <div class="step-gap" id="step-4-gap" hidden>
+              The <code>write-prs</code> skill does not require exact related PR
+              numbers or cross-PR dependency links in this step.
+            </div>
+            <div class="step-gap" id="step-5-gap" hidden></div>
+            <div class="step-gap" id="step-6-gap" hidden></div>
+            <div class="step-gap" id="step-7-gap" hidden></div>
+            <div class="step-gap" id="step-8-gap" hidden></div>
+            <div class="step-gap" id="step-9-gap" hidden></div>
+            <div class="step-gap" id="step-10-gap" hidden></div>
+            <div class="step-gap" id="step-11-gap" hidden></div>
+            <div class="step-gap" id="step-12-gap" hidden></div>
+            <div class="step-gap" id="step-13-gap" hidden></div>
+          </section>
+        </aside>
+      </div>
+    </main>
+    <script>
+      const stepButtons = Array.from(
+        document.querySelectorAll(".step-button")
+      );
+      const processLayout = document.querySelector(".process-layout");
+      const detailsPanel = document.querySelector(".details-panel");
+      const narrowLayout = window.matchMedia("(max-width: 900px)");
+
+      function placeDetailsPanel() {
+        const activeButton = document.querySelector(
+          '.step-button[aria-expanded="true"]'
+        );
+
+        if (narrowLayout.matches) {
+          activeButton.closest("li").append(detailsPanel);
+        } else {
+          processLayout.append(detailsPanel);
+        }
+      }
+
+      function updateStepQuery(stepIndex) {
+        const query = new URLSearchParams(window.location.search);
+        query.set("step", String(stepIndex + 1));
+        window.history.replaceState(
+          null,
+          "",
+          `?${query.toString()}${window.location.hash}`
+        );
+      }
+
+      function activateStep(nextIndex, moveFocus) {
+        stepButtons.forEach((button, index) => {
+          const isActive = index === nextIndex;
+          const item = button.closest("li");
+          const info = document.getElementById(
+            button.getAttribute("aria-controls")
+          );
+          const gap = document.getElementById(`step-${index + 1}-gap`);
+
+          item.classList.toggle("is-active", isActive);
+          button.setAttribute("aria-expanded", String(isActive));
+          button.tabIndex = isActive ? 0 : -1;
+          info.hidden = !isActive;
+          gap.hidden = !isActive;
+        });
+
+        placeDetailsPanel();
+        updateStepQuery(nextIndex);
+        if (moveFocus) stepButtons[nextIndex].focus();
+      }
+
+      stepButtons.forEach((button, index) => {
+        button.addEventListener("click", () => activateStep(index, true));
+        button.addEventListener("keydown", (event) => {
+          let nextIndex = index;
+
+          if (event.key === "ArrowDown") {
+            nextIndex = Math.min(index + 1, stepButtons.length - 1);
+          } else if (event.key === "ArrowUp") {
+            nextIndex = Math.max(index - 1, 0);
+          } else if (event.key === "Home") {
+            nextIndex = 0;
+          } else if (event.key === "End") {
+            nextIndex = stepButtons.length - 1;
+          } else {
+            return;
+          }
+
+          event.preventDefault();
+          activateStep(nextIndex, true);
+        });
+      });
+
+      narrowLayout.addEventListener("change", placeDetailsPanel);
+      const requestedStep = Number(
+        new URLSearchParams(window.location.search).get("step") ?? "1"
+      );
+      const initialStepIndex =
+        Number.isInteger(requestedStep) &&
+        requestedStep >= 1 &&
+        requestedStep <= stepButtons.length
+          ? requestedStep - 1
+          : 0;
+      activateStep(initialStepIndex, false);
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Issue
- The Release Bus v2 deployment flow is difficult to understand as one continuous process. The agent preparation, Release Bus handoff, staging automation, and explicit production gate need a simple visual explanation.

## Fix
- Add one backend-owned standalone HTML diagram that opens directly as a local file without a server.
- Use short numbered steps with a separate details panel so the main process stays easy to scan.

## Changes
- Add a 16-step agent-native release flow from deployment preparation through production E2E.
- Show the handoff from the agent to the Release Bus registry and the scheduled staging worker.
- Split PR composition and conflict checks from the staging build and deployment.
- Add click and keyboard navigation, with the active step stored in the `step` query parameter.
- Add plain-English details and explicit issues/gaps for steps where more context is useful.
- No API, database, Lambda, deploy configuration, or architecture shape changes.

## Validation
- `git diff --check origin/main...HEAD`
- Manual local-browser review of the standalone file and step navigation during development.
- Package lint, build, and tests were not run because this is an isolated HTML documentation artifact with no package integration.

## Risk
- Level: Low
- Why: One standalone HTML file; no runtime or deployment behavior changes.
- Rollback: Revert the three diagram commits or remove the file.

## Deployment
- None. No backend Lambda or service needs redeployment.

## Review Notes
- Please focus on whether the wording and phase boundaries match the current Release Bus v2 behavior while remaining easy to read.